### PR TITLE
refactor: clean up old relation field type references (Spec 61)

### DIFF
--- a/addons/adapter-ui/cap-adapter-ui/__tests__/filter-columns.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/filter-columns.test.ts
@@ -62,9 +62,6 @@ describe("mapFieldType", () => {
   test("returns null for non-filterable types", () => {
     expect(mapFieldType("json")).toBeNull();
     expect(mapFieldType("computed")).toBeNull();
-    expect(mapFieldType("ref")).toBeNull();
-    expect(mapFieldType("has_many")).toBeNull();
-    expect(mapFieldType("many_to_many")).toBeNull();
     expect(mapFieldType("unknown")).toBeNull();
   });
 });

--- a/addons/adapter-ui/cap-adapter-ui/src/components/auto-form/types.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/auto-form/types.ts
@@ -45,7 +45,7 @@ export interface EnrichedSubmitData {
   values: Record<string, unknown>;
   /** Virtual ref records that need to be created first (field name -> virtual record) */
   virtualRefs: Record<string, VirtualRecord>;
-  /** Child record commands for has_many fields (field name -> commands) */
+  /** Child record commands for one_to_many relations (field name -> commands) */
   childCommands: Record<string, ChildCommand[]>;
 }
 

--- a/addons/adapter-ui/cap-adapter-ui/src/components/widgets/index.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/widgets/index.ts
@@ -118,7 +118,7 @@ export function registerDefaultWidgets() {
   // ── Relation widgets — resolved by cardinality from RelationRegistry (Spec 61) ──
   // IDs that share the same display/input components are registered in a loop.
 
-  // Legacy widget ID aliases — kept for backward compatibility with existing view definitions
+  // Single-reference widgets: many_to_one, one_to_one with legacy "ref" alias for backward compatibility
   for (const id of ["many_to_one", "one_to_one", "ref"] as const) {
     widgetRegistry.register({
       definition: { id, fieldTypes: "string", modes: ["display", "input"], isDefault: false },

--- a/addons/adapter-ui/cap-adapter-ui/src/components/widgets/index.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/widgets/index.ts
@@ -118,7 +118,7 @@ export function registerDefaultWidgets() {
   // ── Relation widgets — resolved by cardinality from RelationRegistry (Spec 61) ──
   // IDs that share the same display/input components are registered in a loop.
 
-  // Single-ref widgets: many_to_one, one_to_one, and backward-compatible "ref" alias
+  // Legacy widget ID aliases — kept for backward compatibility with existing view definitions
   for (const id of ["many_to_one", "one_to_one", "ref"] as const) {
     widgetRegistry.register({
       definition: { id, fieldTypes: "string", modes: ["display", "input"], isDefault: false },
@@ -127,7 +127,7 @@ export function registerDefaultWidgets() {
     });
   }
 
-  // Collection widgets: one_to_many and backward-compatible "has_many" alias
+  // Collection widgets: one_to_many with legacy "has_many" alias for backward compatibility
   for (const id of ["one_to_many", "has_many"] as const) {
     widgetRegistry.register({
       definition: { id, fieldTypes: "string", modes: ["display", "input"], isDefault: false },

--- a/addons/adapter-ui/cap-adapter-ui/src/components/widgets/relation-utils.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/widgets/relation-utils.ts
@@ -1,5 +1,5 @@
 /**
- * Shared utilities for relationship widgets (ref, has_many, many_to_many).
+ * Shared utilities for relationship widgets (many_to_one, one_to_one, one_to_many, many_to_many).
  */
 
 export interface RelatedRecord {

--- a/addons/demo/cap-purchase-demo/src/views/form.ts
+++ b/addons/demo/cap-purchase-demo/src/views/form.ts
@@ -5,7 +5,7 @@
  * - Layout with groups, notebooks, and pages
  * - Derived fields displayed as readonly
  * - State-dependent action visibility
- * - has_many child records in notebook tab
+ * - one_to_many child records in notebook tab
  */
 
 import type { ViewDefinition } from "@linchkit/core";

--- a/packages/cli/src/mcp-dev/prompts.ts
+++ b/packages/cli/src/mcp-dev/prompts.ts
@@ -92,10 +92,9 @@ Naming conventions:
 | date | Date only | min, max |
 | datetime | Date and time | min, max |
 | enum | Fixed set of values | options (required) |
-| ref | Reference to another entity | entity, required |
-| has_many | One-to-many relation | entity |
-| many_to_many | Many-to-many relation | entity |
 | json | Arbitrary JSON | — |
+
+> **Relationships** between entities are defined using \`defineRelation()\`, not field types. See Spec 46/61.
 
 ## System Fields (DO NOT define — auto-managed)
 id, tenant_id, created_at, updated_at, created_by, updated_by, _version


### PR DESCRIPTION
## Summary
- Remove deprecated `ref`/`has_many`/`many_to_many` field type references from MCP prompts, comments, and tests
- Add `defineRelation()` guidance note in MCP help table
- Keep backward-compatible widget ID aliases with updated documentation
- Remove dead test cases for non-existent field types

Closes #87

## Test plan
- [ ] `bun run check` passes (Biome lint/format)
- [ ] `bun run typecheck` passes
- [ ] `bun test` passes — filter-columns test still validates remaining field types
- [ ] MCP prompt help table no longer references old field types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified relationship field terminology and inline comments across the UI and demo views.
  * Updated guidance to emphasize using defineRelation() for declaring relationships.

* **Tests**
  * Removed redundant assertions related to relationship-type mapping in the test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->