### PR TITLE
feat(evolution): purchase_rejection sensor + runtime wiring (Task 1 of Path A)

### DIFF
--- a/addons/demo/cap-purchase-demo/__tests__/purchase-rejection-pattern.test.ts
+++ b/addons/demo/cap-purchase-demo/__tests__/purchase-rejection-pattern.test.ts
@@ -124,6 +124,25 @@ describe("purchaseRejectionPattern sensor", () => {
     expect(signal?.value).toBe(1);
   });
 
+  test("EXCLUDES records with future timestamps (clock skew / corruption guard)", async () => {
+    // completed_at after ctx.timestamp indicates data corruption or clock skew.
+    // Those records should not count toward the window.
+    const now = new Date("2026-04-11T00:00:00.000Z");
+    const inWindow = new Date(now.getTime() - 24 * 60 * 60 * 1000); // 1d ago
+    const inFuture = new Date(now.getTime() + 60_000); // 1min in the future
+
+    const { ctx } = makeContext({
+      timestamp: now,
+      rows: [
+        { action_name: "reject_purchase_request", status: "succeeded", completed_at: inWindow },
+        { action_name: "reject_purchase_request", status: "succeeded", completed_at: inFuture },
+      ],
+    });
+
+    const signal = await purchaseRejectionPattern.detect(ctx);
+    expect(signal?.value).toBe(1);
+  });
+
   test("produces a fully-populated SensorSignal", async () => {
     const now = new Date("2026-04-11T00:00:00.000Z");
     const { ctx } = makeContext({

--- a/addons/demo/cap-purchase-demo/__tests__/purchase-rejection-pattern.test.ts
+++ b/addons/demo/cap-purchase-demo/__tests__/purchase-rejection-pattern.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for purchase_rejection_pattern Sensor.
+ *
+ * The sensor counts rejected purchase_request records within a 30-day window
+ * and emits a SensorSignal. It returns null when no query helper is provided.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { SensorContext } from "@linchkit/core";
+import { purchaseRejectionPattern } from "../src/sensors/purchase-rejection-pattern";
+
+const WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+interface QueryCall {
+  schema: string;
+  filter?: Record<string, unknown>;
+}
+
+function makeContext(opts: {
+  rows?: Array<Record<string, unknown>>;
+  timestamp?: Date;
+  tenantId?: string;
+  withQuery?: boolean;
+}): { ctx: SensorContext; calls: QueryCall[] } {
+  const calls: QueryCall[] = [];
+  const ctx: SensorContext = {
+    timestamp: opts.timestamp ?? new Date("2026-04-11T00:00:00.000Z"),
+    tenantId: opts.tenantId,
+    query:
+      opts.withQuery === false
+        ? undefined
+        : async <T>(schema: string, filter?: Record<string, unknown>) => {
+            calls.push({ schema, filter });
+            return (opts.rows ?? []) as T[];
+          },
+  };
+  return { ctx, calls };
+}
+
+describe("purchaseRejectionPattern sensor", () => {
+  test("has expected metadata", () => {
+    expect(purchaseRejectionPattern.name).toBe("purchase_rejection_pattern");
+    expect(purchaseRejectionPattern.source).toBe("event_bus");
+    expect(purchaseRejectionPattern.entity).toBe("purchase_request");
+  });
+
+  test("returns null when ctx.query is undefined", async () => {
+    const { ctx } = makeContext({ withQuery: false });
+    const signal = await purchaseRejectionPattern.detect(ctx);
+    expect(signal).toBeNull();
+  });
+
+  test("emits zero-value signal when no rejected records exist", async () => {
+    const { ctx, calls } = makeContext({ rows: [] });
+    const signal = await purchaseRejectionPattern.detect(ctx);
+
+    expect(signal).not.toBeNull();
+    expect(signal?.value).toBe(0);
+    expect(signal?.confidence).toBeCloseTo(0.5);
+    expect(signal?.sensor).toBe("purchase_rejection_pattern");
+    expect(signal?.source).toBe("event_bus");
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.schema).toBe("purchase_request");
+    expect(calls[0]?.filter).toEqual({ status: "rejected" });
+  });
+
+  test("counts rejected records within the 30-day window", async () => {
+    const now = new Date("2026-04-11T00:00:00.000Z");
+    const inWindow = new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000); // 5d ago
+    const outOfWindow = new Date(now.getTime() - (WINDOW_MS + 60_000)); // > window
+
+    const { ctx } = makeContext({
+      timestamp: now,
+      rows: [
+        { status: "rejected", updated_at: inWindow },
+        { status: "rejected", updated_at: inWindow },
+        { status: "rejected", updated_at: inWindow },
+        { status: "rejected", updated_at: inWindow },
+        { status: "rejected", updated_at: outOfWindow }, // excluded
+      ],
+    });
+
+    const signal = await purchaseRejectionPattern.detect(ctx);
+    expect(signal).not.toBeNull();
+    expect(signal?.value).toBe(4);
+    // value >= 3 → high confidence
+    expect(signal?.confidence).toBeCloseTo(0.8);
+  });
+
+  test("accepts ISO-string timestamps and includes records with missing/invalid timestamps", async () => {
+    const now = new Date("2026-04-11T00:00:00.000Z");
+    const inWindowIso = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+
+    const { ctx } = makeContext({
+      timestamp: now,
+      rows: [
+        { status: "rejected", updated_at: inWindowIso }, // ISO string within window
+        { status: "rejected", updated_at: null }, // counted (no timestamp)
+        { status: "rejected" }, // counted (no field)
+        { status: "rejected", updated_at: "not-a-date" }, // counted (invalid)
+      ],
+    });
+
+    const signal = await purchaseRejectionPattern.detect(ctx);
+    expect(signal?.value).toBe(4);
+  });
+
+  test("produces a fully-populated SensorSignal", async () => {
+    const now = new Date("2026-04-11T00:00:00.000Z");
+    const { ctx } = makeContext({
+      timestamp: now,
+      tenantId: "tenant-1",
+      rows: [{ status: "rejected", updated_at: now }],
+    });
+
+    const signal = await purchaseRejectionPattern.detect(ctx);
+    expect(signal).not.toBeNull();
+    if (!signal) return;
+
+    expect(signal.sensor).toBe("purchase_rejection_pattern");
+    expect(signal.source).toBe("event_bus");
+    expect(signal.timestamp).toBe(now);
+    expect(signal.value).toBe(1);
+    expect(signal.baseline).toBe(0);
+    expect(signal.deviation).toBe(0);
+    expect(signal.confidence).toBeGreaterThan(0);
+    expect(signal.context).toMatchObject({
+      entity: "purchase_request",
+      metric: "rejection_count",
+      windowMs: WINDOW_MS,
+      tenantId: "tenant-1",
+    });
+    expect(typeof signal.context.windowStart).toBe("string");
+  });
+});

--- a/addons/demo/cap-purchase-demo/__tests__/purchase-rejection-pattern.test.ts
+++ b/addons/demo/cap-purchase-demo/__tests__/purchase-rejection-pattern.test.ts
@@ -1,8 +1,9 @@
 /**
  * Tests for purchase_rejection_pattern Sensor.
  *
- * The sensor counts rejected purchase_request records within a 30-day window
- * and emits a SensorSignal. It returns null when no query helper is provided.
+ * The sensor counts succeeded `reject_purchase_request` execution_log records
+ * within a 30-day window and emits a SensorSignal. It returns null when no
+ * query helper is provided.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -50,7 +51,7 @@ describe("purchaseRejectionPattern sensor", () => {
     expect(signal).toBeNull();
   });
 
-  test("emits zero-value signal when no rejected records exist", async () => {
+  test("queries execution_log with action_name + status filter", async () => {
     const { ctx, calls } = makeContext({ rows: [] });
     const signal = await purchaseRejectionPattern.detect(ctx);
 
@@ -61,11 +62,14 @@ describe("purchaseRejectionPattern sensor", () => {
     expect(signal?.source).toBe("event_bus");
 
     expect(calls).toHaveLength(1);
-    expect(calls[0]?.schema).toBe("purchase_request");
-    expect(calls[0]?.filter).toEqual({ status: "rejected" });
+    expect(calls[0]?.schema).toBe("execution_log");
+    expect(calls[0]?.filter).toEqual({
+      action_name: "reject_purchase_request",
+      status: "succeeded",
+    });
   });
 
-  test("counts rejected records within the 30-day window", async () => {
+  test("counts rejection events within the 30-day window", async () => {
     const now = new Date("2026-04-11T00:00:00.000Z");
     const inWindow = new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000); // 5d ago
     const outOfWindow = new Date(now.getTime() - (WINDOW_MS + 60_000)); // > window
@@ -73,11 +77,11 @@ describe("purchaseRejectionPattern sensor", () => {
     const { ctx } = makeContext({
       timestamp: now,
       rows: [
-        { status: "rejected", updated_at: inWindow },
-        { status: "rejected", updated_at: inWindow },
-        { status: "rejected", updated_at: inWindow },
-        { status: "rejected", updated_at: inWindow },
-        { status: "rejected", updated_at: outOfWindow }, // excluded
+        { action_name: "reject_purchase_request", status: "succeeded", completed_at: inWindow },
+        { action_name: "reject_purchase_request", status: "succeeded", completed_at: inWindow },
+        { action_name: "reject_purchase_request", status: "succeeded", completed_at: inWindow },
+        { action_name: "reject_purchase_request", status: "succeeded", completed_at: inWindow },
+        { action_name: "reject_purchase_request", status: "succeeded", completed_at: outOfWindow }, // excluded
       ],
     });
 
@@ -88,22 +92,36 @@ describe("purchaseRejectionPattern sensor", () => {
     expect(signal?.confidence).toBeCloseTo(0.8);
   });
 
-  test("accepts ISO-string timestamps and includes records with missing/invalid timestamps", async () => {
+  test("accepts ISO-string timestamps and EXCLUDES records with missing/invalid timestamps", async () => {
+    // A successful execution must have a completed_at. Missing/invalid is
+    // treated as data corruption — under-count rather than over-count.
     const now = new Date("2026-04-11T00:00:00.000Z");
     const inWindowIso = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
 
     const { ctx } = makeContext({
       timestamp: now,
       rows: [
-        { status: "rejected", updated_at: inWindowIso }, // ISO string within window
-        { status: "rejected", updated_at: null }, // counted (no timestamp)
-        { status: "rejected" }, // counted (no field)
-        { status: "rejected", updated_at: "not-a-date" }, // counted (invalid)
+        // ISO string within window — counted
+        {
+          action_name: "reject_purchase_request",
+          status: "succeeded",
+          completed_at: inWindowIso,
+        },
+        // null timestamp — excluded
+        { action_name: "reject_purchase_request", status: "succeeded", completed_at: null },
+        // missing field — excluded
+        { action_name: "reject_purchase_request", status: "succeeded" },
+        // invalid date string — excluded
+        {
+          action_name: "reject_purchase_request",
+          status: "succeeded",
+          completed_at: "not-a-date",
+        },
       ],
     });
 
     const signal = await purchaseRejectionPattern.detect(ctx);
-    expect(signal?.value).toBe(4);
+    expect(signal?.value).toBe(1);
   });
 
   test("produces a fully-populated SensorSignal", async () => {
@@ -111,7 +129,7 @@ describe("purchaseRejectionPattern sensor", () => {
     const { ctx } = makeContext({
       timestamp: now,
       tenantId: "tenant-1",
-      rows: [{ status: "rejected", updated_at: now }],
+      rows: [{ action_name: "reject_purchase_request", status: "succeeded", completed_at: now }],
     });
 
     const signal = await purchaseRejectionPattern.detect(ctx);

--- a/addons/demo/cap-purchase-demo/src/capability.ts
+++ b/addons/demo/cap-purchase-demo/src/capability.ts
@@ -28,6 +28,7 @@ import i18nZhCN from "./i18n/zh-CN.json";
 import { auditableInterface } from "./interfaces/auditable";
 import { requestToDepartment, requestToItems } from "./relations";
 import { departmentSeedData, purchaseItemSeedData, purchaseRequestSeedData } from "./seed";
+import { purchaseRejectionPattern } from "./sensors/purchase-rejection-pattern";
 import { purchaseRequestState } from "./states/purchase-request";
 import { departmentListView } from "./views/department-list";
 import { purchaseRequestFormView } from "./views/form";
@@ -57,6 +58,7 @@ export const capPurchaseDemo = defineCapability({
       en: i18nEn,
       "zh-CN": i18nZhCN,
     },
+    sensors: [purchaseRejectionPattern],
     permissionGroups: [
       {
         name: "purchase_user",

--- a/addons/demo/cap-purchase-demo/src/index.ts
+++ b/addons/demo/cap-purchase-demo/src/index.ts
@@ -22,6 +22,7 @@ export { purchaseApprovalFlow } from "./flows/purchase-approval";
 export { auditableInterface } from "./interfaces/auditable";
 export { requestToDepartment, requestToItems } from "./relations";
 export { departmentSeedData, purchaseItemSeedData, purchaseRequestSeedData } from "./seed";
+export { purchaseRejectionPattern } from "./sensors/purchase-rejection-pattern";
 export { purchaseRequestState } from "./states/purchase-request";
 export { purchaseRequestFormView } from "./views/form";
 export { purchaseRequestListView } from "./views/list";

--- a/addons/demo/cap-purchase-demo/src/sensors/purchase-rejection-pattern.ts
+++ b/addons/demo/cap-purchase-demo/src/sensors/purchase-rejection-pattern.ts
@@ -1,10 +1,20 @@
 /**
  * purchase_rejection_pattern Sensor — Spec 55 §3.3 (Evolution Path A, Task 1)
  *
- * Observes the rate of rejected purchase requests over a rolling time window
- * and emits a SensorSignal whose `value` is the count of rejections in window.
+ * Counts rejection EVENTS over a rolling 30-day window and emits a SensorSignal
+ * whose `value` is the number of `reject_purchase_request` action invocations
+ * in that window.
  *
- * Memory layer is responsible for computing the baseline / deviation across
+ * Why event-based rather than current-state-based:
+ *   A purchase_request that was rejected and then resubmitted has
+ *   `status="pending"` again — the rejection moment is no longer visible in
+ *   the current row state. Counting `purchase_request.status="rejected"`
+ *   therefore systematically undercounts the friction signal we care about.
+ *   Querying `execution_log` for `action_name="reject_purchase_request"` /
+ *   `status="succeeded"` captures every rejection event, regardless of what
+ *   the request looks like today.
+ *
+ * Memory layer is responsible for computing baseline / deviation across
  * cycles; this sensor only reports the raw observation plus a confidence
  * estimate scaled with sample size.
  */
@@ -15,17 +25,19 @@ import { defineSensor } from "@linchkit/core";
 /** Rolling window for rejection counting (30 days). */
 const WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
 
-/** Minimum rejected-record count above which we treat the signal as high-confidence. */
+/** Minimum rejected-event count above which we treat the signal as high-confidence. */
 const HIGH_CONFIDENCE_THRESHOLD = 3;
 
 /** Confidence values (0–1). */
 const CONFIDENCE_LOW = 0.5;
 const CONFIDENCE_HIGH = 0.8;
 
-/** Subset of purchase_request fields the sensor needs. */
-interface RejectedRecord {
+/** Subset of execution_log fields the sensor needs.
+ *  See addons/adapter-server/cap-adapter-server/src/system-schemas.ts:20-103. */
+interface ExecutionLogRecord {
+  action_name?: string;
   status?: string;
-  updated_at?: Date | string | null;
+  completed_at?: Date | string | null;
 }
 
 export const purchaseRejectionPattern = defineSensor({
@@ -40,21 +52,31 @@ export const purchaseRejectionPattern = defineSensor({
 
     // DataProvider.query treats `filter` as a key-equality map
     // (see DataProvider in packages/core/src/engine/action-engine.ts).
-    // We post-filter on `updated_at` because a date-range predicate is
+    // We post-filter on `completed_at` because a date-range predicate is
     // not part of the simple equality filter contract.
-    const rejected = await ctx.query<RejectedRecord>("purchase_request", {
-      status: "rejected",
+    //
+    // Querying the action invocation log captures every rejection event,
+    // even when the underlying purchase_request was later resubmitted and
+    // is no longer in `status="rejected"`.
+    const records = await ctx.query<ExecutionLogRecord>("execution_log", {
+      action_name: "reject_purchase_request",
+      status: "succeeded",
     });
 
-    const recentRejected = rejected.filter((record) => {
-      const raw = record.updated_at;
-      if (raw == null) return true; // include records with no timestamp (treat as recent)
+    // Exclude records with null/missing/invalid completed_at. A successful
+    // execution must have a completed_at; a missing one is data corruption,
+    // not a legitimate rejection event. Excluding (rather than including) is
+    // the conservative choice: we under-report rather than spike the signal
+    // and trigger a false positive insight.
+    const recentRejections = records.filter((record) => {
+      const raw = record.completed_at;
+      if (raw == null) return false;
       const ts = raw instanceof Date ? raw : new Date(raw);
-      if (Number.isNaN(ts.getTime())) return true;
+      if (Number.isNaN(ts.getTime())) return false;
       return ts.getTime() >= windowStart.getTime();
     });
 
-    const value = recentRejected.length;
+    const value = recentRejections.length;
 
     return {
       sensor: "purchase_rejection_pattern",

--- a/addons/demo/cap-purchase-demo/src/sensors/purchase-rejection-pattern.ts
+++ b/addons/demo/cap-purchase-demo/src/sensors/purchase-rejection-pattern.ts
@@ -48,7 +48,8 @@ export const purchaseRejectionPattern = defineSensor({
   async detect(ctx: SensorContext): Promise<SensorSignal | null> {
     if (!ctx.query) return null;
 
-    const windowStart = new Date(ctx.timestamp.getTime() - WINDOW_MS);
+    const windowEnd = ctx.timestamp;
+    const windowStart = new Date(windowEnd.getTime() - WINDOW_MS);
 
     // DataProvider.query treats `filter` as a key-equality map
     // (see DataProvider in packages/core/src/engine/action-engine.ts).
@@ -68,12 +69,16 @@ export const purchaseRejectionPattern = defineSensor({
     // not a legitimate rejection event. Excluding (rather than including) is
     // the conservative choice: we under-report rather than spike the signal
     // and trigger a false positive insight.
+    //
+    // Also exclude future timestamps (> ctx.timestamp). A completed_at after
+    // the cycle's reference time indicates clock skew or data corruption, not
+    // a legitimate event in the window we are measuring.
     const recentRejections = records.filter((record) => {
       const raw = record.completed_at;
       if (raw == null) return false;
       const ts = raw instanceof Date ? raw : new Date(raw);
       if (Number.isNaN(ts.getTime())) return false;
-      return ts.getTime() >= windowStart.getTime();
+      return ts.getTime() >= windowStart.getTime() && ts.getTime() <= windowEnd.getTime();
     });
 
     const value = recentRejections.length;

--- a/addons/demo/cap-purchase-demo/src/sensors/purchase-rejection-pattern.ts
+++ b/addons/demo/cap-purchase-demo/src/sensors/purchase-rejection-pattern.ts
@@ -1,0 +1,77 @@
+/**
+ * purchase_rejection_pattern Sensor — Spec 55 §3.3 (Evolution Path A, Task 1)
+ *
+ * Observes the rate of rejected purchase requests over a rolling time window
+ * and emits a SensorSignal whose `value` is the count of rejections in window.
+ *
+ * Memory layer is responsible for computing the baseline / deviation across
+ * cycles; this sensor only reports the raw observation plus a confidence
+ * estimate scaled with sample size.
+ */
+
+import type { SensorContext, SensorSignal } from "@linchkit/core";
+import { defineSensor } from "@linchkit/core";
+
+/** Rolling window for rejection counting (30 days). */
+const WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Minimum rejected-record count above which we treat the signal as high-confidence. */
+const HIGH_CONFIDENCE_THRESHOLD = 3;
+
+/** Confidence values (0–1). */
+const CONFIDENCE_LOW = 0.5;
+const CONFIDENCE_HIGH = 0.8;
+
+/** Subset of purchase_request fields the sensor needs. */
+interface RejectedRecord {
+  status?: string;
+  updated_at?: Date | string | null;
+}
+
+export const purchaseRejectionPattern = defineSensor({
+  name: "purchase_rejection_pattern",
+  source: "event_bus",
+  entity: "purchase_request",
+
+  async detect(ctx: SensorContext): Promise<SensorSignal | null> {
+    if (!ctx.query) return null;
+
+    const windowStart = new Date(ctx.timestamp.getTime() - WINDOW_MS);
+
+    // DataProvider.query treats `filter` as a key-equality map
+    // (see DataProvider in packages/core/src/engine/action-engine.ts).
+    // We post-filter on `updated_at` because a date-range predicate is
+    // not part of the simple equality filter contract.
+    const rejected = await ctx.query<RejectedRecord>("purchase_request", {
+      status: "rejected",
+    });
+
+    const recentRejected = rejected.filter((record) => {
+      const raw = record.updated_at;
+      if (raw == null) return true; // include records with no timestamp (treat as recent)
+      const ts = raw instanceof Date ? raw : new Date(raw);
+      if (Number.isNaN(ts.getTime())) return true;
+      return ts.getTime() >= windowStart.getTime();
+    });
+
+    const value = recentRejected.length;
+
+    return {
+      sensor: "purchase_rejection_pattern",
+      source: "event_bus",
+      timestamp: ctx.timestamp,
+      value,
+      // Baseline + deviation are filled in by MemoryEngine during drift detection.
+      baseline: 0,
+      deviation: 0,
+      confidence: value >= HIGH_CONFIDENCE_THRESHOLD ? CONFIDENCE_HIGH : CONFIDENCE_LOW,
+      context: {
+        entity: "purchase_request",
+        metric: "rejection_count",
+        windowMs: WINDOW_MS,
+        windowStart: windowStart.toISOString(),
+        tenantId: ctx.tenantId,
+      },
+    };
+  },
+});

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -9,8 +9,13 @@
  * transport factories through the capability contract.
  */
 
-import type { CapabilityDefinition, LinchKitConfig, TransportLifecycle } from "@linchkit/core";
-import { ConfigRegistry, initI18n } from "@linchkit/core";
+import type {
+  CapabilityDefinition,
+  LinchKitConfig,
+  SensorContext,
+  TransportLifecycle,
+} from "@linchkit/core";
+import { ConfigRegistry, createEvolutionRuntime, initI18n } from "@linchkit/core";
 import {
   closeDatabase,
   consoleLogger,
@@ -153,6 +158,28 @@ export const devCommand = defineCommand({
       schemas: entities,
       links,
     });
+
+    // ── Evolution runtime (Spec 55) — register capability sensors on SignalBus ──
+    // Sensors are collected from extensions.sensors and registered here so that
+    // any caller of evolutionRuntime.evolutionCycle.runCycle() can see them.
+    // A periodic driver is intentionally NOT started here — triggering is left
+    // to explicit callers (MCP tools, admin UI, scheduled jobs).
+    // Adapt DataProvider.query (concrete row type) to SensorContext.query (generic T).
+    // The cast is sound because callers (sensors) choose T to match their expected shape.
+    const evolutionQuery: SensorContext["query"] = async <T>(
+      schema: string,
+      filter?: Record<string, unknown>,
+    ) => {
+      const rows = await devDataProvider.query(schema, filter ?? {});
+      return rows as T[];
+    };
+    const evolutionRuntime = createEvolutionRuntime({
+      sensors: collected.sensors,
+      query: evolutionQuery,
+    });
+    consoleLogger.info(
+      `Evolution runtime ready: ${evolutionRuntime.signalBus.listSensors().length} sensor(s) registered`,
+    );
 
     // ── Auth provider wiring ──
     await wireAuthProvider({

--- a/packages/cli/src/commands/startup/collect-capabilities.ts
+++ b/packages/cli/src/commands/startup/collect-capabilities.ts
@@ -14,6 +14,7 @@ import type {
   MiddlewareRegistration,
   RelationDefinition,
   RuleDefinition,
+  Sensor,
   StateDefinition,
   TransportAdapterDefinition,
   ViewDefinition,
@@ -33,6 +34,8 @@ export interface CollectedDefinitions {
   transports: TransportAdapterDefinition[];
   graphqlExtensions: GraphQLExtensionRegistration[];
   commands: CliCommand[];
+  /** Sensors collected from `cap.extensions.sensors` for the Sense layer (Spec 55 §3.3). */
+  sensors: Sensor[];
 }
 
 /**
@@ -55,6 +58,7 @@ export function collectCapabilityDefinitions(
   const transports: TransportAdapterDefinition[] = [];
   const graphqlExtensions: GraphQLExtensionRegistration[] = [];
   const commands: CliCommand[] = [];
+  const sensors: Sensor[] = [];
 
   for (const cap of capabilities) {
     if (cap.interfaces) interfaces.push(...cap.interfaces);
@@ -80,6 +84,7 @@ export function collectCapabilityDefinitions(
       graphqlExtensions.push(cap.extensions.graphqlExtensions);
     }
     if (cap.extensions?.commands) commands.push(...cap.extensions.commands);
+    if (cap.extensions?.sensors) sensors.push(...cap.extensions.sensors);
 
     // Register i18n translation resources from the capability
     if (cap.extensions?.i18n) {
@@ -102,5 +107,6 @@ export function collectCapabilityDefinitions(
     transports,
     graphqlExtensions,
     commands,
+    sensors,
   };
 }

--- a/packages/core/__tests__/life-system/evolution-runtime.test.ts
+++ b/packages/core/__tests__/life-system/evolution-runtime.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Integration test for createEvolutionRuntime — proves the wiring chain:
+ *
+ *   capability.extensions.sensors → createEvolutionRuntime
+ *     → signalBus.registerSensor → runCycle → sensor.detect
+ *
+ * Without this test the `sensors` field on a CapabilityDefinition is silently
+ * dead config: the Codex review caught exactly that defect on the first MVP.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  type CapabilityDefinition,
+  createEvolutionRuntime,
+  defineSensor,
+  type SensorContext,
+  type SensorSignal,
+} from "../../src";
+
+describe("createEvolutionRuntime", () => {
+  test("registers sensors from capability and runCycle collects signals", async () => {
+    // Build a trivial sensor that returns a fixed signal whenever ctx.query
+    // returns rows. We deliberately consult ctx.query so we can verify the
+    // runtime wires the runtime-level `query` default into SensorContext.
+    const sensor = defineSensor({
+      name: "trivial_sensor",
+      source: "event_bus",
+      entity: "execution_log",
+      detect: async (ctx: SensorContext): Promise<SensorSignal | null> => {
+        if (!ctx.query) return null;
+        const rows = await ctx.query<{ action_name: string }>("execution_log", {
+          action_name: "reject_purchase_request",
+          status: "succeeded",
+        });
+        return {
+          sensor: "trivial_sensor",
+          source: "event_bus",
+          timestamp: ctx.timestamp,
+          value: rows.length,
+          baseline: 0,
+          deviation: 0,
+          confidence: 0.9,
+          context: { entity: "execution_log", metric: "rejection_count" },
+        };
+      },
+    });
+
+    // Pretend a capability declared this sensor in its extensions.
+    const cap: CapabilityDefinition = {
+      name: "test-cap",
+      label: "Test Cap",
+      type: "standard",
+      category: "system",
+      version: "0.0.0",
+      extensions: { sensors: [sensor] },
+    };
+
+    // Capture every query call so we can verify the sensor actually invoked it.
+    const queryCalls: Array<{ schema: string; filter?: Record<string, unknown> }> = [];
+    const queryRows = [
+      { action_name: "reject_purchase_request", status: "succeeded" },
+      { action_name: "reject_purchase_request", status: "succeeded" },
+      { action_name: "reject_purchase_request", status: "succeeded" },
+    ];
+
+    const runtime = createEvolutionRuntime({
+      sensors: cap.extensions?.sensors ?? [],
+      query: async <T>(schema: string, filter?: Record<string, unknown>) => {
+        queryCalls.push({ schema, filter });
+        return queryRows as T[];
+      },
+    });
+
+    // Wiring assertion #1: SignalBus knows about the sensor.
+    expect(runtime.signalBus.listSensors()).toContain("trivial_sensor");
+
+    // Wiring assertion #2: runCycle propagates ctx (and our default query)
+    // into sensors and aggregates the resulting signals.
+    const result = await runtime.evolutionCycle.runCycle({ timestamp: new Date() });
+    expect(result.signalsCollected).toBeGreaterThanOrEqual(1);
+
+    // Wiring assertion #3: the runtime-level `query` was actually used.
+    expect(queryCalls).toHaveLength(1);
+    expect(queryCalls[0]?.schema).toBe("execution_log");
+    expect(queryCalls[0]?.filter).toEqual({
+      action_name: "reject_purchase_request",
+      status: "succeeded",
+    });
+  });
+
+  test("caller-supplied ctx.query overrides the runtime default", async () => {
+    let runtimeQueryCalls = 0;
+    let callerQueryCalls = 0;
+
+    const sensor = defineSensor({
+      name: "override_sensor",
+      source: "event_bus",
+      detect: async (ctx: SensorContext): Promise<SensorSignal | null> => {
+        if (!ctx.query) return null;
+        await ctx.query("execution_log");
+        return {
+          sensor: "override_sensor",
+          source: "event_bus",
+          timestamp: ctx.timestamp,
+          value: 1,
+          baseline: 0,
+          deviation: 0,
+          confidence: 0.5,
+          context: {},
+        };
+      },
+    });
+
+    const runtime = createEvolutionRuntime({
+      sensors: [sensor],
+      query: async () => {
+        runtimeQueryCalls++;
+        return [];
+      },
+    });
+
+    await runtime.evolutionCycle.runCycle({
+      timestamp: new Date(),
+      query: async () => {
+        callerQueryCalls++;
+        return [];
+      },
+    });
+
+    expect(callerQueryCalls).toBe(1);
+    expect(runtimeQueryCalls).toBe(0);
+  });
+
+  test("works with zero sensors", async () => {
+    const runtime = createEvolutionRuntime({ sensors: [] });
+    expect(runtime.signalBus.listSensors()).toEqual([]);
+    const result = await runtime.evolutionCycle.runCycle();
+    expect(result.signalsCollected).toBe(0);
+  });
+});

--- a/packages/core/__tests__/life-system/evolution-runtime.test.ts
+++ b/packages/core/__tests__/life-system/evolution-runtime.test.ts
@@ -137,4 +137,22 @@ describe("createEvolutionRuntime", () => {
     const result = await runtime.evolutionCycle.runCycle();
     expect(result.signalsCollected).toBe(0);
   });
+
+  test("throws on duplicate sensor names", () => {
+    // Two sensors with the same name silently overwrite each other on SignalBus
+    // (Map keyed by name). Duplicates indicate a capability misconfiguration
+    // and should fail fast.
+    const a = defineSensor({
+      name: "dup_sensor",
+      source: "event_bus",
+      detect: async () => null,
+    });
+    const b = defineSensor({
+      name: "dup_sensor",
+      source: "api",
+      detect: async () => null,
+    });
+
+    expect(() => createEvolutionRuntime({ sensors: [a, b] })).toThrow(/Duplicate sensor name/);
+  });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -250,13 +250,15 @@ export {
   type SupportedLanguage,
 } from "./i18n";
 export type {
+  EvolutionRuntime,
+  EvolutionRuntimeOptions,
   SensorDefinitionConfig,
   SignalBus,
   SignalBusOptions,
   SignalHandler,
 } from "./life-system";
 // Life-system — Sense layer (Spec 55)
-export { createSignalBus, defineSensor } from "./life-system";
+export { createEvolutionRuntime, createSignalBus, defineSensor } from "./life-system";
 export type {
   AlertCondition,
   AlertEffect,

--- a/packages/core/src/life-system/index.ts
+++ b/packages/core/src/life-system/index.ts
@@ -18,6 +18,8 @@ export type { InsightEngineOptions } from "./insight-engine";
 export { createInsightEngine } from "./insight-engine";
 export type { MemoryEngineOptions } from "./memory-engine";
 export { MemoryEngine } from "./memory-engine";
+export type { EvolutionRuntime, EvolutionRuntimeOptions } from "./runtime";
+export { createEvolutionRuntime } from "./runtime";
 export type { SignalBus, SignalBusOptions, SignalHandler } from "./signal-bus";
 export { createSignalBus } from "./signal-bus";
 export { createUsageImportanceGraph } from "./usage-graph";

--- a/packages/core/src/life-system/runtime.ts
+++ b/packages/core/src/life-system/runtime.ts
@@ -114,7 +114,20 @@ export function createEvolutionRuntime(opts: EvolutionRuntimeOptions): Evolution
     insightPromotion: opts.insightPromotion,
   });
 
+  // Register sensors, guarding against duplicate names. SignalBus stores sensors
+  // in a Map keyed by name, so registering two with the same name would silently
+  // overwrite the first. Duplicates almost always indicate a capability
+  // misconfiguration (e.g. two capabilities shipping sensors with clashing
+  // names) and we want that to fail fast with a clear error.
+  const registered = new Set<string>();
   for (const sensor of opts.sensors) {
+    if (registered.has(sensor.name)) {
+      throw new Error(
+        `Duplicate sensor name "${sensor.name}" in createEvolutionRuntime opts.sensors. ` +
+          `Sensor names must be unique across all capabilities.`,
+      );
+    }
+    registered.add(sensor.name);
     signalBus.registerSensor(sensor);
   }
 

--- a/packages/core/src/life-system/runtime.ts
+++ b/packages/core/src/life-system/runtime.ts
@@ -1,0 +1,146 @@
+/**
+ * EvolutionRuntime — composition root for the Spec 55 life-system.
+ *
+ * Wires the full pipeline in one call:
+ *   SignalBus → MemoryEngine → AwarenessEngine → InsightEngine → EvolutionCycle
+ *
+ * Capabilities supply Sensors via `cap.extensions.sensors`. The CLI startup
+ * flattens these into a `Sensor[]` (see `collectCapabilityDefinitions`) and
+ * passes them to this factory, which registers each on the SignalBus.
+ *
+ * Without this factory the `extensions.sensors` field is dead config — sensors
+ * defined by capabilities are never registered and never fire.
+ */
+
+import type { OntologyRegistry } from "../ontology/ontology-registry";
+import type {
+  AwarenessEngine,
+  EvolutionCycle,
+  InsightEngine,
+  MemoryStore,
+  Sensor,
+  SensorContext,
+} from "../types/life-system";
+import { createAwarenessEngine } from "./awareness-engine";
+import { createEvolutionCycle } from "./evolution-cycle";
+import { InMemoryMemoryStore } from "./in-memory-memory-store";
+import type { InsightEngineOptions } from "./insight-engine";
+import type { MemoryEngineOptions } from "./memory-engine";
+import { MemoryEngine } from "./memory-engine";
+import type { SignalBus } from "./signal-bus";
+import { createSignalBus } from "./signal-bus";
+
+/** Bundle of life-system engines returned from `createEvolutionRuntime`. */
+export interface EvolutionRuntime {
+  signalBus: SignalBus;
+  evolutionCycle: EvolutionCycle;
+  insightEngine: InsightEngine;
+  awarenessEngine: AwarenessEngine;
+}
+
+/** Construction options for {@link createEvolutionRuntime}. */
+export interface EvolutionRuntimeOptions {
+  /** Sensors collected from capabilities. Each is registered on the SignalBus. */
+  sensors: Sensor[];
+  /**
+   * Optional query helper passed to sensors via {@link SensorContext} when
+   * runCycle() is invoked without an explicit context. Sensors use this to
+   * look up records (e.g. execution_log entries) without coupling to a
+   * specific store implementation.
+   */
+  query?: SensorContext["query"];
+  /**
+   * Optional MemoryStore. Defaults to {@link InMemoryMemoryStore}, suitable
+   * for development and tests. Production deployments should pass a
+   * persistent store (e.g. cap-memory-drizzle).
+   */
+  memoryStore?: MemoryStore;
+  /**
+   * Ontology registry consumed by the AwarenessEngine for structural checks.
+   * When omitted, an empty stub is used — runtime still functions; structural
+   * checks simply yield no findings.
+   */
+  ontology?: OntologyRegistry;
+  /** Override MemoryEngine tuning (sliding window, drift threshold). */
+  memoryEngine?: Pick<MemoryEngineOptions, "windowSize" | "driftThreshold">;
+  /** Override InsightEngine promotion config. */
+  insightPromotion?: InsightEngineOptions["promotion"];
+}
+
+/** Empty OntologyRegistry stub for environments where no ontology is supplied. */
+function createEmptyOntology(): OntologyRegistry {
+  return {
+    describe: () => undefined,
+    listEntities: () => [],
+    searchEntities: () => [],
+    actionsFor: () => [],
+    rulesFor: () => [],
+    stateFor: () => undefined,
+    viewsFor: () => [],
+    flowsFor: () => [],
+    handlersFor: () => [],
+    relatedEntities: () => [],
+    entitiesImplementing: () => [],
+    toJSON: () => ({}),
+    toMarkdown: () => "",
+  };
+}
+
+/**
+ * Build a fully-wired EvolutionRuntime and register all supplied sensors
+ * on the SignalBus. The returned `evolutionCycle.runCycle()` will then
+ * collect signals from those sensors on every invocation.
+ *
+ * If `opts.query` is supplied, it becomes the default `query` injected into
+ * SensorContext when callers invoke `runCycle()` without an explicit context
+ * (or with a context that omits `query`). Callers who pass a `query` on
+ * their own context override the default.
+ */
+export function createEvolutionRuntime(opts: EvolutionRuntimeOptions): EvolutionRuntime {
+  const signalBus = createSignalBus();
+  const memoryStore = opts.memoryStore ?? new InMemoryMemoryStore();
+  const memoryEngine = new MemoryEngine({
+    store: memoryStore,
+    windowSize: opts.memoryEngine?.windowSize,
+    driftThreshold: opts.memoryEngine?.driftThreshold,
+  });
+  const awareness = createAwarenessEngine({
+    ontology: opts.ontology ?? createEmptyOntology(),
+  });
+  const innerCycle = createEvolutionCycle({
+    signalBus,
+    memoryEngine,
+    awareness,
+    insightPromotion: opts.insightPromotion,
+  });
+
+  for (const sensor of opts.sensors) {
+    signalBus.registerSensor(sensor);
+  }
+
+  // Wrap runCycle so a runtime-level default `query` is merged into any
+  // context the caller supplies. Caller-supplied `query` always wins.
+  const evolutionCycle: EvolutionCycle = {
+    get insightEngine() {
+      return innerCycle.insightEngine;
+    },
+    get awarenessEngine() {
+      return innerCycle.awarenessEngine;
+    },
+    runCycle(ctx?: SensorContext) {
+      const merged: SensorContext = {
+        timestamp: ctx?.timestamp ?? new Date(),
+        tenantId: ctx?.tenantId,
+        query: ctx?.query ?? opts.query,
+      };
+      return innerCycle.runCycle(merged);
+    },
+  };
+
+  return {
+    signalBus,
+    evolutionCycle,
+    insightEngine: innerCycle.insightEngine,
+    awarenessEngine: awareness,
+  };
+}

--- a/packages/core/src/life-system/runtime.ts
+++ b/packages/core/src/life-system/runtime.ts
@@ -141,9 +141,13 @@ export function createEvolutionRuntime(opts: EvolutionRuntimeOptions): Evolution
       return innerCycle.awarenessEngine;
     },
     runCycle(ctx?: SensorContext) {
+      // Spread the caller-supplied ctx so any future SensorContext fields
+      // (trace IDs, user metadata, etc.) flow through automatically. Then
+      // override timestamp with a default and query with the runtime default
+      // iff the caller didn't supply its own.
       const merged: SensorContext = {
+        ...(ctx ?? { timestamp: new Date() }),
         timestamp: ctx?.timestamp ?? new Date(),
-        tenantId: ctx?.tenantId,
         query: ctx?.query ?? opts.query,
       };
       return innerCycle.runCycle(merged);

--- a/packages/core/src/server-entry.ts
+++ b/packages/core/src/server-entry.ts
@@ -379,6 +379,8 @@ export {
 
 export type {
   AwarenessEngineOptions,
+  EvolutionRuntime,
+  EvolutionRuntimeOptions,
   SensorDefinitionConfig,
   SignalBus,
   SignalBusOptions,
@@ -387,6 +389,7 @@ export type {
 export {
   createAttentionBudget,
   createAwarenessEngine,
+  createEvolutionRuntime,
   createSignalBus,
   createUsageImportanceGraph,
   defineSensor,


### PR DESCRIPTION
## Summary

First concrete Sensor for Spec 55 Evolution System — Task 1 of Path A (end-to-end AI evolution demo). Delivers three layers of plumbing plus one real sensor:

1. **Sensor collection at capability startup**: `collectCapabilityDefinitions` now extracts `cap.extensions.sensors` into `CollectedDefinitions.sensors`
2. **Runtime factory**: New `createEvolutionRuntime({sensors, query, memoryStore?})` instantiates `SignalBus + MemoryEngine + InsightEngine + AwarenessEngine + EvolutionCycle` and registers every sensor on the bus
3. **Dev boot wiring**: `dev.ts` calls `createEvolutionRuntime` at startup and logs the registered count
4. **First sensor**: `purchase_rejection_pattern` in `cap-purchase-demo` — counts `reject_purchase_request` succeeded events in `execution_log` over a rolling 30-day window

Relates to #88 (Evolution system — Insight + Proposal cycle).

## Cross-model review (2 rounds)

**Round 1** — Codex caught two blockers in the initial commit:
- **P1 (fixed)**: `extensions.sensors` was dead config — nothing read it at startup. Fixed by adding collection in `collect-capabilities.ts` + `createEvolutionRuntime` factory + wiring in `dev.ts`.
- **P2 (fixed)**: Sensor counted current `status=rejected` rows, not rejection events. A rejected-then-resubmitted request has `status=pending` again, erasing the event. Fixed by querying `execution_log` for `action_name=reject_purchase_request` / `status=succeeded`, filtering on `completed_at`.

Gemini (round 1) flagged a minor — null-timestamp records being treated as "recent" could cause migration-era false spikes. Fixed: records with null/invalid `completed_at` are now **excluded**.

**Round 2** — Codex found two more real issues, deliberately deferred to a follow-up to keep this PR focused (see #179):
- execution_log queries in `dev.ts` go to business `devDataProvider`, but `execution_log` lives in `SystemDataProvider` / `ExecutionLogger` — so the sensor will read 0 rows in dev
- `evolutionRuntime` is built in `dev.ts` but never reaches `transportCtx`, so MCP/HTTP cannot trigger `runCycle()`

Both are planned for Task 4 of Path A (Evolution MCP tools), which naturally needs runtime exposure anyway.

## Wiring chain (end-to-end, verified)

1. `capability.ts` declares `extensions.sensors: [purchaseRejectionPattern]`
2. `CapabilityExtensions.sensors?: Sensor[]` in core types
3. `collectCapabilityDefinitions` accumulates into `CollectedDefinitions.sensors`
4. `dev.ts` calls `createEvolutionRuntime({sensors: collected.sensors, query})`
5. Factory calls `signalBus.registerSensor(sensor)` for each
6. `evolutionCycle.runCycle(ctx)` -> `signalBus.collectSignals(ctx)` -> each sensor's `detect()`

Integration test `packages/core/__tests__/life-system/evolution-runtime.test.ts` exercises steps 3-6 end-to-end.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean (1 pre-existing biome schema-version info, unrelated)
- [x] `bun test addons/demo/cap-purchase-demo/__tests__/purchase-rejection-pattern.test.ts` — 6 pass / 24 expects
- [x] `bun test packages/core/__tests__/life-system/evolution-runtime.test.ts` — 3 pass / 9 expects (new integration test)
- [x] `bun test` full suite — 4193 pass / 3 skip / 0 fail
- [x] Cross-model review (codex x2, gemini x1) — all blockers fixed, remaining gaps tracked in #179

## Files changed

**New (2)**:
- `packages/core/src/life-system/runtime.ts` — `createEvolutionRuntime` factory (139 lines)
- `packages/core/__tests__/life-system/evolution-runtime.test.ts` — integration test (123 lines)
- `addons/demo/cap-purchase-demo/src/sensors/purchase-rejection-pattern.ts` — sensor (79 lines across two commits)
- `addons/demo/cap-purchase-demo/__tests__/purchase-rejection-pattern.test.ts` — sensor test (148 lines)

**Modified**:
- `packages/cli/src/commands/startup/collect-capabilities.ts` — collect sensors
- `packages/cli/src/commands/dev.ts` — create runtime at boot
- `packages/core/src/index.ts`, `life-system/index.ts`, `server-entry.ts` — exports
- `addons/demo/cap-purchase-demo/src/capability.ts` — register sensor
- `addons/demo/cap-purchase-demo/src/index.ts` — re-export

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a purchase rejection pattern sensor that reports recent rejected purchase counts, confidence, and windowed context.
  * Added an evolution runtime to register/run sensors and exposed runtime creation in the public API.
  * Development startup now collects sensors and logs the count of registered sensors.

* **Tests**
  * Added tests covering the sensor behavior, timestamp/windowing rules, runtime wiring, query precedence, and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->