### PR TITLE
feat(evolution): MCP tools + runtime to transports (Task 4, closes #179)

### DIFF
--- a/addons/adapter-mcp/cap-adapter-mcp/__tests__/insight-tools.test.ts
+++ b/addons/adapter-mcp/cap-adapter-mcp/__tests__/insight-tools.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for the list_insights MCP tool.
+ *
+ * Verifies filtering by entity, type, limit slicing, and the JSON contract
+ * returned to the MCP client.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { Insight, InsightEngine, InsightType } from "@linchkit/core/types";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerInsightTools } from "../src/insight-tools";
+
+// ── Test helpers ────────────────────────────────────────
+
+interface RegisteredTool {
+  handler: (
+    args: Record<string, unknown>,
+    extra: unknown,
+  ) => Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+  }>;
+}
+
+type ToolsMap = Record<string, RegisteredTool>;
+
+function getTools(server: unknown): ToolsMap {
+  return (server as { _registeredTools: ToolsMap })._registeredTools;
+}
+
+function parseToolResult(result: { content: Array<{ type: string; text: string }> }): unknown {
+  return JSON.parse(result.content[0]?.text ?? "");
+}
+
+function makeInsight(overrides: Partial<Insight> & { id: string }): Insight {
+  return {
+    id: overrides.id,
+    type: overrides.type ?? "anomaly",
+    confidence: overrides.confidence ?? 0.85,
+    impact: overrides.impact ?? "medium",
+    causality: overrides.causality ?? "correlational",
+    entity: overrides.entity ?? "purchase_request",
+    summary: overrides.summary ?? "Test insight",
+    createdAt: overrides.createdAt ?? new Date("2026-04-10T12:00:00Z"),
+    evidence: overrides.evidence ?? {
+      signals: [],
+      context: {},
+    },
+  };
+}
+
+function createMockEngine(insights: Insight[]): InsightEngine {
+  return {
+    getInsights: () => insights,
+    generateInsights: async () => insights,
+    recordDriftCandidate: () => {
+      // no-op for tests
+    },
+  };
+}
+
+// ── Test fixtures ───────────────────────────────────────
+
+const INSIGHT_FIXTURES: Insight[] = [
+  makeInsight({ id: "i-1", type: "anomaly", entity: "purchase_request" }),
+  makeInsight({ id: "i-2", type: "friction", entity: "purchase_request" }),
+  makeInsight({ id: "i-3", type: "pattern", entity: "purchase_item" }),
+  makeInsight({ id: "i-4", type: "structural", entity: "purchase_item" }),
+  makeInsight({ id: "i-5", type: "positive", entity: "department" }),
+];
+
+// ── Tests ───────────────────────────────────────────────
+
+describe("registerInsightTools", () => {
+  let server: McpServer;
+
+  beforeEach(() => {
+    server = new McpServer({ name: "test", version: "1.0.0" });
+    registerInsightTools(server, createMockEngine(INSIGHT_FIXTURES));
+  });
+
+  test("registers list_insights tool", () => {
+    const tools = getTools(server);
+    expect(tools.list_insights).toBeDefined();
+  });
+
+  test("list_insights with no filter returns all insights", async () => {
+    const tools = getTools(server);
+    const result = await tools.list_insights?.handler({}, {});
+
+    const parsed = parseToolResult(result) as {
+      total: number;
+      returned: number;
+      insights: Array<Record<string, unknown>>;
+    };
+    expect(parsed.total).toBe(5);
+    expect(parsed.returned).toBe(5);
+    expect(parsed.insights.length).toBe(5);
+  });
+
+  test("list_insights filters by entity", async () => {
+    const tools = getTools(server);
+    const result = await tools.list_insights?.handler({ entity: "purchase_request" }, {});
+
+    const parsed = parseToolResult(result) as {
+      total: number;
+      insights: Array<Record<string, unknown>>;
+    };
+    expect(parsed.total).toBe(2);
+    expect(parsed.insights.every((i) => i.entity === "purchase_request")).toBe(true);
+  });
+
+  test("list_insights filters by type", async () => {
+    const tools = getTools(server);
+    const result = await tools.list_insights?.handler({ type: "structural" as InsightType }, {});
+
+    const parsed = parseToolResult(result) as {
+      total: number;
+      insights: Array<Record<string, unknown>>;
+    };
+    expect(parsed.total).toBe(1);
+    expect(parsed.insights[0]?.id).toBe("i-4");
+    expect(parsed.insights[0]?.type).toBe("structural");
+  });
+
+  test("list_insights combines entity and type filters", async () => {
+    const tools = getTools(server);
+    const result = await tools.list_insights?.handler(
+      { entity: "purchase_item", type: "pattern" as InsightType },
+      {},
+    );
+
+    const parsed = parseToolResult(result) as {
+      total: number;
+      insights: Array<Record<string, unknown>>;
+    };
+    expect(parsed.total).toBe(1);
+    expect(parsed.insights[0]?.id).toBe("i-3");
+  });
+
+  test("list_insights respects limit parameter", async () => {
+    const tools = getTools(server);
+    const result = await tools.list_insights?.handler({ limit: 2 }, {});
+
+    const parsed = parseToolResult(result) as {
+      total: number;
+      returned: number;
+      insights: Array<Record<string, unknown>>;
+    };
+    // total is the filtered count (5), returned is the slice length (2).
+    expect(parsed.total).toBe(5);
+    expect(parsed.returned).toBe(2);
+    expect(parsed.insights.length).toBe(2);
+  });
+
+  test("list_insights serializes evidence baseline dates as ISO strings", async () => {
+    const baselineDate = new Date("2026-03-01T00:00:00Z");
+    const insight = makeInsight({
+      id: "with-baseline",
+      evidence: {
+        signals: [],
+        baseline: {
+          entity: "purchase_request",
+          metric: "rejection_rate",
+          value: 0.42,
+          calculatedAt: baselineDate,
+        },
+        context: {},
+      },
+    });
+    const localServer = new McpServer({ name: "t2", version: "1.0.0" });
+    registerInsightTools(localServer, createMockEngine([insight]));
+
+    const result = await getTools(localServer).list_insights?.handler({}, {});
+    const parsed = parseToolResult(result) as {
+      insights: Array<{ evidence: { baseline?: { calculatedAt: string } } }>;
+    };
+    expect(parsed.insights[0]?.evidence.baseline?.calculatedAt).toBe("2026-03-01T00:00:00.000Z");
+  });
+
+  test("list_insights honors checkToolPolicy when blocked", async () => {
+    const localServer = new McpServer({ name: "t3", version: "1.0.0" });
+    registerInsightTools(localServer, createMockEngine(INSIGHT_FIXTURES), {
+      checkToolPolicy: () => ({
+        content: [{ type: "text" as const, text: JSON.stringify({ error: "denied" }) }],
+        isError: true,
+      }),
+    });
+
+    const result = await getTools(localServer).list_insights?.handler({}, {});
+    expect(result.isError).toBe(true);
+    const parsed = parseToolResult(result) as Record<string, unknown>;
+    expect(parsed.error).toBe("denied");
+  });
+
+  test("list_insights clamps limit to MAX_LIMIT", async () => {
+    const tools = getTools(server);
+    const result = await tools.list_insights?.handler({ limit: 999 }, {});
+
+    const parsed = parseToolResult(result) as { total: number; returned: number };
+    // Only 5 insights exist; clamping doesn't manufacture more.
+    expect(parsed.total).toBe(5);
+    expect(parsed.returned).toBe(5);
+  });
+});

--- a/addons/adapter-mcp/cap-adapter-mcp/__tests__/proposal-tools.test.ts
+++ b/addons/adapter-mcp/cap-adapter-mcp/__tests__/proposal-tools.test.ts
@@ -63,11 +63,12 @@ describe("registerProposalTools", () => {
     registerProposalTools(server, proposalEngine);
   });
 
-  test("registers three proposal tools", () => {
+  test("registers four proposal tools", () => {
     const tools = getTools(server);
     expect(tools.create_proposal).toBeDefined();
     expect(tools.get_proposal_status).toBeDefined();
     expect(tools.list_proposals).toBeDefined();
+    expect(tools.approve_proposal).toBeDefined();
   });
 
   test("create_proposal creates a proposal in draft status", async () => {
@@ -265,6 +266,130 @@ describe("registerProposalTools", () => {
     const proposal = proposalEngine.getProposal(proposalId);
     expect(proposal.author.type).toBe("ai");
     expect(proposal.author.id).toBe("mcp-agent");
+  });
+
+  // ── approve_proposal tests ──────────────────────────
+
+  test("approve_proposal moves a validated proposal to approved", async () => {
+    const tools = getTools(server);
+
+    // Create a draft proposal with a valid event definition (validation passes
+    // for events that just need a name).
+    const createResult = await tools.create_proposal?.handler(
+      {
+        title: "Approve me",
+        description: "Will be approved",
+        capability: "approval_test",
+        changeType: "patch",
+        changes: [
+          {
+            target: "event",
+            operation: "create",
+            name: "thing_created",
+            definition: { name: "thing_created", category: "domain" },
+          },
+        ],
+      },
+      {},
+    );
+    const created = parseToolResult(createResult) as Record<string, unknown>;
+    const proposalId = created.id as string;
+
+    // Move draft → validated via the engine directly (validation is a separate step
+    // not exposed as an MCP tool here)
+    proposalEngine.submitProposal({ proposalId });
+    expect(proposalEngine.getProposal(proposalId).status).toBe("validated");
+
+    // Approve via MCP tool
+    const approveResult = await tools.approve_proposal?.handler(
+      { proposalId, reviewer: "alice" },
+      {},
+    );
+
+    const approved = parseToolResult(approveResult) as Record<string, unknown>;
+    expect(approveResult.isError).toBeUndefined();
+    expect(approved.id).toBe(proposalId);
+    expect(approved.status).toBe("approved");
+    expect(approved.approvedBy).toEqual({ type: "ai", id: "alice" });
+    expect(approved.approvedAt).toBeDefined();
+  });
+
+  test("approve_proposal returns error for unknown ID", async () => {
+    const tools = getTools(server);
+
+    const result = await tools.approve_proposal?.handler(
+      { proposalId: "missing-id", reviewer: "bob" },
+      {},
+    );
+
+    expect(result.isError).toBe(true);
+    const parsed = parseToolResult(result) as Record<string, unknown>;
+    expect(parsed.error).toContain("not found");
+  });
+
+  test("approve_proposal returns error when proposal is not validated", async () => {
+    const tools = getTools(server);
+
+    // Create draft (status = "draft", not "validated")
+    const createResult = await tools.create_proposal?.handler(
+      {
+        title: "Still draft",
+        description: "Not yet submitted",
+        capability: "approval_test",
+        changeType: "patch",
+        changes: [{ target: "entity", operation: "create", name: "thing2" }],
+      },
+      {},
+    );
+    const created = parseToolResult(createResult) as Record<string, unknown>;
+    const proposalId = created.id as string;
+
+    const result = await tools.approve_proposal?.handler({ proposalId, reviewer: "carol" }, {});
+
+    expect(result.isError).toBe(true);
+    const parsed = parseToolResult(result) as Record<string, unknown>;
+    expect(parsed.error).toContain("validated");
+  });
+
+  test("approve_proposal falls back to session actor when reviewer is omitted", async () => {
+    const localServer = new McpServer({ name: "approve-test", version: "1.0.0" });
+    const localEngine = createProposalEngine();
+    registerProposalTools(localServer, localEngine, {
+      getSessionActor: () => ({
+        type: "human",
+        id: "session-user-42",
+        name: "Session User",
+      }),
+    });
+
+    const localTools = getTools(localServer);
+    const createResult = await localTools.create_proposal?.handler(
+      {
+        title: "Session approval",
+        description: "Approved by session actor",
+        capability: "approval_test",
+        changeType: "patch",
+        changes: [
+          {
+            target: "event",
+            operation: "create",
+            name: "thing3_created",
+            definition: { name: "thing3_created", category: "domain" },
+          },
+        ],
+      },
+      {},
+    );
+    const created = parseToolResult(createResult) as Record<string, unknown>;
+    const proposalId = created.id as string;
+    localEngine.submitProposal({ proposalId });
+    expect(localEngine.getProposal(proposalId).status).toBe("validated");
+
+    const approveResult = await localTools.approve_proposal?.handler({ proposalId }, {});
+
+    const approved = parseToolResult(approveResult) as Record<string, unknown>;
+    expect(approveResult.isError).toBeUndefined();
+    expect(approved.approvedBy).toEqual({ type: "human", id: "session-user-42" });
   });
 });
 

--- a/addons/adapter-mcp/cap-adapter-mcp/src/factory.ts
+++ b/addons/adapter-mcp/cap-adapter-mcp/src/factory.ts
@@ -81,6 +81,10 @@ export function createCapAdapterMcp(options?: CapAdapterMcpOptions): CapabilityD
         bearerToken,
         tenantId,
         graphqlEndpoint,
+        executionLogger: ctx.executionLogger,
+        // EvolutionRuntime is optional on TransportContext; when present we
+        // expose its InsightEngine so MCP clients can call list_insights.
+        insightEngine: ctx.evolutionRuntime?.insightEngine,
       });
 
       if (transportMode === "stdio") {
@@ -125,6 +129,8 @@ export function createCapAdapterMcp(options?: CapAdapterMcpOptions): CapabilityD
         bearerToken,
         tenantId,
         graphqlEndpoint,
+        executionLogger: ctx.executionLogger,
+        insightEngine: ctx.evolutionRuntime?.insightEngine,
       };
 
       const {

--- a/addons/adapter-mcp/cap-adapter-mcp/src/insight-tools.ts
+++ b/addons/adapter-mcp/cap-adapter-mcp/src/insight-tools.ts
@@ -1,0 +1,144 @@
+/**
+ * Insight tools for MCP runtime
+ *
+ * These tools allow AI agents to query promoted Insights from the
+ * Spec 55 life-system InsightEngine. Insights are evidence-backed
+ * observations (anomalies, friction, patterns, structural issues,
+ * positive signals) — they are not suggestions and never auto-apply.
+ */
+
+import type { Insight, InsightEngine, InsightType } from "@linchkit/core/types";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { toMcpShape } from "./zod-compat";
+
+/** Error result returned when a tool is blocked by policy */
+interface ToolBlockedResult {
+  [key: string]: unknown;
+  content: Array<{ type: "text"; text: string }>;
+  isError: true;
+}
+
+export interface InsightToolsOptions {
+  /**
+   * Tool policy checker. Returns an error result if the tool is not allowed,
+   * or undefined if the tool is permitted.
+   */
+  checkToolPolicy?: (toolName: string, category: string) => ToolBlockedResult | undefined;
+}
+
+/** Default cap on returned insights when no limit is provided. */
+const DEFAULT_LIMIT = 50;
+/** Hard upper bound on returned insights. */
+const MAX_LIMIT = 200;
+
+/**
+ * Register insight query tools on the MCP server.
+ *
+ * Tools registered:
+ * - list_insights: List promoted insights with optional entity/type/limit filters
+ */
+export function registerInsightTools(
+  server: McpServer,
+  insightEngine: InsightEngine,
+  options?: InsightToolsOptions,
+): void {
+  const checkToolPolicy = options?.checkToolPolicy;
+
+  // ── list_insights ─────────────────────────────────────
+  const listInsightsShape = {
+    entity: z.string().describe("Filter insights by entity name").optional(),
+    type: z
+      .enum(["anomaly", "friction", "pattern", "structural", "positive"])
+      .describe("Filter insights by type")
+      .optional(),
+    limit: z
+      .number()
+      .int()
+      .describe(`Maximum number of insights to return (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT})`)
+      .optional(),
+  };
+
+  server.tool(
+    "list_insights",
+    "List promoted insights from the evolution life-system, optionally filtered " +
+      "by entity name and/or type. Insights are evidence-backed observations " +
+      "produced by the InsightEngine — they are not suggestions and never auto-apply.",
+    toMcpShape(listInsightsShape),
+    async (args: { entity?: string; type?: InsightType; limit?: number }) => {
+      // Defense-in-depth: verify tool is allowed for current session
+      const blocked = checkToolPolicy?.("list_insights", "insight");
+      if (blocked) return blocked;
+
+      try {
+        const limit = Math.min(Math.max(args.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
+        const all = insightEngine.getInsights();
+
+        const filtered = all.filter((insight) => {
+          if (args.entity !== undefined && insight.entity !== args.entity) return false;
+          if (args.type !== undefined && insight.type !== args.type) return false;
+          return true;
+        });
+
+        const sliced = filtered.slice(0, limit);
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  total: filtered.length,
+                  returned: sliced.length,
+                  insights: sliced.map(serializeInsight),
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (_err) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                error: "Failed to list insights",
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+// ── Helpers ───────────────────────────────────────────────
+
+/** Serialize an Insight to a JSON-safe format (dates to ISO strings). */
+function serializeInsight(insight: Insight): Record<string, unknown> {
+  return {
+    id: insight.id,
+    type: insight.type,
+    causality: insight.causality,
+    entity: insight.entity,
+    summary: insight.summary,
+    confidence: insight.confidence,
+    impact: insight.impact,
+    createdAt: insight.createdAt.toISOString(),
+    evidence: {
+      signalCount: insight.evidence.signals.length,
+      baseline: insight.evidence.baseline
+        ? {
+            entity: insight.evidence.baseline.entity,
+            metric: insight.evidence.baseline.metric,
+            value: insight.evidence.baseline.value,
+            calculatedAt: insight.evidence.baseline.calculatedAt.toISOString(),
+          }
+        : undefined,
+      context: insight.evidence.context,
+    },
+  };
+}

--- a/addons/adapter-mcp/cap-adapter-mcp/src/mcp-server.ts
+++ b/addons/adapter-mcp/cap-adapter-mcp/src/mcp-server.ts
@@ -24,12 +24,13 @@ import type {
   StateDefinition,
 } from "@linchkit/core";
 import type { ProposalEngine } from "@linchkit/core/server";
-import type { ExecutionLogger } from "@linchkit/core/types";
+import type { ExecutionLogger, InsightEngine } from "@linchkit/core/types";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { McpClientRegistry } from "./client-registry";
 import { registerExecutionLogTools } from "./execution-log-tools";
 import { fieldsToJsonSchema } from "./field-to-json-schema";
+import { registerInsightTools } from "./insight-tools";
 import { registerManagementTools } from "./management-tools";
 import { registerProposalTools } from "./proposal-tools";
 import { registerScaffoldTools } from "./scaffold-tools";
@@ -81,6 +82,12 @@ export interface McpAdapterOptions {
    * When provided, registers get_execution_log, get_recent_executions tools.
    */
   executionLogger?: ExecutionLogger;
+  /**
+   * InsightEngine from the Spec 55 life-system runtime.
+   * When provided, registers list_insights tool so MCP clients can read
+   * promoted insights (anomalies, friction, patterns, structural, positive).
+   */
+  insightEngine?: InsightEngine;
 }
 
 /**
@@ -131,6 +138,7 @@ export async function createMcpAdapter(options: McpAdapterOptions): Promise<McpA
     clientRegistry,
     proposalEngine,
     executionLogger,
+    insightEngine,
   } = options;
 
   const server = new McpServer({ name, version });
@@ -319,6 +327,7 @@ export async function createMcpAdapter(options: McpAdapterOptions): Promise<McpA
       { name: "create_proposal", category: "proposals" },
       { name: "get_proposal_status", category: "proposals" },
       { name: "list_proposals", category: "proposals" },
+      { name: "approve_proposal", category: "proposals" },
     );
   }
 
@@ -329,6 +338,12 @@ export async function createMcpAdapter(options: McpAdapterOptions): Promise<McpA
       { name: "get_execution_log", category: "observability" },
       { name: "get_recent_executions", category: "observability" },
     );
+  }
+
+  // Register insight tools if InsightEngine is available
+  if (insightEngine) {
+    registerInsightTools(server, insightEngine, { checkToolPolicy });
+    allToolNames.push({ name: "list_insights", category: "insight" });
   }
 
   // Register resources

--- a/addons/adapter-mcp/cap-adapter-mcp/src/proposal-tools.ts
+++ b/addons/adapter-mcp/cap-adapter-mcp/src/proposal-tools.ts
@@ -43,6 +43,7 @@ export interface ProposalToolsOptions {
  * - create_proposal: Create a new proposal in draft status
  * - get_proposal_status: Get proposal details by ID
  * - list_proposals: List proposals with optional filters
+ * - approve_proposal: Approve a validated proposal (validated → approved)
  */
 export function registerProposalTools(
   server: McpServer,
@@ -273,6 +274,73 @@ export function registerProposalTools(
               type: "text" as const,
               text: JSON.stringify({
                 error: "Operation failed",
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  // ── approve_proposal ──────────────────────────────────
+  const approveProposalShape = {
+    proposalId: z.string().describe("Proposal ID to approve"),
+    reviewer: z
+      .string()
+      .describe("Reviewer identifier (defaults to the current MCP session actor when omitted)")
+      .optional(),
+  };
+
+  server.tool(
+    "approve_proposal",
+    "Approve a validated proposal (validated → approved). " +
+      "Approval is the precondition for commit/deploy and never auto-applies the change. " +
+      "Reviewer defaults to the current MCP session actor when not supplied.",
+    toMcpShape(approveProposalShape),
+    async (args: { proposalId: string; reviewer?: string }) => {
+      // Defense-in-depth: verify tool is allowed for current session
+      const blocked4 = options?.checkToolPolicy?.("approve_proposal", "proposals");
+      if (blocked4) return blocked4;
+
+      try {
+        // Derive reviewer: explicit arg wins, fall back to session actor.
+        const sessionActor = options?.getSessionActor?.();
+        const approverType = sessionActor?.type === "human" ? "human" : "ai";
+        const approverId = args.reviewer ?? sessionActor?.id ?? "mcp-agent";
+
+        const approved = proposalEngine.approveProposal({
+          proposalId: args.proposalId,
+          approvedBy: { type: approverType, id: approverId },
+        });
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  id: approved.id,
+                  title: approved.title,
+                  status: approved.status,
+                  capability: approved.capability,
+                  approvedBy: approved.approvedBy,
+                  approvedAt: approved.approvedAt?.toISOString(),
+                  updatedAt: approved.updatedAt.toISOString(),
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (err) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                error: err instanceof Error ? err.message : "Failed to approve proposal",
               }),
             },
           ],

--- a/packages/cli/src/commands/dev-wiring.ts
+++ b/packages/cli/src/commands/dev-wiring.ts
@@ -18,13 +18,11 @@ import type {
   CapabilityDefinition,
   DataProvider,
   EntityDefinition,
-  ExecutionLogFindOptions,
   LinchKitConfig,
   MiddlewareRegistration,
   RelationDefinition,
   RuleDefinition,
   Sensor,
-  SensorContext,
   StateDefinition,
   TransportContext,
   ViewDefinition,
@@ -32,6 +30,7 @@ import type {
 import {
   type ConfigRegistry,
   createDerivedPropertyEngine,
+  createDispatchQuery,
   createEvolutionRuntime,
 } from "@linchkit/core";
 import {
@@ -427,33 +426,12 @@ export async function wireDevEngines(input: WireDevEnginesInput): Promise<WireDe
   );
 
   // ── Evolution runtime (Spec 55) — register capability sensors on SignalBus ──
-  // Sensors observe runtime data via SensorContext.query. We dispatch by
-  // schema name so that `execution_log` queries reach ExecutionLogger
-  // (the right backing store) while regular entity queries go through the
-  // DataProvider. Without this routing, sensors that look at execution_log
-  // would silently see zero rows in both PostgreSQL and in-memory modes.
-  const dispatchQuery: SensorContext["query"] = async <T>(
-    schemaName: string,
-    filter?: Record<string, unknown>,
-  ): Promise<T[]> => {
-    if (schemaName === "execution_log") {
-      const actionName = typeof filter?.action_name === "string" ? filter.action_name : undefined;
-      const entityName = typeof filter?.entity_name === "string" ? filter.entity_name : undefined;
-      const statusVal = typeof filter?.status === "string" ? filter.status : undefined;
-      const result = await executionLogger.findMany({
-        action: actionName,
-        entity: entityName,
-        status: statusVal as ExecutionLogFindOptions["status"],
-        pageSize: 1000,
-      });
-      return result.items as T[];
-    }
-    const rows = await dataProvider.query(schemaName, filter ?? {});
-    return rows as T[];
-  };
+  // Dispatch query routes `execution_log` → ExecutionLogger and other schemas
+  // → DataProvider. Without this split, sensors reading execution_log would
+  // silently see zero rows in both PostgreSQL and in-memory dev modes.
   const evolutionRuntime = createEvolutionRuntime({
     sensors,
-    query: dispatchQuery,
+    query: createDispatchQuery({ dataProvider, executionLogger }),
   });
   consoleLogger.info(
     `Evolution runtime ready: ${evolutionRuntime.signalBus.listSensors().length} sensor(s) registered`,

--- a/packages/cli/src/commands/dev-wiring.ts
+++ b/packages/cli/src/commands/dev-wiring.ts
@@ -18,15 +18,22 @@ import type {
   CapabilityDefinition,
   DataProvider,
   EntityDefinition,
+  ExecutionLogFindOptions,
   LinchKitConfig,
   MiddlewareRegistration,
   RelationDefinition,
   RuleDefinition,
+  Sensor,
+  SensorContext,
   StateDefinition,
   TransportContext,
   ViewDefinition,
 } from "@linchkit/core";
-import { type ConfigRegistry, createDerivedPropertyEngine } from "@linchkit/core";
+import {
+  type ConfigRegistry,
+  createDerivedPropertyEngine,
+  createEvolutionRuntime,
+} from "@linchkit/core";
 import {
   type ActionRegistry,
   AIAuditLogger,
@@ -90,6 +97,9 @@ export interface WireDevEnginesInput {
   middlewares: MiddlewareRegistration[];
   capabilities: CapabilityDefinition[];
 
+  /** Sensors collected from cap.extensions.sensors (Spec 55 §3.3) */
+  sensors: Sensor[];
+
   // Database state (may be undefined if no DB)
   dbInstance?: ReturnType<typeof import("@linchkit/core/server").createDatabase>;
   dataProvider: DataProvider;
@@ -124,6 +134,7 @@ export async function wireDevEngines(input: WireDevEnginesInput): Promise<WireDe
     rules,
     middlewares,
     capabilities,
+    sensors,
     dbInstance,
     dataProvider,
   } = input;
@@ -415,6 +426,39 @@ export async function wireDevEngines(input: WireDevEnginesInput): Promise<WireDe
     `HealthCheckRegistry: ${healthCheckRegistry.list().length} check(s) registered (${healthCheckRegistry.list().join(", ")})`,
   );
 
+  // ── Evolution runtime (Spec 55) — register capability sensors on SignalBus ──
+  // Sensors observe runtime data via SensorContext.query. We dispatch by
+  // schema name so that `execution_log` queries reach ExecutionLogger
+  // (the right backing store) while regular entity queries go through the
+  // DataProvider. Without this routing, sensors that look at execution_log
+  // would silently see zero rows in both PostgreSQL and in-memory modes.
+  const dispatchQuery: SensorContext["query"] = async <T>(
+    schemaName: string,
+    filter?: Record<string, unknown>,
+  ): Promise<T[]> => {
+    if (schemaName === "execution_log") {
+      const actionName = typeof filter?.action_name === "string" ? filter.action_name : undefined;
+      const entityName = typeof filter?.entity_name === "string" ? filter.entity_name : undefined;
+      const statusVal = typeof filter?.status === "string" ? filter.status : undefined;
+      const result = await executionLogger.findMany({
+        action: actionName,
+        entity: entityName,
+        status: statusVal as ExecutionLogFindOptions["status"],
+        pageSize: 1000,
+      });
+      return result.items as T[];
+    }
+    const rows = await dataProvider.query(schemaName, filter ?? {});
+    return rows as T[];
+  };
+  const evolutionRuntime = createEvolutionRuntime({
+    sensors,
+    query: dispatchQuery,
+  });
+  consoleLogger.info(
+    `Evolution runtime ready: ${evolutionRuntime.signalBus.listSensors().length} sensor(s) registered`,
+  );
+
   const transportCtx: TransportContext = {
     commandLayer,
     executor,
@@ -444,6 +488,7 @@ export async function wireDevEngines(input: WireDevEnginesInput): Promise<WireDe
     aiAuditLogger,
     aiService,
     aiConfig: config.ai,
+    evolutionRuntime,
   };
 
   return {

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -9,13 +9,8 @@
  * transport factories through the capability contract.
  */
 
-import type {
-  CapabilityDefinition,
-  LinchKitConfig,
-  SensorContext,
-  TransportLifecycle,
-} from "@linchkit/core";
-import { ConfigRegistry, createEvolutionRuntime, initI18n } from "@linchkit/core";
+import type { CapabilityDefinition, LinchKitConfig, TransportLifecycle } from "@linchkit/core";
+import { ConfigRegistry, initI18n } from "@linchkit/core";
 import {
   closeDatabase,
   consoleLogger,
@@ -159,28 +154,6 @@ export const devCommand = defineCommand({
       links,
     });
 
-    // ── Evolution runtime (Spec 55) — register capability sensors on SignalBus ──
-    // Sensors are collected from extensions.sensors and registered here so that
-    // any caller of evolutionRuntime.evolutionCycle.runCycle() can see them.
-    // A periodic driver is intentionally NOT started here — triggering is left
-    // to explicit callers (MCP tools, admin UI, scheduled jobs).
-    // Adapt DataProvider.query (concrete row type) to SensorContext.query (generic T).
-    // The cast is sound because callers (sensors) choose T to match their expected shape.
-    const evolutionQuery: SensorContext["query"] = async <T>(
-      schema: string,
-      filter?: Record<string, unknown>,
-    ) => {
-      const rows = await devDataProvider.query(schema, filter ?? {});
-      return rows as T[];
-    };
-    const evolutionRuntime = createEvolutionRuntime({
-      sensors: collected.sensors,
-      query: evolutionQuery,
-    });
-    consoleLogger.info(
-      `Evolution runtime ready: ${evolutionRuntime.signalBus.listSensors().length} sensor(s) registered`,
-    );
-
     // ── Auth provider wiring ──
     await wireAuthProvider({
       capabilities,
@@ -211,6 +184,7 @@ export const devCommand = defineCommand({
       rules,
       middlewares,
       capabilities,
+      sensors: collected.sensors,
       dbInstance,
       dataProvider: devDataProvider,
       usingDatabase,

--- a/packages/core/__tests__/life-system/dispatch-query.test.ts
+++ b/packages/core/__tests__/life-system/dispatch-query.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Tests for createDispatchQuery — runtime query routing.
+ *
+ * Verifies that `execution_log` queries reach ExecutionLogger while all
+ * other schemas are delegated to the business DataProvider. Without this
+ * split, sensors querying `execution_log` silently return 0 rows.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { DataProvider } from "../../src/engine/action-engine";
+import { createDispatchQuery } from "../../src/life-system/dispatch-query";
+import type {
+  ExecutionLogEntry,
+  ExecutionLogFindOptions,
+  ExecutionLogger,
+  ExecutionLogListResult,
+} from "../../src/types/execution-log";
+
+interface ExecutionLoggerCall {
+  options?: ExecutionLogFindOptions;
+}
+
+interface DataProviderCall {
+  schema: string;
+  filter: Record<string, unknown>;
+}
+
+function makeExecutionLogger(items: ExecutionLogEntry[]): {
+  logger: ExecutionLogger;
+  calls: ExecutionLoggerCall[];
+} {
+  const calls: ExecutionLoggerCall[] = [];
+  const logger: ExecutionLogger = {
+    log: () => {},
+    getAll: () => items,
+    getByAction: (action) => items.filter((i) => i.action === action),
+    getByEntity: (entity) => items.filter((i) => i.entity === entity),
+    getByStatus: (status) => items.filter((i) => i.status === status),
+    getById: (id) => items.find((i) => i.id === id),
+    findMany: (options) => {
+      calls.push({ options });
+      const result: ExecutionLogListResult = {
+        items,
+        total: items.length,
+        page: 1,
+        pageSize: options?.pageSize ?? items.length,
+      };
+      return result;
+    },
+  };
+  return { logger, calls };
+}
+
+function makeDataProvider(rows: Array<Record<string, unknown>>): {
+  provider: DataProvider;
+  calls: DataProviderCall[];
+} {
+  const calls: DataProviderCall[] = [];
+  const provider: DataProvider = {
+    async get() {
+      throw new Error("not used in test");
+    },
+    async query(schema, filter) {
+      calls.push({ schema, filter });
+      return rows;
+    },
+    async create() {
+      throw new Error("not used in test");
+    },
+    async update() {
+      throw new Error("not used in test");
+    },
+    async delete() {
+      throw new Error("not used in test");
+    },
+    async count() {
+      return rows.length;
+    },
+  };
+  return { provider, calls };
+}
+
+function makeExecutionLogEntry(overrides: Partial<ExecutionLogEntry> = {}): ExecutionLogEntry {
+  return {
+    id: "exec-1",
+    action: "reject_purchase_request",
+    entity: "purchase_request",
+    status: "succeeded",
+    startedAt: new Date("2026-04-10T00:00:00Z"),
+    completedAt: new Date("2026-04-10T00:00:01Z"),
+    ...overrides,
+  };
+}
+
+describe("createDispatchQuery", () => {
+  test("routes execution_log queries to ExecutionLogger (not DataProvider)", async () => {
+    const entry = makeExecutionLogEntry();
+    const { logger, calls: loggerCalls } = makeExecutionLogger([entry]);
+    const { provider, calls: providerCalls } = makeDataProvider([]);
+
+    const query = createDispatchQuery({ dataProvider: provider, executionLogger: logger });
+
+    const rows = await query<ExecutionLogEntry>("execution_log", {
+      action_name: "reject_purchase_request",
+      status: "succeeded",
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe("exec-1");
+    expect(loggerCalls).toHaveLength(1);
+    expect(loggerCalls[0]?.options).toMatchObject({
+      action: "reject_purchase_request",
+      status: "succeeded",
+    });
+    expect(providerCalls).toHaveLength(0);
+  });
+
+  test("routes non-system queries to DataProvider (not ExecutionLogger)", async () => {
+    const businessRow = { id: "pr-1", title: "Buy pencils" };
+    const { logger, calls: loggerCalls } = makeExecutionLogger([]);
+    const { provider, calls: providerCalls } = makeDataProvider([businessRow]);
+
+    const query = createDispatchQuery({ dataProvider: provider, executionLogger: logger });
+
+    const rows = await query("purchase_request", { status: "draft" });
+
+    expect(rows).toEqual([businessRow]);
+    expect(providerCalls).toHaveLength(1);
+    expect(providerCalls[0]).toEqual({
+      schema: "purchase_request",
+      filter: { status: "draft" },
+    });
+    expect(loggerCalls).toHaveLength(0);
+  });
+
+  test("translates entity_name filter to ExecutionLogger's `entity` field", async () => {
+    const { logger, calls } = makeExecutionLogger([]);
+    const { provider } = makeDataProvider([]);
+    const query = createDispatchQuery({ dataProvider: provider, executionLogger: logger });
+
+    await query("execution_log", { entity_name: "purchase_request" });
+
+    expect(calls[0]?.options).toMatchObject({ entity: "purchase_request" });
+  });
+
+  test("ignores non-string filter values safely", async () => {
+    const { logger, calls } = makeExecutionLogger([]);
+    const { provider } = makeDataProvider([]);
+    const query = createDispatchQuery({ dataProvider: provider, executionLogger: logger });
+
+    await query("execution_log", {
+      action_name: 42, // not a string — must be dropped, not crash
+      status: true, // not a string — must be dropped
+    });
+
+    expect(calls[0]?.options).toMatchObject({
+      action: undefined,
+      status: undefined,
+    });
+  });
+
+  test("passes empty filter to DataProvider when none supplied", async () => {
+    const { logger } = makeExecutionLogger([]);
+    const { provider, calls } = makeDataProvider([]);
+    const query = createDispatchQuery({ dataProvider: provider, executionLogger: logger });
+
+    await query("purchase_request");
+
+    expect(calls[0]?.filter).toEqual({});
+  });
+
+  test("honors a custom executionLogPageSize", async () => {
+    const { logger, calls } = makeExecutionLogger([]);
+    const { provider } = makeDataProvider([]);
+    const query = createDispatchQuery({
+      dataProvider: provider,
+      executionLogger: logger,
+      executionLogPageSize: 50,
+    });
+
+    await query("execution_log");
+
+    expect(calls[0]?.options?.pageSize).toBe(50);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -258,7 +258,12 @@ export type {
   SignalHandler,
 } from "./life-system";
 // Life-system — Sense layer (Spec 55)
-export { createEvolutionRuntime, createSignalBus, defineSensor } from "./life-system";
+export {
+  createDispatchQuery,
+  createEvolutionRuntime,
+  createSignalBus,
+  defineSensor,
+} from "./life-system";
 export type {
   AlertCondition,
   AlertEffect,

--- a/packages/core/src/life-system/dispatch-query.ts
+++ b/packages/core/src/life-system/dispatch-query.ts
@@ -1,0 +1,70 @@
+/**
+ * Dispatch query helper — routes SensorContext queries to the right backing store.
+ *
+ * LinchKit runtime has two disjoint data sources:
+ *   - Business DataProvider — entity rows (users, orders, purchase_requests…)
+ *   - ExecutionLogger       — execution_log rows (action invocations)
+ *
+ * Sensors declare `ctx.query(schema, filter)` usage without knowing which backend
+ * owns a given schema. This helper dispatches by schema name so sensors that look
+ * at `execution_log` actually reach the logger (not the DataProvider which doesn't
+ * register system tables).
+ *
+ * Spec 55 §3.3 — sensors query via SensorContext, routing is a runtime concern.
+ */
+
+import type { DataProvider } from "../engine/action-engine";
+import type { ExecutionLogFindOptions, ExecutionLogger } from "../types/execution-log";
+import type { SensorContext } from "../types/life-system";
+
+export interface CreateDispatchQueryOptions {
+  /** Business data provider for non-system schemas. */
+  dataProvider: DataProvider;
+  /** Execution log source for the `execution_log` schema. */
+  executionLogger: ExecutionLogger;
+  /**
+   * Upper bound on rows pulled from the execution log per call.
+   * Defaults to 1000. Sensors that need unbounded history should
+   * paginate explicitly (not yet implemented — see Spec 55 roadmap).
+   */
+  executionLogPageSize?: number;
+}
+
+const DEFAULT_EXECUTION_LOG_PAGE_SIZE = 1000;
+
+/**
+ * Build a `SensorContext["query"]` function that routes `execution_log`
+ * queries to the ExecutionLogger and all other schemas to the DataProvider.
+ *
+ * The generic `T` cast at the boundary is intentional: sensors declare the
+ * row shape they expect (e.g. `ExecutionLogEntry` fields). Runtime schema
+ * validation is deliberately NOT performed here — if a sensor reads a field
+ * that doesn't exist it'll get `undefined`, which is caught by unit tests.
+ */
+export function createDispatchQuery(
+  opts: CreateDispatchQueryOptions,
+): NonNullable<SensorContext["query"]> {
+  const pageSize = opts.executionLogPageSize ?? DEFAULT_EXECUTION_LOG_PAGE_SIZE;
+
+  return async <T = unknown>(schema: string, filter?: Record<string, unknown>): Promise<T[]> => {
+    if (schema === "execution_log") {
+      // Translate the generic equality filter into the logger's typed filter.
+      // Only a subset of execution_log fields are routed today; add more as
+      // sensors need them (actor_id, capability, channel, …).
+      const actionName = typeof filter?.action_name === "string" ? filter.action_name : undefined;
+      const entityName = typeof filter?.entity_name === "string" ? filter.entity_name : undefined;
+      const statusVal = typeof filter?.status === "string" ? filter.status : undefined;
+
+      const result = await opts.executionLogger.findMany({
+        action: actionName,
+        entity: entityName,
+        status: statusVal as ExecutionLogFindOptions["status"],
+        pageSize,
+      });
+      return result.items as T[];
+    }
+
+    const rows = await opts.dataProvider.query(schema, filter ?? {});
+    return rows as T[];
+  };
+}

--- a/packages/core/src/life-system/index.ts
+++ b/packages/core/src/life-system/index.ts
@@ -11,6 +11,8 @@ export type { AwarenessEngineOptions } from "./awareness-engine";
 export { createAwarenessEngine } from "./awareness-engine";
 export type { SensorDefinitionConfig } from "./define-sensor";
 export { defineSensor } from "./define-sensor";
+export type { CreateDispatchQueryOptions } from "./dispatch-query";
+export { createDispatchQuery } from "./dispatch-query";
 export type { EvolutionCycleOptions } from "./evolution-cycle";
 export { createEvolutionCycle } from "./evolution-cycle";
 export { InMemoryMemoryStore } from "./in-memory-memory-store";

--- a/packages/core/src/server-entry.ts
+++ b/packages/core/src/server-entry.ts
@@ -389,6 +389,7 @@ export type {
 export {
   createAttentionBudget,
   createAwarenessEngine,
+  createDispatchQuery,
   createEvolutionRuntime,
   createSignalBus,
   createUsageImportanceGraph,

--- a/packages/core/src/types/transport.ts
+++ b/packages/core/src/types/transport.ts
@@ -21,6 +21,7 @@ import type { EntityRegistry } from "../entity/entity-registry";
 import type { RelationRegistry } from "../entity/relation-registry";
 import type { EventBus } from "../event/event-bus";
 import type { FlowEngine, FlowRegistry } from "../flow/types";
+import type { EvolutionRuntime } from "../life-system/runtime";
 import type { OntologyRegistry } from "../ontology";
 import type { ActionDefinition } from "./action";
 import type { AIService, AIServiceConfig } from "./ai";
@@ -81,6 +82,14 @@ export interface TransportContext {
   aiService?: AIService;
   /** AI service config — raw config for resolving language models directly */
   aiConfig?: AIServiceConfig;
+  /**
+   * Evolution runtime — Spec 55 life-system pipeline (Sense→Memory→Awareness→Insight).
+   * Transports (MCP, HTTP) use this to trigger evolution cycles, list insights,
+   * and manage proposals. Constructed by the CLI dev wiring after the
+   * execution logger so its query helper can route execution_log lookups
+   * to the right backend (Drizzle or in-memory).
+   */
+  evolutionRuntime?: EvolutionRuntime;
 }
 
 /** Lifecycle handle returned by transport factory */


### PR DESCRIPTION
## Summary

Task 4 of Path A Evolution: exposes `EvolutionRuntime` to transports + routes `execution_log` queries correctly + adds two Evolution MCP tools. Closes #179. Stacked on top of #180.

## What this PR does

### 1. Runtime wiring (closes #179)

Previously `evolutionRuntime` was built in `dev.ts` and never reached transports, and `devDataProvider.query("execution_log")` returned nothing because `execution_log` lives in `ExecutionLogger`, not the business data provider. Both issues surfaced in Codex round-2 review on #180.

- `TransportContext.evolutionRuntime?: EvolutionRuntime` — transports (MCP, HTTP) can now reach the life-system pipeline
- `wireDevEngines` constructs the runtime after `ExecutionLogger` is ready and attaches it to `transportCtx`
- `dev.ts` now just forwards `collected.sensors` (runtime construction moved out)
- New `createDispatchQuery({dataProvider, executionLogger})` helper (core) routes `execution_log` → `ExecutionLogger.findMany()` and everything else → `DataProvider.query()`

### 2. Evolution MCP tools

- `list_insights` (new file `insight-tools.ts`) — lists promoted insights with optional entity/type/limit filters, honors `checkToolPolicy` gate
- `approve_proposal` (added to existing `proposal-tools.ts`) — transitions a validated proposal to approved via `proposalEngine.approveProposal()`
- `factory.ts` now forwards `ctx.executionLogger` and `ctx.evolutionRuntime?.insightEngine` to the MCP adapter — so `get_execution_log`, `get_recent_executions` (already registered) and `list_insights` actually surface in MCP clients now

### 3. `get_proposal` deliberately NOT added

Existing `get_proposal_status` already covers the "fetch a proposal by id" use case (returns the full proposal). Adding a redundant tool would just confuse AI clients.

## Cross-model review (Gemini round 1)

Flagged 2 MAJOR + 6 MINOR/NIT findings. Evaluation:

| Finding | Severity | Decision |
|---|---|---|
| `pageSize: 1000` hardcoded in dispatchQuery | MAJOR | **Fixed** (extracted `createDispatchQuery` with configurable `executionLogPageSize`, documented default + pagination TODO) |
| No unit test for dispatchQuery routing | MINOR | **Fixed** (6 focused tests: execution_log routing, fallback to DataProvider, filter translation, non-string safety, empty filter, custom page size) |
| `dispatchQuery` return cast lacks runtime validation | MAJOR | **Rejected** — sensors are internal and declare their own row shapes; runtime schema validation is overkill for internal code. Documented the cast rationale inline |
| Filter mapping ignores `actor_id`, `capability`, etc. | MINOR | **Deferred** — documented as "add as sensors need them"; current three fields (`action_name`, `entity_name`, `status`) cover the MVP sensor |
| `serializeInsight` omits raw signals | MINOR | **Deferred** — lean MCP responses are a feature; drill-down can be a separate `get_insight_evidence` tool later |
| Default reviewer fallback `"mcp-agent"` | NIT | **Accepted as designed** — escape hatch for tests; real sessions use the actor id |
| `InsightType` zod enum must stay in sync with core | MINOR | **Accepted for now** — documented; revisit when we add a new insight type |
| Runtime init order | NIT (positive) | No action |

Codex: attempted but hung after ~10 min producing only grep dumps (no review findings). Not re-run to keep cycle time reasonable. Gemini's findings were thorough.

## Wiring chain verification (end-to-end)

1. `capability.ts` declares `extensions.sensors: [...]` (from #180)
2. `collectCapabilityDefinitions` flattens into `CollectedDefinitions.sensors` (from #180)
3. `dev.ts` forwards `sensors: collected.sensors` → `wireDevEngines`
4. `wireDevEngines` builds `createDispatchQuery({dataProvider, executionLogger})` → `createEvolutionRuntime({sensors, query})`
5. Runtime attached to `transportCtx.evolutionRuntime`
6. MCP `factory.ts` reads `ctx.evolutionRuntime?.insightEngine` + `ctx.executionLogger` → passes to `createMcpAdapter`
7. `mcp-server.ts` conditionally registers `list_insights` when `insightEngine` is present, `approve_proposal` when `proposalEngine` is present (the latter was already wired from earlier work)

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean (1 pre-existing biome schema info, unrelated)
- [x] `bun test packages/core/__tests__/life-system/dispatch-query.test.ts` — 6 pass
- [x] `bun test addons/adapter-mcp/cap-adapter-mcp/__tests__/insight-tools.test.ts` — 9 pass
- [x] `bun test addons/adapter-mcp/cap-adapter-mcp/__tests__/proposal-tools.test.ts` — full coverage incl. approve_proposal happy path + not-found + wrong-state + session-fallback
- [x] `bun test` full suite — **4214 pass / 3 skip / 0 fail**
- [x] Cross-model review (Gemini) — all findings addressed or deferred with rationale

## Known limitations (for future work)

1. `dispatchQuery` caps execution_log reads at 1000 rows — sufficient for MVP demo scale; pagination needed for production scale with >1000 events/window
2. Filter translation for execution_log covers `action_name`, `entity_name`, `status` only — extend as sensors need more fields
3. `InsightType` zod enum in `insight-tools.ts` duplicates the core type — refactor to derive once, not twice

None of these block Task 4's deliverable — they're documented inline as tech debt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP tool to list insights with optional filtering by entity and type, supporting configurable result limits
  * Added MCP tool to approve proposals with automatic reviewer fallback to the current session actor
  * Integrated policy-based access control for tool invocations

* **Tests**
  * Added comprehensive test suites validating insight listing, proposal approval, and query routing functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->