### PR TITLE
docs: update INDEX.md — add specs 64/65, update spec 45

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,20 @@ After merging:
 1. **Update `docs/specs/INDEX.md`** — If a spec's implementation status changed
 2. **Add changeset** — If npm-published code changed: `bunx changeset`
 3. **Close related GitHub issues** — `gh issue close <number>`
+4. **Clean up local branches** — Delete the merged feature branch: `git branch -d <branch>`
+5. **Clean up worktrees** — If subagents were used, remove worktrees and their branches:
+   ```bash
+   git worktree remove .claude/worktrees/<agent-id>
+   git branch -D worktree-agent-<id>
+   ```
+6. **Prune remote tracking** — `git remote prune origin` to clean stale remote refs
+
+### Hygiene Rules
+
+- **Never leave worktrees after task completion** — Remove worktrees as soon as files are copied and committed. Do not accumulate across sessions.
+- **Never leave local branches after PR merge** — Delete immediately in Phase 6.
+- **Session start cleanup** — If stale worktrees or branches exist from prior sessions, clean them before starting new work.
+- **New issues must have a priority label** — Use P0-P3 from the issue template.
 
 ---
 

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -1,6 +1,6 @@
 # LinchKit Spec Index
 
-> 67 specs grouped by domain. Format: `[number] Title — one-line summary (milestone, status)`.
+> 69 specs grouped by domain. Format: `[number] Title — one-line summary (milestone, status)`.
 > **Status legend**: `Done` = implemented and tested, `Partial` = core done / details pending, `Draft` = spec only, not implemented, `Deprecated` = superseded by newer spec.
 > **How to use**: Scan this index to locate relevant specs. Read specs on-demand by domain — do not read them all at once.
 
@@ -201,8 +201,8 @@ Capability definition, extension, composition, and distribution.
 |--------|-------|
 | Done | 48 |
 | Partial | 11 |
-| Draft | 9 |
-| **Total** | **68** unique specs |
+| Draft | 10 |
+| **Total** | **69** unique specs |
 
 ### Change Log
 

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -30,6 +30,7 @@ LinchKit's 9 first-class building blocks.
 | [47](./47_schema_interface.md) | Entity Interface | InterfaceRegistry + `implements` — reusable field contracts, compliance checks | M2 | Done |
 | [48](./48_derived_properties.md) | Derived Properties | `derived` config for computed fields, evaluated at query time | M2 | Done |
 | [49](./49_schema_inheritance.md) | Entity Inheritance | Single-parent `extends`, field/Action/Rule/State inheritance chain | M2 | Done |
+| [64](./64_entity_onchange.md) | Entity Onchange | Server-side form computation — interactive pre-save field updates via `onchange` hooks on Entity | M5 | Draft |
 
 ## Meta-Model — Life System
 
@@ -52,8 +53,9 @@ How the meta-model executes at runtime.
 | [26](./26_transaction_model.md) | Transaction Model | Action-level transactions, Flow-level Saga pattern, compensation | M1 | Partial |
 | [32](./32_state_machine_implementation.md) | State Machine Impl | Transition validation, guard evaluation, auto-transitions, history records | M0 | Done |
 | [39](./39_execution_contract.md) | Execution Contract | Input/output contracts, execution lifecycle, idempotency, parent-child executions | M0 | Done |
+| [65](./65_execution_context.md) | Execution Context | `ExecutionMeta` — immutable metadata propagation through Action→EventHandler→nested Action chain | M5 | Draft |
 | [40](./40_rule_execute_action_boundary.md) | Rule-Action Boundary | When rules trigger Actions vs passive checks | M1 | Done |
-| [45](./45_reactive_automation.md) | Reactive Automation | AutomationEngine + TriggerBinding — event/fieldChange/stateChange/schedule/flowCompleted triggers | M3 | Done |
+| [45](./45_reactive_automation.md) | Reactive Automation | `defineWatcher()` — data-condition triggers (threshold/staleness/set_change/schedule). AutomationEngine removed, merged into EventHandler. | M3 | Partial |
 | [59](./59_runtime_overlay.md) | Runtime Overlay | Additive runtime entity changes (field add, enum extend) via ProposalEngine, promotion to code | M3 | Done |
 
 ## Capability System
@@ -176,8 +178,8 @@ Capability definition, extension, composition, and distribution.
 | What you want to do | Specs to read |
 |---------------------|---------------|
 | Develop a new Capability | 01, 20, 42, 39, 04, 57 |
-| Entity/field changes | 03, 46, 47, 48, 49, 59 |
-| Rules & automation | 05, 23, 40, 45 |
+| Entity/field changes | 03, 46, 47, 48, 49, 59, 64 |
+| Rules & automation | 05, 23, 40, 45, 65 |
 | API/GraphQL changes | 16, 44 |
 | UI component development | 13, 54 |
 | AI features | 36, 15, 22, 27, 52, 60 |
@@ -197,14 +199,15 @@ Capability definition, extension, composition, and distribution.
 
 | Status | Count |
 |--------|-------|
-| Done | 49 |
-| Partial | 10 |
-| Draft | 7 |
-| **Total** | **66** unique specs |
+| Done | 48 |
+| Partial | 11 |
+| Draft | 9 |
+| **Total** | **68** unique specs |
 
 ### Change Log
 
 | Date | Change |
 |------|--------|
+| 2026-04-09 | Added specs 64 (Entity Onchange), 65 (Execution Context); updated spec 45 (AutomationEngine removed, Watcher remains) |
 | 2026-04-09 | Added spec 62 (AI Proposal Data Migration) |
 | 2026-04-08 | Full audit: aligned all statuses with codebase reality; added specs 59 & 60 |

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -55,7 +55,7 @@ How the meta-model executes at runtime.
 | [39](./39_execution_contract.md) | Execution Contract | Input/output contracts, execution lifecycle, idempotency, parent-child executions | M0 | Done |
 | [65](./65_execution_context.md) | Execution Context | `ExecutionMeta` — immutable metadata propagation through Action→EventHandler→nested Action chain | M5 | Draft |
 | [40](./40_rule_execute_action_boundary.md) | Rule-Action Boundary | When rules trigger Actions vs passive checks | M1 | Done |
-| [45](./45_reactive_automation.md) | Reactive Automation | `defineWatcher()` — data-condition triggers (threshold/staleness/set_change/schedule). AutomationEngine removed, merged into EventHandler. | M3 | Partial |
+| [45](./45_reactive_automation.md) | Reactive Automation | `defineWatcher()` — data-condition triggers (threshold/staleness/set_change/schedule). AutomationEngine removed; WatcherEngine evaluates conditions via EventBus and executes effects through CommandLayer. | M3 | Partial |
 | [59](./59_runtime_overlay.md) | Runtime Overlay | Additive runtime entity changes (field add, enum extend) via ProposalEngine, promotion to code | M3 | Done |
 
 ## Capability System


### PR DESCRIPTION
## Summary
- Add Spec 64 (Entity Onchange) to Meta-Model — Skeleton section
- Add Spec 65 (Execution Context) to Runtime Engines section
- Update Spec 45 status: Done → Partial (AutomationEngine removed in #146, Watcher remains)
- Update quick lookup table and statistics (66 → 68 specs, Done 49→48, Draft 7→9)
- Add changelog entry

## Related
- #148 Entity onchange (Spec 64)
- #149 Execution context (Spec 65)
- #150 Spec 45 cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added two new specification documents: Entity Onchange and Execution Context (M5 Draft)
  * Updated spec index counts and revised status distribution; adjusted Reactive Automation entry to Partial
  * Enhanced development workflow docs with post-merge cleanup procedures and explicit branch/worktree hygiene rules, plus required priority labeling for new issues
<!-- end of auto-generated comment: release notes by coderabbit.ai -->