### PR TITLE
fix: 修复 Vercel 部署问题

### DIFF
--- a/.github/workflows/vercel-deploy-status.yml
+++ b/.github/workflows/vercel-deploy-status.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Run smoke tests
         run: |
           export PLAYWRIGHT_BASE_URL="${{ github.event.deployment_status.target_url }}"
-          bun playwright test e2e/${{ steps.deployment.outputs.app }}/smoke.spec.ts --project=chromium --reporter=json > test-results.json
+          bun playwright test e2e/${{ steps.deployment.outputs.app }}/smoke.e2e.ts --project=chromium --reporter=json > test-results.json
         continue-on-error: true
 
       - name: Comment on PR

--- a/apps/demo-app/vercel.json
+++ b/apps/demo-app/vercel.json
@@ -5,10 +5,6 @@
   "framework": "nextjs",
   "outputDirectory": ".next",
   "env": {
-    "DATABASE_URL": "@demo_database_url",
-    "DIRECT_URL": "@demo_direct_url",
-    "NEXTAUTH_URL": "@demo_nextauth_url",
-    "NEXTAUTH_SECRET": "@demo_nextauth_secret",
     "NODE_ENV": "production"
   }
 }

--- a/apps/starter/vercel.json
+++ b/apps/starter/vercel.json
@@ -5,13 +5,6 @@
   "framework": "nextjs",
   "outputDirectory": ".next",
   "env": {
-    "DATABASE_URL": "@database_url",
-    "DIRECT_URL": "@direct_url",
-    "SUPABASE_URL": "@supabase_url",
-    "SUPABASE_ANON_KEY": "@supabase_anon_key",
-    "JWT_SECRET": "@jwt_secret",
-    "NEXTAUTH_URL": "@nextauth_url",
-    "NEXTAUTH_SECRET": "@nextauth_secret",
     "NODE_ENV": "production"
   }
 }


### PR DESCRIPTION
## Summary

- 修复 GitHub Actions 中 E2E 测试文件路径错误 (`smoke.spec.ts` -> `smoke.e2e.ts`)
- 移除 `demo-app` 和 `starter` 应用 `vercel.json` 中引用不存在的 Vercel Secrets 的环境变量
- 保留 `NODE_ENV=production` 配置

## 问题分析

之前的部署失败是因为：
1. `vercel.json` 中引用了不存在的 Secrets（如 `@demo_database_url`, `@database_url` 等）
2. GitHub Actions 中 E2E 测试文件路径不正确

## 解决方案

1. **移除环境变量引用**: 暂时移除 `vercel.json` 中的环境变量配置，避免引用不存在的 Secrets
2. **修复测试路径**: 更正 GitHub Actions 中的测试文件路径
3. **后续配置**: 这些环境变量应该通过 Vercel 仪表板为每个项目单独配置

## Test plan

- [x] 修复 GitHub Actions 工作流中的文件路径
- [x] 验证 `vercel.json` 配置语法正确
- [x] 通过 `bun run validate:light` 验证代码质量
- [ ] 推送后验证 Vercel 部署是否成功
- [ ] 验证 GitHub Actions E2E 测试是否正常运行

🤖 Generated with [Claude Code](https://claude.ai/code)