### PR TITLE
feat: SSE Last-Event-ID reconnection replay (#136)

### DIFF
--- a/addons/adapter-mcp/cap-adapter-mcp/src/execution-log-tools.ts
+++ b/addons/adapter-mcp/cap-adapter-mcp/src/execution-log-tools.ts
@@ -83,7 +83,7 @@ export function registerExecutionLogTools(
             },
           ],
         };
-      } catch (err) {
+      } catch (_err) {
         return {
           content: [
             {
@@ -153,7 +153,7 @@ export function registerExecutionLogTools(
             },
           ],
         };
-      } catch (err) {
+      } catch (_err) {
         return {
           content: [
             {

--- a/addons/adapter-mcp/cap-adapter-mcp/src/proposal-tools.ts
+++ b/addons/adapter-mcp/cap-adapter-mcp/src/proposal-tools.ts
@@ -147,7 +147,7 @@ export function registerProposalTools(
             },
           ],
         };
-      } catch (err) {
+      } catch (_err) {
         return {
           content: [
             {
@@ -207,7 +207,7 @@ export function registerProposalTools(
             },
           ],
         };
-      } catch (err) {
+      } catch (_err) {
         return {
           content: [
             {
@@ -266,7 +266,7 @@ export function registerProposalTools(
             },
           ],
         };
-      } catch (err) {
+      } catch (_err) {
         return {
           content: [
             {

--- a/addons/adapter-server/cap-adapter-server/__tests__/subscription-manager.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/subscription-manager.test.ts
@@ -768,6 +768,185 @@ describe("SubscriptionManager", () => {
     });
   });
 
+  // ── Replay buffer (Last-Event-ID) ─────────────────────────
+
+  describe("replay buffer", () => {
+    test("stores recent events in replay buffer", async () => {
+      const mock = createMockConnection();
+      manager.addConnection({
+        userId: "user-1",
+        actor: { type: "user", id: "user-1", groups: [] },
+        filter: { entities: ["task"] },
+        push: mock.push,
+        close: mock.close,
+      });
+
+      await bus.emit(makeEventRecord({ entity: "task", recordId: "task-1" }));
+      await bus.emit(makeEventRecord({ entity: "task", recordId: "task-2" }));
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(manager.replayBufferSize).toBe(2);
+    });
+
+    test("replayFrom returns events after the given ID", async () => {
+      // Emit events that go into the replay buffer
+      const mock1 = createMockConnection();
+      manager.addConnection({
+        userId: "user-1",
+        actor: { type: "user", id: "user-1", groups: [] },
+        filter: { entities: ["task"] },
+        push: mock1.push,
+        close: mock1.close,
+      });
+
+      await bus.emit(makeEventRecord({ entity: "task", recordId: "task-1" }));
+      await bus.emit(makeEventRecord({ entity: "task", recordId: "task-2" }));
+      await bus.emit(makeEventRecord({ entity: "task", recordId: "task-3" }));
+      await new Promise((r) => setTimeout(r, 50));
+
+      // mock1 received all 3 events
+      expect(mock1.events.length).toBe(3);
+
+      // Now simulate a reconnect: new connection, replay from event ID "1" (first event)
+      const mock2 = createMockConnection();
+      const connId2 = manager.addConnection({
+        userId: "user-2",
+        actor: { type: "user", id: "user-2", groups: [] },
+        filter: { entities: ["task"] },
+        push: mock2.push,
+        close: mock2.close,
+      });
+
+      expect(connId2).not.toBeNull();
+      // Replay from event "1" — should get events 2 and 3
+      const replayed = manager.replayFrom("1", connId2 as string);
+      expect(replayed).toBe(2);
+      expect(mock2.events.length).toBe(2);
+    });
+
+    test("replayFrom respects connection entity filter", async () => {
+      const mock1 = createMockConnection();
+      manager.addConnection({
+        userId: "user-1",
+        actor: { type: "user", id: "user-1", groups: [] },
+        filter: { entities: [] }, // subscribe to all
+        push: mock1.push,
+        close: mock1.close,
+      });
+
+      // Emit events for different entities
+      await bus.emit(makeEventRecord({ entity: "task", recordId: "task-1" }));
+      await bus.emit(makeEventRecord({ entity: "order", recordId: "order-1" }));
+      await bus.emit(makeEventRecord({ entity: "task", recordId: "task-2" }));
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(manager.replayBufferSize).toBe(3);
+
+      // New connection only subscribes to "task"
+      const mock2 = createMockConnection();
+      const connId2 = manager.addConnection({
+        userId: "user-2",
+        actor: { type: "user", id: "user-2", groups: [] },
+        filter: { entities: ["task"] },
+        push: mock2.push,
+        close: mock2.close,
+      });
+
+      // Replay from event "1" — should only get task events (events 2=order skipped, 3=task)
+      const replayed = manager.replayFrom("1", connId2 as string);
+      expect(replayed).toBe(1); // Only task-2 (event "3"), order-1 (event "2") is filtered out
+      expect(mock2.events.length).toBe(1);
+      expect(mock2.events[0]?.entity).toBe("task");
+    });
+
+    test("ring buffer evicts oldest events when full", async () => {
+      // Create a manager with a small replay buffer
+      const smallManager = new SubscriptionManager(bus, {
+        heartbeatInterval: 0,
+        idleTimeout: 0,
+        maxConnectionsPerUser: 3,
+        maxBufferSize: 100,
+        maxReplayBufferSize: 3,
+      });
+      smallManager.start();
+
+      const mock = createMockConnection();
+      smallManager.addConnection({
+        userId: "user-1",
+        actor: { type: "user", id: "user-1", groups: [] },
+        filter: { entities: [] },
+        push: mock.push,
+        close: mock.close,
+      });
+
+      // Emit 5 events into a buffer of size 3
+      for (let i = 0; i < 5; i++) {
+        await bus.emit(makeEventRecord({ entity: "task", recordId: `task-${i}` }));
+      }
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Buffer should only contain the last 3 events
+      expect(smallManager.replayBufferSize).toBe(3);
+
+      // Reconnect and replay from a very old event ID ("1") — should replay all 3 buffered events
+      // Since event "1" was evicted, replayFrom falls back to replaying everything
+      const mock2 = createMockConnection();
+      const connId2 = smallManager.addConnection({
+        userId: "user-2",
+        actor: { type: "user", id: "user-2", groups: [] },
+        filter: { entities: [] },
+        push: mock2.push,
+        close: mock2.close,
+      });
+
+      const replayed = smallManager.replayFrom("1", connId2 as string);
+      expect(replayed).toBe(3); // All buffered events replayed since "1" was evicted
+
+      smallManager.stop();
+    });
+
+    test("stop() clears the replay buffer", async () => {
+      const mock = createMockConnection();
+      manager.addConnection({
+        userId: "user-1",
+        actor: { type: "user", id: "user-1", groups: [] },
+        filter: { entities: [] },
+        push: mock.push,
+        close: mock.close,
+      });
+
+      await bus.emit(makeEventRecord({ entity: "task" }));
+      await new Promise((r) => setTimeout(r, 50));
+      expect(manager.replayBufferSize).toBeGreaterThan(0);
+
+      manager.stop();
+      expect(manager.replayBufferSize).toBe(0);
+    });
+
+    test("replayFrom returns 0 for unknown connection ID", () => {
+      const replayed = manager.replayFrom("1", "nonexistent-conn");
+      expect(replayed).toBe(0);
+    });
+
+    test("events include eventId field after dispatch", async () => {
+      const mock = createMockConnection();
+      manager.addConnection({
+        userId: "user-1",
+        actor: { type: "user", id: "user-1", groups: [] },
+        filter: { entities: [] },
+        push: mock.push,
+        close: mock.close,
+      });
+
+      await bus.emit(makeEventRecord({ entity: "task", recordId: "task-1" }));
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(mock.events.length).toBe(1);
+      expect(mock.events[0]?.eventId).toBeDefined();
+      expect(typeof mock.events[0]?.eventId).toBe("string");
+    });
+  });
+
   // ── Dead connection close ──────────────────────────────────
 
   describe("dead connection cleanup", () => {

--- a/addons/adapter-server/cap-adapter-server/src/routes/subscription-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/subscription-api.ts
@@ -68,6 +68,12 @@ export function mountSubscriptionRoutes(app: Elysia, options: ServerOptions): vo
     const filter = parseSubscriptionQuery(query as Record<string, string | undefined>);
     filter.tenantId = tenantId;
 
+    // Check for Last-Event-ID: from header (standard SSE) or query param (fetch-based clients)
+    const lastEventId =
+      request.headers.get("last-event-id") ??
+      (query as Record<string, string | undefined>).lastEventId ??
+      null;
+
     // Set up SSE response via ReadableStream
     let connectionId: string | null = null;
 
@@ -77,8 +83,9 @@ export function mountSubscriptionRoutes(app: Elysia, options: ServerOptions): vo
 
         const push = (event: SubscriptionEvent | null): boolean => {
           try {
-            const eventId = subManager.nextEventId();
-            const text = formatSSEEvent(event, event ? eventId : undefined);
+            // Use the eventId stamped by SubscriptionManager on the event
+            const eventId = event?.eventId;
+            const text = formatSSEEvent(event, eventId);
             controller.enqueue(encoder.encode(text));
             return true;
           } catch {
@@ -118,6 +125,11 @@ export function mountSubscriptionRoutes(app: Elysia, options: ServerOptions): vo
         controller.enqueue(
           encoder.encode(`event: connected\ndata: ${JSON.stringify({ connectionId })}\n\n`),
         );
+
+        // Replay missed events if client sent Last-Event-ID
+        if (lastEventId && connectionId) {
+          subManager.replayFrom(lastEventId, connectionId);
+        }
       },
       cancel() {
         if (connectionId) {

--- a/addons/adapter-server/cap-adapter-server/src/subscription-manager.ts
+++ b/addons/adapter-server/cap-adapter-server/src/subscription-manager.ts
@@ -296,14 +296,15 @@ export class SubscriptionManager {
       }
     }
 
-    // Assign event ID and store in replay buffer
+    // Assign event ID directly and store in replay buffer
     const eventId = this.nextEventId();
+    subEvent.eventId = eventId;
     this.storeInReplayBuffer(eventId, subEvent);
 
     // Dispatch to all matching connections
     for (const conn of this.connections.values()) {
       if (this.matchesConnection(conn, subEvent)) {
-        this.pushToConnection(conn, subEvent, eventId);
+        this.pushToConnection(conn, subEvent);
       }
     }
   }
@@ -336,13 +337,8 @@ export class SubscriptionManager {
   }
 
   /** Push an event to a connection, handling backpressure */
-  private pushToConnection(conn: SSEConnection, event: SubscriptionEvent, eventId?: string): void {
+  private pushToConnection(conn: SSEConnection, event: SubscriptionEvent): void {
     conn.lastActivity = Date.now();
-
-    // Stamp event ID for SSE formatting if provided
-    if (eventId) {
-      event = { ...event, eventId };
-    }
 
     // Backpressure: drop if buffer is full
     if (conn.buffer.length >= this.config.maxBufferSize) {
@@ -369,6 +365,7 @@ export class SubscriptionManager {
 
   /** Store an event in the ring buffer, evicting oldest when full */
   private storeInReplayBuffer(id: string, event: SubscriptionEvent): void {
+    if (this.config.maxReplayBufferSize <= 0) return;
     if (this.recentEvents.length >= this.config.maxReplayBufferSize) {
       this.recentEvents.shift();
     }
@@ -393,7 +390,7 @@ export class SubscriptionManager {
       let count = 0;
       for (const entry of this.recentEvents) {
         if (this.matchesConnection(conn, entry.event)) {
-          this.pushToConnection(conn, entry.event, entry.id);
+          this.pushToConnection(conn, entry.event);
           count++;
         }
       }
@@ -405,7 +402,7 @@ export class SubscriptionManager {
     const eventsToReplay = this.recentEvents.slice(lastIdx + 1);
     for (const entry of eventsToReplay) {
       if (this.matchesConnection(conn, entry.event)) {
-        this.pushToConnection(conn, entry.event, entry.id);
+        this.pushToConnection(conn, entry.event);
         count++;
       }
     }

--- a/addons/adapter-server/cap-adapter-server/src/subscription-manager.ts
+++ b/addons/adapter-server/cap-adapter-server/src/subscription-manager.ts
@@ -37,6 +37,9 @@ export interface SubscriptionEvent {
   actor: { id: string; type: string };
   timestamp: string;
   executionId?: string;
+
+  /** Monotonic event ID for Last-Event-ID replay (set by SubscriptionManager) */
+  eventId?: string;
 }
 
 // ── Subscription filter ──────────────────────────────────────
@@ -74,6 +77,7 @@ const DEFAULT_CONFIG: Required<SubscriptionConfig> = {
   heartbeatInterval: 30_000,
   idleTimeout: 300_000,
   maxBufferSize: 100,
+  maxReplayBufferSize: 500,
 };
 
 // ── Event type mapping ───────────────────────────────────────
@@ -112,6 +116,9 @@ export class SubscriptionManager {
   private idleCheckTimer: ReturnType<typeof setInterval> | null = null;
   private eventBusUnsubscribers: Array<() => void> = [];
   private eventIdCounter = 0;
+
+  /** Ring buffer of recent events for Last-Event-ID replay on reconnection */
+  private recentEvents: Array<{ id: string; event: SubscriptionEvent }> = [];
 
   /** Optional callback to check if an actor can read a given schema */
   private canReadEntity?: (actor: Actor, entityName: string) => boolean;
@@ -161,6 +168,9 @@ export class SubscriptionManager {
       conn.close();
     }
     this.connections.clear();
+
+    // Clear replay buffer
+    this.recentEvents = [];
   }
 
   /**
@@ -286,10 +296,14 @@ export class SubscriptionManager {
       }
     }
 
+    // Assign event ID and store in replay buffer
+    const eventId = this.nextEventId();
+    this.storeInReplayBuffer(eventId, subEvent);
+
     // Dispatch to all matching connections
     for (const conn of this.connections.values()) {
       if (this.matchesConnection(conn, subEvent)) {
-        this.pushToConnection(conn, subEvent);
+        this.pushToConnection(conn, subEvent, eventId);
       }
     }
   }
@@ -322,8 +336,13 @@ export class SubscriptionManager {
   }
 
   /** Push an event to a connection, handling backpressure */
-  private pushToConnection(conn: SSEConnection, event: SubscriptionEvent): void {
+  private pushToConnection(conn: SSEConnection, event: SubscriptionEvent, eventId?: string): void {
     conn.lastActivity = Date.now();
+
+    // Stamp event ID for SSE formatting if provided
+    if (eventId) {
+      event = { ...event, eventId };
+    }
 
     // Backpressure: drop if buffer is full
     if (conn.buffer.length >= this.config.maxBufferSize) {
@@ -344,6 +363,58 @@ export class SubscriptionManager {
       conn.close();
       this.connections.delete(conn.id);
     }
+  }
+
+  // ── Replay buffer ───────────────────────────────────────
+
+  /** Store an event in the ring buffer, evicting oldest when full */
+  private storeInReplayBuffer(id: string, event: SubscriptionEvent): void {
+    if (this.recentEvents.length >= this.config.maxReplayBufferSize) {
+      this.recentEvents.shift();
+    }
+    this.recentEvents.push({ id, event });
+  }
+
+  /**
+   * Replay buffered events to a connection starting after lastEventId.
+   *
+   * Only events that match the connection's filter are replayed.
+   * Returns the number of events replayed.
+   */
+  replayFrom(lastEventId: string, connectionId: string): number {
+    const conn = this.connections.get(connectionId);
+    if (!conn) return 0;
+
+    // Find the index of the last event the client received
+    const lastIdx = this.recentEvents.findIndex((e) => e.id === lastEventId);
+    if (lastIdx === -1) {
+      // lastEventId not found in buffer — it may have been evicted.
+      // Replay everything in the buffer that matches the connection's filter.
+      let count = 0;
+      for (const entry of this.recentEvents) {
+        if (this.matchesConnection(conn, entry.event)) {
+          this.pushToConnection(conn, entry.event, entry.id);
+          count++;
+        }
+      }
+      return count;
+    }
+
+    // Replay events after lastIdx
+    let count = 0;
+    const eventsToReplay = this.recentEvents.slice(lastIdx + 1);
+    for (const entry of eventsToReplay) {
+      if (this.matchesConnection(conn, entry.event)) {
+        this.pushToConnection(conn, entry.event, entry.id);
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /** Get the current replay buffer size (for testing/diagnostics) */
+  get replayBufferSize(): number {
+    return this.recentEvents.length;
   }
 
   // ── Heartbeat ─────────────────────────────────────────────

--- a/addons/adapter-ui/cap-adapter-ui/src/hooks/use-subscription.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/hooks/use-subscription.ts
@@ -295,6 +295,8 @@ export function useEntitySubscription(
 
   const reconnectAttemptRef = useRef(0);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /** Track last received event ID for reconnection replay */
+  const lastEventIdRef = useRef<string | null>(null);
 
   const cleanup = useCallback(() => {
     if (reconnectTimerRef.current) {
@@ -322,6 +324,11 @@ export function useEntitySubscription(
         const params = new URLSearchParams();
         if (entitiesKey) params.set("entities", entitiesKey);
         if (idsKey) params.set("ids", idsKey);
+
+        // Send last event ID for reconnection replay
+        if (lastEventIdRef.current) {
+          params.set("lastEventId", lastEventIdRef.current);
+        }
 
         const url = `/api/subscribe?${params.toString()}`;
 
@@ -362,16 +369,24 @@ export function useEntitySubscription(
           buffer = lines.pop() ?? "";
 
           let currentEventType = "";
+          let currentEventId = "";
           let eventData = "";
 
           for (const line of lines) {
-            if (line.startsWith("event: ")) {
+            if (line.startsWith("id: ")) {
+              currentEventId = line.slice(4).trim();
+            } else if (line.startsWith("event: ")) {
               currentEventType = line.slice(7).trim();
             } else if (line.startsWith("data: ")) {
               eventData += line.slice(6);
             } else if (line.startsWith(":")) {
+              // SSE comment (e.g. keepalive) — ignore
             } else if (line === "" && eventData) {
-              // End of event
+              // End of event — track last event ID for reconnection
+              if (currentEventId) {
+                lastEventIdRef.current = currentEventId;
+              }
+
               try {
                 const parsed = JSON.parse(eventData);
 
@@ -390,6 +405,7 @@ export function useEntitySubscription(
               }
               eventData = "";
               currentEventType = "";
+              currentEventId = "";
             }
           }
         }

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/entity-form-actions.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/entity-form-actions.ts
@@ -241,6 +241,7 @@ export function useFormActions(opts: UseFormActionsOptions) {
       t,
       // biome-ignore lint/correctness/useExhaustiveDependencies: prepareMutationInput only depends on schema which is stable
       prepareMutationInput,
+      relationFkColumns.has,
     ],
   );
 

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/entity-form-actions.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/entity-form-actions.ts
@@ -9,7 +9,7 @@ import type { EntityDefinition } from "@linchkit/core/types";
 import { toast } from "@linchkit/ui-kit/components";
 import type { NavigateOptions } from "@tanstack/react-router";
 import type { TFunction } from "i18next";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import type { EnrichedSubmitData } from "../components/auto-form/types";
 import type { StateTransitionInfo } from "../components/status-bar";
 import type { ResolvedEntityBundle } from "../hooks/use-entity-bundle";
@@ -67,17 +67,20 @@ export function useFormActions(opts: UseFormActionsOptions) {
 
   // Build set of auto-generated FK column names from relations (e.g., "department_id")
   // These may not be in schema.fields but are valid mutation input fields.
-  const relationFkColumns = new Set<string>();
-  if (bundle?.relations && entityName) {
-    for (const rel of bundle.relations) {
-      if (
-        rel.from === entityName &&
-        (rel.cardinality === "many_to_one" || rel.cardinality === "one_to_one")
-      ) {
-        relationFkColumns.add(`${rel.fromName}_id`);
+  const relationFkColumns = useMemo(() => {
+    const fkSet = new Set<string>();
+    if (bundle?.relations && entityName) {
+      for (const rel of bundle.relations) {
+        if (
+          rel.from === entityName &&
+          (rel.cardinality === "many_to_one" || rel.cardinality === "one_to_one")
+        ) {
+          fkSet.add(`${rel.fromName}_id`);
+        }
       }
     }
-  }
+    return fkSet;
+  }, [bundle?.relations, entityName]);
 
   /** Prepare mutation input by stripping non-input fields. FK fields (string type) are passed through directly. */
   function prepareMutationInput(data: Record<string, unknown>): Record<string, unknown> {
@@ -239,9 +242,9 @@ export function useFormActions(opts: UseFormActionsOptions) {
       navigate,
       fetchRecord,
       t,
-      // biome-ignore lint/correctness/useExhaustiveDependencies: prepareMutationInput only depends on schema which is stable
+      // biome-ignore lint/correctness/useExhaustiveDependencies: prepareMutationInput depends on schema and relationFkColumns
       prepareMutationInput,
-      relationFkColumns.has,
+      relationFkColumns,
     ],
   );
 

--- a/packages/cli/__tests__/describe-relations.test.ts
+++ b/packages/cli/__tests__/describe-relations.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { defineRelation, type RelationDefinition } from "@linchkit/core";
+import { defineRelation } from "@linchkit/core";
 import {
   buildRelationsOverview,
   printRelationsOverview,

--- a/packages/core/__tests__/ai-context-masker.test.ts
+++ b/packages/core/__tests__/ai-context-masker.test.ts
@@ -140,7 +140,7 @@ describe("round-trip mask/unmask", () => {
     const { masked, session } = maskContext(original);
 
     // Simulate AI response that references the masked token
-    const aiResponse = `I will contact ${masked.match(/\[MASKED_EMAIL_\d+\]/)![0]} regarding the order.`;
+    const aiResponse = `I will contact ${masked.match(/\[MASKED_EMAIL_\d+\]/)?.[0]} regarding the order.`;
 
     const unmasked = unmaskContext(aiResponse, session);
     expect(unmasked).toContain("john@example.com");

--- a/packages/core/__tests__/ai-rate-limiter.test.ts
+++ b/packages/core/__tests__/ai-rate-limiter.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { AIRateLimiter } from "../src/ai/ai-rate-limiter";
 
 describe("AIRateLimiter", () => {
@@ -52,8 +52,8 @@ describe("AIRateLimiter", () => {
     const result = limiter.check(identity);
     expect(result.allowed).toBe(false);
     expect(result.retryAfterMs).toBeDefined();
-    expect(result.retryAfterMs!).toBeGreaterThan(0);
-    expect(result.retryAfterMs!).toBeLessThanOrEqual(10_000);
+    expect(result.retryAfterMs).toBeGreaterThan(0);
+    expect(result.retryAfterMs).toBeLessThanOrEqual(10_000);
   });
 
   // ── Per-user isolation ────────────────────────────────
@@ -183,8 +183,8 @@ describe("AIRateLimiter", () => {
     expect(stats.requestsPerWindow[0].count).toBe(2);
     expect(stats.requestsPerWindow[0].limit).toBe(10);
     expect(stats.tokensPerHour).toBeDefined();
-    expect(stats.tokensPerHour!.used).toBe(300);
-    expect(stats.tokensPerHour!.limit).toBe(5000);
+    expect(stats.tokensPerHour?.used).toBe(300);
+    expect(stats.tokensPerHour?.limit).toBe(5000);
   });
 
   // ── Reset ─────────────────────────────────────────────

--- a/packages/core/src/ai/ai-modification-rules.ts
+++ b/packages/core/src/ai/ai-modification-rules.ts
@@ -107,7 +107,7 @@ export class AIModificationRuleRegistry {
 
     // Try field-specific match first
     if (field) {
-      const fieldRule = entityRules.find((r) => r.fields !== undefined && r.fields.includes(field));
+      const fieldRule = entityRules.find((r) => r.fields?.includes(field));
       if (fieldRule) {
         return this.evaluateRule(fieldRule, level);
       }

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -86,4 +86,6 @@ export interface SubscriptionConfig {
   idleTimeout?: number;
   /** Maximum buffered events per connection before dropping (default: 100) */
   maxBufferSize?: number;
+  /** Maximum events stored in the replay buffer for Last-Event-ID reconnection (default: 500) */
+  maxReplayBufferSize?: number;
 }


### PR DESCRIPTION
## Summary
- Add ring buffer (default 500 events) to SubscriptionManager for reconnection replay
- Server reads `Last-Event-ID` from header and `lastEventId` query param
- Client tracks last event ID and sends it on reconnect for seamless event recovery
- Event IDs assigned centrally in `dispatchEvent()` for consistency across connections
- Fallback: if requested ID was evicted, replay all buffered matching events

Closes #136

## Test plan
- [x] `bun run check` — 0 errors (on modified files)
- [x] `bun run typecheck` — passes
- [x] `bun test` — 4184 pass, 0 fail (7 new replay buffer tests)
- [x] Cross-model review (Codex + manual evaluation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Last-Event-ID replay support to subscriptions, enabling automatic recovery of missed events when reconnecting. The system now retains recently emitted events and replays them to clients upon reconnection.
  * Introduced new `maxReplayBufferSize` configuration option (default: 500 events) to control replay buffer behavior.

* **Tests**
  * Added comprehensive test coverage for subscription replay buffer functionality, including buffer eviction and replay behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->