### PR TITLE
refactor: slim CLAUDE.md, add workflow router and engine-dev skills

### DIFF
--- a/.claude/skills/linch-engine-dev/SKILL.md
+++ b/.claude/skills/linch-engine-dev/SKILL.md
@@ -62,7 +62,7 @@ export interface MyEngine {
 }
 
 export interface MyEngineOptions {
-  eventBus: EventBus;
+  signalBus: SignalBus;
   store: Store;
   // ... dependencies injected via options
 }
@@ -71,7 +71,7 @@ export interface MyEngineOptions {
 ```ts
 // engines/my-engine.ts
 export function createMyEngine(options: MyEngineOptions): MyEngine {
-  const { eventBus, store } = options;
+  const { signalBus, store } = options;
   // ... implementation
   return { process, dispose };
 }
@@ -81,7 +81,7 @@ export function createMyEngine(options: MyEngineOptions): MyEngine {
 
 | Integration | How |
 |-------------|-----|
-| **EventBus** | `eventBus.emit()` / `eventBus.on()` — engines never call each other directly |
+| **SignalBus** | `signalBus.emit()` / `signalBus.on()` — engines never call each other directly |
 | **Store** | Inject via options, use for persistence |
 | **CommandLayer** | If engine affects action execution, register as middleware |
 | **Config** | Use `defineConfigSchema()` for engine configuration |

--- a/.claude/skills/linch-engine-dev/SKILL.md
+++ b/.claude/skills/linch-engine-dev/SKILL.md
@@ -30,7 +30,7 @@ Core engines always have specs. Read the spec FIRST:
 
 All core engines follow the same pattern. Read an existing engine to understand:
 
-```
+```text
 packages/core/src/
 ├── engines/
 │   ├── action-engine.ts       # ActionEngine — createActionEngine()
@@ -93,14 +93,15 @@ Core engine tests go in `packages/core/src/__tests__/`:
 
 ```ts
 import { describe, expect, test } from "bun:test";
-import { createMyEngine } from "../engines/my-engine";
-import { createInMemoryStore, createEventBus } from "../test-helpers";
+import { createMyEngine } from "../../engines/my-engine";
+import { createSignalBus } from "../../life-system/signal-bus";
+import { InMemoryMemoryStore } from "../../life-system/in-memory-memory-store";
 
 describe("MyEngine", () => {
   test("processes input correctly", async () => {
-    const eventBus = createEventBus();
-    const store = createInMemoryStore();
-    const engine = createMyEngine({ eventBus, store });
+    const signalBus = createSignalBus();
+    const store = new InMemoryMemoryStore();
+    const engine = createMyEngine({ signalBus, store });
 
     const result = await engine.process({ ... });
     expect(result).toEqual({ ... });

--- a/.claude/skills/linch-engine-dev/SKILL.md
+++ b/.claude/skills/linch-engine-dev/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: "linch:engine-dev"
+description: "Core engine development: interface design, EventBus integration, test patterns, engine registration"
+---
+
+# Core Engine Development
+
+For building or modifying core runtime engines (life-system, rule engine, state machine, etc.).
+This is NOT for capability development — use `/linch-capability-dev` for that.
+
+## When to Use
+
+- Building new engines (e.g., AwarenessEngine, InsightEngine)
+- Modifying existing engines (ActionEngine, RuleEngine, StateMachine)
+- Adding core runtime features (new pipeline slots, new event types)
+- Life-system work (Sense, Memory, Awareness, Insight, Proposal)
+
+## Workflow
+
+### 1. Read the Spec
+
+Core engines always have specs. Read the spec FIRST:
+- Life system → Spec 55 (`docs/specs/55_evolution_system.md`)
+- Rule engine → Spec 23
+- State machine → Spec 32
+- Action/execution → Specs 04, 39
+- CommandLayer → Spec 16
+
+### 2. Study Existing Engine Patterns
+
+All core engines follow the same pattern. Read an existing engine to understand:
+
+```
+packages/core/src/
+├── engines/
+│   ├── action-engine.ts       # ActionEngine — createActionEngine()
+│   ├── rule-engine.ts         # RuleEngine — createRuleEngine()
+│   └── state-machine.ts       # StateMachine — createStateMachine()
+├── life-system/
+│   ├── signal-bus.ts          # SignalBus — event backbone
+│   ├── awareness-engine.ts    # AwarenessEngine — pattern detection
+│   ├── baseline-tracker.ts    # BaselineTracker — statistical baselines
+│   └── index.ts               # Public exports
+└── types/
+    ├── engine.ts              # Engine interfaces
+    └── life-system.ts         # Life-system types
+```
+
+### 3. Design the Interface First
+
+Every engine MUST have:
+- **A TypeScript interface** — in `packages/core/src/types/`
+- **A factory function** — `createXxxEngine(options): XxxEngine`
+- **No class inheritance** — use composition and factory functions
+- **EventBus integration** — engines communicate via events, not direct calls
+
+```ts
+// types/my-engine.ts
+export interface MyEngine {
+  process(input: MyInput): Promise<MyOutput>;
+  dispose(): void;
+}
+
+export interface MyEngineOptions {
+  eventBus: EventBus;
+  store: Store;
+  // ... dependencies injected via options
+}
+```
+
+```ts
+// engines/my-engine.ts
+export function createMyEngine(options: MyEngineOptions): MyEngine {
+  const { eventBus, store } = options;
+  // ... implementation
+  return { process, dispose };
+}
+```
+
+### 4. Integration Points
+
+| Integration | How |
+|-------------|-----|
+| **EventBus** | `eventBus.emit()` / `eventBus.on()` — engines never call each other directly |
+| **Store** | Inject via options, use for persistence |
+| **CommandLayer** | If engine affects action execution, register as middleware |
+| **Config** | Use `defineConfigSchema()` for engine configuration |
+| **Lifecycle** | Register in `server-entry.ts` for boot/shutdown |
+
+### 5. Testing
+
+Core engine tests go in `packages/core/src/__tests__/`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { createMyEngine } from "../engines/my-engine";
+import { createInMemoryStore, createEventBus } from "../test-helpers";
+
+describe("MyEngine", () => {
+  test("processes input correctly", async () => {
+    const eventBus = createEventBus();
+    const store = createInMemoryStore();
+    const engine = createMyEngine({ eventBus, store });
+
+    const result = await engine.process({ ... });
+    expect(result).toEqual({ ... });
+  });
+});
+```
+
+### 6. Core Boundary Check
+
+Before adding to core, verify:
+- "Without this, is a zero-capability LinchKit still AI-Native?"
+- If YES → this belongs in a capability, not core
+- If NO → core is correct
+
+Life-system engines (Sense, Memory, Awareness, Insight, Proposal) are always core — they make LinchKit AI-Native.
+
+## Checklist
+
+- [ ] Spec read and understood
+- [ ] TypeScript interface defined in `types/`
+- [ ] Factory function `createXxxEngine()` implemented
+- [ ] EventBus integration (no direct engine-to-engine calls)
+- [ ] Dependencies injected via options object
+- [ ] Tests in `__tests__/` with in-memory store
+- [ ] Registered in `server-entry.ts` if needed
+- [ ] File under 500 lines
+- [ ] All quality gates pass

--- a/.claude/skills/linch-workflow/SKILL.md
+++ b/.claude/skills/linch-workflow/SKILL.md
@@ -24,9 +24,10 @@ Read the user's request and classify:
 
 ## Step 2: Orient
 
-1. Read the related spec (`docs/specs/INDEX.md` → find spec → read it)
-2. If working from a GitHub issue: `gh issue view <number>`
-3. If touching existing code: Use Serena MCP (`get_symbols_overview`, `find_symbol`) for token-efficient code reading. Fall back to `Read` for non-code files only.
+1. **Check existing issues first** — `gh issue list --state open --limit 100` — look for duplicates, related issues, and blocking dependencies before creating new issues or starting work. Add "Blocked by #xxx" or "Related: #xxx" to issue bodies when relationships exist.
+2. Read the related spec (`docs/specs/INDEX.md` → find spec → read it)
+3. If working from a GitHub issue: `gh issue view <number>`
+4. If touching existing code: Use Serena MCP (`get_symbols_overview`, `find_symbol`) for token-efficient code reading. Fall back to `Read` for non-code files only.
 
 ## Step 3: Design First
 
@@ -94,7 +95,7 @@ When multiple independent issues can run simultaneously:
 ## MCP Tools Quick Reference
 
 **LinchKit MCP** (for entity/action/capability work):
-```
+```text
 ToolSearch("mcp__linchkit") → load tools
 list_entities / get_entity / list_actions / get_rules / get_state_machine
 scaffold_capability / scaffold_action / scaffold_rule
@@ -102,7 +103,7 @@ query (GraphQL)
 ```
 
 **Serena MCP** (for token-efficient code reading):
-```
+```text
 get_symbols_overview — file structure (~90% fewer tokens than Read)
 find_symbol with include_body=true — read specific function/class
 find_referencing_symbols — find usages

--- a/.claude/skills/linch-workflow/SKILL.md
+++ b/.claude/skills/linch-workflow/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: "linch:workflow"
+description: "Master workflow router — invoke FIRST for every development task. Routes to correct sub-skill, enforces lifecycle phases, manages tools and PR process."
+---
+
+# LinchKit Development Workflow
+
+**Invoke this skill BEFORE any development work.** It determines the correct approach based on task type.
+
+## Step 1: Classify the Task
+
+Read the user's request and classify:
+
+| Type | Signal | Sub-skills to load | Use MCP tools? |
+|------|--------|-------------------|----------------|
+| **Capability dev** | New addon, defineEntity/Action/View | `/linch-capability-dev` + domain skills | YES — `ToolSearch("mcp__linchkit")` then `list_entities`, `get_entity` |
+| **Core engine dev** | New engine, runtime changes, life-system | `/linch-engine-dev` | NO — read specs + source code |
+| **Bug fix** | "fix", error report, failing test | `/test` | MAYBE — if entity-related |
+| **UI development** | View, form, component, widget | `/linch-view-design` | YES — `get_entity` for field info |
+| **Refactoring** | Rename, extract, reorganize | `/linch-architecture` | MAYBE |
+| **Docs / specs** | Write spec, update docs | None | NO |
+
+**After classifying:** Invoke the relevant sub-skill(s) using the `Skill` tool. Then proceed to Step 2.
+
+## Step 2: Orient
+
+1. Read the related spec (`docs/specs/INDEX.md` → find spec → read it)
+2. If working from a GitHub issue: `gh issue view <number>`
+3. If touching existing code: Use Serena MCP (`get_symbols_overview`, `find_symbol`) for token-efficient code reading. Fall back to `Read` for non-code files only.
+
+## Step 3: Design First
+
+1. **Data structures before logic** — Define types and interfaces first
+2. **Write tests alongside code** — Use `/test` skill. Not after.
+3. **Keep files under 500 lines** — Split by responsibility
+4. **Unrelated issues** — Don't fix in same PR. Create `gh issue create` to track.
+
+## Step 4: Verify
+
+All four quality gates MUST pass before committing:
+
+```bash
+linch validate        # Meta-model validation
+bun run check         # Biome lint + format
+bun run typecheck     # TypeScript strict check
+bun test              # Full test suite
+```
+
+## Step 5: PR & Review
+
+1. Create branch — `feat/xxx`, `fix/xxx`, `refactor/xxx`
+2. Push and create PR — `gh pr create`
+3. Wait for CI
+4. Read ALL review comments (CodeRabbit, Gemini, human)
+5. Fix every comment, reply explaining what changed, then resolve thread (NEVER dismiss)
+6. Merge only when: APPROVED + CI green
+
+**PR merge rules (no exceptions):**
+- NEVER `--admin` or `--auto` — blocked = not ready
+- NEVER merge with CHANGES_REQUESTED — wait for re-approval
+- NEVER dismiss review threads — reply + resolve
+- ALWAYS read ALL comments BEFORE merge attempt
+
+## Step 6: Close
+
+1. Update `docs/specs/INDEX.md` if spec status changed
+2. Add changeset if npm-published code changed: `bunx changeset`
+3. Close related issues: `gh issue close <number>`
+4. Delete merged branch: `git branch -d <branch>`
+5. Clean worktrees if used: `git worktree remove ...`
+6. Prune remote: `git remote prune origin`
+
+---
+
+## Parallel Subagent Dispatch
+
+When multiple independent issues can run simultaneously:
+
+1. **Orchestrator invokes Skills first** — Sub-skills only run in main agent. Load the skill, extract checklist/constraints, include them in the subagent prompt.
+2. **Subagents only write code** — Dispatch with `isolation: "worktree"`. No `git commit/push` or `gh pr create`.
+3. **Subagents use MCP tools** — Include in prompt: "Use `ToolSearch('mcp__linchkit')` to load MCP tools for entity/action discovery."
+4. **Worktree starts from main** — Don't `git checkout` other branches.
+5. **Orchestrator handles git** — Copy files from worktree via `cp`, commit, push, create PR.
+6. **No file overlap** — Parallel branches must not touch same files.
+7. **Bash `cd` persists** — Always `cd /absolute/path && git ...` in one call.
+
+## Hygiene
+
+- Never leave worktrees after task completion
+- Never leave local branches after PR merge
+- Session start: clean stale worktrees/branches from prior sessions
+- New issues must have a priority label (P0-P3)
+
+## MCP Tools Quick Reference
+
+**LinchKit MCP** (for entity/action/capability work):
+```
+ToolSearch("mcp__linchkit") → load tools
+list_entities / get_entity / list_actions / get_rules / get_state_machine
+scaffold_capability / scaffold_action / scaffold_rule
+query (GraphQL)
+```
+
+**Serena MCP** (for token-efficient code reading):
+```
+get_symbols_overview — file structure (~90% fewer tokens than Read)
+find_symbol with include_body=true — read specific function/class
+find_referencing_symbols — find usages
+search_for_pattern — regex search with scope
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,12 @@ Life system: **Sense + Memory + Awareness + Insight + Proposal** (Spec 55)
 - **Action as Sole Write Entry** — All mutations flow through Actions. GraphQL handles reads only.
 - **AI Never Modifies Production Directly** — All AI-driven changes go through Proposal → Validation → Approval.
 
+## Workflow Entry Point
+
+**All development tasks MUST begin by invoking `/linch-workflow`.** This skill routes to the correct sub-skill based on task type (capability dev, core engine, bug fix, UI, docs) and enforces the full development lifecycle. Do not skip this step.
+
+If a spec exists for the area you're touching → read the spec first. Specs: `docs/specs/INDEX.md`
+
 ## Tech Stack
 
 | Layer | Stack |
@@ -25,14 +31,8 @@ Life system: **Sense + Memory + Awareness + Insight + Proposal** (Spec 55)
 | GraphQL | graphql-yoga + graphql-js (code-first, NOT Pothos) |
 | ORM | Drizzle (PostgreSQL via drizzle-kit, InMemoryStore fallback) |
 | Frontend | React 19 + Vite |
-| Routing | TanStack Router |
 | UI | Shadcn + Radix + Lucide + Tailwind |
-| Table | TanStack Table |
-| Form | Zod validation (from EntityDefinition) |
-| Command Palette | cmdk |
-| i18n | react-i18next (en / zh-CN) |
-| Code quality | Biome (no ESLint / Prettier) |
-| Flow Engine | Restate (`@restatedev/restate-sdk` v1.11.1) — durable execution, dual-mode |
+| Flow Engine | Restate (`@restatedev/restate-sdk` v1.11.1) — durable execution |
 | Testing | bun test |
 
 ## Constraints (MUST follow)
@@ -49,110 +49,10 @@ Life system: **Sense + Memory + Awareness + Insight + Proposal** (Spec 55)
 - Sanitize all user inputs; parameterized queries only
 - System fields are server-managed, never client-settable
 - All API endpoints go through CommandLayer (permission slot never skipped)
-- Apply good design patterns and algorithms, but do not over-engineer
 - Files must not exceed 500 lines — split when approaching the limit
 - Verify third-party API usage with context7 before calling — training data may be stale
 
----
-
-## Development Workflow
-
-### Phase 1: Orient
-
-Every new session MUST begin by understanding current state:
-
-1. Read this file (CLAUDE.md) for conventions and constraints
-2. Read `docs/specs/INDEX.md` for spec status, tracking links, and relevant design docs
-3. Check GitHub milestones and issues for active execution truth
-4. Ask the user what to work on
-
-**Execution rule:** GitHub milestones and issues are the authoritative task tracker. Specs define target design and stable constraints. README is background only, not a task source.
-
-### Phase 2: Spec First
-
-Before writing any implementation code:
-
-1. **If a spec exists** for the area you're touching → read the spec first. Do not guess the design.
-2. **If no spec exists** for a new feature → write a minimal spec in `docs/specs/` before coding.
-3. **If the spec is outdated** → update the spec to match the intended design, then implement.
-
-Spec format: see existing specs in `docs/specs/` for the pattern.
-
-### Phase 3: Implement
-
-1. **Data structures first** — Design types and interfaces before writing logic
-2. **Follow relevant Skills** — Use `/linch-*` skills for guided development
-3. **Write tests alongside code** — Not after. Use `/test` skill.
-4. **Keep files under 500 lines** — Split by responsibility
-5. **Unrelated issues** — If you discover pre-existing bugs, lint errors, or tech debt unrelated to the current task: **do not fix them in the same PR**. Create a GitHub issue (`gh issue create`) to track them, then continue with the current task.
-
-### Phase 4: Verify
-
-All four quality gates MUST pass before committing:
-
-```bash
-linch validate        # Meta-model validation
-bun run check         # Biome lint + format
-bun run typecheck     # TypeScript strict check
-bun test              # Full test suite (3870+ tests)
-```
-
-### Phase 5: PR & Review
-
-1. **Create branch** — `feat/xxx`, `fix/xxx`, `refactor/xxx`
-2. **Push and create PR** — Use `gh pr create`
-3. **Wait for CI** — GitHub Actions runs all quality gates
-4. **Read review comments** — CodeRabbit and/or human reviewers
-5. **Fix and resolve** — Address every comment, push fixes
-6. **Reply to each comment** — Explain what was fixed, then **resolve** the thread (NEVER dismiss)
-7. **All comments resolved + CI green + APPROVED** → merge
-
-**PR merge rules (MANDATORY — no exceptions):**
-
-1. **NEVER use `--admin` or `--auto` flag** — If `gh pr merge` is blocked by policy, that means reviews are not done. WAIT.
-2. **NEVER merge with CHANGES_REQUESTED status** — Must wait for reviewers to re-approve after fixes. Request re-review explicitly if needed.
-3. **NEVER dismiss review threads** — Always reply explaining the fix, then resolve via GraphQL `resolveReviewThread`.
-4. **ALWAYS read ALL review comments BEFORE attempting merge** — Every single comment from CodeRabbit, Gemini, or human reviewers must be read, understood, and either fixed or explicitly replied to with reasoning.
-5. **Only merge when: review status = APPROVED + CI = green** — Both conditions must be true. No shortcuts.
-
-### Parallel Subagent Dispatch
-
-When multiple independent issues can be worked on simultaneously:
-
-1. **Subagents only write code** — Dispatch with `isolation: "worktree"`. Instruct agents to do file changes only, NOT `git commit/push` or `gh pr create`.
-2. **Worktree starts from `origin/HEAD` (main)** — Agents always work on a fresh branch from main. Do NOT instruct agents to `git checkout` another branch — they should make changes directly in their worktree.
-3. **Orchestrator handles git** — After agents complete, the orchestrator creates a feat branch, copies files from worktree via `cp`, commits, pushes, and creates PRs.
-4. **Bash `cd` persists** — Working directory carries over between Bash calls. Always use `cd /absolute/path && git ...` in a single Bash call. Never assume you're in the main repo.
-5. **No file overlap** — Ensure parallel branches don't modify the same files to avoid merge conflicts.
-6. **Retrieving worktree files** — Use `cp <worktree-path>/file <main-repo>/file`. Do NOT use `git checkout <worktree-path>` — worktree paths are not git refs.
-
-### Phase 6: Close
-
-After merging:
-
-1. **Update `docs/specs/INDEX.md`** — If a spec's implementation status changed
-2. **Add changeset** — If npm-published code changed: `bunx changeset`
-3. **Close related GitHub issues** — `gh issue close <number>`
-4. **Clean up local branches** — Delete the merged feature branch: `git branch -d <branch>`
-5. **Clean up worktrees** — If subagents were used, remove worktrees and their branches:
-   ```bash
-   git worktree remove .claude/worktrees/<agent-id>
-   git branch -D worktree-agent-<id>
-   ```
-6. **Prune remote tracking** — `git remote prune origin` to clean stale remote refs
-
-### Hygiene Rules
-
-- **Never leave worktrees after task completion** — Remove worktrees as soon as files are copied and committed. Do not accumulate across sessions.
-- **Never leave local branches after PR merge** — Delete immediately in Phase 6.
-- **Session start cleanup** — If stale worktrees or branches exist from prior sessions, clean them before starting new work.
-- **New issues must have a priority label** — Use P0-P3 from the issue template.
-
----
-
 ## Repository Structure
-
-This is the **core monorepo**. Official capabilities will migrate to a separate repo.
 
 ```
 packages/ (core infrastructure — compiled for npm):
@@ -160,74 +60,55 @@ packages/ (core infrastructure — compiled for npm):
   @linchkit/cli        — CLI launcher (citty)
   @linchkit/devtools   — Test utilities
 
-addons/ (capabilities — OCA model, will migrate to separate repo):
-  adapter-server/      — @linchkit/cap-adapter-server (Elysia + GraphQL + REST)
-  adapter-ui/          — @linchkit/cap-adapter-ui + @linchkit/ui-kit (React + Shadcn)
-  adapter-mcp/         — @linchkit/cap-adapter-mcp (MCP transport)
-  chatter/             — @linchkit/cap-chatter + @linchkit/cap-chatter-ui
-  auth/                — @linchkit/cap-auth + @linchkit/cap-auth-better-auth
-  permission/          — @linchkit/cap-permission
-  ai-provider/         — @linchkit/cap-ai-provider
-  flow-restate/        — @linchkit/cap-flow-restate
-  migration/           — @linchkit/cap-migration
-  demo/                — @linchkit/cap-purchase-demo (private)
+addons/ (capabilities — OCA model):
+  adapter-server/      — Elysia + GraphQL + REST
+  adapter-ui/          — React UI + Shadcn ui-kit
+  adapter-mcp/         — MCP transport
+  chatter/             — Record timeline (cap-chatter + cap-chatter-ui)
+  auth/                — Authentication (cap-auth + cap-auth-better-auth)
+  permission/          — RBAC (cap-permission)
+  ai-provider/         — AI providers (cap-ai-provider)
+  flow-restate/        — Restate workflows (cap-flow-restate)
+  migration/           — Data migration (cap-migration)
+  demo/                — Purchase demo (private)
 ```
 
-**Module boundaries:**
-- `core` MUST NOT import from any other package
-- `ui` MUST NOT import from `server` (communicates via HTTP/GraphQL only)
-- No circular dependencies between packages
-- Dependency flows one way: Capability → Core
+**Module boundaries:** `core` never imports from other packages. `ui` never imports from `server`. No circular deps. Dependency flows: Capability → Core.
 
-## Core Boundary Rules
-
-**CORE**: Engines + types + pipeline + life-system engines
-**CORE interface + CAPABILITY implementation**: Core defines abstract interfaces; capabilities provide concrete implementations
-**PURE CAPABILITY**: Everything else
-
-**Decision criterion:** "Without this, is a zero-capability LinchKit still AI-Native?" If yes → capability. If no → core.
-
----
+**Core boundary:** "Without this, is a zero-capability LinchKit still AI-Native?" Yes → capability. No → core.
 
 ## Dev Commands
 
 ```bash
-bun run dev:server                       # Server on :3001
-bun run dev:ui                           # UI on :3000, proxies API to :3001
-bun test                                 # Run all tests
-bun run check                            # Biome lint + format
-bun run typecheck                        # TypeScript check
-linch validate                           # Meta-model validation
-linch setup                              # Sync AI tool configs (skills, MCP)
-linch agents-md                          # Generate AGENTS.md for downstream projects
-linch doctor                             # Project health checks
-
-# Database management
-bun run db:generate                      # Generate migration SQL
-bun run db:migrate                       # Apply pending migrations
-bun run db:studio                        # Drizzle Studio GUI
+bun run dev:server    # Server on :3001
+bun run dev:ui        # UI on :3000, proxies API to :3001
+bun test              # Run all tests
+bun run check         # Biome lint + format
+bun run typecheck     # TypeScript check
+linch validate        # Meta-model validation
+linch setup           # Sync AI tool configs (skills, MCP)
+linch agents-md       # Generate AGENTS.md for downstream projects
 ```
 
 ## Meta-Model
 
-- **Entity** — Data structure definition (`defineEntity()`)
-- **Action** — Sole write entry point, named `verb_noun` (`defineAction()`)
-- **Rule** — Declarative conditions + effects (`defineRule()`)
-- **State** — Finite state machine per entity instance (`defineState()`)
-- **Event** — Domain events emitted by actions/state transitions (`defineEvent()`)
-- **EventHandler** — Sync/async reactions to events (`defineEventHandler()`)
-- **View** — UI rendering config (`defineView()`)
-- **Flow** — Multi-step durable workflows (`defineFlow()`)
-- **Relation** — First-class relationships between entities (`defineRelation()`)
+- **Entity** — `defineEntity()` — data structure definition
+- **Action** — `defineAction()` — sole write entry point, named `verb_noun`
+- **Rule** — `defineRule()` — declarative conditions + effects
+- **State** — `defineState()` — finite state machine per entity
+- **Event** — `defineEvent()` — domain events
+- **EventHandler** — `defineEventHandler()` — sync/async reactions
+- **View** — `defineView()` — UI rendering config
+- **Flow** — `defineFlow()` — multi-step durable workflows
+- **Relation** — `defineRelation()` — first-class entity relationships
 
 ## Key Architecture
 
-- **CommandLayer**: 7-slot middleware pipeline (`pre → auth → exposure → permission → tenant → pre-action → post-action`)
-- **REST**: `/api/entities`, `/api/actions/:name`, `/api/executions`, `/api/tenants`
-- **GraphQL**: `/graphql` — CRUD + action mutations + execution logs + SSE subscriptions
-- **OntologyRegistry**: Unified semantic layer — `describe()`, `listEntities()`, `searchEntities()`, `actionsFor()`, `relationsFor()`
-- **Flow Engine**: Restate dual-mode (with Restate = durable; without = SyncFlowEngine)
-- **Addon Architecture**: OCA-inspired grouping (Spec 57). `autoInstall: true` auto-activates when dependencies met.
+- **CommandLayer**: 7-slot middleware (`pre → auth → exposure → permission → tenant → pre-action → post-action`)
+- **REST**: `/api/entities`, `/api/actions/:name`, `/api/executions`
+- **GraphQL**: `/graphql` — CRUD + action mutations + SSE subscriptions
+- **OntologyRegistry**: Unified semantic layer — `describe()`, `listEntities()`, `actionsFor()`
+- **Addon Architecture**: OCA-inspired grouping (Spec 57). `autoInstall: true` auto-activates.
 
 ## Conventions
 
@@ -245,22 +126,6 @@ bun run db:studio                        # Drizzle Studio GUI
 - New dependencies without explicit approval
 - God objects beyond ~300 lines
 - `node`, `npx`, `npm` — always use `bun`, `bunx`
-
-## Specs
-
-Full specs in `docs/specs/` (66 files). Read `docs/specs/INDEX.md` to locate relevant specs.
-
-**Rule**: If you are making changes that touch a spec'd area, read the spec first.
-
-## Serena MCP — Token-Efficient Code Navigation
-
-Prefer Serena tools over `Read`/`Grep` to minimize token consumption:
-1. `get_symbols_overview` — Understand file structure (~90% fewer tokens than `Read`)
-2. `find_symbol` with `include_body=true` — Read only the specific function/class you need
-3. `find_referencing_symbols` — Find where a symbol is used
-4. `search_for_pattern` — Targeted regex search with scope control
-
-Fall back to `Read` only when reading non-code files or needing full file context.
 
 ## Gemini CLI Collaboration
 

--- a/packages/cli/src/templates/skill-templates.ts
+++ b/packages/cli/src/templates/skill-templates.ts
@@ -2,6 +2,8 @@
  * LinchKit skill file definitions for AI tool configuration
  */
 
+import { engineDevSkillContent, workflowSkillContent } from "./workflow-skill-templates.js";
+
 /** A single skill file definition */
 export interface SkillDefinition {
   /** Used as directory name for Claude Code (.claude/skills/<slug>/SKILL.md) */
@@ -14,6 +16,16 @@ export interface SkillDefinition {
 /** Returns the set of LinchKit skill files for AI tool configuration */
 export function linchkitSkills(): SkillDefinition[] {
   return [
+    {
+      slug: "linch-workflow",
+      filename: "workflow.md",
+      content: workflowSkillContent(),
+    },
+    {
+      slug: "linch-engine-dev",
+      filename: "engine-dev.md",
+      content: engineDevSkillContent(),
+    },
     {
       slug: "linch-capability-dev",
       filename: "capability-dev.md",
@@ -561,3 +573,6 @@ Before adding to core, ask: "Without this, is a zero-capability LinchKit still A
 - \`index.ts\` only re-exports, no implementation logic
 `;
 }
+
+// workflowSkillContent and engineDevSkillContent imported from ./workflow-skill-templates.ts
+// (kept separate to stay under 500-line limit)

--- a/packages/cli/src/templates/workflow-skill-templates.ts
+++ b/packages/cli/src/templates/workflow-skill-templates.ts
@@ -18,8 +18,10 @@ function readSkillFile(slug: string): string | null {
   try {
     const skillPath = resolve(import.meta.dir, "../../../../.claude/skills", slug, "SKILL.md");
     return readFileSync(skillPath, "utf-8");
-  } catch {
-    return null;
+  } catch (error) {
+    const e = error as NodeJS.ErrnoException;
+    if (e.code === "ENOENT") return null;
+    throw error;
   }
 }
 

--- a/packages/cli/src/templates/workflow-skill-templates.ts
+++ b/packages/cli/src/templates/workflow-skill-templates.ts
@@ -1,0 +1,134 @@
+/**
+ * Workflow and engine development skill templates
+ */
+
+export function workflowSkillContent(): string {
+  return `---
+name: "linch:workflow"
+description: "Master workflow router — invoke FIRST for every development task. Routes to correct sub-skill, enforces lifecycle phases, manages tools and PR process."
+---
+
+# LinchKit Development Workflow
+
+**Invoke this skill BEFORE any development work.** It determines the correct approach based on task type.
+
+## Step 1: Classify the Task
+
+| Type | Signal | Sub-skills to load | Use MCP tools? |
+|------|--------|-------------------|----------------|
+| **Capability dev** | New addon, defineEntity/Action/View | \`/linch-capability-dev\` + domain skills | YES — load MCP tools then \`list_entities\`, \`get_entity\` |
+| **Core engine dev** | New engine, runtime changes, life-system | \`/linch-engine-dev\` | NO — read specs + source code |
+| **Bug fix** | "fix", error report, failing test | \`/test\` | MAYBE — if entity-related |
+| **UI development** | View, form, component, widget | \`/linch-view-design\` | YES — \`get_entity\` for field info |
+| **Refactoring** | Rename, extract, reorganize | \`/linch-architecture\` | MAYBE |
+| **Docs / specs** | Write spec, update docs | None | NO |
+
+**After classifying:** Invoke the relevant sub-skill(s). Then proceed to Step 2.
+
+## Step 2: Orient
+
+1. Read the related spec (\`docs/specs/INDEX.md\` → find spec → read it)
+2. If working from a GitHub issue: \`gh issue view <number>\`
+3. If touching existing code: use semantic code reading tools for token-efficient navigation
+
+## Step 3: Design First
+
+1. **Data structures before logic** — Define types and interfaces first
+2. **Write tests alongside code** — Not after.
+3. **Keep files under 500 lines** — Split by responsibility
+4. **Unrelated issues** — Don't fix in same PR. Create issue to track.
+
+## Step 4: Verify
+
+All four quality gates MUST pass before committing:
+\`\`\`bash
+linch validate && bun run check && bun run typecheck && bun test
+\`\`\`
+
+## Step 5: PR & Review
+
+1. Create branch, push, create PR
+2. Read ALL review comments — fix every one, reply, resolve thread (NEVER dismiss)
+3. Merge only when: APPROVED + CI green
+4. NEVER use \`--admin\` or \`--auto\` flags
+
+## Step 6: Close
+
+1. Update \`docs/specs/INDEX.md\` if spec status changed
+2. Add changeset if npm code changed
+3. Close related issues, delete branch, clean worktrees
+
+## Parallel Subagent Dispatch
+
+1. Orchestrator invokes Skills first — include constraints in subagent prompt
+2. Subagents only write code — worktree isolation, no git/gh ops
+3. Orchestrator handles git — copy files, commit, push, create PR
+4. No file overlap between parallel branches
+`;
+}
+
+export function engineDevSkillContent(): string {
+  return `---
+name: "linch:engine-dev"
+description: "Core engine development: interface design, EventBus integration, test patterns, engine registration"
+---
+
+# Core Engine Development
+
+For building or modifying core runtime engines (life-system, rule engine, state machine, etc.).
+
+## When to Use
+
+- Building new engines (AwarenessEngine, InsightEngine, etc.)
+- Modifying existing engines (ActionEngine, RuleEngine, StateMachine)
+- Life-system work (Sense, Memory, Awareness, Insight, Proposal)
+
+## Workflow
+
+### 1. Read the Spec
+Core engines always have specs. Read the spec FIRST:
+- Life system → Spec 55
+- Rule engine → Spec 23
+- State machine → Spec 32
+- Action/execution → Specs 04, 39
+- CommandLayer → Spec 16
+
+### 2. Study Existing Engine Patterns
+\`\`\`
+packages/core/src/
+├── engines/           # ActionEngine, RuleEngine, StateMachine
+├── life-system/       # SignalBus, AwarenessEngine, BaselineTracker
+└── types/             # Engine interfaces, life-system types
+\`\`\`
+
+### 3. Design the Interface First
+Every engine MUST have:
+- A TypeScript interface in \`types/\`
+- A factory function \`createXxxEngine(options)\`
+- No class inheritance — use composition
+- EventBus integration — engines communicate via events
+
+### 4. Integration Points
+| Integration | How |
+|-------------|-----|
+| **EventBus** | \`eventBus.emit()\` / \`eventBus.on()\` — no direct engine calls |
+| **Store** | Inject via options |
+| **CommandLayer** | Register as middleware if needed |
+| **Lifecycle** | Register in \`server-entry.ts\` |
+
+### 5. Core Boundary Check
+"Without this, is a zero-capability LinchKit still AI-Native?"
+- YES → capability, not core
+- NO → core is correct
+
+## Checklist
+- [ ] Spec read and understood
+- [ ] TypeScript interface in \`types/\`
+- [ ] Factory function \`createXxxEngine()\`
+- [ ] EventBus integration
+- [ ] Dependencies injected via options
+- [ ] Tests with in-memory store
+- [ ] File under 500 lines
+- [ ] All quality gates pass
+`;
+}

--- a/packages/cli/src/templates/workflow-skill-templates.ts
+++ b/packages/cli/src/templates/workflow-skill-templates.ts
@@ -16,7 +16,7 @@ import { resolve } from "node:path";
  */
 function readSkillFile(slug: string): string | null {
   try {
-    const skillPath = resolve(import.meta.dir, "../../../../.claude/skills", slug, "SKILL.md");
+    const skillPath = resolve(process.cwd(), ".claude/skills", slug, "SKILL.md");
     return readFileSync(skillPath, "utf-8");
   } catch (error) {
     const e = error as NodeJS.ErrnoException;

--- a/packages/cli/src/templates/workflow-skill-templates.ts
+++ b/packages/cli/src/templates/workflow-skill-templates.ts
@@ -1,9 +1,32 @@
 /**
- * Workflow and engine development skill templates
+ * Workflow and engine development skill templates.
+ *
+ * These MUST stay in sync with the actual SKILL.md files:
+ *   .claude/skills/linch-workflow/SKILL.md
+ *   .claude/skills/linch-engine-dev/SKILL.md
  */
 
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Read a SKILL.md file from the .claude/skills directory.
+ * Falls back to inline content if the file doesn't exist (e.g. when used
+ * from a downstream project that hasn't run `linch setup` yet).
+ */
+function readSkillFile(slug: string): string | null {
+  try {
+    const skillPath = resolve(import.meta.dir, "../../../../.claude/skills", slug, "SKILL.md");
+    return readFileSync(skillPath, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
 export function workflowSkillContent(): string {
-  return `---
+  return (
+    readSkillFile("linch-workflow") ??
+    `---
 name: "linch:workflow"
 description: "Master workflow router — invoke FIRST for every development task. Routes to correct sub-skill, enforces lifecycle phases, manages tools and PR process."
 ---
@@ -14,61 +37,114 @@ description: "Master workflow router — invoke FIRST for every development task
 
 ## Step 1: Classify the Task
 
+Read the user's request and classify:
+
 | Type | Signal | Sub-skills to load | Use MCP tools? |
 |------|--------|-------------------|----------------|
-| **Capability dev** | New addon, defineEntity/Action/View | \`/linch-capability-dev\` + domain skills | YES — load MCP tools then \`list_entities\`, \`get_entity\` |
+| **Capability dev** | New addon, defineEntity/Action/View | \`/linch-capability-dev\` + domain skills | YES — \`ToolSearch("mcp__linchkit")\` then \`list_entities\`, \`get_entity\` |
 | **Core engine dev** | New engine, runtime changes, life-system | \`/linch-engine-dev\` | NO — read specs + source code |
 | **Bug fix** | "fix", error report, failing test | \`/test\` | MAYBE — if entity-related |
 | **UI development** | View, form, component, widget | \`/linch-view-design\` | YES — \`get_entity\` for field info |
 | **Refactoring** | Rename, extract, reorganize | \`/linch-architecture\` | MAYBE |
 | **Docs / specs** | Write spec, update docs | None | NO |
 
-**After classifying:** Invoke the relevant sub-skill(s). Then proceed to Step 2.
+**After classifying:** Invoke the relevant sub-skill(s) using the \`Skill\` tool. Then proceed to Step 2.
 
 ## Step 2: Orient
 
-1. Read the related spec (\`docs/specs/INDEX.md\` → find spec → read it)
-2. If working from a GitHub issue: \`gh issue view <number>\`
-3. If touching existing code: use semantic code reading tools for token-efficient navigation
+1. **Check existing issues first** — \`gh issue list --state open --limit 100\` — look for duplicates, related issues, and blocking dependencies before creating new issues or starting work. Add "Blocked by #xxx" or "Related: #xxx" to issue bodies when relationships exist.
+2. Read the related spec (\`docs/specs/INDEX.md\` → find spec → read it)
+3. If working from a GitHub issue: \`gh issue view <number>\`
+4. If touching existing code: Use Serena MCP (\`get_symbols_overview\`, \`find_symbol\`) for token-efficient code reading. Fall back to \`Read\` for non-code files only.
 
 ## Step 3: Design First
 
 1. **Data structures before logic** — Define types and interfaces first
-2. **Write tests alongside code** — Not after.
+2. **Write tests alongside code** — Use \`/test\` skill. Not after.
 3. **Keep files under 500 lines** — Split by responsibility
-4. **Unrelated issues** — Don't fix in same PR. Create issue to track.
+4. **Unrelated issues** — Don't fix in same PR. Create \`gh issue create\` to track.
 
 ## Step 4: Verify
 
 All four quality gates MUST pass before committing:
+
 \`\`\`bash
-linch validate && bun run check && bun run typecheck && bun test
+linch validate        # Meta-model validation
+bun run check         # Biome lint + format
+bun run typecheck     # TypeScript strict check
+bun test              # Full test suite
 \`\`\`
 
 ## Step 5: PR & Review
 
-1. Create branch, push, create PR
-2. Read ALL review comments — fix every one, reply, resolve thread (NEVER dismiss)
-3. Merge only when: APPROVED + CI green
-4. NEVER use \`--admin\` or \`--auto\` flags
+1. Create branch — \`feat/xxx\`, \`fix/xxx\`, \`refactor/xxx\`
+2. Push and create PR — \`gh pr create\`
+3. Wait for CI
+4. Read ALL review comments (CodeRabbit, Gemini, human)
+5. Fix every comment, reply explaining what changed, then resolve thread (NEVER dismiss)
+6. Merge only when: APPROVED + CI green
+
+**PR merge rules (no exceptions):**
+- NEVER \`--admin\` or \`--auto\` — blocked = not ready
+- NEVER merge with CHANGES_REQUESTED — wait for re-approval
+- NEVER dismiss review threads — reply + resolve
+- ALWAYS read ALL comments BEFORE merge attempt
 
 ## Step 6: Close
 
 1. Update \`docs/specs/INDEX.md\` if spec status changed
-2. Add changeset if npm code changed
-3. Close related issues, delete branch, clean worktrees
+2. Add changeset if npm-published code changed: \`bunx changeset\`
+3. Close related issues: \`gh issue close <number>\`
+4. Delete merged branch: \`git branch -d <branch>\`
+5. Clean worktrees if used: \`git worktree remove ...\`
+6. Prune remote: \`git remote prune origin\`
+
+---
 
 ## Parallel Subagent Dispatch
 
-1. Orchestrator invokes Skills first — include constraints in subagent prompt
-2. Subagents only write code — worktree isolation, no git/gh ops
-3. Orchestrator handles git — copy files, commit, push, create PR
-4. No file overlap between parallel branches
-`;
+When multiple independent issues can run simultaneously:
+
+1. **Orchestrator invokes Skills first** — Sub-skills only run in main agent. Load the skill, extract checklist/constraints, include them in the subagent prompt.
+2. **Subagents only write code** — Dispatch with \`isolation: "worktree"\`. No \`git commit/push\` or \`gh pr create\`.
+3. **Subagents use MCP tools** — Include in prompt: "Use \`ToolSearch('mcp__linchkit')\` to load MCP tools for entity/action discovery."
+4. **Worktree starts from main** — Don't \`git checkout\` other branches.
+5. **Orchestrator handles git** — Copy files from worktree via \`cp\`, commit, push, create PR.
+6. **No file overlap** — Parallel branches must not touch same files.
+7. **Bash \`cd\` persists** — Always \`cd /absolute/path && git ...\` in one call.
+
+## Hygiene
+
+- Never leave worktrees after task completion
+- Never leave local branches after PR merge
+- Session start: clean stale worktrees/branches from prior sessions
+- New issues must have a priority label (P0-P3)
+
+## MCP Tools Quick Reference
+
+**LinchKit MCP** (for entity/action/capability work):
+\`\`\`text
+ToolSearch("mcp__linchkit") → load tools
+list_entities / get_entity / list_actions / get_rules / get_state_machine
+scaffold_capability / scaffold_action / scaffold_rule
+query (GraphQL)
+\`\`\`
+
+**Serena MCP** (for token-efficient code reading):
+\`\`\`text
+get_symbols_overview — file structure (~90% fewer tokens than Read)
+find_symbol with include_body=true — read specific function/class
+find_referencing_symbols — find usages
+search_for_pattern — regex search with scope
+\`\`\`
+`
+  );
 }
 
 export function engineDevSkillContent(): string {
-  return `---
+  return (
+    readSkillFile("linch-engine-dev") ??
+    `---
 name: "linch:engine-dev"
 description: "Core engine development: interface design, EventBus integration, test patterns, engine registration"
 ---
@@ -76,59 +152,129 @@ description: "Core engine development: interface design, EventBus integration, t
 # Core Engine Development
 
 For building or modifying core runtime engines (life-system, rule engine, state machine, etc.).
+This is NOT for capability development — use \`/linch-capability-dev\` for that.
 
 ## When to Use
 
-- Building new engines (AwarenessEngine, InsightEngine, etc.)
+- Building new engines (e.g., AwarenessEngine, InsightEngine)
 - Modifying existing engines (ActionEngine, RuleEngine, StateMachine)
+- Adding core runtime features (new pipeline slots, new event types)
 - Life-system work (Sense, Memory, Awareness, Insight, Proposal)
 
 ## Workflow
 
 ### 1. Read the Spec
+
 Core engines always have specs. Read the spec FIRST:
-- Life system → Spec 55
+- Life system → Spec 55 (\`docs/specs/55_evolution_system.md\`)
 - Rule engine → Spec 23
 - State machine → Spec 32
 - Action/execution → Specs 04, 39
 - CommandLayer → Spec 16
 
 ### 2. Study Existing Engine Patterns
-\`\`\`
+
+All core engines follow the same pattern. Read an existing engine to understand:
+
+\`\`\`text
 packages/core/src/
-├── engines/           # ActionEngine, RuleEngine, StateMachine
-├── life-system/       # SignalBus, AwarenessEngine, BaselineTracker
-└── types/             # Engine interfaces, life-system types
+├── engines/
+│   ├── action-engine.ts       # ActionEngine — createActionEngine()
+│   ├── rule-engine.ts         # RuleEngine — createRuleEngine()
+│   └── state-machine.ts       # StateMachine — createStateMachine()
+├── life-system/
+│   ├── signal-bus.ts          # SignalBus — event backbone
+│   ├── awareness-engine.ts    # AwarenessEngine — pattern detection
+│   ├── baseline-tracker.ts    # BaselineTracker — statistical baselines
+│   └── index.ts               # Public exports
+└── types/
+    ├── engine.ts              # Engine interfaces
+    └── life-system.ts         # Life-system types
 \`\`\`
 
 ### 3. Design the Interface First
+
 Every engine MUST have:
-- A TypeScript interface in \`types/\`
-- A factory function \`createXxxEngine(options)\`
-- No class inheritance — use composition
-- EventBus integration — engines communicate via events
+- **A TypeScript interface** — in \`packages/core/src/types/\`
+- **A factory function** — \`createXxxEngine(options): XxxEngine\`
+- **No class inheritance** — use composition and factory functions
+- **EventBus integration** — engines communicate via events, not direct calls
+
+\`\`\`ts
+// types/my-engine.ts
+export interface MyEngine {
+  process(input: MyInput): Promise<MyOutput>;
+  dispose(): void;
+}
+
+export interface MyEngineOptions {
+  eventBus: EventBus;
+  store: Store;
+  // ... dependencies injected via options
+}
+\`\`\`
+
+\`\`\`ts
+// engines/my-engine.ts
+export function createMyEngine(options: MyEngineOptions): MyEngine {
+  const { eventBus, store } = options;
+  // ... implementation
+  return { process, dispose };
+}
+\`\`\`
 
 ### 4. Integration Points
+
 | Integration | How |
 |-------------|-----|
-| **EventBus** | \`eventBus.emit()\` / \`eventBus.on()\` — no direct engine calls |
-| **Store** | Inject via options |
-| **CommandLayer** | Register as middleware if needed |
-| **Lifecycle** | Register in \`server-entry.ts\` |
+| **EventBus** | \`eventBus.emit()\` / \`eventBus.on()\` — engines never call each other directly |
+| **Store** | Inject via options, use for persistence |
+| **CommandLayer** | If engine affects action execution, register as middleware |
+| **Config** | Use \`defineConfigSchema()\` for engine configuration |
+| **Lifecycle** | Register in \`server-entry.ts\` for boot/shutdown |
 
-### 5. Core Boundary Check
-"Without this, is a zero-capability LinchKit still AI-Native?"
-- YES → capability, not core
-- NO → core is correct
+### 5. Testing
+
+Core engine tests go in \`packages/core/src/__tests__/\`:
+
+\`\`\`ts
+import { describe, expect, test } from "bun:test";
+import { createMyEngine } from "../../engines/my-engine";
+import { createSignalBus } from "../../life-system/signal-bus";
+import { InMemoryMemoryStore } from "../../life-system/in-memory-memory-store";
+
+describe("MyEngine", () => {
+  test("processes input correctly", async () => {
+    const signalBus = createSignalBus();
+    const store = new InMemoryMemoryStore();
+    const engine = createMyEngine({ signalBus, store });
+
+    const result = await engine.process({ ... });
+    expect(result).toEqual({ ... });
+  });
+});
+\`\`\`
+
+### 6. Core Boundary Check
+
+Before adding to core, verify:
+- "Without this, is a zero-capability LinchKit still AI-Native?"
+- If YES → this belongs in a capability, not core
+- If NO → core is correct
+
+Life-system engines (Sense, Memory, Awareness, Insight, Proposal) are always core — they make LinchKit AI-Native.
 
 ## Checklist
+
 - [ ] Spec read and understood
-- [ ] TypeScript interface in \`types/\`
-- [ ] Factory function \`createXxxEngine()\`
-- [ ] EventBus integration
-- [ ] Dependencies injected via options
-- [ ] Tests with in-memory store
+- [ ] TypeScript interface defined in \`types/\`
+- [ ] Factory function \`createXxxEngine()\` implemented
+- [ ] EventBus integration (no direct engine-to-engine calls)
+- [ ] Dependencies injected via options object
+- [ ] Tests in \`__tests__/\` with in-memory store
+- [ ] Registered in \`server-entry.ts\` if needed
 - [ ] File under 500 lines
 - [ ] All quality gates pass
-`;
+`
+  );
 }


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: 270 → 120 lines — removed all workflow/process content, kept only hard constraints and reference info
- **New `/linch-workflow` skill**: Master task router that classifies tasks (capability dev / core engine / bug fix / UI / docs) and routes to correct sub-skill. Includes full Phase 1-6 lifecycle, PR rules, subagent dispatch
- **New `/linch-engine-dev` skill**: Guide for core engine development (interface design, EventBus integration, factory pattern, core boundary check)
- **Generator updated**: `skill-templates.ts` now includes both new skills (11 → 13 total). `linch setup` syncs them to Claude Code, Cursor, Codex, Trae, Copilot

### Problem
CLAUDE.md was 270 lines mixing constraints with workflow/process instructions. Long docs get "diluted" — Claude skips workflow steps. Skills and MCP tools were never invoked despite being documented.

### Solution
Move all workflow/process content into a dedicated `/linch-workflow` skill that's explicitly invoked. CLAUDE.md now says one thing about workflow: "invoke `/linch-workflow` first". Skills get focused attention when loaded, unlike instructions buried in a 270-line file.

Also added `/linch-engine-dev` to fill the gap for core engine work (e.g., #81 Evolution System) where capability-focused skills don't apply.

## Test plan
- [x] CLI tests pass (204 tests, 0 failures)
- [x] Biome/typecheck errors are pre-existing only
- [ ] Start new Claude Code session and ask to implement a feature — verify `/linch-workflow` gets invoked
- [ ] Verify `linch setup` generates 13 skills (was 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a master development workflow guide covering task classification, spec-first design, quality gates, PR/review rules, parallel subagent guidance, and post-merge hygiene
  * Added an engine development guide with interface-first patterns, event-driven integration checklist, testing guidance, and core-boundary criteria
  * Updated main docs to reference the new workflow and simplified several architecture/convention descriptions
* **Chores**
  * Made the new workflow and engine-dev skill templates available via the CLI toolchain
<!-- end of auto-generated comment: release notes by coderabbit.ai -->