### PR TITLE
feat(core): add cache diagnostics with stats and health check

### DIFF
--- a/packages/core/__tests__/cache-stats.test.ts
+++ b/packages/core/__tests__/cache-stats.test.ts
@@ -238,8 +238,9 @@ describe("createCacheHealthCheck()", () => {
     const result = check() as HealthCheckResult;
 
     expect(result.status).toBe("healthy");
-    // Probe key should be cleaned up
-    expect(cm.get("__custom_probe__")).toBeUndefined();
+    // Probe keys use unique suffix and are cleaned up — no leftover keys with the prefix
+    const stats = cm.getStats();
+    expect(stats.totalEntries).toBe(0);
   });
 
   test("reports durationMs >= 0", () => {

--- a/packages/core/__tests__/cache-stats.test.ts
+++ b/packages/core/__tests__/cache-stats.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, test } from "bun:test";
+import { createCacheHealthCheck } from "../src/cache/cache-health";
+import { CacheManager } from "../src/cache/cache-manager";
+import { InMemoryCacheProvider } from "../src/cache/in-memory-cache";
+
+// ── getStats() ───────────────────────────────────────────
+
+describe("CacheManager.getStats()", () => {
+  test("returns zeroed stats on fresh cache", () => {
+    const cm = new CacheManager();
+    const stats = cm.getStats();
+
+    expect(stats.totalEntries).toBe(0);
+    expect(stats.hits).toBe(0);
+    expect(stats.misses).toBe(0);
+    expect(stats.hitRate).toBe(0);
+    expect(stats.evictions).toBe(0);
+    expect(stats.estimatedMemoryBytes).toBe(0);
+    expect(stats.namespaces).toEqual({});
+  });
+
+  test("tracks hits and misses correctly", () => {
+    const cm = new CacheManager();
+    cm.set("a", 1);
+    cm.set("b", 2);
+
+    cm.get("a"); // hit
+    cm.get("b"); // hit
+    cm.get("c"); // miss
+
+    const stats = cm.getStats();
+    expect(stats.hits).toBe(2);
+    expect(stats.misses).toBe(1);
+    expect(stats.hitRate).toBeCloseTo(2 / 3, 5);
+  });
+
+  test("tracks total entries", () => {
+    const cm = new CacheManager();
+    cm.set("x", 10);
+    cm.set("y", 20);
+    cm.set("z", 30);
+
+    const stats = cm.getStats();
+    expect(stats.totalEntries).toBe(3);
+  });
+
+  test("tracks evictions with small maxSize", () => {
+    const l1 = new InMemoryCacheProvider({ maxSize: 2 });
+    const cm = new CacheManager({ l1 });
+
+    cm.set("a", 1);
+    cm.set("b", 2);
+    cm.set("c", 3); // evicts "a"
+
+    const stats = cm.getStats();
+    expect(stats.evictions).toBe(1);
+    expect(stats.totalEntries).toBe(2);
+  });
+
+  test("calculates memory estimate with default avg size", () => {
+    const cm = new CacheManager();
+    cm.set("a", 1);
+    cm.set("b", 2);
+
+    const stats = cm.getStats();
+    // default avgEntrySizeBytes = 256
+    expect(stats.estimatedMemoryBytes).toBe(2 * 256);
+  });
+
+  test("calculates memory estimate with custom avg size", () => {
+    const cm = new CacheManager();
+    cm.set("a", 1);
+    cm.set("b", 2);
+    cm.set("c", 3);
+
+    const stats = cm.getStats({ avgEntrySizeBytes: 512 });
+    expect(stats.estimatedMemoryBytes).toBe(3 * 512);
+  });
+
+  test("provides per-namespace breakdown", () => {
+    const cm = new CacheManager();
+    const nsA = cm.namespace("alpha");
+    const nsB = cm.namespace("beta");
+
+    nsA.set("k1", 1);
+    nsA.set("k2", 2);
+    nsB.set("k1", 10);
+
+    const stats = cm.getStats();
+    expect(stats.namespaces.alpha).toBe(2);
+    expect(stats.namespaces.beta).toBe(1);
+  });
+
+  test("groups keys without colon under _default namespace", () => {
+    const cm = new CacheManager();
+    cm.set("bare_key", 42);
+
+    const stats = cm.getStats();
+    expect(stats.namespaces._default).toBe(1);
+  });
+
+  test("exposes raw l1 and l2 stats", () => {
+    const cm = new CacheManager();
+    cm.set("x", 1);
+    cm.get("x");
+
+    const stats = cm.getStats();
+    expect(stats.l1).toBeDefined();
+    expect(stats.l1.hits).toBe(1);
+    expect(stats.l2).toBeUndefined();
+  });
+
+  test("hit rate is 0 when no requests made", () => {
+    const cm = new CacheManager();
+    const stats = cm.getStats();
+    expect(stats.hitRate).toBe(0);
+  });
+
+  test("hit rate is 1.0 when all requests hit", () => {
+    const cm = new CacheManager();
+    cm.set("a", 1);
+    cm.get("a");
+    cm.get("a");
+    cm.get("a");
+
+    const stats = cm.getStats();
+    expect(stats.hitRate).toBe(1);
+  });
+});
+
+// ── InMemoryCacheProvider.keys() ─────────────────────────
+
+describe("InMemoryCacheProvider.keys()", () => {
+  test("returns empty array on fresh provider", () => {
+    const provider = new InMemoryCacheProvider();
+    expect(provider.keys()).toEqual([]);
+  });
+
+  test("returns all stored keys", () => {
+    const provider = new InMemoryCacheProvider();
+    provider.set("a", 1);
+    provider.set("b", 2);
+    provider.set("c", 3);
+
+    const keys = provider.keys();
+    expect(keys).toHaveLength(3);
+    expect(keys).toContain("a");
+    expect(keys).toContain("b");
+    expect(keys).toContain("c");
+  });
+});
+
+// ── createCacheHealthCheck() ─────────────────────────────
+
+describe("createCacheHealthCheck()", () => {
+  test("returns healthy for operational cache", () => {
+    const cm = new CacheManager();
+    const check = createCacheHealthCheck(cm);
+    const result = check() as ReturnType<typeof check>;
+
+    // HealthCheckFn may return sync or async
+    expect(result).toBeDefined();
+    expect((result as { status: string }).status).toBe("healthy");
+    expect((result as { name: string }).name).toBe("cache");
+  });
+
+  test("includes stats metadata when healthy", () => {
+    const cm = new CacheManager();
+    cm.set("a", 1);
+    cm.get("a");
+
+    const check = createCacheHealthCheck(cm);
+    const result = check() as { metadata?: Record<string, unknown> };
+
+    expect(result.metadata).toBeDefined();
+    expect(result.metadata?.totalEntries).toBeDefined();
+    expect(result.metadata?.hitRate).toBeDefined();
+  });
+
+  test("returns degraded when hit rate below threshold", () => {
+    const cm = new CacheManager();
+    cm.set("a", 1);
+    // Generate misses
+    cm.get("miss1");
+    cm.get("miss2");
+    cm.get("miss3");
+    cm.get("miss4");
+    // One hit
+    cm.get("a");
+
+    // Hit rate = 1/5 = 0.20, threshold = 0.50
+    const check = createCacheHealthCheck(cm, { minHitRate: 0.5 });
+    const result = check() as { status: string; message?: string };
+
+    expect(result.status).toBe("degraded");
+    expect(result.message).toContain("below threshold");
+  });
+
+  test("returns healthy when hit rate above threshold", () => {
+    const cm = new CacheManager();
+    cm.set("a", 1);
+    cm.set("b", 2);
+    // All hits
+    cm.get("a");
+    cm.get("b");
+    cm.get("a");
+
+    const check = createCacheHealthCheck(cm, { minHitRate: 0.5 });
+    const result = check() as { status: string };
+
+    expect(result.status).toBe("healthy");
+  });
+
+  test("hit rate check skipped when no traffic yet", () => {
+    const cm = new CacheManager();
+    const check = createCacheHealthCheck(cm, { minHitRate: 0.9 });
+    const result = check() as { status: string };
+
+    // No requests yet, threshold should not trigger degraded
+    expect(result.status).toBe("healthy");
+  });
+
+  test("hit rate threshold 0 (default) never triggers degraded", () => {
+    const cm = new CacheManager();
+    // All misses
+    cm.get("x");
+    cm.get("y");
+
+    const check = createCacheHealthCheck(cm);
+    const result = check() as { status: string };
+
+    expect(result.status).toBe("healthy");
+  });
+
+  test("uses custom probe key", () => {
+    const cm = new CacheManager();
+    const check = createCacheHealthCheck(cm, { probeKey: "__custom_probe__" });
+    const result = check() as { status: string };
+
+    expect(result.status).toBe("healthy");
+    // Probe key should be cleaned up
+    expect(cm.get("__custom_probe__")).toBeUndefined();
+  });
+
+  test("reports durationMs >= 0", () => {
+    const cm = new CacheManager();
+    const check = createCacheHealthCheck(cm);
+    const result = check() as { durationMs: number };
+
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/packages/core/__tests__/cache-stats.test.ts
+++ b/packages/core/__tests__/cache-stats.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { createCacheHealthCheck } from "../src/cache/cache-health";
 import { CacheManager } from "../src/cache/cache-manager";
 import { InMemoryCacheProvider } from "../src/cache/in-memory-cache";
+import type { HealthCheckResult } from "../src/deployment/health-check";
 
 // ── getStats() ───────────────────────────────────────────
 
@@ -156,12 +157,11 @@ describe("createCacheHealthCheck()", () => {
   test("returns healthy for operational cache", () => {
     const cm = new CacheManager();
     const check = createCacheHealthCheck(cm);
-    const result = check() as ReturnType<typeof check>;
+    const result = check() as HealthCheckResult;
 
-    // HealthCheckFn may return sync or async
     expect(result).toBeDefined();
-    expect((result as { status: string }).status).toBe("healthy");
-    expect((result as { name: string }).name).toBe("cache");
+    expect(result.status).toBe("healthy");
+    expect(result.name).toBe("cache");
   });
 
   test("includes stats metadata when healthy", () => {
@@ -170,7 +170,7 @@ describe("createCacheHealthCheck()", () => {
     cm.get("a");
 
     const check = createCacheHealthCheck(cm);
-    const result = check() as { metadata?: Record<string, unknown> };
+    const result = check() as HealthCheckResult;
 
     expect(result.metadata).toBeDefined();
     expect(result.metadata?.totalEntries).toBeDefined();
@@ -190,7 +190,7 @@ describe("createCacheHealthCheck()", () => {
 
     // Hit rate = 1/5 = 0.20, threshold = 0.50
     const check = createCacheHealthCheck(cm, { minHitRate: 0.5 });
-    const result = check() as { status: string; message?: string };
+    const result = check() as HealthCheckResult;
 
     expect(result.status).toBe("degraded");
     expect(result.message).toContain("below threshold");
@@ -206,7 +206,7 @@ describe("createCacheHealthCheck()", () => {
     cm.get("a");
 
     const check = createCacheHealthCheck(cm, { minHitRate: 0.5 });
-    const result = check() as { status: string };
+    const result = check() as HealthCheckResult;
 
     expect(result.status).toBe("healthy");
   });
@@ -214,7 +214,7 @@ describe("createCacheHealthCheck()", () => {
   test("hit rate check skipped when no traffic yet", () => {
     const cm = new CacheManager();
     const check = createCacheHealthCheck(cm, { minHitRate: 0.9 });
-    const result = check() as { status: string };
+    const result = check() as HealthCheckResult;
 
     // No requests yet, threshold should not trigger degraded
     expect(result.status).toBe("healthy");
@@ -227,7 +227,7 @@ describe("createCacheHealthCheck()", () => {
     cm.get("y");
 
     const check = createCacheHealthCheck(cm);
-    const result = check() as { status: string };
+    const result = check() as HealthCheckResult;
 
     expect(result.status).toBe("healthy");
   });
@@ -235,7 +235,7 @@ describe("createCacheHealthCheck()", () => {
   test("uses custom probe key", () => {
     const cm = new CacheManager();
     const check = createCacheHealthCheck(cm, { probeKey: "__custom_probe__" });
-    const result = check() as { status: string };
+    const result = check() as HealthCheckResult;
 
     expect(result.status).toBe("healthy");
     // Probe key should be cleaned up
@@ -245,7 +245,7 @@ describe("createCacheHealthCheck()", () => {
   test("reports durationMs >= 0", () => {
     const cm = new CacheManager();
     const check = createCacheHealthCheck(cm);
-    const result = check() as { durationMs: number };
+    const result = check() as HealthCheckResult;
 
     expect(result.durationMs).toBeGreaterThanOrEqual(0);
   });

--- a/packages/core/src/cache/cache-health.ts
+++ b/packages/core/src/cache/cache-health.ts
@@ -1,0 +1,107 @@
+/**
+ * Cache health check — integrates CacheManager diagnostics with HealthCheckRegistry.
+ *
+ * Verifies that L1 is operational (can set/get a probe key) and optionally
+ * checks that the hit rate is above a configurable threshold.
+ *
+ * See spec: docs/specs/34_cache_strategy.md §9
+ */
+
+import type { HealthCheckFn, HealthCheckResult } from "../deployment/health-check";
+import type { CacheManager } from "./cache-manager";
+
+// ── Options ──────────────────────────────────────────────
+
+export interface CacheHealthCheckOptions {
+  /** Minimum acceptable hit rate (0..1). Below this → degraded. Default: 0 (disabled) */
+  minHitRate?: number;
+  /** Probe key used for operational check. Default: "__health_probe__" */
+  probeKey?: string;
+}
+
+// ── Factory ──────────────────────────────────────────────
+
+/**
+ * Create a health check function for the cache subsystem.
+ *
+ * The check performs two verifications:
+ * 1. **Operational check**: writes and reads a probe key to confirm L1 works.
+ * 2. **Hit rate check** (optional): flags "degraded" if hit rate falls below threshold.
+ *
+ * Compatible with HealthCheckRegistry.register().
+ */
+export function createCacheHealthCheck(
+  cacheManager: CacheManager,
+  options?: CacheHealthCheckOptions,
+): HealthCheckFn {
+  const minHitRate = options?.minHitRate ?? 0;
+  const probeKey = options?.probeKey ?? "__health_probe__";
+
+  return (): HealthCheckResult => {
+    const start = Date.now();
+
+    // Operational check: set + get a probe value
+    const probeValue = `probe_${Date.now()}`;
+    try {
+      cacheManager.set(probeKey, probeValue, { ttl: 5000 });
+      const retrieved = cacheManager.get<string>(probeKey);
+      // Clean up probe key
+      cacheManager.delete(probeKey);
+
+      if (retrieved !== probeValue) {
+        return {
+          name: "cache",
+          status: "unhealthy",
+          message: `Operational check failed: expected "${probeValue}", got "${retrieved}"`,
+          durationMs: Date.now() - start,
+        };
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        name: "cache",
+        status: "unhealthy",
+        message: `Operational check threw: ${msg}`,
+        durationMs: Date.now() - start,
+      };
+    }
+
+    // Stats-based checks
+    const stats = cacheManager.getStats();
+    const totalRequests = stats.hits + stats.misses;
+
+    // Hit rate check (only meaningful after some traffic)
+    if (minHitRate > 0 && totalRequests > 0 && stats.hitRate < minHitRate) {
+      return {
+        name: "cache",
+        status: "degraded",
+        message: `Hit rate ${(stats.hitRate * 100).toFixed(1)}% below threshold ${(minHitRate * 100).toFixed(1)}%`,
+        durationMs: Date.now() - start,
+        metadata: {
+          hitRate: stats.hitRate,
+          minHitRate,
+          totalEntries: stats.totalEntries,
+          hits: stats.hits,
+          misses: stats.misses,
+          evictions: stats.evictions,
+        },
+      };
+    }
+
+    return {
+      name: "cache",
+      status: "healthy",
+      message: `${stats.totalEntries} entries, hit rate ${(stats.hitRate * 100).toFixed(1)}%`,
+      durationMs: Date.now() - start,
+      metadata: {
+        hitRate: stats.hitRate,
+        totalEntries: stats.totalEntries,
+        hits: stats.hits,
+        misses: stats.misses,
+        evictions: stats.evictions,
+        estimatedMemoryBytes: stats.estimatedMemoryBytes,
+        namespaces: stats.namespaces,
+      },
+    };
+  };
+}

--- a/packages/core/src/cache/cache-health.ts
+++ b/packages/core/src/cache/cache-health.ts
@@ -35,12 +35,16 @@ export function createCacheHealthCheck(
   options?: CacheHealthCheckOptions,
 ): HealthCheckFn {
   const minHitRate = options?.minHitRate ?? 0;
-  const probeKey = options?.probeKey ?? "__health_probe__";
+  const probeKeyPrefix = options?.probeKey ?? "__health_probe__";
 
   return (): HealthCheckResult => {
     const start = Date.now();
 
-    // Operational check: set + get a probe value
+    // Snapshot stats BEFORE probe to avoid contaminating hit-rate signal
+    const stats = cacheManager.getStats();
+
+    // Operational check: set + get a unique probe value
+    const probeKey = `${probeKeyPrefix}:${Date.now()}:${Math.random().toString(36).slice(2)}`;
     const probeValue = `probe_${Date.now()}`;
     try {
       cacheManager.set(probeKey, probeValue, { ttl: 5000 });
@@ -66,8 +70,7 @@ export function createCacheHealthCheck(
       cacheManager.delete(probeKey);
     }
 
-    // Stats-based checks
-    const stats = cacheManager.getStats();
+    // Stats-based checks (using pre-probe snapshot)
     const totalRequests = stats.hits + stats.misses;
 
     // Hit rate check (only meaningful after some traffic)

--- a/packages/core/src/cache/cache-health.ts
+++ b/packages/core/src/cache/cache-health.ts
@@ -45,8 +45,6 @@ export function createCacheHealthCheck(
     try {
       cacheManager.set(probeKey, probeValue, { ttl: 5000 });
       const retrieved = cacheManager.get<string>(probeKey);
-      // Clean up probe key
-      cacheManager.delete(probeKey);
 
       if (retrieved !== probeValue) {
         return {
@@ -64,6 +62,8 @@ export function createCacheHealthCheck(
         message: `Operational check threw: ${msg}`,
         durationMs: Date.now() - start,
       };
+    } finally {
+      cacheManager.delete(probeKey);
     }
 
     // Stats-based checks

--- a/packages/core/src/cache/cache-health.ts
+++ b/packages/core/src/cache/cache-health.ts
@@ -34,7 +34,11 @@ export function createCacheHealthCheck(
   cacheManager: CacheManager,
   options?: CacheHealthCheckOptions,
 ): HealthCheckFn {
-  const minHitRate = options?.minHitRate ?? 0;
+  const rawMinHitRate = options?.minHitRate ?? 0;
+  if (!Number.isFinite(rawMinHitRate) || rawMinHitRate < 0 || rawMinHitRate > 1) {
+    throw new RangeError("minHitRate must be a finite number between 0 and 1");
+  }
+  const minHitRate = rawMinHitRate;
   const probeKeyPrefix = options?.probeKey ?? "__health_probe__";
 
   return (): HealthCheckResult => {

--- a/packages/core/src/cache/cache-manager.ts
+++ b/packages/core/src/cache/cache-manager.ts
@@ -158,7 +158,7 @@ export class CacheManager {
     const l2 = this.l2?.stats();
 
     const totalHits = l1.hits + (l2?.hits ?? 0);
-    const totalMisses = l1.misses + (l2?.misses ?? 0);
+    const totalMisses = l2?.misses ?? l1.misses;
     const totalRequests = totalHits + totalMisses;
 
     const avgEntryBytes = options?.avgEntrySizeBytes ?? 256;

--- a/packages/core/src/cache/cache-manager.ts
+++ b/packages/core/src/cache/cache-manager.ts
@@ -12,6 +12,7 @@ import type { EventBus } from "../event/event-bus";
 import type { EventRecord } from "../types/event";
 import type { Logger } from "../types/logger";
 import type { CacheProvider, CacheSetOptions, CacheStats } from "./cache-provider";
+import type { CacheManagerStats, CacheManagerStatsOptions } from "./cache-stats";
 import { InMemoryCacheProvider } from "./in-memory-cache";
 
 // ── Configuration ─────────────────────────────────────────
@@ -148,6 +149,35 @@ export class CacheManager {
     };
   }
 
+  /**
+   * Return comprehensive diagnostics including per-namespace breakdown
+   * and memory estimates. See spec §9.
+   */
+  getStats(options?: CacheManagerStatsOptions): CacheManagerStats {
+    const l1 = this.l1.stats();
+    const l2 = this.l2?.stats();
+
+    const totalHits = l1.hits + (l2?.hits ?? 0);
+    const totalMisses = l1.misses + (l2?.misses ?? 0);
+    const totalRequests = totalHits + totalMisses;
+
+    const avgEntryBytes = options?.avgEntrySizeBytes ?? 256;
+
+    const namespaces = this.collectNamespaceBreakdown();
+
+    return {
+      totalEntries: l1.size + (l2?.size ?? 0),
+      hits: totalHits,
+      misses: totalMisses,
+      hitRate: totalRequests === 0 ? 0 : totalHits / totalRequests,
+      evictions: l1.evictions + (l2?.evictions ?? 0),
+      estimatedMemoryBytes: (l1.size + (l2?.size ?? 0)) * avgEntryBytes,
+      namespaces,
+      l1,
+      l2,
+    };
+  }
+
   // ── Namespace factory ───────────────────────────────────
 
   namespace(ns: string): NamespacedCache {
@@ -200,6 +230,23 @@ export class CacheManager {
       const count = this.invalidateByTag(permTag);
       this.logger?.debug?.(`Cache invalidated ${count} permission entries for tag "${permTag}"`);
     }
+  }
+
+  /**
+   * Scan L1 keys to build per-namespace entry counts.
+   * Only works when L1 exposes a keys() method (e.g. InMemoryCacheProvider).
+   */
+  private collectNamespaceBreakdown(): Record<string, number> {
+    const result: Record<string, number> = {};
+    const provider = this.l1 as { keys?: () => string[] };
+    if (typeof provider.keys !== "function") return result;
+
+    for (const key of provider.keys()) {
+      const colonIdx = key.indexOf(":");
+      const ns = colonIdx === -1 ? "_default" : key.slice(0, colonIdx);
+      result[ns] = (result[ns] ?? 0) + 1;
+    }
+    return result;
   }
 
   private subscribeToEvents(eventBus: EventBus): void {

--- a/packages/core/src/cache/cache-manager.ts
+++ b/packages/core/src/cache/cache-manager.ts
@@ -161,17 +161,25 @@ export class CacheManager {
     const totalMisses = l2?.misses ?? l1.misses;
     const totalRequests = totalHits + totalMisses;
 
-    const avgEntryBytes = options?.avgEntrySizeBytes ?? 256;
+    const rawAvg = options?.avgEntrySizeBytes ?? 256;
+    const avgEntryBytes = Number.isFinite(rawAvg) && rawAvg > 0 ? rawAvg : 256;
 
     const namespaces = this.collectNamespaceBreakdown();
+    const totalEntries = l1.size + (l2?.size ?? 0);
+
+    // Account for L2 entries not visible in L1 namespace scan
+    const namespacedEntries = Object.values(namespaces).reduce((sum, count) => sum + count, 0);
+    if (namespacedEntries < totalEntries) {
+      namespaces._unattributed = totalEntries - namespacedEntries;
+    }
 
     return {
-      totalEntries: l1.size + (l2?.size ?? 0),
+      totalEntries,
       hits: totalHits,
       misses: totalMisses,
       hitRate: totalRequests === 0 ? 0 : totalHits / totalRequests,
       evictions: l1.evictions + (l2?.evictions ?? 0),
-      estimatedMemoryBytes: (l1.size + (l2?.size ?? 0)) * avgEntryBytes,
+      estimatedMemoryBytes: totalEntries * avgEntryBytes,
       namespaces,
       l1,
       l2,

--- a/packages/core/src/cache/cache-stats.ts
+++ b/packages/core/src/cache/cache-stats.ts
@@ -1,0 +1,35 @@
+/**
+ * Cache diagnostics types — comprehensive stats for monitoring and health checks.
+ *
+ * See spec: docs/specs/34_cache_strategy.md §9
+ */
+
+import type { CacheStats } from "./cache-provider";
+
+// ── Stats types ──────────────────────────────────────────
+
+export interface CacheManagerStats {
+  /** Total entries across all layers */
+  totalEntries: number;
+  /** Total cache hits (L1 + L2) */
+  hits: number;
+  /** Total cache misses (L1 + L2) */
+  misses: number;
+  /** Hit rate as a ratio 0..1 */
+  hitRate: number;
+  /** Total evictions across all layers */
+  evictions: number;
+  /** Estimated memory usage in bytes (entries * avgEntrySize) */
+  estimatedMemoryBytes: number;
+  /** Per-namespace entry counts (namespace prefix → count) */
+  namespaces: Record<string, number>;
+  /** Raw L1 stats */
+  l1: CacheStats;
+  /** Raw L2 stats (if L2 is configured) */
+  l2?: CacheStats;
+}
+
+export interface CacheManagerStatsOptions {
+  /** Assumed average entry size in bytes for memory estimation. Default: 256 */
+  avgEntrySizeBytes?: number;
+}

--- a/packages/core/src/cache/cache-stats.ts
+++ b/packages/core/src/cache/cache-stats.ts
@@ -13,7 +13,7 @@ export interface CacheManagerStats {
   totalEntries: number;
   /** Total cache hits (L1 + L2) */
   hits: number;
-  /** Total cache misses (L1 + L2) */
+  /** Manager-level misses (final-layer miss count, not L1+L2 sum) */
   misses: number;
   /** Hit rate as a ratio 0..1 */
   hitRate: number;

--- a/packages/core/src/cache/in-memory-cache.ts
+++ b/packages/core/src/cache/in-memory-cache.ts
@@ -176,6 +176,11 @@ export class InMemoryCacheProvider implements CacheProvider {
     };
   }
 
+  /** Return all current cache keys (for diagnostics). */
+  keys(): string[] {
+    return Array.from(this.store.keys());
+  }
+
   // ── Internal helpers ────────────────────────────────────
 
   private removeEntry(key: string, entry: CacheEntry): void {

--- a/packages/core/src/cache/index.ts
+++ b/packages/core/src/cache/index.ts
@@ -4,8 +4,10 @@
  * See spec: docs/specs/34_cache_strategy.md
  */
 
+export { type CacheHealthCheckOptions, createCacheHealthCheck } from "./cache-health";
 export { CacheManager, type CacheManagerOptions, type NamespacedCache } from "./cache-manager";
 export type { CacheEntry, CacheProvider, CacheSetOptions, CacheStats } from "./cache-provider";
+export type { CacheManagerStats, CacheManagerStatsOptions } from "./cache-stats";
 export { type InMemoryCacheOptions, InMemoryCacheProvider } from "./in-memory-cache";
 export {
   CACHE_INVALIDATION_CHANNEL,


### PR DESCRIPTION
## Summary
- `CacheManager.getStats()` — hits, misses, hit rate, evictions, per-namespace breakdown, memory estimates
- `InMemoryCacheProvider.keys()` — expose cache keys for diagnostics
- `createCacheHealthCheck()` — HealthCheckRegistry-compatible probe with optional hit rate threshold
- 21 tests covering stats tracking, health check pass/fail, edge cases

Partial progress on #73

## Test plan
- [x] 21 new tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cache statistics (hits, misses, hit rate, evictions, estimated memory) with per-namespace breakdown and raw layer stats
  * Added cache health check with probe-based validation, configurable minimum hit-rate, and diagnostic metadata
  * Added ability to list cache keys

* **Tests**
  * Added comprehensive tests covering stats, namespaces, key listing, eviction/memory estimation, and health-check behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->