### PR TITLE
feat: add Dockerfile and production deployment config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,41 @@
+# Dependencies (rebuilt in container)
+node_modules/
+.bun/
+
+# Build output (rebuilt in container)
+dist/
+
+# Version control
+.git/
+.gitignore
+
+# Documentation
+docs/
+*.md
+LICENSE
+
+# Claude / AI tooling
+.claude/
+AGENTS.md
+
+# IDE and editor
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Environment and secrets
+.env
+.env.*
+
+# Test artifacts
+coverage/
+__snapshots__/
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Docker (avoid recursive context)
+Dockerfile
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ── Stage 1: Install dependencies and build ─────────────────
-FROM oven/bun:latest AS builder
+FROM oven/bun:1.2.15 AS builder
 
 WORKDIR /app
 
@@ -35,7 +35,7 @@ COPY config/ config/
 RUN bun run build
 
 # ── Stage 2: Production image ───────────────────────────────
-FROM oven/bun:latest AS production
+FROM oven/bun:1.2.15 AS production
 
 WORKDIR /app
 
@@ -81,9 +81,15 @@ COPY --from=builder /app/addons/ addons/
 # Copy config directory (linchkit.config.ts)
 COPY --from=builder /app/config/ config/
 
+RUN addgroup --system --gid 1001 bunjs && \
+    adduser --system --uid 1001 --ingroup bunjs bunuser
+
+RUN chown -R bunuser:bunjs /app
+USER bunuser
+
 EXPOSE 3001
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD bun -e "fetch('http://localhost:3001/health').then(r => { if (!r.ok) process.exit(1) }).catch(() => process.exit(1))"
 
-CMD ["bun", "run", "dev:server"]
+CMD ["bun", "addons/adapter-server/cap-adapter-server/src/dev.ts"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,89 @@
+# ── Stage 1: Install dependencies and build ─────────────────
+FROM oven/bun:latest AS builder
+
+WORKDIR /app
+
+# Copy workspace config files first for better layer caching
+COPY package.json bun.lock .bunfig.toml tsconfig.json ./
+
+# Copy all package.json files to resolve workspace dependencies
+COPY packages/core/package.json packages/core/package.json
+COPY packages/cli/package.json packages/cli/package.json
+COPY packages/devtools/package.json packages/devtools/package.json
+COPY addons/adapter-server/cap-adapter-server/package.json addons/adapter-server/cap-adapter-server/package.json
+COPY addons/adapter-mcp/cap-adapter-mcp/package.json addons/adapter-mcp/cap-adapter-mcp/package.json
+COPY addons/auth/cap-auth/package.json addons/auth/cap-auth/package.json
+COPY addons/auth/cap-auth-better-auth/package.json addons/auth/cap-auth-better-auth/package.json
+COPY addons/permission/cap-permission/package.json addons/permission/cap-permission/package.json
+COPY addons/ai-provider/cap-ai-provider/package.json addons/ai-provider/cap-ai-provider/package.json
+COPY addons/chatter/cap-chatter/package.json addons/chatter/cap-chatter/package.json
+COPY addons/flow-restate/cap-flow-restate/package.json addons/flow-restate/cap-flow-restate/package.json
+COPY addons/migration/cap-migration/package.json addons/migration/cap-migration/package.json
+COPY addons/demo/cap-purchase-demo/package.json addons/demo/cap-purchase-demo/package.json
+COPY addons/adapter-ui/cap-adapter-ui/package.json addons/adapter-ui/cap-adapter-ui/package.json
+COPY addons/adapter-ui/cap-adapter-ui/ui-kit/package.json addons/adapter-ui/cap-adapter-ui/ui-kit/package.json
+
+# Install all dependencies (including devDependencies for build)
+RUN bun install --frozen-lockfile
+
+# Copy source code
+COPY packages/ packages/
+COPY addons/ addons/
+COPY config/ config/
+
+# Build packages (core, cli, devtools produce dist/ via tsup)
+RUN bun run build
+
+# ── Stage 2: Production image ───────────────────────────────
+FROM oven/bun:latest AS production
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=3001
+
+# Copy workspace config
+COPY package.json bun.lock .bunfig.toml tsconfig.json ./
+
+# Copy all package.json files (needed for workspace resolution)
+COPY --from=builder /app/packages/core/package.json packages/core/package.json
+COPY --from=builder /app/packages/cli/package.json packages/cli/package.json
+COPY --from=builder /app/packages/devtools/package.json packages/devtools/package.json
+COPY --from=builder /app/addons/adapter-server/cap-adapter-server/package.json addons/adapter-server/cap-adapter-server/package.json
+COPY --from=builder /app/addons/adapter-mcp/cap-adapter-mcp/package.json addons/adapter-mcp/cap-adapter-mcp/package.json
+COPY --from=builder /app/addons/auth/cap-auth/package.json addons/auth/cap-auth/package.json
+COPY --from=builder /app/addons/auth/cap-auth-better-auth/package.json addons/auth/cap-auth-better-auth/package.json
+COPY --from=builder /app/addons/permission/cap-permission/package.json addons/permission/cap-permission/package.json
+COPY --from=builder /app/addons/ai-provider/cap-ai-provider/package.json addons/ai-provider/cap-ai-provider/package.json
+COPY --from=builder /app/addons/chatter/cap-chatter/package.json addons/chatter/cap-chatter/package.json
+COPY --from=builder /app/addons/flow-restate/cap-flow-restate/package.json addons/flow-restate/cap-flow-restate/package.json
+COPY --from=builder /app/addons/migration/cap-migration/package.json addons/migration/cap-migration/package.json
+COPY --from=builder /app/addons/demo/cap-purchase-demo/package.json addons/demo/cap-purchase-demo/package.json
+COPY --from=builder /app/addons/adapter-ui/cap-adapter-ui/package.json addons/adapter-ui/cap-adapter-ui/package.json
+COPY --from=builder /app/addons/adapter-ui/cap-adapter-ui/ui-kit/package.json addons/adapter-ui/cap-adapter-ui/ui-kit/package.json
+
+# Install production dependencies only
+RUN bun install --frozen-lockfile --production
+
+# Copy built packages (dist/ from tsup build)
+COPY --from=builder /app/packages/core/dist/ packages/core/dist/
+COPY --from=builder /app/packages/cli/dist/ packages/cli/dist/
+COPY --from=builder /app/packages/devtools/dist/ packages/devtools/dist/
+
+# Copy package source (Bun resolves "bun" export condition → src/*.ts)
+COPY --from=builder /app/packages/core/src/ packages/core/src/
+COPY --from=builder /app/packages/cli/src/ packages/cli/src/
+COPY --from=builder /app/packages/devtools/src/ packages/devtools/src/
+
+# Copy addon source (addons are not compiled, Bun runs TS directly)
+COPY --from=builder /app/addons/ addons/
+
+# Copy config directory (linchkit.config.ts)
+COPY --from=builder /app/config/ config/
+
+EXPOSE 3001
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD bun -e "fetch('http://localhost:3001/health').then(r => { if (!r.ok) process.exit(1) }).catch(() => process.exit(1))"
+
+CMD ["bun", "run", "dev:server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,28 @@ services:
       timeout: 5s
       retries: 5
 
+  linchkit:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: linchkit-app
+    ports:
+      - "3001:3001"
+    environment:
+      NODE_ENV: production
+      PORT: "3001"
+      DATABASE_URL: postgres://linchkit:linchkit@postgres:5432/linchkit
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "bun", "-e", "fetch('http://localhost:3001/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
+      interval: 10s
+      timeout: 5s
+      start_period: 15s
+      retries: 5
+    restart: unless-stopped
+
   restate:
     image: docker.restate.dev/restatedev/restate:latest
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     environment:
       NODE_ENV: production
       PORT: "3001"
-      DATABASE_URL: postgres://linchkit:linchkit@postgres:5432/linchkit
+      DATABASE_URL: ${DATABASE_URL:-postgres://linchkit:linchkit@postgres:5432/linchkit}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Multi-stage Dockerfile using `oven/bun:latest` for production builds
- Added `linchkit` service to docker-compose.yml with health check and postgres dependency
- Added `.dockerignore` to exclude dev artifacts from build context

Closes #72

## Test plan
- [ ] `docker compose build linchkit` — builds successfully
- [ ] `docker compose up` — server starts on :3001 with health check passing
- [ ] Health endpoint `/health` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a packaged container image and a Compose service for running the app as a single deployable service (exposes port 3001).
* **Chores**
  * Multi-stage build produces lean production images, runs as a non-root user, and includes startup health checks with automatic restart.
  * Added an ignore list to keep build context small by excluding dependencies, build outputs, secrets, editor and OS artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->