### PR TITLE
fix: clean up misleading TS2589 comments in MCP dev tools

### DIFF
--- a/packages/cli/src/mcp-dev/discovery-tools.ts
+++ b/packages/cli/src/mcp-dev/discovery-tools.ts
@@ -9,8 +9,6 @@ import type { CollectedDefinitions } from "../commands/startup/collect-capabilit
 import { serializeFields, serializeRelation } from "./helpers";
 import { z } from "./schema";
 
-// Raw shape for registerTool inputSchema. Callback params must be
-// explicitly typed to prevent TS2589 from zod v3 deep type inference.
 const nameInputSchema = { name: z.string().describe("Entity or action name") };
 
 /** Register all discovery tools on the MCP server. */

--- a/packages/cli/src/mcp-dev/discovery-tools.ts
+++ b/packages/cli/src/mcp-dev/discovery-tools.ts
@@ -9,6 +9,7 @@ import type { CollectedDefinitions } from "../commands/startup/collect-capabilit
 import { serializeFields, serializeRelation } from "./helpers";
 import { z } from "./schema";
 
+// Raw shape for registerTool inputSchema.
 const nameInputSchema = { name: z.string().describe("Entity or action name") };
 
 /** Register all discovery tools on the MCP server. */

--- a/packages/cli/src/mcp-dev/prompts.ts
+++ b/packages/cli/src/mcp-dev/prompts.ts
@@ -7,8 +7,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CollectedDefinitions } from "../commands/startup/collect-capabilities";
 import { z } from "./schema";
 
-// Raw shapes for registerPrompt argsSchema. Callback params must be
-// explicitly typed to prevent TS2589 from zod v3 deep type inference.
+// Raw shapes for registerPrompt argsSchema.
 const nameSchema = { name: z.string().describe("Name parameter") };
 const entitySchema = { entity: z.string().describe("Target entity name") };
 const fromToSchema = {

--- a/packages/cli/src/mcp-dev/schema.ts
+++ b/packages/cli/src/mcp-dev/schema.ts
@@ -4,7 +4,7 @@
  * MCP SDK 1.x AnySchema = z3.ZodTypeAny | z4.$ZodType.
  * Only zod/v3 compat layer satisfies z3.ZodTypeAny.
  * zod/v4 classic and default exports don't satisfy either branch (SDK #796).
- * If TS2589 appears on registerPrompt/registerTool calls, see SDK #985.
+ * If TS2589 appears on registerPrompt/registerTool calls, try clearing your TS cache (see SDK #985).
  */
 
 export { z } from "zod/v3";

--- a/packages/cli/src/mcp-dev/schema.ts
+++ b/packages/cli/src/mcp-dev/schema.ts
@@ -1,13 +1,10 @@
 /**
  * Zod re-export for MCP SDK compatibility.
  *
- * MCP SDK's AnySchema = z3.ZodTypeAny | z4.$ZodType.
- * zod/v4 classic wrappers don't satisfy z4.$ZodType (SDK issue #796).
- * zod/v3 compat layer satisfies z3.ZodTypeAny cleanly.
- *
- * When using registerTool/registerPrompt with inputSchema/argsSchema,
- * always annotate callback parameters explicitly to avoid TS2589
- * from zod v3's deeply recursive type inference.
+ * MCP SDK 1.x AnySchema = z3.ZodTypeAny | z4.$ZodType.
+ * Only zod/v3 compat layer satisfies z3.ZodTypeAny.
+ * zod/v4 classic and default exports don't satisfy either branch (SDK #796).
+ * If TS2589 appears on registerPrompt/registerTool calls, see SDK #985.
  */
 
 export { z } from "zod/v3";


### PR DESCRIPTION
## Summary
- Update `schema.ts` comment to accurately reference MCP SDK #796 and #985
- Remove incorrect "prevents TS2589" claims from schema variable comments in `prompts.ts` and `discovery-tools.ts`
- Typecheck passes cleanly — the TS2589 error was intermittent, likely triggered by stale TS cache during zod version experiments

## Context
Investigation found that MCP SDK 1.x has a known type compatibility gap:
- `zod/v3` compat layer → satisfies `z3.ZodTypeAny` ✓ (works)
- `zod/v4` classic → satisfies neither `z3.ZodTypeAny` nor `z4.$ZodType` (SDK #796)
- TS2589 can appear with `zod/v3` under certain cache states (SDK #985)

No functional changes — comments only.

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] All lefthook pre-commit hooks pass (biome, typecheck, conventional-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated inline docs clarifying MCP SDK 1.x schema compatibility with Zod v3/v4.
  * Simplified comments around prompt/tool callback typing; removed TS2589-specific guidance.
  * Replaced explicit callback-typing advice with a recommendation to clear the TypeScript cache if TS2589 appears.
  * Cleaned and consolidated developer-facing comments across CLI tooling documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->