### PR TITLE
feat(dx): add CodeRabbit config and Claude Code hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,7 +26,7 @@
           {
             "type": "command",
             "if": "Bash(git commit*)",
-            "command": "if git diff HEAD~1 --name-only 2>/dev/null | grep -qE '^(packages|addons)/'; then echo 'npm-published code changed. Run bunx changeset if this needs a version bump.'; fi",
+            "command": "if git rev-parse HEAD~1 >/dev/null 2>&1 && git diff HEAD~1 --name-only | grep -qE '^(packages|addons)/'; then echo 'npm-published code changed. Run bunx changeset if this needs a version bump.'; fi",
             "statusMessage": "Checking changeset need..."
           }
         ]
@@ -36,7 +36,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bunx biome check --write --unsafe $CLAUDE_FILE_PATH 2>/dev/null || true",
+            "command": "bunx @biomejs/biome check --write \"$CLAUDE_FILE_PATH\" 2>/dev/null || true",
             "statusMessage": "Auto-formatting..."
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,5 +17,41 @@
       "Write(**)",
       "Edit(**)"
     ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git commit*)",
+            "command": "if git diff HEAD~1 --name-only 2>/dev/null | grep -qE '^(packages|addons)/'; then echo 'npm-published code changed. Run bunx changeset if this needs a version bump.'; fi",
+            "statusMessage": "Checking changeset need..."
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bunx biome check --write --unsafe $CLAUDE_FILE_PATH 2>/dev/null || true",
+            "statusMessage": "Auto-formatting..."
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'Reminder: If you changed spec implementation status, update docs/specs/INDEX.md before ending.'"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,25 @@
+# CodeRabbit configuration
+# https://docs.coderabbit.ai/guides/configure-coderabbit
+language: en
+reviews:
+  request_changes_workflow: true
+  high_level_summary: true
+  poem: false
+  review_status: true
+  auto_review:
+    enabled: true
+    drafts: false
+  path_instructions:
+    - path: "packages/core/**"
+      instructions: |
+        Core package. Must not import from any other package.
+        No concrete implementations — only engines, types, and pipeline.
+    - path: "addons/**"
+      instructions: |
+        Capability packages. Dependency flows one way: Capability -> Core.
+        UI must not import from server packages.
+    - path: "docs/specs/**"
+      instructions: |
+        Specification files. Check that implementation matches spec design.
+chat:
+  auto_reply: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ Spec format: see existing specs in `docs/specs/` for the pattern.
 2. **Follow relevant Skills** — Use `/linch-*` skills for guided development
 3. **Write tests alongside code** — Not after. Use `/test` skill.
 4. **Keep files under 500 lines** — Split by responsibility
+5. **Unrelated issues** — If you discover pre-existing bugs, lint errors, or tech debt unrelated to the current task: **do not fix them in the same PR**. Create a GitHub issue (`gh issue create`) to track them, then continue with the current task.
 
 ### Phase 4: Verify
 
@@ -104,6 +105,16 @@ bun test              # Full test suite (3870+ tests)
 6. **All comments resolved + CI green** → merge
 
 **PR merge gate:** All review comments must be replied to and resolved before merging.
+
+### Parallel Subagent Dispatch
+
+When multiple independent issues can be worked on simultaneously:
+
+1. **Subagents only write code** — Dispatch with `isolation: "worktree"`. Instruct agents to do file changes only, NOT `git commit/push` or `gh pr create`.
+2. **Orchestrator handles git** — After agents complete, the orchestrator commits, pushes, and creates PRs from each worktree.
+3. **Bash `cd` persists** — Working directory carries over between Bash calls. Always use `cd /absolute/path && git ...` in a single Bash call. Never assume you're in the main repo.
+4. **Permission allowlist** — `settings.json` only allows specific Bash patterns. Subagents cannot receive interactive permission prompts, so they fail silently on `git`/`gh` commands.
+5. **No file overlap** — Ensure parallel branches don't modify the same files to avoid merge conflicts.
 
 ### Phase 6: Close
 


### PR DESCRIPTION
## Summary
- Add `.coderabbit.yaml` with auto-review enabled and path-specific instructions for core/addons boundaries (#67)
- Add Claude Code hooks in `.claude/settings.json`: changeset reminder on commit, INDEX.md reminder on session end, auto-format via Biome on file edits (#69)

Closes #67
Closes #69

## Test plan
- [ ] Verify CodeRabbit triggers on next PR to this repo
- [ ] Verify Claude Code hooks load without errors on session start
- [ ] Verify auto-format hook runs after Write/Edit operations
- [ ] Verify changeset reminder appears after committing packages/ or addons/ changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated formatting and commit-time checks that prompt version bumps when package/addon changes are detected; enabled review automation and path-based review constraints to enforce consistency.
* **Documentation**
  * Clarified workflow guidance to avoid bundling unrelated fixes; added orchestration rules for parallel subagent work and a reminder to update spec indexes after spec-status changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->