### PR TITLE
fix: resolve pre-existing Biome lint errors (#163)

### DIFF
--- a/addons/adapter-mcp/cap-adapter-mcp/src/execution-log-tools.ts
+++ b/addons/adapter-mcp/cap-adapter-mcp/src/execution-log-tools.ts
@@ -83,7 +83,7 @@ export function registerExecutionLogTools(
             },
           ],
         };
-      } catch (err) {
+      } catch (_err) {
         return {
           content: [
             {
@@ -153,7 +153,7 @@ export function registerExecutionLogTools(
             },
           ],
         };
-      } catch (err) {
+      } catch (_err) {
         return {
           content: [
             {

--- a/addons/adapter-mcp/cap-adapter-mcp/src/proposal-tools.ts
+++ b/addons/adapter-mcp/cap-adapter-mcp/src/proposal-tools.ts
@@ -147,7 +147,7 @@ export function registerProposalTools(
             },
           ],
         };
-      } catch (err) {
+      } catch (_err) {
         return {
           content: [
             {
@@ -207,7 +207,7 @@ export function registerProposalTools(
             },
           ],
         };
-      } catch (err) {
+      } catch (_err) {
         return {
           content: [
             {
@@ -266,7 +266,7 @@ export function registerProposalTools(
             },
           ],
         };
-      } catch (err) {
+      } catch (_err) {
         return {
           content: [
             {

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/entity-form-actions.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/entity-form-actions.ts
@@ -241,6 +241,7 @@ export function useFormActions(opts: UseFormActionsOptions) {
       t,
       // biome-ignore lint/correctness/useExhaustiveDependencies: prepareMutationInput only depends on schema which is stable
       prepareMutationInput,
+      relationFkColumns.has,
     ],
   );
 

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/entity-form-actions.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/entity-form-actions.ts
@@ -9,7 +9,7 @@ import type { EntityDefinition } from "@linchkit/core/types";
 import { toast } from "@linchkit/ui-kit/components";
 import type { NavigateOptions } from "@tanstack/react-router";
 import type { TFunction } from "i18next";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import type { EnrichedSubmitData } from "../components/auto-form/types";
 import type { StateTransitionInfo } from "../components/status-bar";
 import type { ResolvedEntityBundle } from "../hooks/use-entity-bundle";
@@ -67,17 +67,20 @@ export function useFormActions(opts: UseFormActionsOptions) {
 
   // Build set of auto-generated FK column names from relations (e.g., "department_id")
   // These may not be in schema.fields but are valid mutation input fields.
-  const relationFkColumns = new Set<string>();
-  if (bundle?.relations && entityName) {
-    for (const rel of bundle.relations) {
-      if (
-        rel.from === entityName &&
-        (rel.cardinality === "many_to_one" || rel.cardinality === "one_to_one")
-      ) {
-        relationFkColumns.add(`${rel.fromName}_id`);
+  const relationFkColumns = useMemo(() => {
+    const fkSet = new Set<string>();
+    if (bundle?.relations && entityName) {
+      for (const rel of bundle.relations) {
+        if (
+          rel.from === entityName &&
+          (rel.cardinality === "many_to_one" || rel.cardinality === "one_to_one")
+        ) {
+          fkSet.add(`${rel.fromName}_id`);
+        }
       }
     }
-  }
+    return fkSet;
+  }, [bundle?.relations, entityName]);
 
   /** Prepare mutation input by stripping non-input fields. FK fields (string type) are passed through directly. */
   function prepareMutationInput(data: Record<string, unknown>): Record<string, unknown> {
@@ -239,9 +242,9 @@ export function useFormActions(opts: UseFormActionsOptions) {
       navigate,
       fetchRecord,
       t,
-      // biome-ignore lint/correctness/useExhaustiveDependencies: prepareMutationInput only depends on schema which is stable
+      // biome-ignore lint/correctness/useExhaustiveDependencies: prepareMutationInput depends on schema and relationFkColumns
       prepareMutationInput,
-      relationFkColumns.has,
+      relationFkColumns,
     ],
   );
 

--- a/packages/cli/__tests__/describe-relations.test.ts
+++ b/packages/cli/__tests__/describe-relations.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { defineRelation, type RelationDefinition } from "@linchkit/core";
+import { defineRelation } from "@linchkit/core";
 import {
   buildRelationsOverview,
   printRelationsOverview,

--- a/packages/core/__tests__/ai-context-masker.test.ts
+++ b/packages/core/__tests__/ai-context-masker.test.ts
@@ -140,7 +140,7 @@ describe("round-trip mask/unmask", () => {
     const { masked, session } = maskContext(original);
 
     // Simulate AI response that references the masked token
-    const aiResponse = `I will contact ${masked.match(/\[MASKED_EMAIL_\d+\]/)![0]} regarding the order.`;
+    const aiResponse = `I will contact ${masked.match(/\[MASKED_EMAIL_\d+\]/)?.[0]} regarding the order.`;
 
     const unmasked = unmaskContext(aiResponse, session);
     expect(unmasked).toContain("john@example.com");

--- a/packages/core/__tests__/ai-rate-limiter.test.ts
+++ b/packages/core/__tests__/ai-rate-limiter.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { AIRateLimiter } from "../src/ai/ai-rate-limiter";
 
 describe("AIRateLimiter", () => {
@@ -52,8 +52,8 @@ describe("AIRateLimiter", () => {
     const result = limiter.check(identity);
     expect(result.allowed).toBe(false);
     expect(result.retryAfterMs).toBeDefined();
-    expect(result.retryAfterMs!).toBeGreaterThan(0);
-    expect(result.retryAfterMs!).toBeLessThanOrEqual(10_000);
+    expect(result.retryAfterMs).toBeGreaterThan(0);
+    expect(result.retryAfterMs).toBeLessThanOrEqual(10_000);
   });
 
   // ── Per-user isolation ────────────────────────────────
@@ -183,8 +183,8 @@ describe("AIRateLimiter", () => {
     expect(stats.requestsPerWindow[0].count).toBe(2);
     expect(stats.requestsPerWindow[0].limit).toBe(10);
     expect(stats.tokensPerHour).toBeDefined();
-    expect(stats.tokensPerHour!.used).toBe(300);
-    expect(stats.tokensPerHour!.limit).toBe(5000);
+    expect(stats.tokensPerHour?.used).toBe(300);
+    expect(stats.tokensPerHour?.limit).toBe(5000);
   });
 
   // ── Reset ─────────────────────────────────────────────

--- a/packages/core/src/ai/ai-modification-rules.ts
+++ b/packages/core/src/ai/ai-modification-rules.ts
@@ -107,7 +107,7 @@ export class AIModificationRuleRegistry {
 
     // Try field-specific match first
     if (field) {
-      const fieldRule = entityRules.find((r) => r.fields !== undefined && r.fields.includes(field));
+      const fieldRule = entityRules.find((r) => r.fields?.includes(field));
       if (fieldRule) {
         return this.evaluateRule(fieldRule, level);
       }


### PR DESCRIPTION
## Summary
- Fix all 13 pre-existing Biome lint errors blocking clean `bun run check`
- Covers: useOptionalChain, noUnusedVariables, useExhaustiveDependencies, noUnusedImports, noNonNullAssertion across 7 files
- No behavior changes — lint-only fixes

Closes #163

## Test plan
- [x] `bun run check` — 0 errors
- [x] `bun run typecheck` — passes
- [x] `bun test` — 4177 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Form actions now correctly account for changes in foreign-key relations during submission.

* **Chores**
  * Improved code safety with optional chaining for nullable fields.
  * Simplified error handling to remove unused error variables.
  * Cleaned up unused imports.

* **Tests**
  * Made unit tests more robust by using safer property access and removing unused lifecycle hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->