### PR TITLE
feat(core): add TTL policies and tenant-scoped caching

### DIFF
--- a/packages/core/__tests__/cache-tenant.test.ts
+++ b/packages/core/__tests__/cache-tenant.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { CacheManager } from "../src/cache/cache-manager";
+import { createTenantNamespace } from "../src/cache/tenant-cache";
+
+// ── createTenantNamespace ───────────────────────────────────
+
+describe("createTenantNamespace", () => {
+  let manager: CacheManager;
+
+  beforeEach(() => {
+    manager = new CacheManager();
+  });
+
+  afterEach(() => {
+    manager.clear();
+  });
+
+  it("prefixes keys with namespace and tenant ID", () => {
+    const ns = createTenantNamespace(manager, "query", "t1");
+    ns.set("orders:abc", "result");
+
+    // The key in the underlying manager should be "query:t1:orders:abc"
+    expect(manager.get("query:t1:orders:abc")).toBe("result");
+  });
+
+  it("isolates data between tenants", () => {
+    const nsT1 = createTenantNamespace(manager, "query", "t1");
+    const nsT2 = createTenantNamespace(manager, "query", "t2");
+
+    nsT1.set("key", "tenant1-value");
+    nsT2.set("key", "tenant2-value");
+
+    expect(nsT1.get("key")).toBe("tenant1-value");
+    expect(nsT2.get("key")).toBe("tenant2-value");
+  });
+
+  it("isolates data between namespaces for the same tenant", () => {
+    const queryNs = createTenantNamespace(manager, "query", "t1");
+    const permNs = createTenantNamespace(manager, "perm", "t1");
+
+    queryNs.set("key", "query-value");
+    permNs.set("key", "perm-value");
+
+    expect(queryNs.get("key")).toBe("query-value");
+    expect(permNs.get("key")).toBe("perm-value");
+  });
+
+  it("invalidateAll only clears keys for the specific tenant namespace", () => {
+    const nsT1 = createTenantNamespace(manager, "query", "t1");
+    const nsT2 = createTenantNamespace(manager, "query", "t2");
+
+    nsT1.set("a", 1);
+    nsT1.set("b", 2);
+    nsT2.set("a", 3);
+
+    const count = nsT1.invalidateAll();
+    expect(count).toBe(2);
+
+    // t1 keys are gone
+    expect(nsT1.get("a")).toBeUndefined();
+    expect(nsT1.get("b")).toBeUndefined();
+
+    // t2 key is still alive
+    expect(nsT2.get("a")).toBe(3);
+  });
+
+  it("delete removes only the specified key for the tenant", () => {
+    const ns = createTenantNamespace(manager, "perm", "t1");
+
+    ns.set("actions", ["read"]);
+    ns.set("filter", { status: "active" });
+
+    expect(ns.delete("actions")).toBe(true);
+    expect(ns.get("actions")).toBeUndefined();
+    expect(ns.get("filter")).toEqual({ status: "active" });
+  });
+
+  it("delete returns false for non-existent key", () => {
+    const ns = createTenantNamespace(manager, "perm", "t1");
+    expect(ns.delete("nonexistent")).toBe(false);
+  });
+
+  it("supports tag-based invalidation across tenants", () => {
+    const nsT1 = createTenantNamespace(manager, "query", "t1");
+    const nsT2 = createTenantNamespace(manager, "query", "t2");
+
+    nsT1.set("orders", "t1-orders", { tags: ["entity:orders"] });
+    nsT2.set("orders", "t2-orders", { tags: ["entity:orders"] });
+
+    // Invalidate by tag clears both tenants
+    const count = nsT1.invalidateByTag("entity:orders");
+    expect(count).toBe(2);
+    expect(nsT1.get("orders")).toBeUndefined();
+    expect(nsT2.get("orders")).toBeUndefined();
+  });
+
+  it("supports tenant-scoped tag invalidation", () => {
+    const nsT1 = createTenantNamespace(manager, "query", "t1");
+    const nsT2 = createTenantNamespace(manager, "query", "t2");
+
+    nsT1.set("orders", "t1-orders", { tags: ["entity:t1:orders"] });
+    nsT2.set("orders", "t2-orders", { tags: ["entity:t2:orders"] });
+
+    // Invalidate only t1's orders
+    const count = manager.invalidateByTag("entity:t1:orders");
+    expect(count).toBe(1);
+    expect(nsT1.get("orders")).toBeUndefined();
+    expect(nsT2.get("orders")).toBe("t2-orders");
+  });
+
+  it("supports getWithStaleness for SWR pattern", () => {
+    const ns = createTenantNamespace(manager, "override", "t1");
+    ns.set("entity:order", "merged-def", { ttl: 5000 });
+
+    const result = ns.getWithStaleness("entity:order");
+    expect(result?.value).toBe("merged-def");
+    expect(result?.isStale).toBe(false);
+  });
+
+  it("returns undefined for getWithStaleness on missing key", () => {
+    const ns = createTenantNamespace(manager, "override", "t1");
+    expect(ns.getWithStaleness("missing")).toBeUndefined();
+  });
+});
+
+// ── CacheManager.tenantNamespace convenience ────────────────
+
+describe("CacheManager.tenantNamespace", () => {
+  let manager: CacheManager;
+
+  beforeEach(() => {
+    manager = new CacheManager();
+  });
+
+  afterEach(() => {
+    manager.clear();
+  });
+
+  it("produces same key structure as createTenantNamespace", () => {
+    const fromHelper = createTenantNamespace(manager, "query", "t1");
+    const fromMethod = manager.tenantNamespace("query", "t1");
+
+    fromHelper.set("key", "helper-value");
+    // Method-created namespace should see the same key
+    expect(fromMethod.get("key")).toBe("helper-value");
+  });
+
+  it("provides tenant isolation via convenience method", () => {
+    const nsT1 = manager.tenantNamespace("perm", "t1");
+    const nsT2 = manager.tenantNamespace("perm", "t2");
+
+    nsT1.set("actions", ["admin"]);
+    nsT2.set("actions", ["read"]);
+
+    expect(nsT1.get("actions")).toEqual(["admin"]);
+    expect(nsT2.get("actions")).toEqual(["read"]);
+  });
+
+  it("scoped invalidation via tenantNamespace", () => {
+    const nsT1 = manager.tenantNamespace("query", "t1");
+    const nsT2 = manager.tenantNamespace("query", "t2");
+
+    nsT1.set("a", 1);
+    nsT1.set("b", 2);
+    nsT2.set("a", 3);
+
+    nsT1.invalidateAll();
+
+    expect(nsT1.get("a")).toBeUndefined();
+    expect(nsT2.get("a")).toBe(3);
+  });
+
+  it("applies TTL policies to tenant namespaces", async () => {
+    const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+    manager = new CacheManager({
+      ttlPolicies: [{ namespace: "perm", ttl: 50 }],
+    });
+
+    const ns = manager.tenantNamespace("perm", "t1");
+    ns.set("actions", ["read"]);
+
+    expect(ns.get("actions")).toEqual(["read"]);
+    await sleep(80);
+    expect(ns.get("actions")).toBeUndefined();
+  });
+});

--- a/packages/core/__tests__/cache-ttl-policy.test.ts
+++ b/packages/core/__tests__/cache-ttl-policy.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "bun:test";
+import { CacheManager } from "../src/cache/cache-manager";
+import {
+  type CacheTtlPolicy,
+  DEFAULT_TTL_POLICIES,
+  resolveTtlForNamespace,
+} from "../src/cache/cache-ttl-policy";
+
+// ── resolveTtlForNamespace ──────────────────────────────────
+
+describe("resolveTtlForNamespace", () => {
+  it("returns undefined when no policies are provided", () => {
+    expect(resolveTtlForNamespace("query", [])).toBeUndefined();
+  });
+
+  it("returns undefined when namespace does not match any policy", () => {
+    expect(resolveTtlForNamespace("unknown", DEFAULT_TTL_POLICIES)).toBeUndefined();
+  });
+
+  it("matches exact namespace", () => {
+    const result = resolveTtlForNamespace("override", DEFAULT_TTL_POLICIES);
+    expect(result).toBeDefined();
+    expect(result?.ttl).toBe(5 * 60 * 1000);
+    expect(result?.swrTtl).toBe(1 * 60 * 1000);
+  });
+
+  it("matches namespace prefix with colon separator", () => {
+    const result = resolveTtlForNamespace("query:tenant1", DEFAULT_TTL_POLICIES);
+    expect(result).toBeDefined();
+    expect(result?.ttl).toBe(1 * 60 * 1000);
+    expect(result?.swrTtl).toBeUndefined();
+  });
+
+  it("does not match partial namespace names without colon", () => {
+    // "queryExtra" should NOT match "query" policy
+    const result = resolveTtlForNamespace("queryExtra", DEFAULT_TTL_POLICIES);
+    expect(result).toBeUndefined();
+  });
+
+  it("returns first matching policy when multiple could match", () => {
+    const policies: CacheTtlPolicy[] = [
+      { namespace: "query:tenant1", ttl: 5000 },
+      { namespace: "query", ttl: 60000 },
+    ];
+
+    // More specific policy should win because it appears first
+    const result = resolveTtlForNamespace("query:tenant1", policies);
+    expect(result?.ttl).toBe(5000);
+  });
+
+  it("falls through to broader policy when specific does not match", () => {
+    const policies: CacheTtlPolicy[] = [
+      { namespace: "query:tenant1", ttl: 5000 },
+      { namespace: "query", ttl: 60000 },
+    ];
+
+    const result = resolveTtlForNamespace("query:tenant2", policies);
+    expect(result?.ttl).toBe(60000);
+  });
+
+  it("returns swrTtl only when defined in the policy", () => {
+    const result = resolveTtlForNamespace("perm", DEFAULT_TTL_POLICIES);
+    expect(result).toBeDefined();
+    expect(result?.ttl).toBe(10 * 60 * 1000);
+    expect(result?.swrTtl).toBeUndefined();
+  });
+
+  it("supports deeply nested namespace prefixes", () => {
+    const result = resolveTtlForNamespace("override:t1:entity:order", DEFAULT_TTL_POLICIES);
+    expect(result).toBeDefined();
+    expect(result?.ttl).toBe(5 * 60 * 1000);
+  });
+});
+
+// ── DEFAULT_TTL_POLICIES ────────────────────────────────────
+
+describe("DEFAULT_TTL_POLICIES", () => {
+  it("contains override policy with 5min TTL + 1min SWR", () => {
+    const override = DEFAULT_TTL_POLICIES.find((p) => p.namespace === "override");
+    expect(override).toBeDefined();
+    expect(override?.ttl).toBe(300_000);
+    expect(override?.swrTtl).toBe(60_000);
+  });
+
+  it("contains perm policy with 10min TTL", () => {
+    const perm = DEFAULT_TTL_POLICIES.find((p) => p.namespace === "perm");
+    expect(perm).toBeDefined();
+    expect(perm?.ttl).toBe(600_000);
+    expect(perm?.swrTtl).toBeUndefined();
+  });
+
+  it("contains query policy with 1min TTL", () => {
+    const query = DEFAULT_TTL_POLICIES.find((p) => p.namespace === "query");
+    expect(query).toBeDefined();
+    expect(query?.ttl).toBe(60_000);
+    expect(query?.swrTtl).toBeUndefined();
+  });
+
+  it("has exactly 3 default policies", () => {
+    expect(DEFAULT_TTL_POLICIES).toHaveLength(3);
+  });
+});
+
+// ── CacheManager TTL policy integration ─────────────────────
+
+describe("CacheManager with ttlPolicies", () => {
+  function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  it("auto-applies TTL from policy when namespace matches", async () => {
+    const manager = new CacheManager({
+      ttlPolicies: [{ namespace: "query", ttl: 50 }],
+    });
+
+    const ns = manager.namespace("query");
+    ns.set("key1", "value");
+
+    expect(ns.get("key1")).toBe("value");
+    await sleep(80);
+    expect(ns.get("key1")).toBeUndefined();
+  });
+
+  it("does not apply TTL policy when explicit TTL is provided", async () => {
+    const manager = new CacheManager({
+      ttlPolicies: [{ namespace: "query", ttl: 50 }],
+    });
+
+    const ns = manager.namespace("query");
+    ns.set("key1", "value", { ttl: 300 });
+
+    await sleep(80);
+    // Explicit TTL of 300ms should keep value alive
+    expect(ns.get("key1")).toBe("value");
+  });
+
+  it("auto-applies SWR from policy", async () => {
+    const manager = new CacheManager({
+      ttlPolicies: [{ namespace: "override", ttl: 40, swrTtl: 200 }],
+    });
+
+    const ns = manager.namespace("override");
+    ns.set("key1", "value");
+
+    // Before soft expiry
+    const before = ns.getWithStaleness("key1");
+    expect(before?.value).toBe("value");
+    expect(before?.isStale).toBe(false);
+
+    // After soft expiry, within SWR window
+    await sleep(60);
+    const stale = ns.getWithStaleness("key1");
+    expect(stale?.value).toBe("value");
+    expect(stale?.isStale).toBe(true);
+  });
+
+  it("explicit swrTtl in set() overrides policy swrTtl", async () => {
+    const manager = new CacheManager({
+      ttlPolicies: [{ namespace: "override", ttl: 40, swrTtl: 200 }],
+    });
+
+    const ns = manager.namespace("override");
+    // Provide explicit swrTtl of 10ms (overriding policy's 200ms)
+    ns.set("key1", "value", { swrTtl: 10 });
+
+    await sleep(60);
+    // Hard expiry at 40 + 10 = 50ms, so should be expired
+    expect(ns.get("key1")).toBeUndefined();
+  });
+
+  it("does not apply policy to namespaces that do not match", async () => {
+    const manager = new CacheManager({
+      ttlPolicies: [{ namespace: "query", ttl: 50 }],
+    });
+
+    const ns = manager.namespace("other");
+    ns.set("key1", "value");
+
+    await sleep(80);
+    // No TTL policy matched, so value should still be alive
+    expect(ns.get("key1")).toBe("value");
+  });
+
+  it("applies policy to tenant-prefixed namespaces", async () => {
+    const manager = new CacheManager({
+      ttlPolicies: [{ namespace: "perm", ttl: 50 }],
+    });
+
+    const ns = manager.namespace("perm:tenant1");
+    ns.set("actions", ["read", "write"]);
+
+    expect(ns.get("actions")).toEqual(["read", "write"]);
+    await sleep(80);
+    expect(ns.get("actions")).toBeUndefined();
+  });
+
+  it("preserves tags when auto-applying TTL policy", () => {
+    const manager = new CacheManager({
+      ttlPolicies: [{ namespace: "query", ttl: 60000 }],
+    });
+
+    const ns = manager.namespace("query");
+    ns.set("key1", "value", { tags: ["entity:orders"] });
+
+    // Tag-based invalidation should still work
+    const count = manager.invalidateByTag("entity:orders");
+    expect(count).toBe(1);
+    expect(ns.get("key1")).toBeUndefined();
+  });
+});

--- a/packages/core/src/cache/cache-manager.ts
+++ b/packages/core/src/cache/cache-manager.ts
@@ -13,6 +13,8 @@ import type { EventRecord } from "../types/event";
 import type { Logger } from "../types/logger";
 import type { CacheProvider, CacheSetOptions, CacheStats } from "./cache-provider";
 import type { CacheManagerStats, CacheManagerStatsOptions } from "./cache-stats";
+import type { CacheTtlPolicy } from "./cache-ttl-policy";
+import { resolveTtlForNamespace } from "./cache-ttl-policy";
 import { InMemoryCacheProvider } from "./in-memory-cache";
 
 // ── Configuration ─────────────────────────────────────────
@@ -28,6 +30,8 @@ export interface CacheManagerOptions {
   logger?: Logger;
   /** Default TTL in ms when none is specified on set(). Undefined = no default TTL. */
   defaultTtl?: number;
+  /** Per-namespace TTL policies. Auto-applied when set() has no explicit TTL. */
+  ttlPolicies?: CacheTtlPolicy[];
 }
 
 // ── Namespace handle ──────────────────────────────────────
@@ -67,12 +71,14 @@ export class CacheManager {
   private l2: CacheProvider | undefined;
   private logger: Logger | undefined;
   private defaultTtl: number | undefined;
+  private ttlPolicies: CacheTtlPolicy[];
 
   constructor(options?: CacheManagerOptions) {
     this.l1 = options?.l1 ?? new InMemoryCacheProvider();
     this.l2 = options?.l2;
     this.logger = options?.logger;
     this.defaultTtl = options?.defaultTtl;
+    this.ttlPolicies = options?.ttlPolicies ?? [];
 
     // Wire up event-driven invalidation
     if (options?.eventBus) {
@@ -191,6 +197,7 @@ export class CacheManager {
   namespace(ns: string): NamespacedCache {
     const prefix = `${ns}:`;
     const manager = this;
+    const resolvedPolicy = resolveTtlForNamespace(ns, this.ttlPolicies);
 
     return {
       get<T = unknown>(key: string): T | undefined {
@@ -200,7 +207,17 @@ export class CacheManager {
         return manager.getWithStaleness<T>(`${prefix}${key}`);
       },
       set<T = unknown>(key: string, value: T, options?: CacheSetOptions): void {
-        manager.set(`${prefix}${key}`, value, options);
+        // Auto-apply TTL policy when no explicit TTL is provided
+        if (resolvedPolicy && options?.ttl === undefined) {
+          const merged: CacheSetOptions = {
+            ...options,
+            ttl: resolvedPolicy.ttl,
+            swrTtl: options?.swrTtl ?? resolvedPolicy.swrTtl,
+          };
+          manager.set(`${prefix}${key}`, value, merged);
+        } else {
+          manager.set(`${prefix}${key}`, value, options);
+        }
       },
       delete(key: string): boolean {
         return manager.delete(`${prefix}${key}`);
@@ -212,6 +229,15 @@ export class CacheManager {
         return manager.invalidateByPrefix(prefix);
       },
     };
+  }
+
+  /**
+   * Create a tenant-scoped namespaced cache.
+   * Keys are prefixed with `{ns}:{tenantId}:` for tenant isolation.
+   * Convenience wrapper around `namespace()`.
+   */
+  tenantNamespace(ns: string, tenantId: string): NamespacedCache {
+    return this.namespace(`${ns}:${tenantId}`);
   }
 
   // ── Event-driven invalidation ───────────────────────────

--- a/packages/core/src/cache/cache-manager.ts
+++ b/packages/core/src/cache/cache-manager.ts
@@ -237,6 +237,12 @@ export class CacheManager {
    * Convenience wrapper around `namespace()`.
    */
   tenantNamespace(ns: string, tenantId: string): NamespacedCache {
+    if (ns.includes(":")) {
+      throw new Error(`Cache namespace must not contain ':' delimiter, got "${ns}"`);
+    }
+    if (tenantId.includes(":")) {
+      throw new Error(`Tenant ID must not contain ':' delimiter, got "${tenantId}"`);
+    }
     return this.namespace(`${ns}:${tenantId}`);
   }
 

--- a/packages/core/src/cache/cache-ttl-policy.ts
+++ b/packages/core/src/cache/cache-ttl-policy.ts
@@ -1,0 +1,67 @@
+/**
+ * CacheTtlPolicy — Per-namespace TTL configuration with optional SWR
+ *
+ * Allows declarative TTL assignment per cache namespace, matching the
+ * spec-defined defaults (override: 5min+1min SWR, perm: 10min, query: 1min).
+ *
+ * See spec: docs/specs/34_cache_strategy.md §3.2, §4, §5
+ */
+
+// ── Types ────────────────────────────────────────────────
+
+export interface CacheTtlPolicy {
+  /** Namespace this policy applies to (exact match or prefix match with trailing `:`) */
+  namespace: string;
+  /** Time-to-live in milliseconds */
+  ttl: number;
+  /** Stale-while-revalidate window in milliseconds. Requires `ttl`. */
+  swrTtl?: number;
+}
+
+// ── Resolved TTL result ──────────────────────────────────
+
+export interface ResolvedTtl {
+  ttl: number;
+  swrTtl?: number;
+}
+
+// ── Default policies from spec ───────────────────────────
+
+/**
+ * Default TTL policies derived from Spec 34:
+ * - `override` — Tenant overrides: 5 min TTL + 1 min SWR (§3.2)
+ * - `perm` — Permission decisions: 10 min TTL (§4)
+ * - `query` — GraphQL query results: 1 min TTL (§5)
+ */
+export const DEFAULT_TTL_POLICIES: CacheTtlPolicy[] = [
+  { namespace: "override", ttl: 5 * 60 * 1000, swrTtl: 1 * 60 * 1000 },
+  { namespace: "perm", ttl: 10 * 60 * 1000 },
+  { namespace: "query", ttl: 1 * 60 * 1000 },
+];
+
+// ── Resolution ───────────────────────────────────────────
+
+/**
+ * Find the TTL policy that matches a given namespace.
+ *
+ * Matching strategy (first match wins):
+ * 1. Exact match on namespace name
+ * 2. Prefix match — policy namespace is a prefix of the target (e.g. policy "query" matches "query:tenant1")
+ *
+ * Policies are checked in array order, so more specific entries should appear first
+ * if multiple policies could match the same namespace.
+ */
+export function resolveTtlForNamespace(
+  ns: string,
+  policies: CacheTtlPolicy[],
+): ResolvedTtl | undefined {
+  for (const policy of policies) {
+    if (ns === policy.namespace || ns.startsWith(`${policy.namespace}:`)) {
+      return {
+        ttl: policy.ttl,
+        swrTtl: policy.swrTtl,
+      };
+    }
+  }
+  return undefined;
+}

--- a/packages/core/src/cache/index.ts
+++ b/packages/core/src/cache/index.ts
@@ -8,6 +8,12 @@ export { type CacheHealthCheckOptions, createCacheHealthCheck } from "./cache-he
 export { CacheManager, type CacheManagerOptions, type NamespacedCache } from "./cache-manager";
 export type { CacheEntry, CacheProvider, CacheSetOptions, CacheStats } from "./cache-provider";
 export type { CacheManagerStats, CacheManagerStatsOptions } from "./cache-stats";
+export {
+  type CacheTtlPolicy,
+  DEFAULT_TTL_POLICIES,
+  type ResolvedTtl,
+  resolveTtlForNamespace,
+} from "./cache-ttl-policy";
 export { type InMemoryCacheOptions, InMemoryCacheProvider } from "./in-memory-cache";
 export {
   CACHE_INVALIDATION_CHANNEL,
@@ -15,3 +21,4 @@ export {
   PostgresCacheInvalidator,
   type PostgresCacheInvalidatorOptions,
 } from "./postgres-invalidator";
+export { createTenantNamespace } from "./tenant-cache";

--- a/packages/core/src/cache/tenant-cache.ts
+++ b/packages/core/src/cache/tenant-cache.ts
@@ -1,0 +1,29 @@
+/**
+ * Tenant-scoped cache namespace — prefixes keys with `{ns}:{tenantId}:`
+ *
+ * Wraps CacheManager.namespace() to provide tenant isolation for multi-tenant
+ * caching. Keys are automatically prefixed so different tenants never collide.
+ *
+ * See spec: docs/specs/34_cache_strategy.md §3.2, §4, §5
+ */
+
+import type { CacheManager, NamespacedCache } from "./cache-manager";
+
+/**
+ * Create a tenant-scoped namespaced cache.
+ *
+ * The resulting NamespacedCache prefixes all keys with `{namespace}:{tenantId}:`.
+ * For example, `createTenantNamespace(mgr, "query", "t1")` produces keys like
+ * `query:t1:orders:abc123`.
+ *
+ * This allows efficient tenant-level invalidation via `invalidateAll()`,
+ * which clears all keys with the `{namespace}:{tenantId}:` prefix.
+ */
+export function createTenantNamespace(
+  manager: CacheManager,
+  namespace: string,
+  tenantId: string,
+): NamespacedCache {
+  const tenantNs = `${namespace}:${tenantId}`;
+  return manager.namespace(tenantNs);
+}

--- a/packages/core/src/cache/tenant-cache.ts
+++ b/packages/core/src/cache/tenant-cache.ts
@@ -24,6 +24,12 @@ export function createTenantNamespace(
   namespace: string,
   tenantId: string,
 ): NamespacedCache {
+  if (namespace.includes(":")) {
+    throw new Error(`Cache namespace must not contain ':' delimiter, got "${namespace}"`);
+  }
+  if (tenantId.includes(":")) {
+    throw new Error(`Tenant ID must not contain ':' delimiter, got "${tenantId}"`);
+  }
   const tenantNs = `${namespace}:${tenantId}`;
   return manager.namespace(tenantNs);
 }


### PR DESCRIPTION
## Summary
- Add `CacheTtlPolicy` with namespace-aware TTL resolution (exact + prefix match)
- Default policies per Spec 34: override 5min+1min SWR, perm 10min, query 1min
- `createTenantNamespace()` for tenant-isolated cache keys (`{ns}:{tenantId}:` prefix)
- `CacheManager.tenantNamespace()` convenience method
- Auto-apply TTL policies in `namespace().set()` when no explicit TTL provided

## Test plan
- [x] 20 TTL policy tests (resolution, defaults, CacheManager integration)
- [x] 14 tenant cache tests (isolation, scoped invalidation, tags)
- [x] 38 existing cache tests pass (no regressions)

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable TTL policies for per-namespace cache expiration management
  * Added tenant-scoped cache namespacing for isolated data storage across tenants
  * Added Stale-While-Revalidate support for serving stale cached data during updates
  * Added convenience methods for managing tenant-specific cache entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->