### PR TITLE
feat(tenant): 为租户添加营业执照号码字段

### DIFF
--- a/modules/console/src/entities/tenant.ts
+++ b/modules/console/src/entities/tenant.ts
@@ -21,6 +21,8 @@ export interface TenantMetadata {
   size?: 'small' | 'medium' | 'large' | 'enterprise'
   contactEmail?: string
   contactPhone?: string
+  businessLicenseIssuer?: string  // 营业执照颁发机构
+  businessLicenseExpiry?: string  // 营业执照到期日期 (YYYY-MM-DD)
   [key: string]: unknown
 }
 
@@ -50,6 +52,11 @@ export const TenantEntity = defineEntity('Tenant', {
   description: defineField.text()
     .optional()
     .description('租户描述'),
+  
+  businessLicense: defineField.string()
+    .optional()
+    .max(50)
+    .description('营业执照号码'),
   
   status: defineField.enum(['active', 'suspended', 'deleted', 'pending'])
     .required()

--- a/modules/console/src/pages/tenants/TenantCreate.tsx
+++ b/modules/console/src/pages/tenants/TenantCreate.tsx
@@ -45,6 +45,7 @@ const createTenantSchema = z.object({
     .regex(/^[a-z0-9-]+$/, 'URL标识只能包含小写字母、数字和连字符'),
   domain: z.string().optional(),
   description: z.string().optional(),
+  businessLicense: z.string().max(50, '营业执照号码不能超过50个字符').optional(),
   plan: z.enum(['free', 'starter', 'professional', 'enterprise']),
   billingCycle: z.enum(['monthly', 'yearly']).optional(),
   maxUsers: z.number().min(1, '最大用户数必须大于0').max(10000, '最大用户数不能超过10000'),
@@ -224,6 +225,19 @@ export function TenantCreate() {
               />
               <p className="text-xs text-muted-foreground">
                 可选，设置租户的自定义域名
+              </p>
+            </div>
+            
+            <div className="space-y-2">
+              <Label htmlFor="businessLicense">营业执照号码</Label>
+              <Input
+                id="businessLicense"
+                placeholder="输入营业执照号码"
+                {...register('businessLicense')}
+                error={errors.businessLicense?.message}
+              />
+              <p className="text-xs text-muted-foreground">
+                可选，企业租户的营业执照注册号码
               </p>
             </div>
             

--- a/modules/console/src/pages/tenants/TenantDetail.tsx
+++ b/modules/console/src/pages/tenants/TenantDetail.tsx
@@ -291,6 +291,13 @@ export function TenantDetail() {
                   </div>
                 </div>
                 
+                {tenant.businessLicense && (
+                  <div>
+                    <label className="text-sm font-medium text-muted-foreground">营业执照号码</label>
+                    <div className="mt-1">{tenant.businessLicense}</div>
+                  </div>
+                )}
+                
                 {tenant.description && (
                   <div>
                     <label className="text-sm font-medium text-muted-foreground">描述</label>


### PR DESCRIPTION
## Summary
为租户系统添加营业执照号码管理功能，支持企业客户的合规需求

• 在 TenantEntity 中添加 businessLicense 字段（最大50字符，可选）
• 扩展 TenantMetadata 接口，支持营业执照颁发机构和到期日期
• 更新租户创建表单，添加营业执照号码输入功能
• 更新租户详情页面，显示营业执照号码信息

## Test plan
- [x] Schema 字段定义正确，类型安全
- [x] 表单验证逻辑正常，字段长度限制有效
- [x] 租户创建功能正常，支持营业执照号码输入
- [x] 租户详情页面正确显示营业执照信息
- [x] 向后兼容性良好，现有数据不受影响
- [x] 构建通过，无类型错误

🤖 Generated with [Claude Code](https://claude.ai/code)