### PR TITLE
chore: add protect-main pre-commit hook and git workflow rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ linch agents-md       # Generate AGENTS.md for downstream projects
 - **Never commit directly to `main`.** The main worktree stays on `main` as a dispatch hub.
 - Single task: create a feature branch before making changes.
 - Parallel tasks: use `git worktree add` + separate terminal Claude Code sessions.
-- Branch naming: `fix/`, `feat/`, `refactor/`, `docs/` prefixes.
+- Branch naming: `fix/`, `feat/`, `refactor/`, `docs/`, `chore/` prefixes.
 - Pre-commit hook enforces this — commits to `main` will be rejected.
 
 ## Gemini CLI Collaboration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,14 @@ linch agents-md       # Generate AGENTS.md for downstream projects
 - God objects beyond ~300 lines
 - `node`, `npx`, `npm` — always use `bun`, `bunx`
 
+## Git Workflow
+
+- **Never commit directly to `main`.** The main worktree stays on `main` as a dispatch hub.
+- Single task: create a feature branch before making changes.
+- Parallel tasks: use `git worktree add` + separate terminal Claude Code sessions.
+- Branch naming: `fix/`, `feat/`, `refactor/`, `docs/` prefixes.
+- Pre-commit hook enforces this — commits to `main` will be rejected.
+
 ## Gemini CLI Collaboration
 
 When the user says "与Gemini商讨" or similar:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,7 +6,7 @@ pre-commit:
     biome-check:
       run: bunx @biomejs/biome check --staged --no-errors-on-unmatched
     typecheck:
-      glob: "*.{ts,tsx}"
+      glob: "**/*.{ts,tsx}"
       run: bun run typecheck
 
 commit-msg:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,9 +1,12 @@
 pre-commit:
   parallel: true
   commands:
+    protect-main:
+      run: '[ "$(git rev-parse --abbrev-ref HEAD)" != "main" ] || (echo "ERROR: Direct commits to main are forbidden. Create a feature branch first." && exit 1)'
     biome-check:
-      run: bunx @biomejs/biome check --staged
+      run: bunx @biomejs/biome check --staged --no-errors-on-unmatched
     typecheck:
+      glob: "*.{ts,tsx}"
       run: bun run typecheck
 
 commit-msg:


### PR DESCRIPTION
## Summary
- Add `protect-main` lefthook pre-commit hook to prevent direct commits to `main` branch
- Add `--no-errors-on-unmatched` flag to biome check so non-JS/TS file commits don't fail
- Add `glob: "*.{ts,tsx}"` filter to typecheck hook — only runs when TS files are staged
- Document branch workflow rules in `CLAUDE.md` for AI agent compliance

## Context
Previously lefthook was configured but not installed as a git hook (`pre-commit` file was missing). This PR:
1. Fixes the hook installation (ran `lefthook install --force`)
2. Adds branch protection as defense-in-depth alongside GitHub rulesets
3. Documents the worktree-based parallel development workflow

## Test plan
- [x] Verified `protect-main` blocks commits on `main` branch
- [x] Verified commits pass on feature branches
- [x] Verified biome doesn't fail on non-JS file commits
- [x] Verified typecheck skips when no TS files staged

> **Note:** Pre-existing TS2589 error in `packages/cli/src/mcp-dev/prompts.ts:32` (zod v3 + MCP SDK deep type inference) — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Git workflow guidelines outlining contribution rules, branch naming conventions, and parallel development practices.

* **Chores**
  * Added a pre-commit protection to block direct commits to main.
  * Adjusted linting/type-checking hooks to avoid false errors and scope checks to TypeScript files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->