### PR TITLE
fix(workflow): resolve hook over-match and marker staleness gaps (#182)

### DIFF
--- a/.claude/hooks/__tests__/smoke.sh
+++ b/.claude/hooks/__tests__/smoke.sh
@@ -14,6 +14,22 @@ ROOT=$(git rev-parse --show-toplevel)
 cd "$ROOT"
 
 HOOKS="$ROOT/.claude/hooks"
+
+# Isolate test state — point TMPDIR at a scratch dir so wf_reset / wf_mark
+# don't clobber the developer's real workflow markers. Also track temp files
+# created during the test so a trap can clean them up on any exit path.
+SMOKE_TMP=$(mktemp -d)
+export TMPDIR="$SMOKE_TMP"
+TMP_VICTIM=""
+cleanup() {
+  rm -rf "$SMOKE_TMP"
+  if [ -n "$TMP_VICTIM" ]; then
+    git reset -q -- "$TMP_VICTIM" 2>/dev/null || true
+    rm -f "$TMP_VICTIM"
+  fi
+}
+trap cleanup EXIT INT TERM
+
 # shellcheck source=../workflow-state.sh
 source "$HOOKS/workflow-state.sh"
 
@@ -133,9 +149,9 @@ touch -t "$(date -r "$(_wf_file).check_passed.ref" +%Y%m%d%H%M.%S)" tsconfig.jso
 # Use docs/ (outside the mtime-watched roots) so only the tracked-hash check
 # fires — and sleep 1s to guarantee file mtime < ref mtime on fast runs.
 wf_reset
-tmp_victim="docs/_v_smoke.txt"
-echo "bye" > "$tmp_victim"
-git add "$tmp_victim" 2>/dev/null
+TMP_VICTIM="docs/_v_smoke.txt"
+echo "bye" > "$TMP_VICTIM"
+git add "$TMP_VICTIM" 2>/dev/null
 sleep 1
 wf_mark check_passed
 wf_mark typecheck_passed
@@ -143,8 +159,9 @@ wf_mark tests_passed
 unset rc
 out=$(make_input "git commit -m msg" | "$HOOKS/pre-commit.sh" 2>&1) || rc=$? ; rc=${rc:-0}
 check "baseline with staged file → exit 0" "[ \"$rc\" = 0 ]"
-git rm -qf "$tmp_victim" 2>/dev/null
-rm -f "$tmp_victim"
+git rm -qf "$TMP_VICTIM" 2>/dev/null
+rm -f "$TMP_VICTIM"
+TMP_VICTIM=""  # already cleaned; unset so trap doesn't retry
 unset rc
 out=$(make_input "git commit -m msg" | "$HOOKS/pre-commit.sh" 2>&1) || rc=$? ; rc=${rc:-0}
 check "tracked-file removal stales gate → exit 2" "[ \"$rc\" = 2 ]"

--- a/.claude/hooks/__tests__/smoke.sh
+++ b/.claude/hooks/__tests__/smoke.sh
@@ -42,7 +42,14 @@ wf_reset
 wf_mark check_passed
 check "mark sets wf_has" "wf_has check_passed"
 check "ref file created" "[ -f \"$WF.check_passed.ref\" ]"
+check "files snapshot created" "[ -f \"$WF.check_passed.files\" ]"
 check "fresh right after mark" "wf_fresh check_passed"
+
+# Gemini review: wf_mark must dedupe — calling it twice yields exactly one entry.
+wf_mark check_passed
+wf_mark check_passed
+entries=$(grep -c "^check_passed=" "$WF" 2>/dev/null || echo 0)
+check "wf_mark dedupes entries" "[ \"$entries\" = 1 ]"
 
 sleep 1
 touch .claude/hooks/workflow-state.sh
@@ -81,6 +88,15 @@ check "wrapped cd-then-commit → exit 2" "[ \"$rc\" = 2 ]"
 unset rc
 out=$(make_input "git add . && git commit -m msg" | "$HOOKS/pre-commit.sh" 2>&1) || rc=$? ; rc=${rc:-0}
 check "wrapped add-then-commit → exit 2" "[ \"$rc\" = 2 ]"
+
+# Gemini review: trailing shell separators must match too.
+unset rc
+out=$(make_input "git commit;make test" | "$HOOKS/pre-commit.sh" 2>&1) || rc=$? ; rc=${rc:-0}
+check "commit-then-semicolon → exit 2" "[ \"$rc\" = 2 ]"
+
+unset rc
+out=$(make_input "git commit&&echo done" | "$HOOKS/pre-commit.sh" 2>&1) || rc=$? ; rc=${rc:-0}
+check "commit-then-&& → exit 2" "[ \"$rc\" = 2 ]"
 
 unset rc
 wf_mark check_passed
@@ -152,6 +168,15 @@ check "no review marker → exit 2" "[ \"$rc\" = 2 ]"
 unset rc
 out=$(make_input "cd /tmp && gh pr create --title x" | "$HOOKS/pre-pr.sh" 2>&1) || rc=$? ; rc=${rc:-0}
 check "wrapped cd-then-gh-pr-create → exit 2" "[ \"$rc\" = 2 ]"
+
+# Gemini review: trailing shell separators must match too.
+unset rc
+out=$(make_input "gh pr create;echo done" | "$HOOKS/pre-pr.sh" 2>&1) || rc=$? ; rc=${rc:-0}
+check "gh-pr-create-then-semicolon → exit 2" "[ \"$rc\" = 2 ]"
+
+unset rc
+out=$(make_input "gh pr create&&echo ok" | "$HOOKS/pre-pr.sh" 2>&1) || rc=$? ; rc=${rc:-0}
+check "gh-pr-create-then-&& → exit 2" "[ \"$rc\" = 2 ]"
 
 unset rc
 wf_mark cross_model_review

--- a/.claude/hooks/__tests__/smoke.sh
+++ b/.claude/hooks/__tests__/smoke.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+# Smoke tests for the workflow hooks. Run from repo root:
+#   bash .claude/hooks/__tests__/smoke.sh
+#
+# Covers:
+#   1. wf_fresh freshness semantics (marker + ref file + source mtime)
+#   2. pre-commit.sh stdin parsing — no-op when command isn't really git commit
+#   3. pre-commit.sh — blocks when gates missing; allows when fresh; blocks when stale
+#   4. pre-pr.sh stdin parsing — no-op when command isn't really gh pr create
+#   5. pre-pr.sh — blocks without cross_model_review, allows with it
+set -euo pipefail
+
+ROOT=$(git rev-parse --show-toplevel)
+cd "$ROOT"
+
+HOOKS="$ROOT/.claude/hooks"
+# shellcheck source=../workflow-state.sh
+source "$HOOKS/workflow-state.sh"
+
+pass=0
+fail=0
+check() {
+  if eval "$2"; then
+    echo "  ok   $1"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL $1"
+    fail=$((fail + 1))
+  fi
+}
+
+make_input() {
+  # Build the stdin JSON the Claude Code harness sends to PreToolUse Bash hooks.
+  # $1 = command string
+  printf '{"tool_input":{"command":%s}}' "$(jq -Rn --arg c "$1" '$c')"
+}
+
+WF=$(_wf_file)
+
+echo "== wf_fresh =="
+wf_reset
+wf_mark check_passed
+check "mark sets wf_has" "wf_has check_passed"
+check "ref file created" "[ -f \"$WF.check_passed.ref\" ]"
+check "fresh right after mark" "wf_fresh check_passed"
+
+sleep 1
+touch .claude/hooks/workflow-state.sh
+check "stale after source edit" "! wf_fresh check_passed"
+
+wf_mark check_passed
+check "fresh again after re-mark" "wf_fresh check_passed"
+
+wf_reset
+check "reset empties state file" "[ ! -s \"$WF\" ]"
+check "reset removes ref file" "[ ! -f \"$WF.check_passed.ref\" ]"
+
+echo
+echo "== pre-commit.sh =="
+wf_reset
+
+out=$(make_input "echo example-unrelated-cmd body" | "$HOOKS/pre-commit.sh" 2>&1) || rc=$? ; rc=${rc:-0}
+check "unrelated command → exit 0" "[ \"$rc\" = 0 ]"
+
+unset rc
+# Regression: #182 original — hook must NOT fire when 'git commit' appears
+# only inside a quoted argument (no shell separator before it).
+out=$(make_input "gh issue create --body 'see git commit later'" | "$HOOKS/pre-commit.sh" 2>&1) || rc=$? ; rc=${rc:-0}
+check "quoted 'git commit' in body → exit 0" "[ \"$rc\" = 0 ]"
+
+unset rc
+out=$(make_input "git commit -m msg" | "$HOOKS/pre-commit.sh" 2>&1) || rc=$? ; rc=${rc:-0}
+check "real commit, no gates → exit 2" "[ \"$rc\" = 2 ]"
+check "error mentions BLOCKED" "printf '%s' \"\$out\" | grep -q BLOCKED"
+
+unset rc
+# Codex P1 regression: wrapped `cd /x && git commit` must enforce gates.
+out=$(make_input "cd /tmp && git commit -m msg" | "$HOOKS/pre-commit.sh" 2>&1) || rc=$? ; rc=${rc:-0}
+check "wrapped cd-then-commit → exit 2" "[ \"$rc\" = 2 ]"
+
+unset rc
+out=$(make_input "git add . && git commit -m msg" | "$HOOKS/pre-commit.sh" 2>&1) || rc=$? ; rc=${rc:-0}
+check "wrapped add-then-commit → exit 2" "[ \"$rc\" = 2 ]"
+
+unset rc
+wf_mark check_passed
+wf_mark typecheck_passed
+wf_mark tests_passed
+out=$(make_input "git commit -m msg" | "$HOOKS/pre-commit.sh" 2>&1) || rc=$? ; rc=${rc:-0}
+check "all gates fresh → exit 0" "[ \"$rc\" = 0 ]"
+
+unset rc
+out=$(make_input "cd /tmp && git commit -m msg" | "$HOOKS/pre-commit.sh" 2>&1) || rc=$? ; rc=${rc:-0}
+check "wrapped commit with fresh gates → exit 0" "[ \"$rc\" = 0 ]"
+
+unset rc
+sleep 1
+touch .claude/hooks/post-quality-gate.sh  # simulate source edit
+out=$(make_input "git commit -m msg" | "$HOOKS/pre-commit.sh" 2>&1) || rc=$? ; rc=${rc:-0}
+check "stale gate after edit → exit 2" "[ \"$rc\" = 2 ]"
+check "stale message mentions 'stale'" "printf '%s' \"\$out\" | grep -qi stale"
+
+# Codex P1 regression: root config edit must stale the gate.
+wf_reset
+wf_mark check_passed
+wf_mark typecheck_passed
+wf_mark tests_passed
+sleep 1
+touch tsconfig.json
+unset rc
+out=$(make_input "git commit -m msg" | "$HOOKS/pre-commit.sh" 2>&1) || rc=$? ; rc=${rc:-0}
+check "root tsconfig edit stales gate → exit 2" "[ \"$rc\" = 2 ]"
+# Revert mtime so rest of test doesn't cascade
+touch -t "$(date -r "$(_wf_file).check_passed.ref" +%Y%m%d%H%M.%S)" tsconfig.json 2>/dev/null || true
+
+# Codex P2 regression: deleting a tracked file must stale the gate.
+# Use docs/ (outside the mtime-watched roots) so only the tracked-hash check
+# fires — and sleep 1s to guarantee file mtime < ref mtime on fast runs.
+wf_reset
+tmp_victim="docs/_v_smoke.txt"
+echo "bye" > "$tmp_victim"
+git add "$tmp_victim" 2>/dev/null
+sleep 1
+wf_mark check_passed
+wf_mark typecheck_passed
+wf_mark tests_passed
+unset rc
+out=$(make_input "git commit -m msg" | "$HOOKS/pre-commit.sh" 2>&1) || rc=$? ; rc=${rc:-0}
+check "baseline with staged file → exit 0" "[ \"$rc\" = 0 ]"
+git rm -qf "$tmp_victim" 2>/dev/null
+rm -f "$tmp_victim"
+unset rc
+out=$(make_input "git commit -m msg" | "$HOOKS/pre-commit.sh" 2>&1) || rc=$? ; rc=${rc:-0}
+check "tracked-file removal stales gate → exit 2" "[ \"$rc\" = 2 ]"
+
+wf_reset
+
+echo
+echo "== pre-pr.sh =="
+unset rc
+out=$(make_input "echo some-other-action --body 'xyz'" | "$HOOKS/pre-pr.sh" 2>&1) || rc=$? ; rc=${rc:-0}
+check "non-matching command → exit 0" "[ \"$rc\" = 0 ]"
+
+unset rc
+out=$(make_input "gh issue create --body 'mentions gh pr create later'" | "$HOOKS/pre-pr.sh" 2>&1) || rc=$? ; rc=${rc:-0}
+check "quoted 'gh pr create' in body → exit 0" "[ \"$rc\" = 0 ]"
+
+unset rc
+out=$(make_input "gh pr create --title x" | "$HOOKS/pre-pr.sh" 2>&1) || rc=$? ; rc=${rc:-0}
+check "no review marker → exit 2" "[ \"$rc\" = 2 ]"
+
+unset rc
+out=$(make_input "cd /tmp && gh pr create --title x" | "$HOOKS/pre-pr.sh" 2>&1) || rc=$? ; rc=${rc:-0}
+check "wrapped cd-then-gh-pr-create → exit 2" "[ \"$rc\" = 2 ]"
+
+unset rc
+wf_mark cross_model_review
+out=$(make_input "gh pr create --title x" | "$HOOKS/pre-pr.sh" 2>&1) || rc=$? ; rc=${rc:-0}
+check "with review marker → exit 0" "[ \"$rc\" = 0 ]"
+
+wf_reset
+
+echo
+echo "== post-commit.sh =="
+# post-commit should no-op on non-matching commands.
+unset rc
+out=$(make_input "echo a string" | "$HOOKS/post-commit.sh" 2>&1) || rc=$? ; rc=${rc:-0}
+check "post-commit no-op on non-match" "[ \"$rc\" = 0 ]"
+
+# And should NOT wipe QG markers anymore.
+wf_mark check_passed
+wf_mark typecheck_passed
+wf_mark tests_passed
+wf_mark cross_model_review
+unset rc
+out=$(make_input "git commit -m msg" | "$HOOKS/post-commit.sh" 2>&1) || rc=$? ; rc=${rc:-0}
+check "post-commit keeps check_passed" "wf_has check_passed"
+check "post-commit keeps tests_passed" "wf_has tests_passed"
+check "post-commit keeps cross_model_review" "wf_has cross_model_review"
+
+wf_reset
+
+echo
+echo "== summary =="
+echo "pass: $pass"
+echo "fail: $fail"
+[ "$fail" -eq 0 ]

--- a/.claude/hooks/post-commit.sh
+++ b/.claude/hooks/post-commit.sh
@@ -15,7 +15,7 @@
 INPUT=$(cat)
 COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)
 
-if ! printf '%s' "$COMMAND" | grep -Eq '(^|[;&|])[[:space:]]*git[[:space:]]+commit([[:space:]]|$)'; then
+if ! printf '%s' "$COMMAND" | grep -Eq '(^|[;&|])[[:space:]]*git[[:space:]]+commit([[:space:];&|]|$)'; then
   exit 0
 fi
 

--- a/.claude/hooks/post-commit.sh
+++ b/.claude/hooks/post-commit.sh
@@ -1,17 +1,26 @@
 #!/bin/bash
-# PostToolUse hook for git commit — check changeset need and reset quality gates.
-# Preserves cross_model_review marker so gh pr create is not blocked after fixup commits.
-source "$(dirname "$0")/workflow-state.sh"
+# PostToolUse hook for git commit — notify about changeset need.
+#
+# Matcher `Bash(git commit*)` substring-matches the whole command, so verify
+# the real command before acting on it. We match `git commit` at a shell
+# command boundary so wrapped forms (`cd /r && git commit`) still fire this.
+#
+# Historically this hook also wiped quality-gate markers after every commit.
+# That forced re-running the full gate suite on every follow-up commit in
+# review-fix flows. We now rely on `wf_fresh` (in workflow-state.sh) to check
+# whether tracked source/root-config files changed since the last marker —
+# the markers stay valid as long as the code hasn't changed, and become stale
+# automatically when it does.
+
+INPUT=$(cat)
+COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)
+
+if ! printf '%s' "$COMMAND" | grep -Eq '(^|[;&|])[[:space:]]*git[[:space:]]+commit([[:space:]]|$)'; then
+  exit 0
+fi
 
 # Check if npm-published code changed (commit-scoped, not work-tree)
 if git rev-parse HEAD~1 >/dev/null 2>&1 \
   && git diff-tree --no-commit-id --name-only -r HEAD | grep -qE '^(packages|addons)/'; then
   echo "npm-published code changed. Run bunx changeset if this needs a version bump."
-fi
-
-# Reset only quality gate markers (not cross_model_review)
-WF=$(_wf_file)
-if [ -f "$WF" ]; then
-  grep -vE '^(check_passed|typecheck_passed|tests_passed)=' "$WF" > "$WF.tmp" || true
-  mv "$WF.tmp" "$WF"
 fi

--- a/.claude/hooks/pre-commit.sh
+++ b/.claude/hooks/pre-commit.sh
@@ -15,7 +15,7 @@
 INPUT=$(cat)
 COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)
 
-if ! printf '%s' "$COMMAND" | grep -Eq '(^|[;&|])[[:space:]]*git[[:space:]]+commit([[:space:]]|$)'; then
+if ! printf '%s' "$COMMAND" | grep -Eq '(^|[;&|])[[:space:]]*git[[:space:]]+commit([[:space:];&|]|$)'; then
   exit 0
 fi
 

--- a/.claude/hooks/pre-commit.sh
+++ b/.claude/hooks/pre-commit.sh
@@ -11,6 +11,13 @@
 # This correctly covers wrapped forms like `cd /repo && git commit -m x` or
 # `git add . && git commit -m y` (required by the workflow) while still
 # rejecting `git commit` inside a quoted argument.
+#
+# Known limitation: a quoted body that itself contains a separator + `git
+# commit` (e.g. `gh issue create --body 'run ; git commit later'`) will still
+# match, because the regex doesn't track shell quoting state. Fully
+# quote-aware parsing in pure bash regex is impractical; this hook is a
+# guardrail and `git commit` inside an issue-body argument is a narrow edge
+# case. Re-run the skipped gates if you hit it.
 
 INPUT=$(cat)
 COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)
@@ -22,14 +29,15 @@ fi
 source "$(dirname "$0")/workflow-state.sh"
 
 MISSING=""
-wf_fresh check_passed     || MISSING="$MISSING bun-run-check"
-wf_fresh typecheck_passed || MISSING="$MISSING bun-run-typecheck"
-wf_fresh tests_passed     || MISSING="$MISSING bun-test"
+wf_fresh check_passed     || MISSING="$MISSING"$'\n  - bun run check'
+wf_fresh typecheck_passed || MISSING="$MISSING"$'\n  - bun run typecheck'
+wf_fresh tests_passed     || MISSING="$MISSING"$'\n  - bun test'
 
 if [ -n "$MISSING" ]; then
-  echo "BLOCKED: Quality gates not passed or stale:$MISSING" >&2
+  printf 'BLOCKED: Quality gates not passed or stale:%s\n' "$MISSING" >&2
   echo "Run the listed commands before committing." >&2
-  echo "(A gate becomes stale when tracked source files change or the repo-root" >&2
-  echo " config — tsconfig.json / biome.json / package.json / bun.lock — changes.)" >&2
+  echo "(A gate becomes stale when tracked source files change, the tracked" >&2
+  echo " file set changes (git add/rm/mv), or a repo-root config file changes" >&2
+  echo " — tsconfig.json / biome.json / package.json / bun.lock / etc.)" >&2
   exit 2
 fi

--- a/.claude/hooks/pre-commit.sh
+++ b/.claude/hooks/pre-commit.sh
@@ -1,14 +1,35 @@
 #!/bin/bash
-# PreToolUse hook for git commit — ensure quality gates passed.
+# PreToolUse hook for git commit — ensure quality gates are fresh.
+#
+# Claude Code's `if: "Bash(git commit*)"` matcher substring-matches the whole
+# command string, so this hook receives invocations it shouldn't enforce on
+# (e.g. `gh issue create --body "... git commit ..."`). We parse the real tool
+# input from stdin and only enforce when `git commit` appears as an actual
+# command boundary:
+#   - at the start of the command, OR
+#   - after a shell separator (`&&`, `||`, `;`, `|`).
+# This correctly covers wrapped forms like `cd /repo && git commit -m x` or
+# `git add . && git commit -m y` (required by the workflow) while still
+# rejecting `git commit` inside a quoted argument.
+
+INPUT=$(cat)
+COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)
+
+if ! printf '%s' "$COMMAND" | grep -Eq '(^|[;&|])[[:space:]]*git[[:space:]]+commit([[:space:]]|$)'; then
+  exit 0
+fi
+
 source "$(dirname "$0")/workflow-state.sh"
 
 MISSING=""
-wf_has check_passed    || MISSING="$MISSING bun-run-check"
-wf_has typecheck_passed || MISSING="$MISSING bun-run-typecheck"
-wf_has tests_passed    || MISSING="$MISSING bun-test"
+wf_fresh check_passed     || MISSING="$MISSING bun-run-check"
+wf_fresh typecheck_passed || MISSING="$MISSING bun-run-typecheck"
+wf_fresh tests_passed     || MISSING="$MISSING bun-test"
 
 if [ -n "$MISSING" ]; then
-  echo "BLOCKED: Quality gates not passed:$MISSING" >&2
-  echo "Run them before committing." >&2
+  echo "BLOCKED: Quality gates not passed or stale:$MISSING" >&2
+  echo "Run the listed commands before committing." >&2
+  echo "(A gate becomes stale when tracked source files change or the repo-root" >&2
+  echo " config — tsconfig.json / biome.json / package.json / bun.lock — changes.)" >&2
   exit 2
 fi

--- a/.claude/hooks/pre-pr.sh
+++ b/.claude/hooks/pre-pr.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 # PreToolUse hook for gh pr create — ensure cross-model review was done.
+#
+# Matcher `Bash(gh pr create*)` substring-matches the whole command string, so
+# this hook fires for any Bash call whose content mentions "gh pr create"
+# (e.g. a HEREDOC body in `gh issue create`). Parse the real tool input and
+# only enforce on actual `gh pr create` invocations — matched at a shell
+# command boundary (start-of-line or after `&&` / `||` / `;` / `|`), which
+# also handles wrapped forms like `cd /repo && gh pr create ...`.
+
+INPUT=$(cat)
+COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)
+
+if ! printf '%s' "$COMMAND" | grep -Eq '(^|[;&|])[[:space:]]*gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)'; then
+  exit 0
+fi
+
 source "$(dirname "$0")/workflow-state.sh"
 
 if ! wf_has cross_model_review; then

--- a/.claude/hooks/pre-pr.sh
+++ b/.claude/hooks/pre-pr.sh
@@ -11,7 +11,7 @@
 INPUT=$(cat)
 COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)
 
-if ! printf '%s' "$COMMAND" | grep -Eq '(^|[;&|])[[:space:]]*gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)'; then
+if ! printf '%s' "$COMMAND" | grep -Eq '(^|[;&|])[[:space:]]*gh[[:space:]]+pr[[:space:]]+create([[:space:];&|]|$)'; then
   exit 0
 fi
 

--- a/.claude/hooks/stop-check.sh
+++ b/.claude/hooks/stop-check.sh
@@ -11,33 +11,25 @@ if [ -z "$CHANGES" ]; then
   exit 0
 fi
 
-# There are uncommitted changes — show remaining workflow steps
+# gate_row <marker> <label> — print one line, flagging stale gates.
+gate_row() {
+  local marker="$1" label="$2"
+  if wf_fresh "$marker"; then
+    echo "  ✓ $label"
+  elif wf_has "$marker"; then
+    echo "  ⚠ $label    (stale — source changed since it ran)"
+  else
+    echo "  □ $label    (not done)"
+  fi
+}
+
 echo "⚠ Uncommitted changes detected. Remaining workflow steps:"
 echo ""
 
-if ! wf_has check_passed; then
-  echo "  □ bun run check        (not done)"
-else
-  echo "  ✓ bun run check"
-fi
-
-if ! wf_has typecheck_passed; then
-  echo "  □ bun run typecheck    (not done)"
-else
-  echo "  ✓ bun run typecheck"
-fi
-
-if ! wf_has tests_passed; then
-  echo "  □ bun test             (not done)"
-else
-  echo "  ✓ bun test"
-fi
-
-if ! wf_has cross_model_review; then
-  echo "  □ Cross-model review   (not done)"
-else
-  echo "  ✓ Cross-model review"
-fi
+gate_row check_passed     "bun run check       "
+gate_row typecheck_passed "bun run typecheck   "
+gate_row tests_passed     "bun test            "
+gate_row cross_model_review "Cross-model review "
 
 echo "  □ git commit"
 echo "  □ gh pr create"

--- a/.claude/hooks/workflow-state.sh
+++ b/.claude/hooks/workflow-state.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Workflow state helper — shared by all workflow hooks.
 # State file: $TMPDIR/linchkit-wf-<project-id>-<branch-slug>
-# Each line: key=timestamp
+# Each line: key=timestamp (each marker appears at most once — wf_mark dedupes)
 # Freshness refs:
 #   <state-file>.<key>.ref   — touch'ed when the marker is set
 #   <state-file>.<key>.files — checksum of `git ls-files` at mark time
@@ -31,9 +31,18 @@ _wf_tracked_hash() {
 wf_mark() {
   # Record a workflow step as done AND snapshot the current state so wf_fresh
   # can detect any edits, additions, or deletions made after the marker was set.
-  echo "$1=$(date +%s)" >> "$(_wf_file)"
-  touch "$(_wf_file).$1.ref" 2>/dev/null || true
-  _wf_tracked_hash > "$(_wf_file).$1.files" 2>/dev/null || true
+  # Dedupe: remove any prior entry for this marker before appending. Without
+  # this, the state file grows unbounded across successive marks (post-commit
+  # no longer resets).
+  local wf
+  wf=$(_wf_file)
+  if [ -f "$wf" ]; then
+    grep -v "^$1=" "$wf" > "$wf.tmp" 2>/dev/null || true
+    mv "$wf.tmp" "$wf" 2>/dev/null || true
+  fi
+  echo "$1=$(date +%s)" >> "$wf"
+  touch "$wf.$1.ref" 2>/dev/null || true
+  _wf_tracked_hash > "$wf.$1.files" 2>/dev/null || true
 }
 
 wf_reset() {
@@ -61,16 +70,16 @@ wf_reset() {
 wf_fresh() {
   local marker="$1"
   wf_has "$marker" || return 1
-  local ref snap
-  ref="$(_wf_file).${marker}.ref"
+  local ref snap wf
+  wf=$(_wf_file)
+  ref="$wf.${marker}.ref"
   [ -f "$ref" ] || return 0
-  snap="$(_wf_file).${marker}.files"
+  snap="$wf.${marker}.files"
 
   # (a) Tracked file set unchanged? Catches git rm / git add / rename.
   if [ -f "$snap" ]; then
-    local current
+    local current previous
     current=$(_wf_tracked_hash)
-    local previous
     previous=$(cat "$snap" 2>/dev/null)
     [ "$current" = "$previous" ] || return 1
   fi
@@ -78,29 +87,25 @@ wf_fresh() {
   local root
   root=$(git rev-parse --show-toplevel 2>/dev/null) || return 0
 
-  # Source directories that affect check/typecheck/test.
-  local roots=""
+  # Source directories and root-level config files that affect gates.
+  # Array-based so paths with spaces work correctly.
+  local paths=()
   for dir in packages addons apps scripts .claude; do
-    [ -d "$root/$dir" ] && roots="$roots $root/$dir"
+    [ -d "$root/$dir" ] && paths+=("$root/$dir")
   done
-
-  # Root-level config files that affect check/typecheck/test. Only include if
-  # the file actually exists — find errors on missing paths.
-  local root_files=""
   for f in \
     package.json bun.lock bunfig.toml .bunfig.toml \
     tsconfig.json tsconfig.base.json \
     biome.json turbo.json drizzle.config.ts lefthook.yml; do
-    [ -f "$root/$f" ] && root_files="$root_files $root/$f"
+    [ -f "$root/$f" ] && paths+=("$root/$f")
   done
 
-  [ -z "$roots" ] && [ -z "$root_files" ] && return 0
+  [ ${#paths[@]} -eq 0 ] && return 0
 
   # (b) mtime comparison. -prune excludes heavy dirs; -path prune for nested
   # worktrees so other branches' edits don't invalidate this branch's gates.
-  # shellcheck disable=SC2086
   local newer
-  newer=$(find $roots $root_files \
+  newer=$(find "${paths[@]}" \
     \( -name node_modules -o -name dist -o -name .bun -o -name .turbo -o -name .next \) -prune \
     -o -path "$root/.claude/worktrees" -prune \
     -o -type f -newer "$ref" -print 2>/dev/null | head -1)

--- a/.claude/hooks/workflow-state.sh
+++ b/.claude/hooks/workflow-state.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 # Workflow state helper — shared by all workflow hooks.
-# State file: $TMPDIR/linchkit-wf-<branch-slug>
+# State file: $TMPDIR/linchkit-wf-<project-id>-<branch-slug>
 # Each line: key=timestamp
+# Freshness refs:
+#   <state-file>.<key>.ref   — touch'ed when the marker is set
+#   <state-file>.<key>.files — checksum of `git ls-files` at mark time
 
 _wf_file() {
   local branch project_id
@@ -12,21 +15,96 @@ _wf_file() {
 }
 
 wf_has() {
-  # Check if a workflow step has been recorded.
+  # Check if a workflow step has been recorded (ignores freshness).
   # Usage: wf_has tests_passed
   # Anchored to line start to prevent "check_passed" matching "typecheck_passed"
   grep -q "^$1=" "$(_wf_file)" 2>/dev/null
 }
 
+# _wf_tracked_hash — checksum of the tracked file list. Used by wf_mark /
+# wf_fresh to detect additions/removals (including `git rm` or `git mv`)
+# that `find -newer` would otherwise miss.
+_wf_tracked_hash() {
+  git ls-files 2>/dev/null | sort | cksum | cut -d' ' -f1
+}
+
 wf_mark() {
-  # Record a workflow step as done.
-  # Usage: wf_mark tests_passed
+  # Record a workflow step as done AND snapshot the current state so wf_fresh
+  # can detect any edits, additions, or deletions made after the marker was set.
   echo "$1=$(date +%s)" >> "$(_wf_file)"
+  touch "$(_wf_file).$1.ref" 2>/dev/null || true
+  _wf_tracked_hash > "$(_wf_file).$1.files" 2>/dev/null || true
 }
 
 wf_reset() {
-  # Clear all workflow state (called after commit).
-  > "$(_wf_file)" 2>/dev/null || true
+  # Clear all workflow state AND its reference / snapshot files.
+  local wf
+  wf=$(_wf_file)
+  > "$wf" 2>/dev/null || true
+  rm -f "$wf".*.ref "$wf".*.files 2>/dev/null || true
+}
+
+# wf_fresh — marker is present AND nothing relevant changed since it was set.
+# Use this instead of wf_has in pre-commit / pre-pr gates so multi-commit
+# review-fix flows don't have to re-run gates when nothing changed between
+# commits, while still catching real source changes.
+#
+# Fresh = wf_has <marker> AND .ref exists AND
+#   (a) no tracked file has been added/removed since the mark AND
+#   (b) nothing under packages/, addons/, apps/, scripts/, .claude/, or the
+#       repo-root config files (tsconfig.json, biome.json, package.json,
+#       bun.lock, turbo.json, etc.) is newer than the .ref file
+#       (node_modules / dist / .bun / .turbo / .next excluded).
+#
+# Legacy behavior: if the .ref file is missing (older hook state), the marker
+# is treated as fresh — keeps upgrade path simple.
+wf_fresh() {
+  local marker="$1"
+  wf_has "$marker" || return 1
+  local ref snap
+  ref="$(_wf_file).${marker}.ref"
+  [ -f "$ref" ] || return 0
+  snap="$(_wf_file).${marker}.files"
+
+  # (a) Tracked file set unchanged? Catches git rm / git add / rename.
+  if [ -f "$snap" ]; then
+    local current
+    current=$(_wf_tracked_hash)
+    local previous
+    previous=$(cat "$snap" 2>/dev/null)
+    [ "$current" = "$previous" ] || return 1
+  fi
+
+  local root
+  root=$(git rev-parse --show-toplevel 2>/dev/null) || return 0
+
+  # Source directories that affect check/typecheck/test.
+  local roots=""
+  for dir in packages addons apps scripts .claude; do
+    [ -d "$root/$dir" ] && roots="$roots $root/$dir"
+  done
+
+  # Root-level config files that affect check/typecheck/test. Only include if
+  # the file actually exists — find errors on missing paths.
+  local root_files=""
+  for f in \
+    package.json bun.lock bunfig.toml .bunfig.toml \
+    tsconfig.json tsconfig.base.json \
+    biome.json turbo.json drizzle.config.ts lefthook.yml; do
+    [ -f "$root/$f" ] && root_files="$root_files $root/$f"
+  done
+
+  [ -z "$roots" ] && [ -z "$root_files" ] && return 0
+
+  # (b) mtime comparison. -prune excludes heavy dirs; -path prune for nested
+  # worktrees so other branches' edits don't invalidate this branch's gates.
+  # shellcheck disable=SC2086
+  local newer
+  newer=$(find $roots $root_files \
+    \( -name node_modules -o -name dist -o -name .bun -o -name .turbo -o -name .next \) -prune \
+    -o -path "$root/.claude/worktrees" -prune \
+    -o -type f -newer "$ref" -print 2>/dev/null | head -1)
+  [ -z "$newer" ]
 }
 
 wf_show() {

--- a/.claude/skills/linch-workflow/SKILL.md
+++ b/.claude/skills/linch-workflow/SKILL.md
@@ -52,7 +52,12 @@ Read the user's request and classify:
 
 Quality gates MUST pass before committing.
 Hooks track progress in a per-branch state file (via `.claude/hooks/workflow-state.sh`).
-`git commit` is blocked until check/typecheck/test are **fresh**. A gate is fresh when it ran AND no tracked source file under `packages/`, `addons/`, `apps/`, `scripts/`, or `.claude/` has been modified since. Follow-up commits on unchanged code don't need re-runs; commits after an edit do.
+`git commit` is blocked until check/typecheck/test are **fresh**. A gate is fresh when it ran AND none of the following changed since:
+- any tracked source file under `packages/`, `addons/`, `apps/`, `scripts/`, or `.claude/` was modified
+- the tracked file set changed (any `git add` / `git rm` / rename)
+- a repo-root config affecting the gates changed — `package.json`, `bun.lock`, `tsconfig.json` / `tsconfig.base.json`, `biome.json`, `turbo.json`, `drizzle.config.ts`, `lefthook.yml`, or the bun config files
+
+Follow-up commits on unchanged code don't need re-runs; commits after any of the above do.
 
 ```bash
 linch validate        # Meta-model validation (manual — run when touching definitions)
@@ -171,7 +176,7 @@ When PR_parent is squash-merged, PR_child stuck on the parent branch becomes `CO
 If stacked and parent just squash-merged:
 1. Fetch: `git fetch origin main`
 2. Rebase child onto new main, dropping parent commits:
-   ```
+   ```bash
    git rebase --onto origin/main <old-parent-tip> <child-branch>
    ```
 3. ⚠️ `git push --force-with-lease origin <child-branch>` — harness denies; route via user `!`.

--- a/.claude/skills/linch-workflow/SKILL.md
+++ b/.claude/skills/linch-workflow/SKILL.md
@@ -52,13 +52,13 @@ Read the user's request and classify:
 
 Quality gates MUST pass before committing.
 Hooks track progress in a per-branch state file (via `.claude/hooks/workflow-state.sh`).
-`git commit` is blocked until check/typecheck/test all pass. `linch validate` is manual.
+`git commit` is blocked until check/typecheck/test are **fresh**. A gate is fresh when it ran AND no tracked source file under `packages/`, `addons/`, `apps/`, `scripts/`, or `.claude/` has been modified since. Follow-up commits on unchanged code don't need re-runs; commits after an edit do.
 
 ```bash
 linch validate        # Meta-model validation (manual — run when touching definitions)
-bun run check         # Biome lint + format (hook-tracked)
-bun run typecheck     # TypeScript strict check (hook-tracked)
-bun test              # Full test suite (hook-tracked, must be exact `bun test` not filtered)
+bun run check         # Biome lint + format (hook-tracked, fresh-gated)
+bun run typecheck     # TypeScript strict check (hook-tracked, fresh-gated)
+bun test              # Full test suite (hook-tracked, fresh-gated — must be exact `bun test`, not filtered)
 ```
 
 ## Step 5: Cross-Model Review
@@ -108,6 +108,27 @@ Before creating a PR, request cross-model review for a second opinion.
 6. **Mark complete**: `./.claude/hooks/post-quality-gate.sh cross_model_review`
    This is required — `gh pr create` is blocked by hook until this marker exists.
 
+### Harness deny list vs workflow escape hatches
+
+The Claude Code harness denies several git/gh commands for safety. Hitting a deny is **not** "workflow says stop" — it's a safety rail that permits explicit user authorization. When you need one of these:
+
+| Needed action | Denied by harness | Escape |
+|---|---|---|
+| ⚠️ `git push --force-with-lease <branch>` (after rebase) | yes | user `! <command>` |
+| ⚠️ `git push --force <branch>` | yes | user `! <command>` |
+| `git rebase --onto <new-base> <old-base>` | yes | user `! <command>` |
+| `git reset --hard <ref>` | yes | user `! <command>` |
+| `gh pr merge --admin` (ruleset blocking) | yes | user `! <command>` |
+| `gh pr merge --auto` | yes | user `! <command>` |
+
+When you need an escape:
+1. State the concrete goal (what & why)
+2. Show the exact command — single-line, never buried inside a multi-command chain
+3. Name the branch explicitly (never `git push --force` without a target; never on `main`)
+4. Ask the user to run it via `! <command>` in the prompt
+
+Any command containing `force` — including `--force-with-lease` — gets its own dedicated line with a ⚠️ marker. Do not slip it into a pipe or `&&` chain.
+
 ## Step 6: PR & Review
 
 1. Verify you're on the correct feature branch (not `main`)
@@ -115,13 +136,47 @@ Before creating a PR, request cross-model review for a second opinion.
 3. Wait for CI
 4. Read ALL review comments (CodeRabbit, Gemini, human)
 5. Fix every comment, reply explaining what changed, then resolve thread (NEVER dismiss)
-6. Merge only when: APPROVED + CI green
+6. Merge only when: APPROVED + CI green + **`mergeStateStatus` ≠ BLOCKED**
+
+**Merge readiness check (before attempting merge):**
+
+`reviewDecision: APPROVED` and all CI checks green are necessary but **not sufficient** on a protected branch with rulesets. Before `gh pr merge`, inspect:
+
+```bash
+gh pr view <num> --json reviewDecision,mergeStateStatus,statusCheckRollup
+```
+
+If `mergeStateStatus == "BLOCKED"` an uncleared rule is in play. Investigate both the classic protection and rulesets:
+
+```bash
+gh api repos/{owner}/{repo}/branches/main/protection
+gh api repos/{owner}/{repo}/rules/branches/main
+```
+
+Present the specific blocker to the user (e.g. "required Copilot review missing", "required check `lint` hasn't started", "ruleset X requires an approving review from CODEOWNERS") and propose a concrete path: trigger the missing reviewer, wait for check, ask user to `! gh pr merge --admin`, etc. Never guess the merge will succeed if `BLOCKED`.
 
 **PR merge rules (no exceptions):**
-- NEVER `--admin` or `--auto` — blocked = not ready
+- NEVER `--admin` or `--auto` yourself — they are denied by the harness. If truly needed, route via user `!` with explicit justification.
 - NEVER merge with CHANGES_REQUESTED — wait for re-approval
 - NEVER dismiss review threads — reply + resolve
 - ALWAYS read ALL comments BEFORE merge attempt
+- NEVER force-push to `main`; warn immediately if requested
+
+### Stacked PRs + squash-merge aftermath
+
+When PR_parent is squash-merged, PR_child stuck on the parent branch becomes `CONFLICTING` — the rebase base no longer matches any commit in `main`.
+
+**Prefer serial merges:** land A, then open B from `main`. Stack only when genuinely blocked.
+
+If stacked and parent just squash-merged:
+1. Fetch: `git fetch origin main`
+2. Rebase child onto new main, dropping parent commits:
+   ```
+   git rebase --onto origin/main <old-parent-tip> <child-branch>
+   ```
+3. ⚠️ `git push --force-with-lease origin <child-branch>` — harness denies; route via user `!`.
+
+Never cherry-pick parent's commits into the child PR as a workaround — it creates duplicate history once the parent merges.
 
 ## Step 7: Close
 

--- a/packages/cli/src/templates/workflow-skill-templates.ts
+++ b/packages/cli/src/templates/workflow-skill-templates.ts
@@ -82,13 +82,13 @@ Read the user's request and classify:
 
 Quality gates MUST pass before committing.
 Hooks track progress in a per-branch state file (via \`.claude/hooks/workflow-state.sh\`).
-\`git commit\` is blocked until check/typecheck/test all pass. \`linch validate\` is manual.
+\`git commit\` is blocked until check/typecheck/test are **fresh**. A gate is fresh when it ran AND no tracked source file under \`packages/\`, \`addons/\`, \`apps/\`, \`scripts/\`, or \`.claude/\` has been modified since. Follow-up commits on unchanged code don't need re-runs; commits after an edit do.
 
 \`\`\`bash
 linch validate        # Meta-model validation (manual — run when touching definitions)
-bun run check         # Biome lint + format (hook-tracked)
-bun run typecheck     # TypeScript strict check (hook-tracked)
-bun test              # Full test suite (hook-tracked, must be exact \`bun test\` not filtered)
+bun run check         # Biome lint + format (hook-tracked, fresh-gated)
+bun run typecheck     # TypeScript strict check (hook-tracked, fresh-gated)
+bun test              # Full test suite (hook-tracked, fresh-gated — must be exact \`bun test\`, not filtered)
 \`\`\`
 
 ## Step 5: Cross-Model Review
@@ -138,6 +138,27 @@ Before creating a PR, request cross-model review for a second opinion.
 6. **Mark complete**: \`./.claude/hooks/post-quality-gate.sh cross_model_review\`
    This is required — \`gh pr create\` is blocked by hook until this marker exists.
 
+### Harness deny list vs workflow escape hatches
+
+The Claude Code harness denies several git/gh commands for safety. Hitting a deny is **not** "workflow says stop" — it's a safety rail that permits explicit user authorization. When you need one of these:
+
+| Needed action | Denied by harness | Escape |
+|---|---|---|
+| ⚠️ \`git push --force-with-lease <branch>\` (after rebase) | yes | user \`! <command>\` |
+| ⚠️ \`git push --force <branch>\` | yes | user \`! <command>\` |
+| \`git rebase --onto <new-base> <old-base>\` | yes | user \`! <command>\` |
+| \`git reset --hard <ref>\` | yes | user \`! <command>\` |
+| \`gh pr merge --admin\` (ruleset blocking) | yes | user \`! <command>\` |
+| \`gh pr merge --auto\` | yes | user \`! <command>\` |
+
+When you need an escape:
+1. State the concrete goal (what & why)
+2. Show the exact command — single-line, never buried inside a multi-command chain
+3. Name the branch explicitly (never \`git push --force\` without a target; never on \`main\`)
+4. Ask the user to run it via \`! <command>\` in the prompt
+
+Any command containing \`force\` — including \`--force-with-lease\` — gets its own dedicated line with a ⚠️ marker. Do not slip it into a pipe or \`&&\` chain.
+
 ## Step 6: PR & Review
 
 1. Verify you're on the correct feature branch (not \`main\`)
@@ -145,13 +166,47 @@ Before creating a PR, request cross-model review for a second opinion.
 3. Wait for CI
 4. Read ALL review comments (CodeRabbit, Gemini, human)
 5. Fix every comment, reply explaining what changed, then resolve thread (NEVER dismiss)
-6. Merge only when: APPROVED + CI green
+6. Merge only when: APPROVED + CI green + **\`mergeStateStatus\` ≠ BLOCKED**
+
+**Merge readiness check (before attempting merge):**
+
+\`reviewDecision: APPROVED\` and all CI checks green are necessary but **not sufficient** on a protected branch with rulesets. Before \`gh pr merge\`, inspect:
+
+\`\`\`bash
+gh pr view <num> --json reviewDecision,mergeStateStatus,statusCheckRollup
+\`\`\`
+
+If \`mergeStateStatus == "BLOCKED"\` an uncleared rule is in play. Investigate both the classic protection and rulesets:
+
+\`\`\`bash
+gh api repos/{owner}/{repo}/branches/main/protection
+gh api repos/{owner}/{repo}/rules/branches/main
+\`\`\`
+
+Present the specific blocker to the user (e.g. "required Copilot review missing", "required check \`lint\` hasn't started", "ruleset X requires an approving review from CODEOWNERS") and propose a concrete path: trigger the missing reviewer, wait for check, ask user to \`! gh pr merge --admin\`, etc. Never guess the merge will succeed if \`BLOCKED\`.
 
 **PR merge rules (no exceptions):**
-- NEVER \`--admin\` or \`--auto\` — blocked = not ready
+- NEVER \`--admin\` or \`--auto\` yourself — they are denied by the harness. If truly needed, route via user \`!\` with explicit justification.
 - NEVER merge with CHANGES_REQUESTED — wait for re-approval
 - NEVER dismiss review threads — reply + resolve
 - ALWAYS read ALL comments BEFORE merge attempt
+- NEVER force-push to \`main\`; warn immediately if requested
+
+### Stacked PRs + squash-merge aftermath
+
+When PR_parent is squash-merged, PR_child stuck on the parent branch becomes \`CONFLICTING\` — the rebase base no longer matches any commit in \`main\`.
+
+**Prefer serial merges:** land A, then open B from \`main\`. Stack only when genuinely blocked.
+
+If stacked and parent just squash-merged:
+1. Fetch: \`git fetch origin main\`
+2. Rebase child onto new main, dropping parent commits:
+   \`\`\`
+   git rebase --onto origin/main <old-parent-tip> <child-branch>
+   \`\`\`
+3. ⚠️ \`git push --force-with-lease origin <child-branch>\` — harness denies; route via user \`!\`.
+
+Never cherry-pick parent's commits into the child PR as a workaround — it creates duplicate history once the parent merges.
 
 ## Step 7: Close
 

--- a/packages/cli/src/templates/workflow-skill-templates.ts
+++ b/packages/cli/src/templates/workflow-skill-templates.ts
@@ -82,7 +82,12 @@ Read the user's request and classify:
 
 Quality gates MUST pass before committing.
 Hooks track progress in a per-branch state file (via \`.claude/hooks/workflow-state.sh\`).
-\`git commit\` is blocked until check/typecheck/test are **fresh**. A gate is fresh when it ran AND no tracked source file under \`packages/\`, \`addons/\`, \`apps/\`, \`scripts/\`, or \`.claude/\` has been modified since. Follow-up commits on unchanged code don't need re-runs; commits after an edit do.
+\`git commit\` is blocked until check/typecheck/test are **fresh**. A gate is fresh when it ran AND none of the following changed since:
+- any tracked source file under \`packages/\`, \`addons/\`, \`apps/\`, \`scripts/\`, or \`.claude/\` was modified
+- the tracked file set changed (any \`git add\` / \`git rm\` / rename)
+- a repo-root config affecting the gates changed — \`package.json\`, \`bun.lock\`, \`tsconfig.json\` / \`tsconfig.base.json\`, \`biome.json\`, \`turbo.json\`, \`drizzle.config.ts\`, \`lefthook.yml\`, or the bun config files
+
+Follow-up commits on unchanged code don't need re-runs; commits after any of the above do.
 
 \`\`\`bash
 linch validate        # Meta-model validation (manual — run when touching definitions)
@@ -201,7 +206,7 @@ When PR_parent is squash-merged, PR_child stuck on the parent branch becomes \`C
 If stacked and parent just squash-merged:
 1. Fetch: \`git fetch origin main\`
 2. Rebase child onto new main, dropping parent commits:
-   \`\`\`
+   \`\`\`bash
    git rebase --onto origin/main <old-parent-tip> <child-branch>
    \`\`\`
 3. ⚠️ \`git push --force-with-lease origin <child-branch>\` — harness denies; route via user \`!\`.


### PR DESCRIPTION
## Summary

Fixes workflow/hooks pain points surfaced during Evolution Path A (#180 #181, Issue #182).

### B1 — Hooks no longer over-match unrelated commands
Claude Code's `if: "Bash(git commit*)"` / `"Bash(gh pr create*)"` matcher substring-matches the whole command string, so `gh issue create --body "... git commit ..."` or any command containing `pr` could fire `pre-commit.sh` / `pre-pr.sh` and wipe / block unrelated work.

`pre-commit.sh` / `pre-pr.sh` / `post-commit.sh` now parse the real command from stdin JSON (`.tool_input.command`) and enforce only when the target subcommand appears at a **shell command boundary** — start-of-line or after `&&` / `||` / `;` / `|`. This correctly handles wrapped forms like `cd /repo && git commit -m x` (required by the workflow's own "always use absolute cd in same call" rule) while rejecting literal substrings inside quoted arguments.

### B2 — QG markers no longer wiped on every commit
`post-commit.sh` used to `wf_reset` the quality-gate markers after every commit, forcing re-runs on every follow-up commit in review-fix flows even when no source had changed.

New `wf_fresh` helper in `workflow-state.sh` checks three things:
1. marker exists (`wf_has`)
2. tracked-file set hash (`git ls-files | cksum`) unchanged since the mark — catches `git rm` / `git mv` / rename that `find -newer` would miss
3. nothing under `packages/`, `addons/`, `apps/`, `scripts/`, `.claude/`, or the repo-root configs (`tsconfig.json` / `biome.json` / `package.json` / `bun.lock` / `turbo.json` / ...) is newer than the `.ref` file (heavy dirs and nested worktrees pruned)

`pre-commit.sh` uses `wf_fresh` instead of `wf_has`; `post-commit.sh` no longer resets. Markers persist across commits on unchanged code, and expire automatically on real edits.

### A1-A4 — Workflow skill docs
`SKILL.md` (and the in-tree `workflow-skill-templates.ts` fallback used by `linch setup` for downstream projects) gains:

- **Step 5 — Harness deny vs escape hatches**: table of every denied git/gh command and the `! <command>` route the user must take. Force-push commands get a dedicated ⚠️ line, never buried in a chain.
- **Step 6 — `mergeStateStatus` check**: `APPROVED + CI green` is necessary but not sufficient on protected branches with rulesets; query `gh pr view --json mergeStateStatus` before attempting merge, present specific blocker to user.
- **Step 6 — Stacked-PR recovery**: `git rebase --onto origin/main <old-parent-tip>` after the parent squash-merges, with the force-push routed via user `!`.

## Cross-model review

| Tool | Findings | Decisions |
|------|----------|-----------|
| Gemini | 3 Low | case rigidity (covered by regex fix), `wf_mark` dedup (defer — cosmetic), `find` perf (defer — <50ms on current tree) |
| Codex | 3 real | (P1) wrapped `cd && git commit` bypass — **fixed** via boundary regex; (P1) root configs not scanned — **fixed** via `root_files` list; (P2) deletions/renames not stale — **fixed** via `git ls-files` hash snapshot |

All three Codex findings were added as regression tests before being closed.

## Test plan
- [x] `.claude/hooks/__tests__/smoke.sh` — 29 assertions covering all three fixes + original #182 bug, 0 fails
- [x] `bun run check` — clean (1 pre-existing biome schema info, unrelated)
- [x] `bun run typecheck` — clean
- [x] `bun test` — 4214 pass / 3 skip / 0 fail
- [x] Cross-model review (Codex + Gemini) — all findings addressed or deferred with rationale

## Files
- `.claude/hooks/workflow-state.sh` — `wf_fresh` + tracked-hash snapshot + root-config scan
- `.claude/hooks/pre-commit.sh` — stdin parse + boundary regex + `wf_fresh`
- `.claude/hooks/pre-pr.sh` — stdin parse + boundary regex
- `.claude/hooks/post-commit.sh` — stdin parse, no longer resets markers
- `.claude/hooks/stop-check.sh` — shows stale gates with ⚠ marker
- `.claude/hooks/__tests__/smoke.sh` — new, 29 assertions
- `.claude/skills/linch-workflow/SKILL.md` + `packages/cli/src/templates/workflow-skill-templates.ts` — A1-A4 doc updates (kept in sync per file header instruction)

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workflow quality gates now track freshness, blocking commits when source files have been modified after checks run.
  * Improved command parsing for pre-commit and PR creation validations.
  * Enhanced workflow state management to prevent cross-repository conflicts.

* **Documentation**
  * Updated merge requirements: merges now require gate freshness alongside approval and CI status.
  * Expanded guidance on harness operation restrictions and required escape patterns.

* **Tests**
  * Added comprehensive smoke tests for workflow hook behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->