### PR TITLE
chore: add --admin merge prohibition to CLAUDE.md

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -55,7 +55,11 @@
       "Bash(git rebase *)",
       "Bash(git branch -D *)",
       "Bash(git branch -d *)",
-      "Bash(gh repo delete*)"
+      "Bash(gh repo delete*)",
+      "Bash(gh pr merge * --admin*)",
+      "Bash(gh pr merge --admin*)",
+      "Bash(gh pr merge * --auto*)",
+      "Bash(gh pr merge --auto*)"
     ]
   },
   "hooks": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,8 @@ bun test              # Full test suite (3870+ tests)
 
 **PR merge gate:** All review comments must be replied to and resolved before merging.
 
+**NEVER use `--admin` flag to bypass branch protection.** If `gh pr merge` is blocked by policy, that means reviews are not done — WAIT. Only merge when review status is APPROVED and CI is green. No exceptions.
+
 ### Parallel Subagent Dispatch
 
 When multiple independent issues can be worked on simultaneously:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,14 +104,16 @@ bun test              # Full test suite (3870+ tests)
 3. **Wait for CI** — GitHub Actions runs all quality gates
 4. **Read review comments** — CodeRabbit and/or human reviewers
 5. **Fix and resolve** — Address every comment, push fixes
-6. **All comments resolved + CI green** → merge
+6. **Reply to each comment** — Explain what was fixed, then **resolve** the thread (NEVER dismiss)
+7. **All comments resolved + CI green + APPROVED** → merge
 
 **PR merge rules (MANDATORY — no exceptions):**
 
 1. **NEVER use `--admin` or `--auto` flag** — If `gh pr merge` is blocked by policy, that means reviews are not done. WAIT.
 2. **NEVER merge with CHANGES_REQUESTED status** — Must wait for reviewers to re-approve after fixes. Request re-review explicitly if needed.
-3. **ALWAYS read ALL review comments BEFORE attempting merge** — Every single comment from CodeRabbit, Gemini, or human reviewers must be read, understood, and either fixed or explicitly replied to with reasoning.
-4. **Only merge when: review status = APPROVED + CI = green** — Both conditions must be true. No shortcuts.
+3. **NEVER dismiss review threads** — Always reply explaining the fix, then resolve via GraphQL `resolveReviewThread`.
+4. **ALWAYS read ALL review comments BEFORE attempting merge** — Every single comment from CodeRabbit, Gemini, or human reviewers must be read, understood, and either fixed or explicitly replied to with reasoning.
+5. **Only merge when: review status = APPROVED + CI = green** — Both conditions must be true. No shortcuts.
 
 ### Parallel Subagent Dispatch
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,9 +106,12 @@ bun test              # Full test suite (3870+ tests)
 5. **Fix and resolve** — Address every comment, push fixes
 6. **All comments resolved + CI green** → merge
 
-**PR merge gate:** All review comments must be replied to and resolved before merging.
+**PR merge rules (MANDATORY — no exceptions):**
 
-**NEVER use `--admin` flag to bypass branch protection.** If `gh pr merge` is blocked by policy, that means reviews are not done — WAIT. Only merge when review status is APPROVED and CI is green. No exceptions.
+1. **NEVER use `--admin` or `--auto` flag** — If `gh pr merge` is blocked by policy, that means reviews are not done. WAIT.
+2. **NEVER merge with CHANGES_REQUESTED status** — Must wait for reviewers to re-approve after fixes. Request re-review explicitly if needed.
+3. **ALWAYS read ALL review comments BEFORE attempting merge** — Every single comment from CodeRabbit, Gemini, or human reviewers must be read, understood, and either fixed or explicitly replied to with reasoning.
+4. **Only merge when: review status = APPROVED + CI = green** — Both conditions must be true. No shortcuts.
 
 ### Parallel Subagent Dispatch
 


### PR DESCRIPTION
## Summary
- Add explicit rule: NEVER use `--admin` to bypass branch protection
- Must wait for APPROVED review status before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified PR merge rules: require replying to review comments, resolving threads, only merge when approved and CI is green, never merge if changes were requested, and read all review comments before merging.
* **Chores**
  * Tightened deny list to block merge-bypass flags and specific merge command usages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->