### PR TITLE
refactor(core): clean up remaining relation field type references

### DIFF
--- a/packages/core/__tests__/documentation.test.ts
+++ b/packages/core/__tests__/documentation.test.ts
@@ -509,7 +509,7 @@ describe("generateOpenAPISpec", () => {
     const doc = generateApiDoc(ontology);
     const spec = generateOpenAPISpec(doc);
 
-    // purchase_request_input should not have has_many or computed fields
+    // purchase_request_input should not have computed fields
     const inputSchema = spec.components.schemas.purchase_request_input;
     // All purchase_request fields are writable in our test data
     expect(inputSchema.properties).toBeDefined();

--- a/packages/core/__tests__/impact-analysis.test.ts
+++ b/packages/core/__tests__/impact-analysis.test.ts
@@ -12,7 +12,7 @@ function linearChain(): SemanticRelation[] {
       type: "references",
       from: { capability: "cap_a", entity: "entity_a" },
       to: { capability: "cap_b", entity: "entity_b" },
-      source: "schema_ref",
+      source: "manual",
     },
     {
       id: "b->triggers->c",
@@ -39,7 +39,7 @@ function cyclicGraph(): SemanticRelation[] {
       type: "references",
       from: { entity: "entity_a" },
       to: { entity: "entity_b" },
-      source: "schema_ref",
+      source: "manual",
     },
     {
       id: "b->triggers->c",
@@ -66,14 +66,14 @@ function branchingGraph(): SemanticRelation[] {
       type: "references",
       from: { entity: "entity_a" },
       to: { entity: "entity_b" },
-      source: "schema_ref",
+      source: "manual",
     },
     {
       id: "a->contains->c",
       type: "contains",
       from: { entity: "entity_a" },
       to: { entity: "entity_c" },
-      source: "schema_has_many",
+      source: "manual",
     },
     {
       id: "b->triggers->d",

--- a/packages/core/__tests__/mermaid-export.test.ts
+++ b/packages/core/__tests__/mermaid-export.test.ts
@@ -11,14 +11,14 @@ function sampleRelations(): SemanticRelation[] {
       type: "references",
       from: { capability: "sales", entity: "order" },
       to: { capability: "crm", entity: "customer" },
-      source: "schema_ref",
+      source: "manual",
     },
     {
       id: "order->contains->order_line",
       type: "contains",
       from: { capability: "sales", entity: "order" },
       to: { capability: "sales", entity: "order_line" },
-      source: "schema_has_many",
+      source: "manual",
     },
     {
       id: "order->triggers->invoice",
@@ -64,7 +64,7 @@ describe("generateSemanticMermaid", () => {
         type: "references",
         from: { entity: "a" },
         to: { entity: "b" },
-        source: "schema_ref",
+        source: "manual",
       },
     ]);
 
@@ -118,7 +118,7 @@ describe("generateSemanticMermaid", () => {
         type: "references",
         from: { entity: "my-entity" },
         to: { entity: "other.entity" },
-        source: "schema_ref",
+        source: "manual",
       },
     ]);
 

--- a/packages/core/src/engine/proposal-generator.ts
+++ b/packages/core/src/engine/proposal-generator.ts
@@ -141,7 +141,7 @@ LinchKit has the following concepts:
 
 ${contextSection}
 
-Valid field types: string, text, number, boolean, date, datetime, enum, json, state, computed, ref, has_many, many_to_many
+Valid field types: string, text, number, boolean, date, datetime, enum, json, state, computed
 
 Rules for generating proposals:
 1. For "create" changes, always include a complete "definition" object

--- a/packages/core/src/entity/entity-registry.ts
+++ b/packages/core/src/entity/entity-registry.ts
@@ -20,7 +20,7 @@ import type { InterfaceRegistry } from "./entity-interface";
 
 // ── Non-storable field types ────────────────────────────────────
 
-const NON_STORABLE_TYPES = new Set(["computed", "has_many", "many_to_many"]);
+const NON_STORABLE_TYPES = new Set(["computed"]);
 
 /** Maximum inheritance depth (A -> B -> C = depth 2, max allowed is 3 levels total) */
 const MAX_INHERITANCE_DEPTH = 3;

--- a/packages/core/src/ontology/semantic-inference.ts
+++ b/packages/core/src/ontology/semantic-inference.ts
@@ -6,11 +6,13 @@
  *
  * Inference sources (in order of spec 24 §2.2):
  * 1. capability.dependencies → depends_on
- * 2. Schema ref/has_many fields → references / contains
- * 3. capability.bridges → bridges / affects
- * 4. EventHandler cross-module listeners → triggers / affects
- * 5. Flow cross-module action steps → orchestrates
- * 6. Rule cross-module context queries → reads_from
+ * 2. capability.bridges → bridges / affects
+ * 3. EventHandler cross-module listeners → triggers / affects
+ * 4. Flow cross-module action steps → orchestrates
+ * 5. Rule cross-module context queries → reads_from
+ *
+ * Note: Entity field-level inference (ref → references, has_many → contains) was
+ * removed in Spec 61. All entity relationships are now declared via defineRelation().
  */
 
 import type { CapabilityDefinition } from "../types/capability";

--- a/packages/core/src/types/semantic-relation.ts
+++ b/packages/core/src/types/semantic-relation.ts
@@ -15,8 +15,8 @@
  */
 export type SemanticRelationType =
   | "depends_on" // A depends on B existing (from capability.dependencies)
-  | "contains" // A contains B records (from has_many fields)
-  | "references" // A references B (from ref fields)
+  | "contains" // A contains B records (manual — entity relations use defineRelation())
+  | "references" // A references B (manual — entity relations use defineRelation())
   | "affects" // A changes affect B (from Bridge/EventHandler cross-module)
   | "triggers" // A triggers events in B (from EventHandler cross-module)
   | "orchestrates" // A orchestrates B actions (from Flow cross-module steps)
@@ -29,8 +29,6 @@ export type SemanticRelationType =
 /** Source of inference — which mechanism detected this relation */
 export type SemanticRelationSource =
   | "capability_dependency"
-  | "schema_ref"
-  | "schema_has_many"
   | "bridge_definition"
   | "event_handler"
   | "flow_step"

--- a/packages/core/src/types/widget.ts
+++ b/packages/core/src/types/widget.ts
@@ -12,8 +12,8 @@ import type { FieldType } from "./entity";
 
 export type WidgetMode = "display" | "input";
 
-/** Relation widget types — used by relation-aware widgets registered by cardinality */
-export type RelationWidgetType = "ref" | "has_many" | "many_to_many";
+/** Relation widget types — keyed by cardinality, used by relation-aware widgets */
+export type RelationWidgetType = "one_to_one" | "many_to_one" | "one_to_many" | "many_to_many";
 
 /** All widget-registrable type identifiers */
 export type WidgetFieldType = FieldType | RelationWidgetType;


### PR DESCRIPTION
## Summary
- Remove `has_many`/`many_to_many` from `NON_STORABLE_TYPES` (field types already removed)
- Update `RelationWidgetType` to use cardinality values (`one_to_one`, `many_to_one`, etc.)
- Remove `schema_ref`/`schema_has_many` from `SemanticRelationSource`
- Remove old field types from AI proposal prompt
- Update test fixtures accordingly

Refs #87 (Part 2: cleanup remaining references)

## Quality Gates
- [x] typecheck: pass
- [x] core tests: 2681 pass
- [x] biome: pass (1 pre-existing issue in cli/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected relationship field handling to ensure relationships are now defined exclusively via `defineRelation()` method rather than auto-derived from schema declarations.

* **Documentation**
  * Updated internal documentation to clarify relationship definition approach and field-type constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->