### PR TITLE
fix(server): use semantic names for GraphQL FK input fields

### DIFF
--- a/addons/adapter-server/cap-adapter-server/src/graphql/schema-to-graphql.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/schema-to-graphql.ts
@@ -459,12 +459,12 @@ export function generateGraphQLInputType(
             link.from === schema.name &&
             (link.cardinality === "many_to_one" || link.cardinality === "one_to_one")
           ) {
-            const fkFieldName = `${link.to}_id`;
+            const fkFieldName = `${link.fromName}_id`;
             // Don't overwrite if already defined
             if (!fields[fkFieldName]) {
               fields[fkFieldName] = {
                 type: GraphQLString,
-                description: `FK reference to ${link.to} (from link "${link.name}")`,
+                description: `FK reference to ${link.to} via "${link.fromName}" (from relation "${link.name}")`,
               };
             }
           }


### PR DESCRIPTION
## Summary
- Change mutation input type FK fields from `${link.to}_id` to `${link.fromName}_id`
- Aligns GraphQL mutation inputs with semantic relation names (Spec 61)

Refs #87 (Part 2: GraphQL semantic names)

## Quality Gates
- [x] 503 adapter-server tests pass
- [x] typecheck: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected foreign-key input field names and descriptions in GraphQL schema generation to accurately reflect source relation identity for relationship links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->