### PR TITLE
refactor(ui): migrate relation widgets to RelationRegistry

### DIFF
--- a/addons/adapter-ui/cap-adapter-ui/src/components/auto-form/auto-form.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/auto-form/auto-form.tsx
@@ -67,6 +67,7 @@ export function AutoForm({
   registerSetField,
   templates,
   overlayFields,
+  relations,
   formId: customFormId,
 }: AutoFormProps) {
   const { t } = useTranslation();
@@ -481,17 +482,43 @@ export function AutoForm({
       }
     }
 
-    // Collect virtual ref records and has_many child commands
+    // Build relation lookup sets from RelationDefinition[] (Spec 61).
+    // Used to identify ref fields (many_to_one/one_to_one) and collection fields
+    // (one_to_many/many_to_many) by semantic name instead of field type.
+    const refFieldNames = new Set<string>();
+    const collectionFieldNames = new Set<string>();
+    if (relations) {
+      for (const rel of relations) {
+        if (rel.from === schema.name) {
+          if (rel.cardinality === "many_to_one" || rel.cardinality === "one_to_one") {
+            refFieldNames.add(rel.fromName);
+          } else {
+            collectionFieldNames.add(rel.fromName);
+          }
+        }
+        if (rel.to === schema.name) {
+          if (rel.cardinality === "many_to_one" || rel.cardinality === "one_to_one") {
+            // Incoming many_to_one means this side is the "one" — appears as collection
+            collectionFieldNames.add(rel.toName);
+          } else if (rel.cardinality === "one_to_many") {
+            // Incoming one_to_many means this side is the "many" — appears as ref
+            refFieldNames.add(rel.toName);
+          } else {
+            collectionFieldNames.add(rel.toName);
+          }
+        }
+      }
+    }
+
+    // Collect virtual ref records and child commands
     const virtualRefs: Record<string, VirtualRecord> = {};
     const childCommands: Record<string, ChildCommand[]> = {};
 
     for (const [key, val] of Object.entries(submitData)) {
-      const fieldDef = schema.fields[key];
-      if (!fieldDef) continue;
-
-      // Detect virtual ref records (string FK fields holding an object with _virtual flag)
+      // Detect virtual ref records — identified by relation metadata or string field + _virtual flag
+      const isRefField = refFieldNames.has(key) || schema.fields[key]?.type === "string";
       if (
-        fieldDef.type === "string" &&
+        isRefField &&
         typeof val === "object" &&
         val !== null &&
         "_virtual" in val &&
@@ -505,8 +532,10 @@ export function AutoForm({
         };
       }
 
-      // Collect has_many child record commands (for relation-managed one_to_many fields)
-      if (Array.isArray(val) && fieldDef.type === "json") {
+      // Collect child record commands for collection relation fields (one_to_many / many_to_many)
+      const isCollectionField =
+        collectionFieldNames.has(key) || schema.fields[key]?.type === "json";
+      if (Array.isArray(val) && isCollectionField) {
         const commands: ChildCommand[] = [];
         const existingRecords = Array.isArray(data?.[key])
           ? (data[key] as Array<Record<string, unknown>>)

--- a/addons/adapter-ui/cap-adapter-ui/src/components/auto-form/auto-form.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/auto-form/auto-form.tsx
@@ -497,11 +497,12 @@ export function AutoForm({
           }
         }
         if (rel.to === schema.name) {
-          if (rel.cardinality === "many_to_one" || rel.cardinality === "one_to_one") {
+          if (rel.cardinality === "many_to_one") {
             // Incoming many_to_one means this side is the "one" — appears as collection
             collectionFieldNames.add(rel.toName);
-          } else if (rel.cardinality === "one_to_many") {
-            // Incoming one_to_many means this side is the "many" — appears as ref
+          } else if (rel.cardinality === "one_to_many" || rel.cardinality === "one_to_one") {
+            // Incoming one_to_many: this side is "many" — holds FK ref
+            // Incoming one_to_one: single related record — also a ref
             refFieldNames.add(rel.toName);
           } else {
             collectionFieldNames.add(rel.toName);

--- a/addons/adapter-ui/cap-adapter-ui/src/components/auto-form/types.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/auto-form/types.ts
@@ -2,7 +2,12 @@
  * AutoForm type definitions.
  */
 
-import type { EntityDefinition, RecordTemplate, ViewDefinition } from "@linchkit/core/types";
+import type {
+  EntityDefinition,
+  RecordTemplate,
+  RelationDefinition,
+  ViewDefinition,
+} from "@linchkit/core/types";
 import type { AiFieldSuggestion } from "../../lib/api";
 import type { FieldOverlayRecord } from "../../lib/overlay-types";
 
@@ -90,4 +95,9 @@ export interface AutoFormProps {
    * Values are stored in and read from the record's `_extensions` object.
    */
   overlayFields?: FieldOverlayRecord[];
+  /**
+   * Relation definitions for the entity. Used to identify virtual ref records
+   * and child record commands by cardinality rather than field type (Spec 61).
+   */
+  relations?: RelationDefinition[];
 }

--- a/addons/adapter-ui/cap-adapter-ui/src/components/widgets/index.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/widgets/index.ts
@@ -116,40 +116,25 @@ export function registerDefaultWidgets() {
   });
 
   // ── Relation widgets — resolved by cardinality from RelationRegistry (Spec 61) ──
+  // IDs that share the same display/input components are registered in a loop.
 
-  // many_to_one / one_to_one: combobox select for FK reference
-  widgetRegistry.register({
-    definition: {
-      id: "many_to_one",
-      fieldTypes: "string",
-      modes: ["display", "input"],
-      isDefault: false,
-    },
-    display: RefDisplay,
-    input: RefInput,
-  });
-  widgetRegistry.register({
-    definition: {
-      id: "one_to_one",
-      fieldTypes: "string",
-      modes: ["display", "input"],
-      isDefault: false,
-    },
-    display: RefDisplay,
-    input: RefInput,
-  });
+  // Single-ref widgets: many_to_one, one_to_one, and backward-compatible "ref" alias
+  for (const id of ["many_to_one", "one_to_one", "ref"] as const) {
+    widgetRegistry.register({
+      definition: { id, fieldTypes: "string", modes: ["display", "input"], isDefault: false },
+      display: RefDisplay,
+      input: RefInput,
+    });
+  }
 
-  // one_to_many: inline sub-table with dialog editing
-  widgetRegistry.register({
-    definition: {
-      id: "one_to_many",
-      fieldTypes: "string",
-      modes: ["display", "input"],
-      isDefault: false,
-    },
-    display: HasManyDisplay,
-    input: HasManyInput,
-  });
+  // Collection widgets: one_to_many and backward-compatible "has_many" alias
+  for (const id of ["one_to_many", "has_many"] as const) {
+    widgetRegistry.register({
+      definition: { id, fieldTypes: "string", modes: ["display", "input"], isDefault: false },
+      display: HasManyDisplay,
+      input: HasManyInput,
+    });
+  }
 
   // many_to_many: multi-select tags
   widgetRegistry.register({
@@ -161,23 +146,6 @@ export function registerDefaultWidgets() {
     },
     display: ManyToManyDisplay,
     input: ManyToManyInput,
-  });
-
-  // Backward-compatible aliases — old widget IDs still resolve
-  widgetRegistry.register({
-    definition: { id: "ref", fieldTypes: "string", modes: ["display", "input"], isDefault: false },
-    display: RefDisplay,
-    input: RefInput,
-  });
-  widgetRegistry.register({
-    definition: {
-      id: "has_many",
-      fieldTypes: "string",
-      modes: ["display", "input"],
-      isDefault: false,
-    },
-    display: HasManyDisplay,
-    input: HasManyInput,
   });
 
   // Translatable string widget — locale tabs + text input for i18n fields

--- a/addons/adapter-ui/cap-adapter-ui/src/components/widgets/index.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/widgets/index.ts
@@ -115,19 +115,34 @@ export function registerDefaultWidgets() {
     display: StringDisplay,
   });
 
-  // ref widget for FK string fields that reference other entities
-  // Registered with id="ref" but bound to string type; resolved via explicit widget overrides
+  // ── Relation widgets — resolved by cardinality from RelationRegistry (Spec 61) ──
+
+  // many_to_one / one_to_one: combobox select for FK reference
   widgetRegistry.register({
-    definition: { id: "ref", fieldTypes: "string", modes: ["display", "input"], isDefault: false },
+    definition: {
+      id: "many_to_one",
+      fieldTypes: "string",
+      modes: ["display", "input"],
+      isDefault: false,
+    },
+    display: RefDisplay,
+    input: RefInput,
+  });
+  widgetRegistry.register({
+    definition: {
+      id: "one_to_one",
+      fieldTypes: "string",
+      modes: ["display", "input"],
+      isDefault: false,
+    },
     display: RefDisplay,
     input: RefInput,
   });
 
-  // has_many widget for one-to-many relationship display (via relation, not field type)
-  // Registered with id="has_many"; resolved via explicit widget overrides on relation fields
+  // one_to_many: inline sub-table with dialog editing
   widgetRegistry.register({
     definition: {
-      id: "has_many",
+      id: "one_to_many",
       fieldTypes: "string",
       modes: ["display", "input"],
       isDefault: false,
@@ -136,8 +151,7 @@ export function registerDefaultWidgets() {
     input: HasManyInput,
   });
 
-  // many_to_many widget for many-to-many relationship display (via relation, not field type)
-  // Registered with id="many_to_many"; resolved via explicit widget overrides on relation fields
+  // many_to_many: multi-select tags
   widgetRegistry.register({
     definition: {
       id: "many_to_many",
@@ -147,6 +161,23 @@ export function registerDefaultWidgets() {
     },
     display: ManyToManyDisplay,
     input: ManyToManyInput,
+  });
+
+  // Backward-compatible aliases — old widget IDs still resolve
+  widgetRegistry.register({
+    definition: { id: "ref", fieldTypes: "string", modes: ["display", "input"], isDefault: false },
+    display: RefDisplay,
+    input: RefInput,
+  });
+  widgetRegistry.register({
+    definition: {
+      id: "has_many",
+      fieldTypes: "string",
+      modes: ["display", "input"],
+      isDefault: false,
+    },
+    display: HasManyDisplay,
+    input: HasManyInput,
   });
 
   // Translatable string widget — locale tabs + text input for i18n fields

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/entity-form-utils.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/entity-form-utils.ts
@@ -7,6 +7,7 @@
 import type {
   EntityDefinition,
   FormLayoutNode,
+  RelationDefinition,
   StateDefinition,
   StateMeta,
   ViewDefinition,
@@ -70,25 +71,74 @@ export function getTransitionActionNames(
 }
 
 /**
- * Relation field types that require subfield selection in GraphQL.
- * Note: ref/has_many/many_to_many field types have been removed (Spec 61).
- * Relations are now declared via defineRelation(). These sets are kept for
- * backward compatibility with views that may reference relation semantic names.
- * TODO: Refactor to use RelationRegistry for subfield resolution.
+ * Build a set of semantic relation field names for a given entity
+ * from RelationDefinition[]. Used to determine which GraphQL fields
+ * need subfield selection `{ id name }`.
  */
-const RELATION_FIELD_TYPES = new Set<string>();
+function buildRelationFieldSet(entityName: string, relations: RelationDefinition[]): Set<string> {
+  const names = new Set<string>();
+  for (const rel of relations) {
+    if (rel.from === entityName) names.add(rel.fromName);
+    if (rel.to === entityName) names.add(rel.toName);
+  }
+  return names;
+}
 
-/** Collection relation types excluded from mutation return types */
-const COLLECTION_RELATION_TYPES = new Set<string>();
+/** Collection cardinalities excluded from mutation return types (one_to_many, many_to_many) */
+const COLLECTION_CARDINALITIES = new Set(["one_to_many", "many_to_many"]);
 
-/** Extract GraphQL field names from view fields, always including the state field */
-export function getRecordFields(view: ViewDefinition, schema?: EntityDefinition): string[] {
+/**
+ * Build a set of semantic relation field names that represent collection relations
+ * (one_to_many / many_to_many) for a given entity. These are excluded from mutation
+ * return types because they are only available on query types.
+ */
+function buildCollectionRelationFields(
+  entityName: string,
+  relations: RelationDefinition[],
+): Set<string> {
+  const names = new Set<string>();
+  for (const rel of relations) {
+    const isFrom = rel.from === entityName;
+    const isTo = rel.to === entityName;
+    if (isFrom && COLLECTION_CARDINALITIES.has(rel.cardinality)) {
+      names.add(rel.fromName);
+    }
+    if (isTo) {
+      // Incoming side: many_to_one from-side appears as one_to_many on to-side
+      const reverseCardinality =
+        rel.cardinality === "many_to_one"
+          ? "one_to_many"
+          : rel.cardinality === "one_to_many"
+            ? "many_to_one"
+            : rel.cardinality;
+      if (COLLECTION_CARDINALITIES.has(reverseCardinality)) {
+        names.add(rel.toName);
+      }
+    }
+  }
+  return names;
+}
+
+/**
+ * Extract GraphQL field names from view fields, always including the state field.
+ * Relation fields are resolved from RelationDefinition[] metadata (Spec 61)
+ * instead of entity field types.
+ */
+export function getRecordFields(
+  view: ViewDefinition,
+  schema?: EntityDefinition,
+  relations?: RelationDefinition[],
+): string[] {
   const fields = new Set<string>(["id"]);
+  const entityName = schema?.name ?? "";
+  const relationFields = relations
+    ? buildRelationFieldSet(entityName, relations)
+    : new Set<string>();
+
   for (const f of view.fields) {
     if (f.field.includes(".")) continue;
-    const fieldDef = schema?.fields?.[f.field];
-    if (fieldDef && RELATION_FIELD_TYPES.has(fieldDef.type ?? "")) {
-      // Include display fields so the UI can show a human-readable label
+    if (relationFields.has(f.field)) {
+      // Relation field — include display subfields for human-readable labels
       fields.add(`${f.field} { id name }`);
     } else {
       fields.add(f.field);
@@ -103,20 +153,21 @@ export function getRecordFields(view: ViewDefinition, schema?: EntityDefinition)
 
 /**
  * Filter record fields safe for mutation return types.
- * Excludes has_many/many_to_many fields which are only available on query types,
- * not on create/update mutation return types.
+ * Excludes collection relation fields (one_to_many / many_to_many) which are
+ * only available on query types, not on create/update mutation return types.
  */
 export function getMutationReturnFields(
   recordFields: string[],
   schema?: EntityDefinition,
+  relations?: RelationDefinition[],
 ): string[] {
-  if (!schema) return recordFields;
+  if (!schema || !relations) return recordFields;
+  const entityName = schema.name;
+  const collectionFields = buildCollectionRelationFields(entityName, relations);
   return recordFields.filter((f) => {
     // Extract field name from "fieldName { subfields }" format
     const fieldName = f.split(" ")[0] ?? f;
-    const fieldDef = schema.fields[fieldName];
-    if (!fieldDef) return true;
-    return !COLLECTION_RELATION_TYPES.has(fieldDef.type ?? "");
+    return !collectionFields.has(fieldName);
   });
 }
 

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/entity-form-actions.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/entity-form-actions.ts
@@ -134,7 +134,11 @@ export function useFormActions(opts: UseFormActionsOptions) {
 
         // Step 3: Create/update parent record
         // Filter out has_many/many_to_many fields — they exist on query types but not mutation return types
-        const mutationReturnFields = getMutationReturnFields(recordFields, schema);
+        const mutationReturnFields = getMutationReturnFields(
+          recordFields,
+          schema,
+          bundle?.relations,
+        );
         let parentRecordId = recordId;
         if (isCreate) {
           const created = await createRecord<{ id: string }>(entityName, mutationInput, [

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/entity-form.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/entity-form.tsx
@@ -115,15 +115,16 @@ export function EntityFormPage() {
   );
   const aiSuggestionCount = Object.keys(aiAutoFill.state.suggestions).length;
 
+  const entityRelations = bundle?.relations;
   const recordFields = useMemo(() => {
     if (!formView) return [];
-    const fields = getRecordFields(formView, schema);
+    const fields = getRecordFields(formView, schema, entityRelations);
     // Include _extensions when overlay fields exist (contains overlay field values)
     if (overlayFields.length > 0 && !fields.includes("_extensions")) {
       fields.push("_extensions");
     }
     return fields;
-  }, [formView, schema, overlayFields]);
+  }, [formView, schema, entityRelations, overlayFields]);
 
   // Stabilize recordFields via ref so fetchRecord doesn't get recreated on every render
   const recordFieldsRef = useRef(recordFields);
@@ -493,6 +494,7 @@ export function EntityFormPage() {
                 autoFormSetFieldRef.current = setter;
               }}
               overlayFields={overlayFields.length > 0 ? overlayFields : undefined}
+              relations={entityRelations}
             />
           </div>
 

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/entity-list.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/entity-list.tsx
@@ -48,56 +48,21 @@ import { bulkDeleteRecords, deleteRecord, queryList } from "../lib/api";
 type ActiveView = "list" | "calendar" | "kanban" | "tree";
 
 /**
- * Relation field types no longer exist (Spec 61). Subfield selection is now
- * determined by link-generated resolver names from buildLinkFieldNames().
- */
-const RELATION_FIELD_TYPES = new Set<string>();
-
-/**
- * Build a set of GraphQL field names that are link-generated resolvers
- * and therefore require subfield selection `{ id }`.
+ * Build a set of GraphQL field names that are relation-generated resolvers
+ * and therefore require subfield selection `{ id name }`.
  *
- * Link resolver naming convention (see link-resolvers.ts):
- * - many_to_one from-side:   fieldName = link.to          (singular)
- * - many_to_one to-side:     fieldName = `${link.from}s`  (plural)
- * - one_to_many from-side:   fieldName = `${link.to}s`    (plural)
- * - one_to_many to-side:     fieldName = link.from         (singular)
- * - one_to_one:              fieldName = link.to / link.from
- * - many_to_many:            fieldName = `${otherSchema}s` (plural)
+ * Uses semantic names from RelationDefinition (Spec 61):
+ * - from-side uses `fromName` (e.g. "department", "items", "authored_documents")
+ * - to-side uses `toName` (e.g. "purchase_requests", "authors")
  */
-function buildLinkFieldNames(
-  links: Array<{ from: string; to: string; cardinality: string }>,
+function buildRelationFieldNames(
+  relations: Array<{ from: string; to: string; fromName: string; toName: string }>,
   entityName?: string,
 ): Set<string> {
   const names = new Set<string>();
-  for (const link of links) {
-    const isFrom = link.from === entityName;
-    const isTo = link.to === entityName;
-
-    switch (link.cardinality) {
-      case "many_to_one":
-        if (isFrom) names.add(link.to); // singular
-        if (isTo) names.add(`${link.from}s`); // plural
-        break;
-      case "one_to_many":
-        if (isFrom) names.add(`${link.to}s`); // plural
-        if (isTo) names.add(link.from); // singular
-        break;
-      case "one_to_one":
-        if (isFrom) names.add(link.to);
-        if (isTo) names.add(link.from);
-        break;
-      case "many_to_many":
-        if (isFrom) names.add(`${link.to}s`);
-        if (isTo) names.add(`${link.from}s`);
-        break;
-      default:
-        // Fallback: add both sides
-        names.add(link.to);
-        names.add(link.from);
-        names.add(`${link.to}s`);
-        names.add(`${link.from}s`);
-    }
+  for (const rel of relations) {
+    if (rel.from === entityName) names.add(rel.fromName);
+    if (rel.to === entityName) names.add(rel.toName);
   }
   return names;
 }
@@ -106,13 +71,15 @@ function buildLinkFieldNames(
 function getQueryFields(
   view: AutoListViewDefinition,
   schemaFields?: Record<string, { type?: string; target?: string }>,
-  links?: Array<{ from: string; to: string; cardinality: string }>,
+  relations?: Array<{ from: string; to: string; fromName: string; toName: string }>,
   entityName?: string,
 ): string[] {
   const fields = new Set<string>(["id"]);
 
-  // Build a set of field names that are link-generated resolvers
-  const linkFieldNames = links ? buildLinkFieldNames(links, entityName) : new Set<string>();
+  // Build a set of field names that are relation-generated resolvers (Spec 61)
+  const relationFieldNames = relations
+    ? buildRelationFieldNames(relations, entityName)
+    : new Set<string>();
 
   for (const f of view.fields) {
     if (f.field.includes(".")) continue;
@@ -120,13 +87,10 @@ function getQueryFields(
     const fieldDef = schemaFields?.[f.field];
 
     // Determine if this field is a relationship that needs subfield selection:
-    // 1. Schema field with relationship type (ref, has_many, many_to_many)
-    // 2. Field name matches a link-generated resolver name
-    // 3. Field not in schema AND not a system field (likely a link resolver)
+    // 1. Field name matches a relation semantic name (fromName/toName)
+    // 2. Field not in schema AND not a system field (likely a relation resolver)
     const isRelation =
-      (fieldDef && RELATION_FIELD_TYPES.has(fieldDef.type ?? "")) ||
-      linkFieldNames.has(f.field) ||
-      (!fieldDef && !SYSTEM_FIELDS.has(f.field));
+      relationFieldNames.has(f.field) || (!fieldDef && !SYSTEM_FIELDS.has(f.field));
 
     if (isRelation) {
       // Request id + display fields for object/list types so the UI can


### PR DESCRIPTION
## Summary
- Register relation widgets by cardinality instead of field type
- Derive relation field sets from RelationDefinition[] metadata
- Use semantic fromName/toName for GraphQL field naming in list/form
- Backward-compatible aliases for existing ref/has_many overrides

Refs #87 (Part 3: UI adapter migration)

## Quality Gates
- [x] typecheck: pass
- [x] 241 adapter-ui tests pass
- [x] biome: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)