### PR TITLE
feat(core): add action metrics and observability summary

### DIFF
--- a/packages/core/__tests__/action-metrics.test.ts
+++ b/packages/core/__tests__/action-metrics.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "bun:test";
+import { createActionExecutor, type DataProvider } from "../src/engine/action-engine";
+import { createCommandLayer } from "../src/engine/command-layer";
+import { AlertEngine } from "../src/observability/alert-engine";
+import { InMemoryMetricsCollector } from "../src/observability/metrics";
+import { registerSystemAlerts } from "../src/observability/system-alerts";
+import type { ActionDefinition, Actor } from "../src/types/action";
+
+// ── Fixtures ────────────────────────────────────────────
+
+const testActor: Actor = { type: "human", id: "user-1", groups: ["admin"] };
+
+const successAction: ActionDefinition = {
+  name: "create_item",
+  entity: "item",
+  label: "Create Item",
+  input: { title: { type: "string", required: true } },
+  policy: { mode: "sync", transaction: false },
+  handler: async (ctx) => ({ title: ctx.input.title }),
+};
+
+const failingAction: ActionDefinition = {
+  name: "fail_item",
+  entity: "item",
+  label: "Fail Item",
+  input: {},
+  policy: { mode: "sync", transaction: false },
+  handler: async () => {
+    throw new Error("Intentional failure");
+  },
+};
+
+function createTestExecutor(actions: ActionDefinition[]) {
+  const dataProvider: DataProvider = {
+    get: async () => ({ id: "1" }),
+    query: async () => [],
+    create: async (_e, data) => ({ id: "1", ...data }),
+    update: async (_e, _id, data) => ({ id: "1", ...data }),
+    delete: async () => {},
+    count: async () => 0,
+  };
+  const executor = createActionExecutor({ dataProvider });
+  for (const a of actions) executor.registry.register(a);
+  return executor;
+}
+
+// ── Tests: Action metrics instrumentation ────────────────
+
+describe("CommandLayer action metrics", () => {
+  it("records action.executions and action.duration_ms on success", async () => {
+    const metrics = new InMemoryMetricsCollector();
+    const executor = createTestExecutor([successAction]);
+    const layer = createCommandLayer({ executor, metrics });
+
+    const result = await layer.execute({
+      command: "create_item",
+      input: { title: "Test" },
+      actor: testActor,
+    });
+
+    expect(result.success).toBe(true);
+
+    // Check action.executions counter
+    const execCount = metrics.getCounter("action.executions", {
+      action: "create_item",
+      status: "success",
+    });
+    expect(execCount).toBe(1);
+
+    // Check action.duration_ms histogram was recorded
+    const durations = metrics.getHistogramValues("action.duration_ms");
+    expect(durations.length).toBeGreaterThanOrEqual(1);
+    expect(durations[0]).toBeGreaterThanOrEqual(0);
+
+    // No errors should be recorded
+    const errorCount = metrics.getCounter("action.errors", { action: "create_item" });
+    expect(errorCount).toBe(0);
+  });
+
+  it("records action.errors on action failure", async () => {
+    const metrics = new InMemoryMetricsCollector();
+    const executor = createTestExecutor([failingAction]);
+    const layer = createCommandLayer({ executor, metrics });
+
+    const result = await layer.execute({
+      command: "fail_item",
+      input: {},
+      actor: testActor,
+    });
+
+    // The executor catches the throw and returns success: false
+    expect(result.success).toBe(false);
+
+    // action.executions should be recorded with error status
+    const execCount = metrics.getCounter("action.executions", {
+      action: "fail_item",
+      status: "error",
+    });
+    expect(execCount).toBe(1);
+
+    // action.errors counter should be incremented
+    const errorCount = metrics.getCounter("action.errors", { action: "fail_item" });
+    expect(errorCount).toBe(1);
+  });
+
+  it("records metrics for unknown action (not found)", async () => {
+    const metrics = new InMemoryMetricsCollector();
+    const executor = createTestExecutor([successAction]);
+    const layer = createCommandLayer({ executor, metrics });
+
+    const result = await layer.execute({
+      command: "nonexistent_action",
+      input: {},
+      actor: testActor,
+    });
+
+    expect(result.success).toBe(false);
+    // Action not found returns early before pipeline runs, no action metrics recorded
+  });
+
+  it("accumulates metrics across multiple executions", async () => {
+    const metrics = new InMemoryMetricsCollector();
+    const executor = createTestExecutor([successAction]);
+    const layer = createCommandLayer({ executor, metrics });
+
+    await layer.execute({ command: "create_item", input: { title: "A" }, actor: testActor });
+    await layer.execute({ command: "create_item", input: { title: "B" }, actor: testActor });
+    await layer.execute({ command: "create_item", input: { title: "C" }, actor: testActor });
+
+    const execCount = metrics.getCounter("action.executions", {
+      action: "create_item",
+      status: "success",
+    });
+    expect(execCount).toBe(3);
+
+    const durations = metrics.getHistogramValues("action.duration_ms");
+    expect(durations.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+// ── Tests: System alerts ────────────────────────────────
+
+describe("registerSystemAlerts", () => {
+  it("registers high_error_rate alert and computes error rate gauge", () => {
+    const metrics = new InMemoryMetricsCollector();
+    const alertEngine = new AlertEngine({ metrics });
+
+    const sysAlerts = registerSystemAlerts({
+      alertEngine,
+      metricsCollector: metrics,
+    });
+
+    // Verify alert is registered
+    const alerts = alertEngine.list();
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]?.name).toBe("high_error_rate");
+
+    // Simulate 10 executions, 2 errors (20% error rate)
+    for (let i = 0; i < 10; i++) {
+      metrics.increment("action.executions", { action: "test_action", status: "success" });
+    }
+    for (let i = 0; i < 2; i++) {
+      metrics.increment("action.errors", { action: "test_action" });
+    }
+
+    sysAlerts.updateErrorRateGauge();
+
+    // Error rate gauge should be 20%
+    const errorRate = metrics.getGauge("action.error_rate_pct");
+    expect(errorRate).toBe(20);
+
+    // Evaluate — should trigger (20% > 10%)
+    const results = alertEngine.evaluateAll();
+    expect(results).toHaveLength(1);
+    expect(results[0]?.triggered).toBe(true);
+    expect(results[0]?.severity).toBe("critical");
+  });
+
+  it("does not trigger alert when error rate is below threshold", () => {
+    const metrics = new InMemoryMetricsCollector();
+    const alertEngine = new AlertEngine({ metrics });
+
+    const sysAlerts = registerSystemAlerts({
+      alertEngine,
+      metricsCollector: metrics,
+    });
+
+    // Simulate 100 executions, 5 errors (5% error rate)
+    for (let i = 0; i < 100; i++) {
+      metrics.increment("action.executions", { action: "test_action", status: "success" });
+    }
+    for (let i = 0; i < 5; i++) {
+      metrics.increment("action.errors", { action: "test_action" });
+    }
+
+    sysAlerts.updateErrorRateGauge();
+
+    const results = alertEngine.evaluateAll();
+    expect(results).toHaveLength(1);
+    expect(results[0]?.triggered).toBe(false);
+  });
+
+  it("reports 0% error rate when no executions exist", () => {
+    const metrics = new InMemoryMetricsCollector();
+    const alertEngine = new AlertEngine({ metrics });
+
+    const sysAlerts = registerSystemAlerts({
+      alertEngine,
+      metricsCollector: metrics,
+    });
+
+    sysAlerts.updateErrorRateGauge();
+
+    const errorRate = metrics.getGauge("action.error_rate_pct");
+    expect(errorRate).toBe(0);
+
+    const results = alertEngine.evaluateAll();
+    expect(results).toHaveLength(1);
+    expect(results[0]?.triggered).toBe(false);
+  });
+});

--- a/packages/core/__tests__/action-metrics.test.ts
+++ b/packages/core/__tests__/action-metrics.test.ts
@@ -116,6 +116,13 @@ describe("CommandLayer action metrics", () => {
 
     expect(result.success).toBe(false);
     // Action not found returns early before pipeline runs, no action metrics recorded
+    expect(
+      metrics.getCounter("action.executions", { action: "nonexistent_action", status: "blocked" }),
+    ).toBe(0);
+    expect(
+      metrics.getCounter("action.executions", { action: "nonexistent_action", status: "error" }),
+    ).toBe(0);
+    expect(metrics.getHistogramValues("action.duration_ms")).toHaveLength(0);
   });
 
   it("accumulates metrics across multiple executions", async () => {

--- a/packages/core/__tests__/action-metrics.test.ts
+++ b/packages/core/__tests__/action-metrics.test.ts
@@ -122,6 +122,7 @@ describe("CommandLayer action metrics", () => {
     expect(
       metrics.getCounter("action.executions", { action: "nonexistent_action", status: "error" }),
     ).toBe(0);
+    expect(metrics.getCounter("action.errors", { action: "nonexistent_action" })).toBe(0);
     expect(metrics.getHistogramValues("action.duration_ms")).toHaveLength(0);
   });
 

--- a/packages/core/__tests__/observability-summary.test.ts
+++ b/packages/core/__tests__/observability-summary.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "bun:test";
+import { HealthCheckRegistry } from "../src/deployment/health-check";
+import { InMemoryMetricsCollector } from "../src/observability/metrics";
+import { buildObservabilitySummary } from "../src/observability/observability-summary";
+
+describe("buildObservabilitySummary", () => {
+  it("returns metrics summary with counters, gauges, and histograms", async () => {
+    const metrics = new InMemoryMetricsCollector();
+    metrics.increment("action.executions", { action: "create_order", status: "success" });
+    metrics.increment("action.executions", { action: "create_order", status: "success" });
+    metrics.increment("action.errors", { action: "create_order" });
+    metrics.gauge("active_connections", 5);
+    metrics.timing("action.duration_ms", 120, { action: "create_order" });
+    metrics.timing("action.duration_ms", 80, { action: "create_order" });
+
+    const summary = await buildObservabilitySummary({ metrics });
+
+    expect(summary.timestamp).toBeDefined();
+    expect(summary.metrics.counters["action.executions"]).toBe(2);
+    expect(summary.metrics.counters["action.errors"]).toBe(1);
+    expect(summary.metrics.gauges.active_connections).toBe(5);
+    expect(summary.metrics.histograms["action.duration_ms"]).toBeDefined();
+    expect(summary.metrics.histograms["action.duration_ms"]?.count).toBe(2);
+    expect(summary.metrics.histograms["action.duration_ms"]?.min).toBe(80);
+    expect(summary.metrics.histograms["action.duration_ms"]?.max).toBe(120);
+    // No health checks provided
+    expect(summary.health).toBeUndefined();
+  });
+
+  it("includes health check results when healthChecks provided", async () => {
+    const metrics = new InMemoryMetricsCollector();
+    const healthChecks = new HealthCheckRegistry();
+    healthChecks.register("liveness", () => ({
+      name: "liveness",
+      status: "healthy",
+      message: "OK",
+      durationMs: 0,
+    }));
+    healthChecks.register("database", () => ({
+      name: "database",
+      status: "degraded",
+      message: "Slow",
+      durationMs: 50,
+    }));
+
+    const summary = await buildObservabilitySummary({ metrics, healthChecks });
+
+    expect(summary.health).toBeDefined();
+    expect(summary.health?.status).toBe("degraded");
+    expect(summary.health?.checks).toHaveLength(2);
+    expect(summary.health?.checks[0]?.name).toBe("liveness");
+    expect(summary.health?.checks[1]?.name).toBe("database");
+  });
+
+  it("returns empty metrics when collector has no data", async () => {
+    const metrics = new InMemoryMetricsCollector();
+
+    const summary = await buildObservabilitySummary({ metrics });
+
+    expect(summary.metrics.counters).toEqual({});
+    expect(summary.metrics.gauges).toEqual({});
+    expect(summary.metrics.histograms).toEqual({});
+  });
+});

--- a/packages/core/src/engine/command-layer.ts
+++ b/packages/core/src/engine/command-layer.ts
@@ -363,6 +363,11 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
       const run = compose(pipeline);
       await run(ctx);
     } catch (err) {
+      metrics.increment("action.executions", { action: ctx.command, status: "error" });
+      metrics.increment("action.errors", { action: ctx.command });
+      metrics.timing("action.duration_ms", Date.now() - pipelineStart, {
+        action: ctx.command,
+      });
       metrics.increment("command.processed", { command: ctx.command, status: "failed" });
       metrics.timing("command.duration_ms", Date.now() - pipelineStart, {
         command: ctx.command,
@@ -398,6 +403,10 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
 
     // If action didn't execute (middleware blocked by not calling next())
     if (!ctx.result) {
+      metrics.increment("action.executions", { action: ctx.command, status: "blocked" });
+      metrics.timing("action.duration_ms", Date.now() - pipelineStart, {
+        action: ctx.command,
+      });
       metrics.increment("command.processed", { command: ctx.command, status: "blocked" });
       metrics.timing("command.duration_ms", Date.now() - pipelineStart, {
         command: ctx.command,
@@ -438,6 +447,15 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
         }
       }
     }
+
+    const actionStatus = ctx.result.success ? "success" : "error";
+    metrics.increment("action.executions", { action: ctx.command, status: actionStatus });
+    if (!ctx.result.success) {
+      metrics.increment("action.errors", { action: ctx.command });
+    }
+    metrics.timing("action.duration_ms", Date.now() - pipelineStart, {
+      action: ctx.command,
+    });
 
     metrics.increment("command.processed", { command: ctx.command, status: "succeeded" });
     metrics.timing("command.duration_ms", Date.now() - pipelineStart, {

--- a/packages/core/src/observability/index.ts
+++ b/packages/core/src/observability/index.ts
@@ -30,6 +30,11 @@ export {
   type MetricsSummary,
   noopMetricsCollector,
 } from "./metrics";
+export {
+  type BuildObservabilitySummaryOptions,
+  buildObservabilitySummary,
+  type ObservabilitySummary,
+} from "./observability-summary";
 export { createPinoLogger, type PinoLoggerOptions } from "./pino-logger";
 export {
   createStructuredLogger,
@@ -39,6 +44,7 @@ export {
   type StructuredLogEntry,
   type StructuredLoggerOptions,
 } from "./structured-logger";
+export { type RegisterSystemAlertsOptions, registerSystemAlerts } from "./system-alerts";
 export {
   getCurrentTrace,
   getTraceDepth,

--- a/packages/core/src/observability/observability-summary.ts
+++ b/packages/core/src/observability/observability-summary.ts
@@ -1,0 +1,58 @@
+/**
+ * Observability Summary — Aggregated view of system metrics and health.
+ *
+ * Combines metric summaries from the MetricsCollector with health check
+ * results from the HealthCheckRegistry into a single structured snapshot
+ * suitable for status endpoints and dashboards.
+ */
+
+import type { AggregatedHealthStatus, HealthCheckRegistry } from "../deployment/health-check";
+import type { InMemoryMetricsCollector, MetricsSummary } from "./metrics";
+
+// ── Types ────────────────────────────────────────────────
+
+export interface ObservabilitySummary {
+  /** Timestamp of when the summary was generated (ISO 8601) */
+  timestamp: string;
+  /** Aggregated metric summaries (counters, gauges, histograms with percentiles) */
+  metrics: MetricsSummary;
+  /** Health check results (only present if healthChecks provided) */
+  health?: AggregatedHealthStatus;
+}
+
+export interface BuildObservabilitySummaryOptions {
+  /** Metrics collector to extract summaries from */
+  metrics: InMemoryMetricsCollector;
+  /** Optional health check registry for liveness/readiness status */
+  healthChecks?: HealthCheckRegistry;
+}
+
+// ── Builder ─────────────────────────────────────────────
+
+/**
+ * Build a structured observability summary combining metrics and health checks.
+ *
+ * Usage:
+ * ```ts
+ * const summary = await buildObservabilitySummary({
+ *   metrics: metricsCollector,
+ *   healthChecks: healthRegistry,
+ * });
+ * ```
+ */
+export async function buildObservabilitySummary(
+  opts: BuildObservabilitySummaryOptions,
+): Promise<ObservabilitySummary> {
+  const metricsSummary = opts.metrics.getSummary();
+
+  const summary: ObservabilitySummary = {
+    timestamp: new Date().toISOString(),
+    metrics: metricsSummary,
+  };
+
+  if (opts.healthChecks) {
+    summary.health = await opts.healthChecks.runAll();
+  }
+
+  return summary;
+}

--- a/packages/core/src/observability/system-alerts.ts
+++ b/packages/core/src/observability/system-alerts.ts
@@ -1,0 +1,82 @@
+/**
+ * System Alerts — Pre-defined alert rule templates for common operational conditions.
+ *
+ * Registers built-in alert rules against the AlertEngine using metrics
+ * from the InMemoryMetricsCollector. These cover common failure modes
+ * like high error rates.
+ */
+
+import type { AlertEngine } from "./alert-engine";
+import { defineSystemAlert } from "./alert-engine";
+import type { InMemoryMetricsCollector } from "./metrics";
+
+// ── Pre-defined alert templates ─────────────────────────
+
+/**
+ * High error rate alert — triggers when action.errors counter exceeds
+ * 10% of total action.executions.
+ *
+ * Since the AlertEngine evaluates raw counter values (not ratios),
+ * this function registers a periodic evaluation callback that computes
+ * the error rate and updates a gauge that the alert engine can check.
+ */
+const HIGH_ERROR_RATE_ALERT = defineSystemAlert({
+  name: "high_error_rate",
+  label: "High Action Error Rate",
+  condition: {
+    metric: "action.error_rate_pct",
+    operator: "gt",
+    value: 10,
+  },
+  effect: {
+    severity: "critical",
+    notify: ["ops"],
+    message: "Action error rate exceeds 10%",
+  },
+});
+
+// ── Registration ────────────────────────────────────────
+
+export interface RegisterSystemAlertsOptions {
+  alertEngine: AlertEngine;
+  metricsCollector: InMemoryMetricsCollector;
+}
+
+/**
+ * Register pre-defined system alert rules and update derived metrics.
+ *
+ * Call `updateErrorRateGauge()` on the returned object before evaluating
+ * alerts to refresh the computed error rate gauge.
+ *
+ * Usage:
+ * ```ts
+ * const sysAlerts = registerSystemAlerts({ alertEngine, metricsCollector });
+ * // Before alert evaluation:
+ * sysAlerts.updateErrorRateGauge();
+ * alertEngine.evaluateAll();
+ * ```
+ */
+export function registerSystemAlerts(opts: RegisterSystemAlertsOptions): {
+  /** Recompute and update the action.error_rate_pct gauge from current counters */
+  updateErrorRateGauge: () => void;
+} {
+  const { alertEngine, metricsCollector } = opts;
+
+  // Register the alert definition
+  alertEngine.register(HIGH_ERROR_RATE_ALERT);
+
+  // Helper to compute and set the error rate gauge
+  function updateErrorRateGauge(): void {
+    const executionCounters = metricsCollector.getCountersByPrefix("action.executions");
+    const errorCounters = metricsCollector.getCountersByPrefix("action.errors");
+
+    const totalExecutions = executionCounters.reduce((sum, c) => sum + c.value, 0);
+    const totalErrors = errorCounters.reduce((sum, c) => sum + c.value, 0);
+
+    const errorRate = totalExecutions > 0 ? (totalErrors / totalExecutions) * 100 : 0;
+
+    metricsCollector.gauge("action.error_rate_pct", errorRate);
+  }
+
+  return { updateErrorRateGauge };
+}


### PR DESCRIPTION
## Summary
- CommandLayer instrumented with `action.executions`, `action.duration_ms`, `action.errors` metrics (tagged by action name)
- `buildObservabilitySummary()` aggregates metrics + health checks into structured output
- `registerSystemAlerts()` provides `high_error_rate` alert template (>10% threshold)
- 10 tests covering metrics recording, summary builder, alert registration

Partial progress on #76

## Test plan
- [x] 10 new tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Action-level metrics now consistently record executions (success/error/blocked), errors, and durations.
  * Added a pre-built high-error-rate system alert and a helper to recompute an error-rate gauge for alerting.
  * Observability summary builder added to aggregate metrics, include timestamps, and optionally include health-check results; observability exports updated.

* **Tests**
  * New tests validating action metrics, system alert registration/evaluation, error-rate computation, and observability summary aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->