### PR TITLE
refactor: remove AI service concrete exports from core (Spec 56)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/src/dev.ts
+++ b/addons/adapter-server/cap-adapter-server/src/dev.ts
@@ -161,6 +161,13 @@ const allActions: ActionDefinition[] = [...crudActions, ...capContributions.acti
 
 // ── Initialize runtime context ──────────────────────────
 
+// Build AI service from config (requires @linchkit/cap-ai-provider when AI is configured)
+let aiService: import("@linchkit/core").AIService | undefined;
+if (config.ai) {
+  const { createAIService } = await import("@linchkit/cap-ai-provider");
+  aiService = createAIService(config.ai);
+}
+
 // Build capability name set for ctx.hasCapability() weak dependency checks
 const capabilityNames = new Set((config.capabilities ?? []).map((c) => c.name));
 
@@ -170,7 +177,7 @@ const runtime = createRuntimeContext({
   states: capContributions.states,
   views: capContributions.views,
   middlewares: capContributions.middlewares,
-  ai: config.ai,
+  ai: aiService,
   capabilityNames,
 });
 

--- a/addons/adapter-server/cap-adapter-server/src/runtime-context.ts
+++ b/addons/adapter-server/cap-adapter-server/src/runtime-context.ts
@@ -12,7 +12,6 @@ import type {
   ActionDefinition,
   ActionExecutor,
   AIService,
-  AIServiceConfig,
   CommandLayer,
   DataProvider,
   EntityDefinition,
@@ -25,7 +24,6 @@ import type {
 } from "@linchkit/core";
 import {
   createActionExecutor,
-  createAIService,
   createCommandLayer,
   createInterfaceRegistry,
   createNoopAIService,
@@ -58,8 +56,8 @@ export interface RuntimeContextOptions {
   middlewares?: MiddlewareRegistration[];
   /** Interface definitions — registered before schemas so field injection/validation works */
   interfaces?: InterfaceDefinition[];
-  /** AI service configuration (optional — system works without it) */
-  ai?: AIServiceConfig;
+  /** Pre-constructed AI service (optional — defaults to noop). Use createAIService() from @linchkit/cap-ai-provider to build one. */
+  ai?: AIService;
   /** External data provider (e.g. DrizzleDataProvider). Falls back to InMemoryStore if not set. */
   dataProvider?: DataProvider;
   /** Event bus — PersistentEventBus when DB is available, plain EventBus otherwise */
@@ -106,8 +104,8 @@ export function createRuntimeContext(options?: RuntimeContextOptions): RuntimeCo
   const firstState = options?.states?.[0];
   const stateMachine = firstState ? createStateMachine(firstState) : undefined;
 
-  // Build AI service (optional — noop if not configured)
-  const ai = options?.ai ? createAIService(options.ai) : createNoopAIService();
+  // Use provided AI service or fall back to noop
+  const ai = options?.ai ?? createNoopAIService();
 
   const executor = createActionExecutor({
     dataProvider,

--- a/packages/core/src/ai/index.ts
+++ b/packages/core/src/ai/index.ts
@@ -31,14 +31,15 @@ export type {
   RateLimitWindow,
 } from "./ai-rate-limiter";
 export { AIRateLimiter } from "./ai-rate-limiter";
+// NOTE: createAIService and resolveLanguageModel moved to @linchkit/cap-ai-provider (Spec 56).
+// Core retains only config helpers and the noop fallback.
 export {
-  createAIService,
   createNoopAIService,
   defaultAIConfig,
-  resolveLanguageModel,
   resolveModel,
   resolveModelRoute,
   resolveTenantConfig,
+  validateConfig,
 } from "./ai-service";
 // Anomaly Detector
 export type {

--- a/packages/core/src/server-entry.ts
+++ b/packages/core/src/server-entry.ts
@@ -186,15 +186,16 @@ export {
 } from "./observability/trace-context";
 
 // === AI service ===
+// NOTE: createAIService and resolveLanguageModel moved to @linchkit/cap-ai-provider (Spec 56).
+// Core retains only config helpers and the noop fallback.
 
 export {
-  createAIService,
   createNoopAIService,
   defaultAIConfig,
-  resolveLanguageModel,
   resolveModel,
   resolveModelRoute,
   resolveTenantConfig,
+  validateConfig as validateAIConfig,
 } from "./ai/ai-service";
 
 // === AI Cost Estimator (server-only) ===


### PR DESCRIPTION
## Summary
- Remove `createAIService` and `resolveLanguageModel` from `@linchkit/core` public exports
- Update `createRuntimeContext` to accept pre-constructed `AIService` instead of `AIServiceConfig`
- Dev server dynamically imports `createAIService` from `@linchkit/cap-ai-provider`
- Core retains only interfaces, config helpers (`resolveModel`, `resolveTenantConfig`), and `createNoopAIService`

Verified: documentation/, methodology/, governance/ already in `@linchkit/devtools`; migration, flow-restate, ai-provider already in addons. Phase 1 extraction is complete.

Closes #77

## Test plan
- [ ] `bun run typecheck` passes
- [ ] `bun run check` passes
- [ ] `bun test` — AI service tests pass (25/25)
- [ ] Dev server starts correctly with AI config
- [ ] Dev server starts correctly without AI config (noop fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved AI service initialization by refactoring how the AI provider is loaded and configured during startup.
  * Reorganized AI-related exports to better separate configuration utilities from service implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->