### PR TITLE
fix: resolve release build failure with TypeScript 6.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,7 @@
     }
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && tsc -p tsconfig.build.json --emitDeclarationOnly",
     "test": "bun test"
   },
   "dependencies": {

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -5,7 +5,9 @@
     "declaration": true,
     "declarationMap": false,
     "sourceMap": false,
-    "outDir": "dist"
+    "rootDir": "src",
+    "outDir": "dist",
+    "paths": {}
   },
   "include": ["src"]
 }

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     index: "src/index.ts",
   },
   format: ["esm"],
-  dts: true,
+  dts: false,
   clean: true,
   target: "es2022",
   banner: {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
     }
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && tsc -p tsconfig.build.json --emitDeclarationOnly",
     "test": "bun test"
   },
   "dependencies": {

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -5,7 +5,9 @@
     "declaration": true,
     "declarationMap": false,
     "sourceMap": false,
-    "outDir": "dist"
+    "rootDir": "src",
+    "outDir": "dist",
+    "paths": {}
   },
   "include": ["src"]
 }

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     "ai/index": "src/ai/index.ts",
   },
   format: ["esm"],
-  dts: true,
+  dts: false,
   clean: true,
   target: "es2022",
   external: [

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -33,7 +33,7 @@
     }
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && tsc -p tsconfig.build.json --emitDeclarationOnly",
     "test": "bun test"
   },
   "dependencies": {

--- a/packages/devtools/tsconfig.build.json
+++ b/packages/devtools/tsconfig.build.json
@@ -5,7 +5,9 @@
     "declaration": true,
     "declarationMap": false,
     "sourceMap": false,
-    "outDir": "dist"
+    "rootDir": "src",
+    "outDir": "dist",
+    "paths": {}
   },
   "include": ["src"]
 }

--- a/packages/devtools/tsup.config.ts
+++ b/packages/devtools/tsup.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     "governance/index": "src/governance/index.ts",
   },
   format: ["esm"],
-  dts: true,
+  dts: false,
   clean: true,
   target: "es2022",
   external: ["@linchkit/core"],


### PR DESCRIPTION
## Summary
- tsup 8.5.1 unconditionally injects `baseUrl: "."` during DTS generation, which TS 6.0 treats as a deprecated error
- Split build: tsup for JS bundling (`dts: false`), tsc for declaration generation (`--emitDeclarationOnly`)
- Added `rootDir` and cleared `paths` in build tsconfigs to prevent cross-package source resolution

Fixes the Release workflow failures on every push to main since TS 6.0 upgrade.

## Test plan
- [x] `bun run --filter @linchkit/core build` — success, `.d.ts` files generated
- [x] `bun run --filter @linchkit/devtools build` — success
- [x] `bun run --filter @linchkit/cli build` — success
- [x] `bun run typecheck` — pass
- [x] `bun test` — 4014 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored the build process across all packages to separate TypeScript type declaration generation from bundling, improving build consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->