### PR TITLE
chore: establish GitHub milestones as execution source of truth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ superpowers/
 
 # Overstory worktrees (dynamic agent workspaces)
 .overstory/worktrees/
+.claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,9 +62,11 @@ Life system: **Sense + Memory + Awareness + Insight + Proposal** (Spec 55)
 Every new session MUST begin by understanding current state:
 
 1. Read this file (CLAUDE.md) for conventions and constraints
-2. Read `docs/specs/INDEX.md` for milestone progress and spec status
-3. Check `gh issue list --milestone <current>` for active tasks
+2. Read `docs/specs/INDEX.md` for spec status, tracking links, and relevant design docs
+3. Check GitHub milestones and issues for active execution truth
 4. Ask the user what to work on
+
+**Execution rule:** GitHub milestones and issues are the authoritative task tracker. Specs define target design and stable constraints. README is background only, not a task source.
 
 ### Phase 2: Spec First
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The AI agent will interactively guide you through capability selection, entity d
 - `linchkit.config.ts` — Project configuration
 - `AGENTS.md` / `CLAUDE.md` — AI development instructions
 - `.mcp.json` — MCP dev server config for AI tools
-- `.claude/skills/linch/` — 10 development skills (entity design, action design, etc.)
+- `.claude/skills/linch/` — development skills (entity design, action design, etc.)
 - `.cursor/rules/linch/` — Same skills for Cursor
 
 ---
@@ -340,7 +340,7 @@ linch publish           # Publish packages
 docker compose up -d    # PostgreSQL + Restate
 
 bun install             # Install dependencies
-bun test                # Run tests (~3700 tests)
+bun test                # Run tests
 bun run dev             # Start dev server (server :3001 + UI :3000)
 bun run dev:server      # Server only
 bun run dev:ui          # UI only (proxies API to :3001)
@@ -352,25 +352,6 @@ bun run db:generate     # Generate migration SQL from schema changes
 bun run db:migrate      # Apply pending migrations
 bun run db:studio       # Open Drizzle Studio GUI
 ```
-
----
-
-## Milestones
-
-- [x] **M0a** — Dev Infrastructure + UI Shell
-- [x] **M0b** — Core Runtime (all engines, E2E purchase management demo)
-- [x] **M1** — Flow Engine (Restate dual-mode), Approval + Proposal engines
-- [x] **M2** — Relations, OntologyRegistry, GraphQL Subscriptions, Entity Interfaces, Inheritance, Derived Properties, Soft Delete, Data Masking, Reactive Automation
-- [ ] **M3** — Developer Experience, Publishing, AI Workspace *(in progress)*
-  - [x] Runtime Entity Overlay (6 phases)
-  - [x] MCP Dev Server + AI development workflow
-  - [x] Publishing infrastructure (Changesets, tsup, CI/CD)
-  - [x] Observability (alerts, impact analysis)
-  - [x] i18n (capability-owned translations)
-  - [ ] Auth + Permission capabilities
-- [ ] **M4** — Production Grade (full multi-tenancy, multi-node, OpenTelemetry)
-
----
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -56,7 +56,7 @@ AI 代理会一步步引导你选择能力、设计实体和动作。
 - `linchkit.config.ts` — 项目配置
 - `AGENTS.md` / `CLAUDE.md` — AI 开发指令
 - `.mcp.json` — MCP 开发服务器配置
-- `.claude/skills/linch/` — 10 个开发技能（实体设计、动作设计等）
+- `.claude/skills/linch/` — 开发技能（实体设计、动作设计等）
 - `.cursor/rules/linch/` — Cursor 版本的同样技能
 
 ---
@@ -340,7 +340,7 @@ linch publish           # 发布包
 docker compose up -d    # PostgreSQL + Restate
 
 bun install             # 安装依赖
-bun test                # 运行测试（约 3700 个）
+bun test                # 运行测试
 bun run dev             # 启动开发服务器（服务端 :3001 + UI :3000）
 bun run dev:server      # 仅启动服务端
 bun run dev:ui          # 仅启动 UI（代理 API 到 :3001）
@@ -352,25 +352,6 @@ bun run db:generate     # 从 schema 变更生成迁移 SQL
 bun run db:migrate      # 执行未应用的迁移
 bun run db:studio       # 打开 Drizzle Studio GUI
 ```
-
----
-
-## 里程碑
-
-- [x] **M0a** — 开发基础设施 + UI 壳子
-- [x] **M0b** — 核心运行时（全部引擎、E2E 采购管理演示）
-- [x] **M1** — Flow 引擎（Restate 双模式）、审批 + Proposal 引擎
-- [x] **M2** — 关系类型、OntologyRegistry、GraphQL 订阅、实体接口、继承、派生属性、软删除、数据脱敏、响应式自动化
-- [ ] **M3** — 开发者体验、发布、AI 工作空间 *（进行中）*
-  - [x] 运行时实体 Overlay（6 阶段完成）
-  - [x] MCP 开发服务器 + AI 开发工作流
-  - [x] 发布基础设施（Changesets、tsup、CI/CD）
-  - [x] 可观测性（告警、影响分析）
-  - [x] i18n（能力级翻译）
-  - [ ] 认证 + 权限能力
-- [ ] **M4** — 生产级（完整多租户、多节点部署、OpenTelemetry）
-
----
 
 ## 许可
 

--- a/docs/specs/00_tech_stack.md
+++ b/docs/specs/00_tech_stack.md
@@ -1,5 +1,13 @@
 # LinchKit 技术栈与基础设施
 
+> Tracking milestones:
+> - foundational architecture reference
+>
+> Related issues:
+> - No dedicated open issue is currently tracked for this spec.
+>
+> Execution source of truth: GitHub milestones and issues.
+
 ## 1. 核心技术选型
 
 | 层面 | 选型 | 理由 |

--- a/docs/specs/00a_product_vision.md
+++ b/docs/specs/00a_product_vision.md
@@ -1,15 +1,6 @@
 # 产品愿景 — 用户说，要有光
 
-> Tracking milestones:
-> - long-range product vision reference across multiple milestones
->
-> Related issues:
-> - No dedicated open issue is currently tracked for this spec.
->
-> Execution source of truth: GitHub milestones and issues.
-
 > **"用户说，要有光。"**
->
 > 系统不是被设计出来的，是从使用中长出来的。
 
 ## 1. 核心理念

--- a/docs/specs/00a_product_vision.md
+++ b/docs/specs/00a_product_vision.md
@@ -1,5 +1,13 @@
 # 产品愿景 — 用户说，要有光
 
+> Tracking milestones:
+> - long-range product vision reference across multiple milestones
+>
+> Related issues:
+> - No dedicated open issue is currently tracked for this spec.
+>
+> Execution source of truth: GitHub milestones and issues.
+
 > **"用户说，要有光。"**
 >
 > 系统不是被设计出来的，是从使用中长出来的。

--- a/docs/specs/01_capability_structure.md
+++ b/docs/specs/01_capability_structure.md
@@ -1,5 +1,14 @@
 # Capability 结构与组织规范
 
+> Tracking milestones:
+> - foundational capability architecture reference
+>
+> Related issues:
+> - GitHub Issue `#84` — Repository separation: core vs official capabilities
+> - GitHub Issue `#85` — Capability Hub: discovery and marketplace
+>
+> Execution source of truth: GitHub milestones and issues.
+
 ## 1. Capability 定义
 
 Capability 是 LinchKit 中系统能力的基本组织单位。一个 Capability 代表一个可以独立存在、独立演进的业务模块。

--- a/docs/specs/02_runtime_change.md
+++ b/docs/specs/02_runtime_change.md
@@ -1,5 +1,13 @@
 # 运行时变更机制
 
+> Tracking milestones:
+> - foundational runtime architecture reference
+>
+> Related issues:
+> - No dedicated open issue is currently tracked for this spec.
+>
+> Execution source of truth: GitHub milestones and issues.
+
 > 本文说明三层 Source of Truth 与运行模式；共享数据库蓝绿发布的兼容性协议见 `38_release_compatibility.md`。
 
 ## 1. Source of Truth 三层模型

--- a/docs/specs/03_schema.md
+++ b/docs/specs/03_schema.md
@@ -1,5 +1,14 @@
 # Schema 设计规范
 
+> Tracking milestones:
+> - foundational meta-model reference
+>
+> Related issues:
+> - GitHub Issue `#87` — Semantic relation unification
+> - No dedicated open issue is currently tracked for the rest of this spec.
+>
+> Execution source of truth: GitHub milestones and issues.
+
 ## 1. 定位
 
 Schema 是 LinchKit 的数据基础。所有其他概念（Action、Rule、State、Event）都围绕 Schema 运转。

--- a/docs/specs/04_action.md
+++ b/docs/specs/04_action.md
@@ -1,5 +1,14 @@
 # Action 设计规范
 
+> Tracking milestones:
+> - foundational meta-model reference
+>
+> Related issues:
+> - GitHub Issue `#78` — AI deep integration: NL intent resolution
+> - No dedicated open issue is currently tracked for the rest of this spec.
+>
+> Execution source of truth: GitHub milestones and issues.
+
 > 本文定义 Action 结构；Action 与 Rule / Approval / Event / Execution / Error 的统一执行时序见 `39_execution_contract.md`。
 
 ## 1. 定位

--- a/docs/specs/05_rule.md
+++ b/docs/specs/05_rule.md
@@ -1,5 +1,14 @@
 # Rule 设计规范
 
+> Tracking milestones:
+> - foundational meta-model reference
+>
+> Related issues:
+> - GitHub Issue `#79` — AI-Rule boundary definition
+> - No dedicated open issue is currently tracked for the rest of this spec.
+>
+> Execution source of truth: GitHub milestones and issues.
+
 > 本文定义 Rule 模型；Rule 在统一执行链中的时序见 `39_execution_contract.md`，`execute_action` 的使用边界见 `40_rule_execute_action_boundary.md`。
 
 ## 1. 定位

--- a/docs/specs/06_state.md
+++ b/docs/specs/06_state.md
@@ -1,5 +1,13 @@
 # State Machine 设计规范
 
+> Tracking milestones:
+> - foundational meta-model reference
+>
+> Related issues:
+> - No dedicated open issue is currently tracked for this spec.
+>
+> Execution source of truth: GitHub milestones and issues.
+
 ## 1. 定位
 
 State Machine 管理业务对象的生命周期状态。状态是业务真相的一部分 — 它决定了当前能做什么操作、不能做什么操作。

--- a/docs/specs/07_event.md
+++ b/docs/specs/07_event.md
@@ -1,5 +1,13 @@
 # Event 设计规范
 
+> Tracking milestones:
+> - foundational meta-model reference
+>
+> Related issues:
+> - No dedicated open issue is currently tracked for this spec.
+>
+> Execution source of truth: GitHub milestones and issues.
+
 > 本文定义事件模型；事件在统一执行链中的产出时序见 `39_execution_contract.md`。
 
 ## 1. 定位

--- a/docs/specs/08_event_handler_and_queue.md
+++ b/docs/specs/08_event_handler_and_queue.md
@@ -1,5 +1,13 @@
 # EventHandler 与队列设计规范
 
+> Tracking milestones:
+> - foundational runtime architecture reference
+>
+> Related issues:
+> - No dedicated open issue is currently tracked for this spec.
+>
+> Execution source of truth: GitHub milestones and issues.
+
 ## 1. 定位
 
 EventHandler 负责事件的后续处理。当 Action 产生事件后，EventHandler 监听并执行后续逻辑（通知、联动、统计等）。

--- a/docs/specs/09_proposal_validation_version.md
+++ b/docs/specs/09_proposal_validation_version.md
@@ -1,5 +1,14 @@
 # Proposal / Validation / Version 设计规范
 
+> Tracking milestones:
+> - foundational governance architecture reference
+>
+> Related issues:
+> - GitHub Issue `#82` — AI Workspace completion
+> - GitHub Issue `#88` — Evolution system: Insight + Proposal cycle
+>
+> Execution source of truth: GitHub milestones and issues.
+
 ## 1. 定位
 
 这三者构成 LinchKit 的变更治理核心：

--- a/docs/specs/10_actor_permission.md
+++ b/docs/specs/10_actor_permission.md
@@ -1,5 +1,13 @@
 # Actor 与权限模型设计规范
 
+> Tracking milestones:
+> - foundational security architecture reference
+>
+> Related issues:
+> - No dedicated open issue is currently tracked for this spec.
+>
+> Execution source of truth: GitHub milestones and issues.
+
 > 权限管理本身作为系统内置 Capability 实现，见 14_system_capabilities.md
 > 认证机制详见 [10a_authentication.md](10a_authentication.md)
 

--- a/docs/specs/10a_authentication.md
+++ b/docs/specs/10a_authentication.md
@@ -1,5 +1,13 @@
 # Token 与认证机制设计规范
 
+> Tracking milestones:
+> - foundational security architecture reference
+>
+> Related issues:
+> - No dedicated open issue is currently tracked for this spec.
+>
+> Execution source of truth: GitHub milestones and issues.
+
 > 权限模型详见 [10_actor_permission.md](10_actor_permission.md)
 > Command Layer 的 auth slot 详见 [16_command_layer_and_api.md](16_command_layer_and_api.md) §2.2
 

--- a/docs/specs/11_execution_log.md
+++ b/docs/specs/11_execution_log.md
@@ -1,5 +1,13 @@
 # Execution Log 设计规范
 
+> Tracking milestones:
+> - foundational observability reference
+>
+> Related issues:
+> - No dedicated open issue is currently tracked for this spec.
+>
+> Execution source of truth: GitHub milestones and issues.
+
 > 本文定义 Execution 的存储与查询；Execution 在统一执行链中的产生时机见 `39_execution_contract.md`。
 
 ## 1. 定位

--- a/docs/specs/12_deployment.md
+++ b/docs/specs/12_deployment.md
@@ -1,6 +1,14 @@
 # 部署架构设计规范
 
 > 本文说明部署流程与组件职责；共享数据库蓝绿下的兼容性硬约束见 `38_release_compatibility.md`。
+>
+> Tracking milestones:
+> - `M5: Production Readiness`
+>
+> Related issues:
+> - GitHub Issue `#72` — Deployment strategy
+>
+> Execution source of truth: GitHub milestones and issues.
 
 ## 1. 整体架构
 

--- a/docs/specs/13_view_and_ui.md
+++ b/docs/specs/13_view_and_ui.md
@@ -1,29 +1,14 @@
 # View 与 UI 设计规范
 
-> Tracking milestones:
-> - foundational UI architecture reference
-> - `M7: Ecosystem`
->
-> Related issues:
-> - GitHub Issue `#86` — Advanced UI views: kanban, calendar, timeline
-> - No dedicated open issue is currently tracked for the rest of this spec.
->
-> Execution source of truth: GitHub milestones and issues.
-
 > **UI 架构原则**：UI 不是 Core 的一部分，而是由 Capability 提供。
->
 > - `cap-adapter-ui` — 官方 UI Shell Capability（React + Shadcn + TanStack），在 `capabilities/` 中。内含基础组件库（原 ui-kit）。
 > - 各业务 Capability — 通过 `defineCapability({ pages, views })` 声明自己的页面和视图
 > - 第三方可实现其他 UI Shell（如 cap-adapter-ui-vue），只要遵守相同的 View/Widget 抽象声明
->
 > 安装 Capability 自动获得 UI 页面，卸载后路由自动移除。不需要 UI 的应用（如纯 MCP 或 Headless API）不安装 cap-adapter-ui 即可。
->
 > **UI 与逻辑完全解耦**：Core 中的 ViewDefinition、FormLayout、WidgetDefinition 都是纯数据声明，不包含任何框架特定代码（无 React/Vue/Angular 依赖）。Capability 只声明"要什么"，UI Shell 负责"怎么渲染"。
->
 > - `extensions.viewTypes` 中的自定义视图类型（map, gantt 等）由 UI Shell 注册具体渲染组件
 > - Widget Registry 由 UI Shell 维护（cap-adapter-ui 用 React 组件，cap-adapter-ui-vue 用 Vue 组件）
 > - 没装任何 UI Shell → 所有 pages/views 声明被忽略，系统以 Headless 模式运行
->
 > cap-adapter-ui 负责：
 > - 路由注册（扫描所有 Capability 的 `pages` 声明）
 > - Sidebar 导航（根据 Capability 的 category + pages 自动生成）

--- a/docs/specs/13_view_and_ui.md
+++ b/docs/specs/13_view_and_ui.md
@@ -1,5 +1,15 @@
 # View 与 UI 设计规范
 
+> Tracking milestones:
+> - foundational UI architecture reference
+> - `M7: Ecosystem`
+>
+> Related issues:
+> - GitHub Issue `#86` — Advanced UI views: kanban, calendar, timeline
+> - No dedicated open issue is currently tracked for the rest of this spec.
+>
+> Execution source of truth: GitHub milestones and issues.
+
 > **UI 架构原则**：UI 不是 Core 的一部分，而是由 Capability 提供。
 >
 > - `cap-adapter-ui` — 官方 UI Shell Capability（React + Shadcn + TanStack），在 `capabilities/` 中。内含基础组件库（原 ui-kit）。

--- a/docs/specs/14_system_capabilities.md
+++ b/docs/specs/14_system_capabilities.md
@@ -1,5 +1,13 @@
 # 系统内置 Capability 设计规范
 
+> Tracking milestones:
+> - `M7: Ecosystem`
+>
+> Related issues:
+> - No dedicated open issue is currently tracked for this spec.
+>
+> Execution source of truth: GitHub milestones and issues.
+
 ## 1. 定位
 
 LinchKit 的系统功能不是框架硬编码的功能，而是官方 Capability 包。

--- a/docs/specs/15_ai_developer_experience.md
+++ b/docs/specs/15_ai_developer_experience.md
@@ -1,5 +1,15 @@
 # AI 开发者体验设计规范
 
+> Tracking milestones:
+> - `M5: Platform Maturity & AI Evolution`
+> - `M7: Ecosystem`
+>
+> Related issues:
+> - GitHub Issue `#82` — AI Workspace completion
+> - GitHub Issue `#89` — Protocol adapters: A2A and AG-UI
+>
+> Execution source of truth: GitHub milestones and issues.
+
 ## 1. 定位
 
 LinchKit 不只是"AI 能用"，而是"AI 天然知道怎么在上面开发"。

--- a/docs/specs/16_command_layer_and_api.md
+++ b/docs/specs/16_command_layer_and_api.md
@@ -1,14 +1,5 @@
 # 统一 Command Layer、API、CLI、MCP 设计规范
 
-> Tracking milestones:
-> - foundational runtime and transport architecture reference
->
-> Related issues:
-> - GitHub Issue `#72` — Deployment strategy
-> - GitHub Issue `#78` — AI deep integration: NL intent resolution
->
-> Execution source of truth: GitHub milestones and issues.
-
 ## 1. 核心架构
 
 ```
@@ -22,11 +13,9 @@ UI ───────┘         │
 所有入口（CLI、MCP、HTTP API、UI）走同一个 Command Layer。核心逻辑写一次，不同传输协议只是适配器。
 
 > 所有入口（HTTP、MCP、UI）均由 Capability（type: adapter）通过 `extensions.transports` 注册。Core 只提供 CommandLayer 管道，不内置任何 transport。CLI 是唯一的内置入口，作为编排器加载 Capability 并启动 transport。
->
 > - `cap-adapter-server` — 注册 HTTP REST + GraphQL transport
 > - `cap-adapter-mcp` — 注册 MCP transport（stdio + Streamable HTTP）
 > - `cap-adapter-ui` — 注册 UI Shell（通过 cap-adapter-server 的 HTTP 服务静态文件）
->
 > 不同部署场景只需加载不同的 adapter Capability，Core 代码不变。
 
 ## 2. Command Layer

--- a/docs/specs/16_command_layer_and_api.md
+++ b/docs/specs/16_command_layer_and_api.md
@@ -1,5 +1,14 @@
 # 统一 Command Layer、API、CLI、MCP 设计规范
 
+> Tracking milestones:
+> - foundational runtime and transport architecture reference
+>
+> Related issues:
+> - GitHub Issue `#72` — Deployment strategy
+> - GitHub Issue `#78` — AI deep integration: NL intent resolution
+>
+> Execution source of truth: GitHub milestones and issues.
+
 ## 1. 核心架构
 
 ```

--- a/docs/specs/21_capability_ecosystem.md
+++ b/docs/specs/21_capability_ecosystem.md
@@ -1,5 +1,14 @@
 # Capability 生态系统设计规范
 
+> Tracking milestones:
+> - `M7: Ecosystem`
+>
+> Related issues:
+> - GitHub Issue `#84` — Repository separation: core vs official capabilities
+> - GitHub Issue `#85` — Capability Hub: discovery and marketplace
+>
+> Execution source of truth: GitHub milestones and issues.
+
 ## 1. 概述
 
 本文档定义 LinchKit Capability 生态系统的全生命周期架构：仓库策略、命名规范、分发机制、信任层级、商业模型、元数据 Schema、安装机制、质量保障、版本兼容性。

--- a/docs/specs/21_capability_hub.md
+++ b/docs/specs/21_capability_hub.md
@@ -1,5 +1,13 @@
 # Capability Hub 设计规范
 
+> Tracking milestones:
+> - `M7: Ecosystem`
+>
+> Related issues:
+> - GitHub Issue `#85` — Capability Hub: discovery and marketplace
+>
+> Execution source of truth: GitHub milestones and issues.
+
 ## 1. 定位
 
 Capability Hub 是 LinchKit 的能力市场，用于发布、分享、安装可复用的 Capability。类似 npm 之于 Node.js。

--- a/docs/specs/25_documentation.md
+++ b/docs/specs/25_documentation.md
@@ -1,6 +1,15 @@
 # 文档能力设计规范
 
 > 文档产物形态见本文；文档维护、校验、索引和归档规则见 `37_documentation_governance.md`。
+>
+> Tracking milestones:
+> - `M5: Production Readiness`
+> - `M5: Platform Maturity & AI Evolution`
+>
+> Related issues:
+> - GitHub Issue `#75` — Documentation auto-generation
+>
+> Execution source of truth: GitHub milestones and issues.
 
 ## 1. 定位
 

--- a/docs/specs/26_transaction_model.md
+++ b/docs/specs/26_transaction_model.md
@@ -1,5 +1,13 @@
 # 事务模型设计规范
 
+> Tracking milestones:
+> - `M5: Production Readiness`
+>
+> Related issues:
+> - No dedicated open issue is currently tracked for this spec.
+>
+> Execution source of truth: GitHub milestones and issues.
+
 ## 1. 三层事务
 
 ### 1.1 单动作事务

--- a/docs/specs/34_cache_strategy.md
+++ b/docs/specs/34_cache_strategy.md
@@ -1,5 +1,13 @@
 # 缓存策略设计规范
 
+> Tracking milestones:
+> - `M5: Production Readiness`
+>
+> Related issues:
+> - GitHub Issue `#73` — Cache strategy completion
+>
+> Execution source of truth: GitHub milestones and issues.
+
 ## 1. 概述
 
 核心设计原则：

--- a/docs/specs/37_documentation_governance.md
+++ b/docs/specs/37_documentation_governance.md
@@ -1,5 +1,13 @@
 # 文档治理规范
 
+> Tracking milestones:
+> - `M5: Production Readiness`
+>
+> Related issues:
+> - No dedicated open issue is currently tracked for this spec.
+>
+> Execution source of truth: GitHub milestones and issues.
+
 ## 1. 定位
 
 `25_documentation.md` 定义的是“文档作为系统能力的产物形态”。

--- a/docs/specs/38_release_compatibility.md
+++ b/docs/specs/38_release_compatibility.md
@@ -1,5 +1,13 @@
 # 发布兼容性与迁移协议
 
+> Tracking milestones:
+> - `M5: Production Readiness`
+>
+> Related issues:
+> - GitHub Issue `#74` — Release compatibility & versioning
+>
+> Execution source of truth: GitHub milestones and issues.
+
 ## 1. 定位
 
 本文定义 LinchKit 在以下场景中的**硬约束**：

--- a/docs/specs/50_milestone_m1_plan.md
+++ b/docs/specs/50_milestone_m1_plan.md
@@ -3,7 +3,6 @@
 > Status: Active | Date: 2026-03-22
 > **Last Updated**: 2026-03-25
 > Prerequisite: **✅ M0b complete** (auth/permission integration finalized)
->
 > ### Current Progress
 > - ✅ M0b: 100% complete (all tasks done, all tests passing)
 > - ✅ M1a Stage 1: Drizzle ORM Infrastructure 100% complete
@@ -40,13 +39,10 @@
 > - ✅ Spec 29: Methodology — complete
 > - ✅ Spec 37: Documentation Governance — complete
 > - ✅ Spec 38: Release Compatibility — complete
->
 > ### Test Coverage
 > - ~1983 tests, 0 failures
->
 > ### Tech Debt Fixed (2026-03-25)
 > - 12 items resolved: resolveApiKey, permission self-registration, identifier validation, Link FK column merging, GraphQL Link resolver tests, console logger fixes, schema-to-zod improvements, schema-to-drizzle Link support, flow types refinement, transport types update, validation engine enhancements, proposal generator improvements
->
 > ### Integration Wiring Completed (2026-03-25)
 > - GraphQL state transitions: availableTransitions query + transition mutation
 > - GraphQL optimistic locking: _version check with 409 conflict response
@@ -61,12 +57,10 @@
 > - 5 CLI commands: docs, check, changelog, validate, info
 > - 4 MCP AI security tools
 > - Purchase demo enhanced (interfaces, derived, automations, masking)
->
 > ### Architecture Improvements
 > - **Browser/Server Boundaries**: Clean separation of browser-safe and server-only code paths across all packages
 > - **Error Hierarchy**: Structured error types with proper HTTP status mapping (validation→400, auth→401, authz→403, not_found→404, business→422, conflict→409, system→500)
 > - **EventBusLike Decoupling**: Core engines depend on `EventBusLike` interface, not concrete EventBus — enables in-memory, persistent, and test implementations interchangeably
->
 > ### Remaining Work (TODO)
 > - Final polish and M2 remaining items
 

--- a/docs/specs/51_data_i18n.md
+++ b/docs/specs/51_data_i18n.md
@@ -2,6 +2,14 @@
 
 > Spec: 51 | Status: Active | Supersedes: spec 41 (original data i18n design)
 > Last Updated: 2026-03-26
+>
+> Tracking milestones:
+> - `M5: Platform Maturity & AI Evolution`
+>
+> Related issues:
+> - No dedicated open issue is currently tracked for this spec.
+>
+> Execution source of truth: GitHub milestones and issues.
 
 ## 1. Overview
 

--- a/docs/specs/52_ai_deep_integration.md
+++ b/docs/specs/52_ai_deep_integration.md
@@ -5,6 +5,15 @@
 > - **Spec 15** covers *developer-facing* AI: MCP tools, Proposals, code scaffolding, CLAUDE.md/AGENTS.md auto-generation, AI Management UI (Proposal approval, Insights dashboard, Evolution timeline, AI assistant panel, AI search/auto-fill). This spec does NOT duplicate those features.
 > - **Spec 36** covers the AI service layer (`ctx.ai`, provider configuration, model aliases, rate limiting, cost control, tool calling). This spec uses `ctx.ai` as the underlying engine and does NOT redefine its API or configuration.
 > - **Spec 22** defines AI rule boundaries. **Spec 27** defines AI security hardening. Both apply here without modification.
+>
+> Tracking milestones:
+> - `M6: AI Intelligence`
+>
+> Related issues:
+> - GitHub Issue `#78` — AI deep integration: NL intent resolution
+> - GitHub Issue `#83` — Record analysis and data quality scanning
+>
+> Execution source of truth: GitHub milestones and issues.
 
 ## 1. Overview
 

--- a/docs/specs/52_ai_deep_integration.md
+++ b/docs/specs/52_ai_deep_integration.md
@@ -1,19 +1,9 @@
 # AI Deep Integration — From Chat to Action
 
 > This spec extends [Spec 15 — AI Developer Experience](./15_ai_developer_experience.md) and [Spec 36 — AI Service](./36_ai_service.md). Read those specs first for context.
->
 > - **Spec 15** covers *developer-facing* AI: MCP tools, Proposals, code scaffolding, CLAUDE.md/AGENTS.md auto-generation, AI Management UI (Proposal approval, Insights dashboard, Evolution timeline, AI assistant panel, AI search/auto-fill). This spec does NOT duplicate those features.
 > - **Spec 36** covers the AI service layer (`ctx.ai`, provider configuration, model aliases, rate limiting, cost control, tool calling). This spec uses `ctx.ai` as the underlying engine and does NOT redefine its API or configuration.
 > - **Spec 22** defines AI rule boundaries. **Spec 27** defines AI security hardening. Both apply here without modification.
->
-> Tracking milestones:
-> - `M6: AI Intelligence`
->
-> Related issues:
-> - GitHub Issue `#78` — AI deep integration: NL intent resolution
-> - GitHub Issue `#83` — Record analysis and data quality scanning
->
-> Execution source of truth: GitHub milestones and issues.
 
 ## 1. Overview
 

--- a/docs/specs/53_chatter_and_collaboration.md
+++ b/docs/specs/53_chatter_and_collaboration.md
@@ -1,7 +1,6 @@
 # Chatter — 统一记录时间线
 
 > 本 spec 扩展 [Spec 14 — System Capabilities](./14_system_capabilities.md) 4.7。请先阅读该 spec。
->
 > Spec 14 列出 `@linchkit/cap-comment` 作为"建议安装"的系统 Capability，提供评论/活动功能。本 spec 提供 `@linchkit/cap-chatter` 的**完整设计**，定位从"聊天+活动日志"升级为**统一记录级时间线**，涵盖字段级变更审计、执行日志、人工评论、AI 对话、状态流转和可观测性数据。
 
 > Status: Draft | Date: 2026-03-27

--- a/docs/specs/54_advanced_ui_features.md
+++ b/docs/specs/54_advanced_ui_features.md
@@ -1,7 +1,6 @@
 # Spec 54 — Advanced UI Features
 
 > This spec extends [Spec 13 — View & UI](./13_view_and_ui.md). Read that spec first for context.
->
 > Spec 13 defines the view system, view types (`list`, `form`, `detail`, `kanban`, `dashboard`, `calendar`, `tree`), layout priority chain, Widget Registry, SearchBar architecture, and AI-native design principles. This spec does NOT redefine those concepts. Instead, it adds:
 > - **Field dependencies** (show/hide) — new `visibleWhen` property for conditional form rendering
 > - **Saved filters / custom views** — persistent named filter presets
@@ -10,20 +9,11 @@
 > - **Rich text editor** — Tiptap-based editor (implementing the `rich_text` field type referenced in spec 13 §7)
 > - **Print / PDF export** — client-side print CSS
 > - **Record templates** — pre-filled field value presets
->
 > Also references: [Spec 14 — System Capabilities](./14_system_capabilities.md) §4.9 (`cap-dashboard`), [Spec 03 — Schema](./03_schema.md), [Spec 46 — Link Type](./46_link_type.md)
 
 > **Status:** Draft
 > **Milestone:** M3
 > **Dependencies:** Spec 13 (View & UI), Spec 03 (Schema), Spec 46 (Link Type)
->
-> Tracking milestones:
-> - `M7: Ecosystem`
->
-> Related issues:
-> - GitHub Issue `#86` — Advanced UI views: kanban, calendar, timeline
->
-> Execution source of truth: GitHub milestones and issues.
 
 ## Overview
 

--- a/docs/specs/54_advanced_ui_features.md
+++ b/docs/specs/54_advanced_ui_features.md
@@ -16,6 +16,14 @@
 > **Status:** Draft
 > **Milestone:** M3
 > **Dependencies:** Spec 13 (View & UI), Spec 03 (Schema), Spec 46 (Link Type)
+>
+> Tracking milestones:
+> - `M7: Ecosystem`
+>
+> Related issues:
+> - GitHub Issue `#86` — Advanced UI views: kanban, calendar, timeline
+>
+> Execution source of truth: GitHub milestones and issues.
 
 ## Overview
 

--- a/docs/specs/55_evolution_system.md
+++ b/docs/specs/55_evolution_system.md
@@ -3,6 +3,16 @@
 > 本规范定义 LinchKit 的自进化能力。与产品愿景（[00a](./00a_product_vision.md)）互补：00a 定义"用户说→系统出现"的显式生长，本规范定义"系统自己感知→自己进化"的隐式生长。
 >
 > 相关规范：[15 — AI 开发者体验](./15_ai_developer_experience.md)（evolver Agent）、[36 — AI 服务层](./36_ai_service.md)（ctx.ai）、[45 — Reactive Automation](./45_reactive_automation.md)（TriggerBinding）、[22 — AI Rule Boundary](./22_ai_rule_boundary.md)（边界约束）。
+>
+> Tracking milestones:
+> - `M6: AI Intelligence`
+> - future AI / evolution milestones as the system moves beyond MVP
+>
+> Related issues:
+> - GitHub Issue `#81` — Evolution system MVP: Sense + Memory + Awareness
+> - GitHub Issue `#88` — Evolution system: Insight + Proposal cycle
+>
+> Execution source of truth: GitHub milestones and issues.
 
 ## 1. 核心理念
 

--- a/docs/specs/55_evolution_system.md
+++ b/docs/specs/55_evolution_system.md
@@ -1,18 +1,7 @@
 # 进化系统 — 活的软件
 
 > 本规范定义 LinchKit 的自进化能力。与产品愿景（[00a](./00a_product_vision.md)）互补：00a 定义"用户说→系统出现"的显式生长，本规范定义"系统自己感知→自己进化"的隐式生长。
->
 > 相关规范：[15 — AI 开发者体验](./15_ai_developer_experience.md)（evolver Agent）、[36 — AI 服务层](./36_ai_service.md)（ctx.ai）、[45 — Reactive Automation](./45_reactive_automation.md)（TriggerBinding）、[22 — AI Rule Boundary](./22_ai_rule_boundary.md)（边界约束）。
->
-> Tracking milestones:
-> - `M6: AI Intelligence`
-> - future AI / evolution milestones as the system moves beyond MVP
->
-> Related issues:
-> - GitHub Issue `#81` — Evolution system MVP: Sense + Memory + Awareness
-> - GitHub Issue `#88` — Evolution system: Insight + Proposal cycle
->
-> Execution source of truth: GitHub milestones and issues.
 
 ## 1. 核心理念
 

--- a/docs/specs/56_core_slimming.md
+++ b/docs/specs/56_core_slimming.md
@@ -3,6 +3,14 @@
 > Status: Draft | Date: 2026-03-27
 > 里程碑: M3
 > 审查来源: Claude Code, Codex GPT-5.4, 原审计（三方独立审查）
+>
+> Tracking milestones:
+> - `M5: Platform Maturity & AI Evolution`
+>
+> Related issues:
+> - GitHub Issue `#77` — Core slimming: move implementations to capabilities
+>
+> Execution source of truth: GitHub milestones and issues.
 
 ## 1. 背景与动机
 

--- a/docs/specs/58_mcp_client_registry.md
+++ b/docs/specs/58_mcp_client_registry.md
@@ -1,7 +1,6 @@
 # MCP Client Registry — AI Agent 接入管理
 
 > 本 spec 扩展 [Spec 15 — AI Developer Experience](./15_ai_developer_experience.md) §3 和 [Spec 20 — Extension Mechanism](./20_extension_mechanism.md) §8.5。
->
 > Spec 15 定义了 MCP 工具集（查询、操作、Proposal），Spec 20 定义了 transport 注册机制。本 spec 补充 **Client 注册、per-client 授权、工具可见性策略、使用统计** 以及配套管理 UI。
 
 > Status: Draft | Date: 2026-04-03

--- a/docs/specs/60_ai_workspace.md
+++ b/docs/specs/60_ai_workspace.md
@@ -3,6 +3,14 @@
 > Status: Design | Date: 2026-04-06
 > Milestone: M3
 > Related: [15 — AI Developer Experience](./15_ai_developer_experience.md), [43 — Ontology Layer](./43_ontology_layer.md), [55 — Evolution System](./55_evolution_system.md), [58 — MCP Client Registry](./58_mcp_client_registry.md)
+>
+> Tracking milestones:
+> - `M5: Platform Maturity & AI Evolution`
+>
+> Related issues:
+> - GitHub Issue `#82` — AI Workspace completion
+>
+> Execution source of truth: GitHub milestones and issues.
 
 ## 1. Motivation
 

--- a/docs/specs/61_semantic_relation_unification.md
+++ b/docs/specs/61_semantic_relation_unification.md
@@ -3,6 +3,14 @@
 > Status: Draft | Date: 2026-04-07
 > Supersedes: Spec 46 (Link Type) partially, Spec 24 (Semantic Relations) partially
 > Milestone: M3
+>
+> Tracking milestones:
+> - `M5: Platform Maturity & AI Evolution`
+>
+> Related issues:
+> - GitHub Issue `#87` — Semantic relation unification
+>
+> Execution source of truth: GitHub milestones and issues.
 
 ## 1. Problem
 

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -5,6 +5,41 @@
 > **Status legend**: `Done` = implemented and tested, `Partial` = core done / details pending, `Draft` = spec only, not implemented, `Deprecated` = superseded by newer spec.
 >
 > **How to use**: Scan this index to locate relevant specs. Read specs on-demand by domain — do not read them all at once.
+>
+> **Execution source of truth**: GitHub milestones and issues are the authoritative task tracker. This index tracks design intent and implementation status; the `Milestone` column is a design-stage target, not the canonical execution plan.
+
+---
+
+## Active Execution Tracking
+
+As of 2026-04-08, active delivery planning is tracked in GitHub, not in this document.
+
+### GitHub Milestones
+
+- `M5: Production Readiness` — deployment, caching, release compatibility, documentation generation, observability completion
+- `M5: Platform Maturity & AI Evolution` — core slimming, semantic relation unification, documentation auto-gen, AI workspace completion
+- `M6: AI Intelligence` — AI deep integration, AI-Rule boundary, AI security hardening, Evolution system MVP
+- `M7: Ecosystem` — Capability Hub, repository separation, advanced UI views, protocol adapters
+
+### Current Open Tracking Issues
+
+- `#72` Deployment strategy (Spec 12)
+- `#73` Cache strategy completion (Spec 34)
+- `#74` Release compatibility & versioning (Spec 38)
+- `#75` Documentation auto-generation (Spec 25)
+- `#77` Core slimming — move implementations to capabilities (Spec 56)
+- `#78` AI deep integration — NL intent resolution (Spec 52)
+- `#79` AI-Rule boundary definition (Spec 22)
+- `#80` AI security hardening (Spec 27)
+- `#81` Evolution system MVP — Sense + Memory + Awareness (Spec 55)
+- `#82` AI Workspace completion (Spec 60)
+- `#83` Record analysis and data quality scanning (Spec 52)
+- `#84` Repository separation — core vs official capabilities
+- `#85` Capability Hub — discovery and marketplace (Spec 21b)
+- `#86` Advanced UI views — kanban, calendar, timeline (Spec 54)
+- `#87` Semantic relation unification (Spec 61)
+- `#88` Evolution system — Insight + Proposal cycle (Spec 55)
+- `#89` Protocol adapters — A2A and AG-UI (Spec 15)
 
 ---
 

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -7,6 +7,11 @@
 > **How to use**: Scan this index to locate relevant specs. Read specs on-demand by domain — do not read them all at once.
 >
 > **Execution source of truth**: GitHub milestones and issues are the authoritative task tracker. This index tracks design intent and implementation status; the `Milestone` column is a design-stage target, not the canonical execution plan.
+>
+> **AI interpretation rule**:
+> - If a spec links to active GitHub issues, treat GitHub as the execution source and the spec as the design reference.
+> - If a spec has no dedicated open issue, treat it as design/reference material unless the user explicitly asks to work on it.
+> - Do not use README as a task source.
 
 ---
 
@@ -40,6 +45,13 @@ As of 2026-04-08, active delivery planning is tracked in GitHub, not in this doc
 - `#87` Semantic relation unification (Spec 61)
 - `#88` Evolution system — Insight + Proposal cycle (Spec 55)
 - `#89` Protocol adapters — A2A and AG-UI (Spec 15)
+
+### Execution Heuristic
+
+- Read GitHub milestones/issues to determine what is actively scheduled now.
+- Read only the spec files relevant to the active issue or requested task.
+- If multiple specs apply, prefer the more specific spec over the more general one.
+- If a spec is `Draft` or `Partial`, verify current code and issue state before assuming missing implementation.
 
 ---
 

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -1,57 +1,8 @@
 # LinchKit Spec Index
 
 > 66 specs grouped by domain. Format: `[number] Title — one-line summary (milestone, status)`.
->
 > **Status legend**: `Done` = implemented and tested, `Partial` = core done / details pending, `Draft` = spec only, not implemented, `Deprecated` = superseded by newer spec.
->
 > **How to use**: Scan this index to locate relevant specs. Read specs on-demand by domain — do not read them all at once.
->
-> **Execution source of truth**: GitHub milestones and issues are the authoritative task tracker. This index tracks design intent and implementation status; the `Milestone` column is a design-stage target, not the canonical execution plan.
->
-> **AI interpretation rule**:
-> - If a spec links to active GitHub issues, treat GitHub as the execution source and the spec as the design reference.
-> - If a spec has no dedicated open issue, treat it as design/reference material unless the user explicitly asks to work on it.
-> - Do not use README as a task source.
-
----
-
-## Active Execution Tracking
-
-As of 2026-04-08, active delivery planning is tracked in GitHub, not in this document.
-
-### GitHub Milestones
-
-- `M5: Production Readiness` — deployment, caching, release compatibility, documentation generation, observability completion
-- `M5: Platform Maturity & AI Evolution` — core slimming, semantic relation unification, documentation auto-gen, AI workspace completion
-- `M6: AI Intelligence` — AI deep integration, AI-Rule boundary, AI security hardening, Evolution system MVP
-- `M7: Ecosystem` — Capability Hub, repository separation, advanced UI views, protocol adapters
-
-### Current Open Tracking Issues
-
-- `#72` Deployment strategy (Spec 12)
-- `#73` Cache strategy completion (Spec 34)
-- `#74` Release compatibility & versioning (Spec 38)
-- `#75` Documentation auto-generation (Spec 25)
-- `#77` Core slimming — move implementations to capabilities (Spec 56)
-- `#78` AI deep integration — NL intent resolution (Spec 52)
-- `#79` AI-Rule boundary definition (Spec 22)
-- `#80` AI security hardening (Spec 27)
-- `#81` Evolution system MVP — Sense + Memory + Awareness (Spec 55)
-- `#82` AI Workspace completion (Spec 60)
-- `#83` Record analysis and data quality scanning (Spec 52)
-- `#84` Repository separation — core vs official capabilities
-- `#85` Capability Hub — discovery and marketplace (Spec 21b)
-- `#86` Advanced UI views — kanban, calendar, timeline (Spec 54)
-- `#87` Semantic relation unification (Spec 61)
-- `#88` Evolution system — Insight + Proposal cycle (Spec 55)
-- `#89` Protocol adapters — A2A and AG-UI (Spec 15)
-
-### Execution Heuristic
-
-- Read GitHub milestones/issues to determine what is actively scheduled now.
-- Read only the spec files relevant to the active issue or requested task.
-- If multiple specs apply, prefer the more specific spec over the more general one.
-- If a spec is `Draft` or `Partial`, verify current code and issue state before assuming missing implementation.
 
 ---
 

--- a/packages/cli/src/commands/agents-md.ts
+++ b/packages/cli/src/commands/agents-md.ts
@@ -7,7 +7,7 @@
  */
 
 import { existsSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { basename, dirname, resolve } from "node:path";
 import type { CapabilityDefinition } from "@linchkit/core";
 import { generateAgentsMd, initI18n, registerTranslations } from "@linchkit/core";
 import { defineCommand } from "citty";
@@ -71,7 +71,8 @@ export const agentsMdCommand = defineCommand({
     const states = capabilities.flatMap((c) => c.states ?? []);
 
     // Derive project name from config path directory
-    const projectDir = resolve(config.configPath, "..");
+    const configDir = dirname(config.configPath);
+    const projectDir = basename(configDir) === "config" ? dirname(configDir) : configDir;
     const projectName = projectDir.split("/").pop() ?? "LinchKit Project";
 
     // Check for user-maintained AGENTS.user.md

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -38,9 +38,6 @@ export const initCommand = defineCommand({
     const requestedName = args.name as string;
     const projectDir = resolve(process.cwd(), requestedName);
     const projectName = basename(projectDir);
-    console.log(
-      `[linch:init:debug] requested=${requestedName} projectDir=${projectDir} projectName=${projectName}`,
-    );
 
     const selectedTools: AiTool[] = args["ai-tools"]
       ? (args["ai-tools"].split(",").map((t: string) => t.trim()) as AiTool[])

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -3,7 +3,7 @@
  */
 
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { basename, resolve } from "node:path";
 import { defineCommand } from "citty";
 import {
   agentsMdTemplate,
@@ -35,19 +35,23 @@ export const initCommand = defineCommand({
     },
   },
   run({ args }) {
-    const projectName = args.name;
-    const projectDir = resolve(process.cwd(), projectName);
+    const requestedName = args.name as string;
+    const projectDir = resolve(process.cwd(), requestedName);
+    const projectName = basename(projectDir);
+    console.log(
+      `[linch:init:debug] requested=${requestedName} projectDir=${projectDir} projectName=${projectName}`,
+    );
 
     const selectedTools: AiTool[] = args["ai-tools"]
       ? (args["ai-tools"].split(",").map((t: string) => t.trim()) as AiTool[])
       : [...ALL_AI_TOOLS];
 
     if (existsSync(projectDir)) {
-      console.error(`Error: Directory "${projectName}" already exists.`);
+      console.error(`Error: Directory "${projectDir}" already exists.`);
       process.exit(1);
     }
 
-    console.log(`Creating LinchKit project: ${projectName}`);
+    console.log(`Creating LinchKit project: ${projectDir}`);
 
     // Create directory structure
     mkdirSync(projectDir, { recursive: true });
@@ -85,7 +89,7 @@ export const initCommand = defineCommand({
     console.log("Project created successfully!");
     console.log("");
     console.log("  Project structure:");
-    console.log(`  ${projectName}/`);
+    console.log(`  ${projectDir}/`);
     console.log("    ├── linchkit.config.ts");
     console.log("    ├── package.json");
     console.log("    ├── tsconfig.json");
@@ -106,7 +110,7 @@ export const initCommand = defineCommand({
     }
     console.log("");
     console.log("  Next steps:");
-    console.log(`    cd ${projectName}`);
+    console.log(`    cd ${projectDir}`);
     console.log("    bun install");
     console.log("    linch dev");
     console.log("");
@@ -126,8 +130,10 @@ export const initCommand = defineCommand({
     ) {
       console.log("    Cursor / Codex / Trae / Copilot:");
       console.log("      I just created this LinchKit project. Help me set it up:");
+      console.log("      first read CLAUDE.md and AGENTS.md, then docs/specs/INDEX.md,");
+      console.log("      treat GitHub milestones/issues as the execution source of truth,");
       console.log("      ask what I want to build, recommend and install capabilities,");
-      console.log("      then help me define entities, actions, and rules.");
+      console.log("      then help me define entities, actions, and rules via the relevant specs.");
       console.log("");
     }
   },

--- a/packages/cli/src/templates/agent-templates.ts
+++ b/packages/cli/src/templates/agent-templates.ts
@@ -8,6 +8,12 @@ export function claudeMdTemplate(projectName: string): string {
 ## Overview
 LinchKit AI-Native Software Capability Runtime project.
 
+## Execution Workflow
+- GitHub milestones and issues are the execution source of truth
+- Specs define target design and stable constraints
+- README is background only, not a task source
+- Read this file first, then AGENTS.md, then docs/specs/INDEX.md, then inspect current GitHub milestones/issues
+
 ## Tech Stack
 - Runtime: Bun
 - Framework: LinchKit
@@ -40,7 +46,6 @@ export const customer = defineEntity({
       { value: 'active', label: 'Active' },
       { value: 'inactive', label: 'Inactive' },
     ]},
-    company: { type: 'ref', target: 'company' },
   },
 })
 \`\`\`
@@ -101,7 +106,7 @@ export default defineConfig({
 \`\`\`
 
 ## Field Types
-string, text, number, boolean, date, datetime, enum, ref, has_many, many_to_many, json
+string, text, number, boolean, date, datetime, enum, json, state
 
 ## Project Structure
 - \`linchkit.config.ts\` — Configuration
@@ -118,6 +123,13 @@ export function agentsMdTemplate(projectName: string): string {
 
 This project uses LinchKit, an AI-Native Software Capability Runtime.
 All business logic is defined declaratively using \`defineXxx()\` functions.
+
+## Execution Workflow
+
+- **Execution source of truth**: GitHub milestones and issues
+- **Specs**: Define target design and stable constraints
+- **README**: Background only, not a task source
+- **Startup order for AI agents**: read \`CLAUDE.md\` / \`AGENTS.md\`, then \`docs/specs/INDEX.md\`, then inspect current GitHub milestones/issues, then read only the relevant specs
 
 ## Key Concepts
 
@@ -139,17 +151,20 @@ When a user asks you to help set up this project, follow this workflow:
 4. **Design actions** — Help define actions using \`defineAction()\` following verb_noun naming
 5. **Design rules/states** — Add business rules and state machines as needed
 6. **Register in config** — Add capabilities to \`linchkit.config.ts\`
-7. **Verify** — Run \`linch dev\` and check that everything works
-8. **Quality gates** — Run \`linch validate\`, \`bun run check\`, \`bun run typecheck\`, \`bun test\`
+7. **Read the relevant spec** — If a spec exists for the area being changed, read it before implementation
+8. **Verify** — Run \`linch dev\` and check that everything works
+9. **Quality gates** — Run \`linch validate\`, \`bun run check\`, \`bun run typecheck\`, \`bun test\`
 
 Ask one question at a time. Use MCP tools (\`linchkit_list_entities\`, \`linchkit_validate_entity\`, etc.) for project introspection.
 
 ## Development Workflow
 
-1. Define capabilities in \`addons/\` directory
-2. Register capabilities in \`linchkit.config.ts\`
-3. Run \`linch dev\` to start the development server
-4. The framework auto-detects changes and applies migrations
+1. Read GitHub milestones/issues to determine the active task
+2. Read the relevant spec files before changing a spec'd area
+3. Define capabilities in \`addons/\` directory
+4. Register capabilities in \`linchkit.config.ts\`
+5. Run \`linch dev\` to start the development server
+6. Run quality gates before commit
 
 ## Entity Field Types Reference
 
@@ -162,10 +177,8 @@ Ask one question at a time. Use MCP tools (\`linchkit_list_entities\`, \`linchki
 | \`date\` | Date only | — |
 | \`datetime\` | Date + time | — |
 | \`enum\` | Fixed options | \`options\`: [{ value, label }] |
-| \`ref\` | Many-to-one reference | \`target\`: entity name |
-| \`has_many\` | One-to-many | \`target\`, \`foreignKey\` |
-| \`many_to_many\` | Many-to-many | \`target\`, \`through\` |
 | \`json\` | Arbitrary JSON | \`schema\`: Zod schema |
+| \`state\` | State machine-backed field | state definition + transitions |
 
 ## Action Types
 
@@ -247,10 +260,11 @@ import { defineRelation } from '@linchkit/core'
 
 export const orderCustomerRelation = defineRelation({
   name: 'order_customer',
-  source: 'order',
-  target: 'customer',
+  from: 'order',
+  to: 'customer',
   cardinality: 'many_to_one',
-  sourceField: 'customer_id',
+  fromName: 'customer',
+  toName: 'orders',
 })
 \`\`\`
 

--- a/packages/cli/src/templates/ai-tool-templates.ts
+++ b/packages/cli/src/templates/ai-tool-templates.ts
@@ -22,6 +22,11 @@ export function cursorRulesTemplate(projectName: string): string {
 
 Read AGENTS.md at the project root for full conventions, meta-model reference, and development workflow.
 
+Execution order for AI work:
+- GitHub milestones and issues are the execution source of truth
+- Specs define target design and stable constraints
+- README is background only, not a task source
+
 ## Quick Reference
 - Runtime: Bun (never Node/npx/npm)
 - Language: TypeScript strict mode
@@ -38,6 +43,11 @@ export function codexMdTemplate(): string {
 
 Read AGENTS.md at the project root for full conventions, meta-model reference, and development workflow.
 
+Execution order for AI work:
+- GitHub milestones and issues are the execution source of truth
+- Specs define target design and stable constraints
+- README is background only, not a task source
+
 Key rules:
 - Runtime: Bun (never Node/npx/npm)
 - TypeScript strict mode
@@ -50,6 +60,11 @@ export function traeRulesTemplate(projectName: string): string {
   return `# ${projectName} — Trae Rules
 
 Read AGENTS.md at the project root for full conventions, meta-model reference, and development workflow.
+
+Execution order for AI work:
+- GitHub milestones and issues are the execution source of truth
+- Specs define target design and stable constraints
+- README is background only, not a task source
 
 ## Quick Reference
 - Runtime: Bun (never Node/npx/npm)
@@ -66,6 +81,11 @@ export function copilotInstructionsTemplate(projectName: string): string {
   return `# ${projectName} — GitHub Copilot Instructions
 
 This project uses LinchKit, an AI-Native Software Capability Runtime.
+
+## Execution Workflow
+- **Execution source of truth**: GitHub milestones and issues
+- **Specs**: Define target design and stable constraints
+- **README**: Background only, not a task source
 
 ## Key Conventions
 - **Runtime**: Bun — never use Node.js, npx, or npm

--- a/packages/cli/src/templates/skill-templates.ts
+++ b/packages/cli/src/templates/skill-templates.ts
@@ -139,8 +139,8 @@ description: "Entity design rules: naming, field types, system fields, inheritan
 | \`date\` | — |
 | \`datetime\` | — |
 | \`enum\` | \`options\`: [{ value, label }] |
-| \`ref\` | \`target\`: entity name |
 | \`json\` | \`schema\`: Zod schema |
+| \`state\` | state machine-backed field |
 
 ## System Fields (DO NOT define — auto-managed)
 \`id\`, \`tenant_id\`, \`created_at\`, \`updated_at\`, \`created_by\`, \`updated_by\`, \`_version\`
@@ -336,20 +336,21 @@ description: "Relation design: cardinality types, defineRelation pattern, cascad
 \`\`\`ts
 defineRelation({
   name: 'order_customer',
-  source: 'order',
-  target: 'customer',
+  from: 'order',
+  to: 'customer',
   cardinality: 'many_to_one',
-  sourceField: 'customer_id',
-  cascade: { onDelete: 'restrict' },
+  fromName: 'customer',
+  toName: 'orders',
+  cascade: 'none',
 })
 \`\`\`
 
 ## Cascade Rules
 | Rule | Description |
 |------|-------------|
-| \`restrict\` | Prevent deletion if related records exist (default) |
-| \`cascade\` | Delete related records |
-| \`set_null\` | Set foreign key to null |
+| \`none\` | Do not cascade deletes or nullification |
+| \`delete\` | Delete related records |
+| \`nullify\` | Set the relation to null when supported |
 `;
 }
 

--- a/packages/core/src/ontology/agents-md-generator.ts
+++ b/packages/core/src/ontology/agents-md-generator.ts
@@ -49,6 +49,7 @@ export function generateAgentsMd(options: AgentsMdOptions): string {
   }
 
   sections.push(renderHeader(options.projectName));
+  sections.push(renderExecutionWorkflow());
   sections.push(renderTechStack());
   sections.push(renderEntities(options.entities));
   sections.push(renderActions(options.actions));
@@ -95,6 +96,18 @@ function renderTechStack(): string {
     "| UI | Shadcn + Radix + Tailwind |",
     "| Testing | bun test |",
     "| Code Quality | Biome |",
+  ].join("\n");
+}
+
+function renderExecutionWorkflow(): string {
+  return [
+    "## Execution Workflow",
+    "",
+    "- **Execution source of truth:** GitHub milestones and issues",
+    "- **Specs:** Define target design and stable constraints",
+    "- **README:** Background and project introduction only, not a task source",
+    "- **Suggested startup order for AI agents:** read `CLAUDE.md` / `AGENTS.md`, then `docs/specs/INDEX.md`, then inspect current GitHub milestones and issues, then read only the relevant spec files",
+    "- **Rule:** If a spec exists for the area being changed, read it before implementation",
   ].join("\n");
 }
 


### PR DESCRIPTION
## Summary
- Add tracking milestones and related GitHub issues to 30+ spec files
- Add M5-M7 execution tracking section to INDEX.md
- Update CLAUDE.md, CLI templates, and agents-md generator with execution workflow
- Remove outdated milestone list and hardcoded counts from README
- Remove ref/has_many from templates (aligns with Spec 61 relation unification)
- Add `.claude/worktrees/` to .gitignore

## Test plan
- [ ] `bun run typecheck` passes
- [ ] `bun run check` passes
- [ ] Verify AGENTS.md generation includes new execution workflow section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added execution-tracking metadata and GitHub milestone/issue references across many specs and the index; clarified that GitHub milestones/issues are the execution source of truth and removed milestone checklists from README (EN & CN).

* **Chores**
  * Updated project/agent setup text and generated templates to reflect the new execution workflow and spec-first guidance.
  * Added a gitignore entry to exclude local AI workspace worktrees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->