### PR TITLE
refactor: unify permission system — remove Action Engine group check (closes #125)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/e2e-auth.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/e2e-auth.test.ts
@@ -13,8 +13,10 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:tes
 import type { ActionDefinition, Actor, EntityDefinition } from "@linchkit/core";
 import {
   createActionExecutor,
+  createCommandLayer,
   InMemoryExecutionLogger,
   InMemoryStore,
+  PipelineError,
 } from "@linchkit/core/server";
 import { buildGraphQLSchema, generateCrudActions } from "../src/graphql/build-schema";
 import { createServer } from "../src/server";
@@ -42,33 +44,38 @@ const publicAction: ActionDefinition = {
   handler: async () => ({ status: "ok" }),
 };
 
-/** An action restricted to the "manager" group */
+/** An action restricted to the "manager" group (enforced by pipeline, not action) */
 const managerAction: ActionDefinition = {
   name: "approve_order",
   entity: "order",
   label: "Approve Order",
   policy: { mode: "sync", transaction: false },
   exposure: "all",
-  permissions: {
-    groups: ["manager"],
-  },
   handler: async (ctx) => {
     const id = ctx.input.id as string;
     return { approved: true, orderId: id };
   },
 };
 
-/** An action restricted to the "admin" group */
+/** An action restricted to the "admin" group (enforced by pipeline, not action) */
 const adminAction: ActionDefinition = {
   name: "delete_all_orders",
   entity: "order",
   label: "Delete All Orders",
   policy: { mode: "sync", transaction: false },
   exposure: "all",
-  permissions: {
-    groups: ["admin"],
-  },
   handler: async () => ({ deleted: true }),
+};
+
+/**
+ * Issue #125: permission enforcement moved from ActionExecutor to a
+ * pipeline-slot middleware. This in-test allowlist maps action name to
+ * required groups (any-of) — a minimal stand-in for the permission
+ * capability that production apps would plug in.
+ */
+const REQUIRED_GROUPS_BY_ACTION: Record<string, string[]> = {
+  approve_order: ["manager"],
+  delete_all_orders: ["admin"],
 };
 
 /** An action that is internal only (not exposed over HTTP) */
@@ -113,9 +120,32 @@ beforeAll(() => {
     executionLogger,
   });
 
+  // Wire a CommandLayer with a permission middleware that reads the
+  // in-test allowlist (REQUIRED_GROUPS_BY_ACTION). This replaces the
+  // ActionExecutor's previous built-in permission check (removed in #125).
+  const commandLayer = createCommandLayer({ executor });
+  commandLayer.use({
+    name: "test_permission_check",
+    slot: "permission",
+    handler: async (ctx, next) => {
+      const required = REQUIRED_GROUPS_BY_ACTION[ctx.command];
+      if (required && required.length > 0) {
+        const hasGroup = ctx.actor.groups.some((g) => required.includes(g));
+        if (!hasGroup) {
+          throw new PipelineError(
+            `Actor does not belong to any of the required groups: ${required.join(", ")}`,
+            "PERMISSION.DENIED",
+          );
+        }
+      }
+      await next();
+    },
+  });
+
   // Configure server with actor resolver that simulates auth
   app = createServer(graphqlSchema, {
     executor,
+    commandLayer,
     executionLogger,
     dataProvider: store,
     resolveRequestActor: async (request: Request): Promise<Actor | undefined> => {

--- a/addons/adapter-server/cap-adapter-server/__tests__/graphql-soft-delete.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/graphql-soft-delete.test.ts
@@ -8,7 +8,12 @@
 
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import type { EntityDefinition } from "@linchkit/core";
-import { createActionExecutor, InMemoryStore } from "@linchkit/core/server";
+import {
+  createActionExecutor,
+  createCommandLayer,
+  InMemoryStore,
+  PipelineError,
+} from "@linchkit/core/server";
 import { buildGraphQLSchema, generateCrudActions } from "../src/graphql/build-schema";
 import { createServer } from "../src/server";
 
@@ -234,5 +239,144 @@ describe("GraphQL soft delete", () => {
     `);
     expect(result.errors).toBeUndefined();
     expect((result.data.restoreSoftDelItem as Record<string, unknown>).title).toBe("Active");
+  });
+});
+
+// ── Permission slot coverage for restore (PR #187) ──────────────────────────
+
+/**
+ * Regression test: the GraphQL `restore_*` mutation must flow through the
+ * CommandLayer's permission slot with `includeDeleted=true` forwarded via
+ * `CommandExecuteOptions`, rather than bypassing the pipeline through the
+ * raw executor. See PR #187.
+ */
+describe("GraphQL restore goes through CommandLayer permission slot", () => {
+  const RESTORE_PORT = 3992;
+  let pipelineStore: InMemoryStore;
+  let pipelineApp: ReturnType<typeof createServer>;
+  /** Records of each permission middleware invocation on this pipeline. */
+  const permissionCalls: Array<{ command: string; includeDeletedOnInput: unknown }> = [];
+  /** When true, the permission middleware denies `restore_*` commands. */
+  let denyRestore = false;
+
+  beforeAll(() => {
+    pipelineStore = new InMemoryStore();
+    const executor = createActionExecutor({ dataProvider: pipelineStore });
+    for (const action of generateCrudActions(schema)) {
+      executor.registry.register(action);
+    }
+
+    const commandLayer = createCommandLayer({ executor });
+    commandLayer.use({
+      name: "record_permission_calls",
+      slot: "permission",
+      handler: async (ctx, next) => {
+        permissionCalls.push({
+          command: ctx.command,
+          includeDeletedOnInput: (ctx.input as Record<string, unknown>).includeDeleted,
+        });
+        if (denyRestore && ctx.command.startsWith("restore_")) {
+          throw new PipelineError(
+            "restore denied by test permission middleware",
+            "PERMISSION.DENIED",
+          );
+        }
+        await next();
+      },
+    });
+
+    const graphqlSchema = buildGraphQLSchema([schema], {
+      executor,
+      commandLayer,
+      dataProvider: pipelineStore,
+    });
+
+    pipelineApp = createServer(graphqlSchema, {
+      executor,
+      commandLayer,
+      dataProvider: pipelineStore,
+    });
+    pipelineApp.listen(RESTORE_PORT);
+  });
+
+  afterAll(() => {
+    pipelineApp.stop();
+  });
+
+  beforeEach(() => {
+    pipelineStore.clear();
+    permissionCalls.length = 0;
+    denyRestore = false;
+  });
+
+  async function gqlPipeline(query: string) {
+    const res = await fetch(`http://localhost:${RESTORE_PORT}/graphql`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query }),
+    });
+    return res.json() as Promise<{ data: Record<string, unknown>; errors?: unknown[] }>;
+  }
+
+  test("restore mutation invokes the permission slot and forwards includeDeleted", async () => {
+    await pipelineStore.create(SCHEMA_NAME, {
+      id: "pipeline_restore",
+      title: "Pipeline Restore",
+      quantity: 3,
+    });
+    await pipelineStore.delete(SCHEMA_NAME, "pipeline_restore");
+
+    const result = await gqlPipeline(`
+      mutation {
+        restoreSoftDelItem(id: "pipeline_restore") {
+          id
+          title
+        }
+      }
+    `);
+    expect(result.errors).toBeUndefined();
+    const restored = result.data.restoreSoftDelItem as Record<string, unknown>;
+    expect(restored.id).toBe("pipeline_restore");
+    expect(restored.title).toBe("Pipeline Restore");
+
+    // Permission slot was invoked for the restore action.
+    const restoreCall = permissionCalls.find((c) => c.command === "restore_soft_del_item");
+    expect(restoreCall).toBeDefined();
+
+    // The deleted row is only reachable when the executor sees includeDeleted=true;
+    // a successful restore therefore proves the flag was forwarded through
+    // CommandExecuteOptions rather than dropped at the pipeline boundary.
+    const raw = await pipelineStore.get(SCHEMA_NAME, "pipeline_restore");
+    expect(raw).toBeDefined();
+    expect(raw.deleted_at).toBeNull();
+  });
+
+  test("permission slot can deny restore, blocking the executor entirely", async () => {
+    await pipelineStore.create(SCHEMA_NAME, {
+      id: "denied_restore",
+      title: "Denied Restore",
+      quantity: 2,
+    });
+    await pipelineStore.delete(SCHEMA_NAME, "denied_restore");
+
+    denyRestore = true;
+
+    const result = await gqlPipeline(`
+      mutation {
+        restoreSoftDelItem(id: "denied_restore") {
+          id
+        }
+      }
+    `);
+    // Either the response carries a GraphQL error or a null payload with the
+    // denial propagated via the ActionResult — in both shapes the raw record
+    // must remain soft-deleted.
+    const payload = result.data?.restoreSoftDelItem ?? null;
+    expect(payload === null || (result.errors && result.errors.length > 0)).toBe(true);
+
+    const raw = await pipelineStore.get(SCHEMA_NAME, "denied_restore", { includeDeleted: true });
+    expect(raw).toBeDefined();
+    expect(raw.deleted_at).toBeDefined();
+    expect(raw.deleted_at).not.toBeNull();
   });
 });

--- a/addons/adapter-server/cap-adapter-server/__tests__/rest-actions.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/rest-actions.test.ts
@@ -9,8 +9,10 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import type { ActionDefinition, EntityDefinition } from "@linchkit/core";
 import {
   createActionExecutor,
+  createCommandLayer,
   InMemoryExecutionLogger,
   InMemoryStore,
+  PipelineError,
 } from "@linchkit/core/server";
 import { buildGraphQLSchema } from "../src/graphql/build-schema";
 import { createServer } from "../src/server";
@@ -48,15 +50,16 @@ const throwAction: ActionDefinition = {
   },
 };
 
-/** An action restricted to the "manager" role */
+/**
+ * An action restricted to the "manager" role.
+ * Issue #125: permission enforcement moved to a pipeline-slot middleware;
+ * the action itself carries no permission metadata.
+ */
 const restrictedAction: ActionDefinition = {
   name: "do_restricted",
   entity: "item",
   label: "Restricted",
   policy: { mode: "sync", transaction: false },
-  permissions: {
-    groups: ["manager"],
-  },
   handler: async () => ({ ok: true }),
 };
 
@@ -175,8 +178,28 @@ describe("REST action endpoint — status codes", () => {
     });
     restrictedExecutor.registry.register(restrictedAction);
 
+    // In-test permission middleware: requires "manager" group for do_restricted.
+    const restrictedCommandLayer = createCommandLayer({ executor: restrictedExecutor });
+    restrictedCommandLayer.use({
+      name: "test_permission_check",
+      slot: "permission",
+      handler: async (ctx, next) => {
+        if (ctx.command === "do_restricted") {
+          const hasGroup = ctx.actor.groups.includes("manager");
+          if (!hasGroup) {
+            throw new PipelineError(
+              "Actor does not belong to any of the required groups: manager",
+              "PERMISSION.DENIED",
+            );
+          }
+        }
+        await next();
+      },
+    });
+
     const restrictedApp = createServer(restrictedGraphqlSchema, {
       executor: restrictedExecutor,
+      commandLayer: restrictedCommandLayer,
       resolveRequestActor: () => ({
         type: "human" as const,
         id: "unprivileged_user",

--- a/addons/adapter-server/cap-adapter-server/src/capability.ts
+++ b/addons/adapter-server/cap-adapter-server/src/capability.ts
@@ -81,6 +81,7 @@ export const capAdapterServer = defineCapability({
           // Build GraphQL schema — uses composite data provider for all schemas
           const graphqlSchema = buildGraphQLSchema(allSchemas, {
             executor: ctx.executor,
+            commandLayer: ctx.commandLayer,
             dataProvider: systemDataProvider ?? ctx.dataProvider,
             relations: ctx.links,
             eventBus: ctx.eventBus,

--- a/addons/adapter-server/cap-adapter-server/src/dev.ts
+++ b/addons/adapter-server/cap-adapter-server/src/dev.ts
@@ -195,6 +195,7 @@ const customActions = capContributions.actions;
 
 const graphqlSchema = buildGraphQLSchema(allEntities, {
   executor: runtime.executor,
+  commandLayer: runtime.commandLayer,
   dataProvider: runtime.dataProvider,
   actions: customActions,
   relations: capContributions.relations,

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
@@ -216,23 +216,10 @@ export function buildGraphQLSchema(
     ctx: GraphQLContext,
     extraOptions?: { includeDeleted?: boolean },
   ): Promise<ActionResult<T>> => {
-    // `includeDeleted` (used by restore_*) isn't yet surfaced on
-    // `CommandExecuteOptions`, so when it's required we fall back to the raw
-    // executor. TODO: promote includeDeleted into CommandExecuteOptions so
-    // restore flows also benefit from the permission slot.
-    if (extraOptions?.includeDeleted) {
-      if (!executor) {
-        throw new Error(
-          "restore action requires options.executor until CommandLayer exposes includeDeleted",
-        );
-      }
-      return executor.execute(name, input, ctx.actor, {
-        channel: "http",
-        tenantId: ctx.tenantId,
-        locale: ctx.locale,
-        includeDeleted: true,
-      }) as Promise<ActionResult<T>>;
-    }
+    // Prefer CommandLayer so cap-permission and other slot middleware
+    // protect every GraphQL mutation, including restore_* flows. The
+    // CommandExecuteOptions surface carries `includeDeleted` now, so these
+    // actions no longer need a raw-executor escape hatch.
     if (commandLayer) {
       return (await commandLayer.execute({
         command: name,
@@ -241,6 +228,7 @@ export function buildGraphQLSchema(
         channel: "http",
         tenantId: ctx.tenantId,
         locale: ctx.locale,
+        includeDeleted: extraOptions?.includeDeleted,
       })) as ActionResult<T>;
     }
     if (!executor) {
@@ -250,6 +238,7 @@ export function buildGraphQLSchema(
       channel: "http",
       tenantId: ctx.tenantId,
       locale: ctx.locale,
+      includeDeleted: extraOptions?.includeDeleted,
     }) as Promise<ActionResult<T>>;
   };
 

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
@@ -9,7 +9,9 @@
 import type {
   ActionDefinition,
   ActionExecutor,
+  ActionResult,
   Actor,
+  CommandLayer,
   DataProvider,
   DataQueryOptions,
   DerivedPropertyEngine,
@@ -143,8 +145,21 @@ const ActionResultType = new GraphQLObjectType({
 // ── Schema builder options ──────────────────────────────────
 
 export interface BuildGraphQLSchemaOptions {
-  /** Action executor for wiring mutations */
+  /**
+   * Action executor for wiring mutations. When `commandLayer` is also
+   * provided, the resolvers prefer the pipeline so cap-permission and other
+   * CommandLayer slots protect GraphQL mutations the same way they protect
+   * REST (issue #125). Raw `executor` is retained as a fallback for test
+   * setups that don't build a CommandLayer.
+   */
   executor?: ActionExecutor;
+  /**
+   * CommandLayer pipeline. When present, GraphQL mutation resolvers route
+   * through `commandLayer.execute(...)` instead of calling `executor.execute`
+   * directly — this is the supported production path (cap-permission and
+   * other slot middleware only run on the pipeline).
+   */
+  commandLayer?: CommandLayer;
   /** Data provider for query resolvers (get, query, count) */
   dataProvider?: DataProvider;
   /** Custom actions to generate typed mutations for (beyond auto-generated CRUD) */
@@ -186,7 +201,60 @@ export function buildGraphQLSchema(
   options?: BuildGraphQLSchemaOptions,
 ): GraphQLSchema {
   const executor = options?.executor;
+  const commandLayer = options?.commandLayer;
   const dataProvider = options?.dataProvider;
+
+  /**
+   * Dispatch a named action through the production pipeline when available,
+   * falling back to the raw executor for test setups that don't supply a
+   * CommandLayer. Preferring commandLayer means cap-permission and any other
+   * permission-slot middleware actually protect GraphQL mutations (issue #125).
+   */
+  const dispatchAction = async <T = unknown>(
+    name: string,
+    input: Record<string, unknown>,
+    ctx: GraphQLContext,
+    extraOptions?: { includeDeleted?: boolean },
+  ): Promise<ActionResult<T>> => {
+    // `includeDeleted` (used by restore_*) isn't yet surfaced on
+    // `CommandExecuteOptions`, so when it's required we fall back to the raw
+    // executor. TODO: promote includeDeleted into CommandExecuteOptions so
+    // restore flows also benefit from the permission slot.
+    if (extraOptions?.includeDeleted) {
+      if (!executor) {
+        throw new Error(
+          "restore action requires options.executor until CommandLayer exposes includeDeleted",
+        );
+      }
+      return executor.execute(name, input, ctx.actor, {
+        channel: "http",
+        tenantId: ctx.tenantId,
+        locale: ctx.locale,
+        includeDeleted: true,
+      }) as Promise<ActionResult<T>>;
+    }
+    if (commandLayer) {
+      return (await commandLayer.execute({
+        command: name,
+        input,
+        actor: ctx.actor,
+        channel: "http",
+        tenantId: ctx.tenantId,
+        locale: ctx.locale,
+      })) as ActionResult<T>;
+    }
+    if (!executor) {
+      throw new Error("GraphQL mutation requires either options.commandLayer or options.executor");
+    }
+    return executor.execute(name, input, ctx.actor, {
+      channel: "http",
+      tenantId: ctx.tenantId,
+      locale: ctx.locale,
+    }) as Promise<ActionResult<T>>;
+  };
+
+  /** True when at least one execution path is available — guards mutation resolvers. */
+  const hasDispatcher = Boolean(commandLayer) || Boolean(executor);
   const relations = options?.relations ?? [];
   const eventBus = options?.eventBus;
   const permissionGroups = options?.permissionGroups ?? [];
@@ -517,20 +585,11 @@ export function buildGraphQLSchema(
       args: {
         input: { type: new GraphQLNonNull(inputType) },
       },
-      resolve: executor
+      resolve: hasDispatcher
         ? async (_root: unknown, args: { input: Record<string, unknown> }, ctx: GraphQLContext) => {
             const locale = ctx.locale;
             const normalizedInput = normalizeTranslatableRow(args.input, entity, locale);
-            const result = await executor.execute(
-              `create_${entityName}`,
-              normalizedInput,
-              ctx.actor,
-              {
-                channel: "http",
-                tenantId: ctx.tenantId,
-                locale,
-              },
-            );
+            const result = await dispatchAction(`create_${entityName}`, normalizedInput, ctx);
             if (!result.success) {
               const errData = result.data as Record<string, unknown> | undefined;
               throw new Error((errData?.error as string) ?? "Create action failed");
@@ -557,7 +616,7 @@ export function buildGraphQLSchema(
           description: "Expected record version for optimistic locking",
         },
       },
-      resolve: executor
+      resolve: hasDispatcher
         ? async (
             _root: unknown,
             args: { id: string; input: Record<string, unknown>; _version?: number },
@@ -578,11 +637,7 @@ export function buildGraphQLSchema(
             if (args._version !== undefined && args._version !== null) {
               input._version = args._version;
             }
-            const result = await executor.execute(`update_${entityName}`, input, ctx.actor, {
-              channel: "http",
-              tenantId: ctx.tenantId,
-              locale,
-            });
+            const result = await dispatchAction(`update_${entityName}`, input, ctx);
             if (!result.success) {
               const errData = result.data as Record<string, unknown> | undefined;
               const errorMessage = (errData?.error as string) ?? "Update action failed";
@@ -622,14 +677,9 @@ export function buildGraphQLSchema(
       args: {
         id: { type: new GraphQLNonNull(GraphQLID) },
       },
-      resolve: executor
+      resolve: hasDispatcher
         ? async (_root: unknown, args: { id: string }, ctx: GraphQLContext) => {
-            const result = await executor.execute(
-              `delete_${entityName}`,
-              { id: args.id },
-              ctx.actor,
-              { channel: "http", tenantId: ctx.tenantId, locale: ctx.locale },
-            );
+            const result = await dispatchAction(`delete_${entityName}`, { id: args.id }, ctx);
             if (result.success) invalidateEntityCache(entityName);
             return result.success;
           }
@@ -642,15 +692,12 @@ export function buildGraphQLSchema(
       args: {
         id: { type: new GraphQLNonNull(GraphQLID) },
       },
-      resolve: executor
+      resolve: hasDispatcher
         ? async (_root: unknown, args: { id: string }, ctx: GraphQLContext) => {
             const locale = ctx.locale;
-            const result = await executor.execute(
-              `restore_${entityName}`,
-              { id: args.id },
-              ctx.actor,
-              { channel: "http", tenantId: ctx.tenantId, locale, includeDeleted: true },
-            );
+            const result = await dispatchAction(`restore_${entityName}`, { id: args.id }, ctx, {
+              includeDeleted: true,
+            });
             if (!result.success) {
               const errData = result.data as Record<string, unknown> | undefined;
               throw new GraphQLError(
@@ -774,11 +821,7 @@ export function buildGraphQLSchema(
                   id: args.id,
                   [stateFieldName]: args.to,
                 };
-                const result = await executor.execute(`update_${entityName}`, input, ctx.actor, {
-                  channel: "http",
-                  tenantId: ctx.tenantId,
-                  locale: ctx.locale,
-                });
+                const result = await dispatchAction(`update_${entityName}`, input, ctx);
                 if (!result.success) {
                   const errData = result.data as Record<string, unknown> | undefined;
                   throw new GraphQLError((errData?.error as string) ?? `State transition failed`);
@@ -823,7 +866,7 @@ export function buildGraphQLSchema(
       type: returnType,
       description: action.description ?? action.label,
       args,
-      resolve: executor
+      resolve: hasDispatcher
         ? async (
             _root: unknown,
             resolverArgs: { id: string; input?: Record<string, unknown> },
@@ -835,11 +878,7 @@ export function buildGraphQLSchema(
               ...resolverArgs.input,
               id: resolverArgs.id,
             };
-            const result = await executor.execute(actionName, input, ctx.actor, {
-              channel: "http",
-              tenantId: ctx.tenantId,
-              locale,
-            });
+            const result = await dispatchAction(actionName, input, ctx);
             if (returnsSchemaType) {
               if (!result.success) {
                 const errData = result.data as Record<string, unknown> | undefined;
@@ -897,14 +936,10 @@ export function buildGraphQLSchema(
         description: "JSON-encoded input object",
       },
     },
-    resolve: executor
+    resolve: hasDispatcher
       ? async (_root: unknown, args: { name: string; input: string }, ctx: GraphQLContext) => {
           const input = safeParseJSON(args.input, "input") as Record<string, unknown>;
-          const result = await executor.execute(args.name, input, ctx.actor, {
-            channel: "http",
-            tenantId: ctx.tenantId,
-            locale: ctx.locale,
-          });
+          const result = await dispatchAction(args.name, input, ctx);
           const errors = !result.success
             ? [
                 {

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
@@ -719,16 +719,6 @@ export function buildGraphQLSchema(
                         reason: `Actor type "${actor.type}" is not allowed`,
                       };
                     }
-                    if (perms.groups?.length) {
-                      const hasGroup = actor.groups.some((g) => perms.groups?.includes(g));
-                      if (!hasGroup) {
-                        return {
-                          ...tr,
-                          allowed: false,
-                          reason: `Requires group: ${perms.groups.join(", ")}`,
-                        };
-                      }
-                    }
                   }
                   return { ...tr, allowed: true, reason: null };
                 });

--- a/addons/demo/cap-purchase-demo/src/actions/approve.ts
+++ b/addons/demo/cap-purchase-demo/src/actions/approve.ts
@@ -9,7 +9,6 @@ export const approveAction: ActionDefinition = {
   entity: "purchase_request",
   label: "t:entities.purchase_request.actions.approve",
   description: "Approve a pending purchase request",
-  permissions: { groups: ["admin", "manager"] },
   policy: { mode: "sync", transaction: true },
   exposure: "all",
   stateTransition: { from: "pending", to: "approved" },

--- a/addons/demo/cap-purchase-demo/src/actions/reject.ts
+++ b/addons/demo/cap-purchase-demo/src/actions/reject.ts
@@ -12,7 +12,6 @@ export const rejectAction: ActionDefinition = {
   input: {
     reason: { type: "text", label: "Rejection Reason", required: true },
   },
-  permissions: { groups: ["admin", "manager"] },
   policy: { mode: "sync", transaction: true },
   exposure: "all",
   stateTransition: { from: "pending", to: "rejected" },

--- a/addons/demo/cap-purchase-demo/src/actions/submit.ts
+++ b/addons/demo/cap-purchase-demo/src/actions/submit.ts
@@ -12,7 +12,6 @@ export const submitAction: ActionDefinition = {
   input: {
     notes: { type: "text", label: "t:entities.purchase_request.fields.notes" },
   },
-  permissions: { groups: ["admin", "manager", "user"] },
   policy: { mode: "sync", transaction: true },
   exposure: "all",
   stateTransition: { from: "draft", to: "pending" },

--- a/addons/permission/cap-permission/src/actions/assign-user.ts
+++ b/addons/permission/cap-permission/src/actions/assign-user.ts
@@ -29,9 +29,6 @@ export const assignUserAction = defineAction({
     idempotent: true,
   },
   exposure: { http: true, ui: true, cli: true, mcp: false },
-  permissions: {
-    groups: ["system_admin"],
-  },
   async handler(ctx) {
     const userId = ctx.input.user_id as string;
     const groupName = ctx.input.group_name as string;

--- a/addons/permission/cap-permission/src/actions/create-group.ts
+++ b/addons/permission/cap-permission/src/actions/create-group.ts
@@ -42,9 +42,6 @@ export const createGroupAction = defineAction({
     idempotent: false,
   },
   exposure: { http: true, ui: true, cli: true, mcp: false },
-  permissions: {
-    groups: ["system_admin"],
-  },
   async handler(ctx) {
     const name = ctx.input.name as string;
     const label = ctx.input.label as string;

--- a/addons/permission/cap-permission/src/actions/revoke-user.ts
+++ b/addons/permission/cap-permission/src/actions/revoke-user.ts
@@ -29,9 +29,6 @@ export const revokeUserAction = defineAction({
     idempotent: true,
   },
   exposure: { http: true, ui: true, cli: true, mcp: false },
-  permissions: {
-    groups: ["system_admin"],
-  },
   async handler(ctx) {
     const userId = ctx.input.user_id as string;
     const groupName = ctx.input.group_name as string;

--- a/addons/permission/cap-permission/src/actions/update-permissions.ts
+++ b/addons/permission/cap-permission/src/actions/update-permissions.ts
@@ -35,9 +35,6 @@ export const updatePermissionsAction = defineAction({
     idempotent: false,
   },
   exposure: { http: true, ui: true, cli: true, mcp: false },
-  permissions: {
-    groups: ["system_admin"],
-  },
   async handler(ctx) {
     const groupName = ctx.input.group_name as string;
     const permissions = ctx.input.permissions as Record<string, unknown>;

--- a/packages/core/__tests__/action-engine.test.ts
+++ b/packages/core/__tests__/action-engine.test.ts
@@ -46,12 +46,16 @@ const declarativeAction: ActionDefinition = {
   policy: { mode: "sync", transaction: true },
 };
 
+// NOTE (issue #125): Permission enforcement was removed from ActionExecutor
+// and is now pipeline-owned (see command-layer-permission.test.ts and
+// cap-permission). We keep a reference action with `actorTypes` only so the
+// field continues to round-trip through the registry for UI hints, but the
+// executor itself performs no permission check.
 const restrictedAction: ActionDefinition = {
   name: "approve_order",
   entity: "order",
   label: "Approve Order",
   permissions: {
-    groups: ["manager", "admin"],
     actorTypes: ["human"],
   },
   policy: { mode: "sync", transaction: true },
@@ -278,32 +282,20 @@ describe("ActionExecutor", () => {
     expect(result.success).toBe(false);
   });
 
-  it("rejects unauthorized actor type", async () => {
+  it("executor does not enforce action.permissions (pipeline-owned per #125)", async () => {
+    // Issue #125: Action Engine no longer runs any permission check. Even an
+    // actor whose type/groups would have previously been rejected now passes
+    // through the executor unchanged. Permission enforcement is the
+    // responsibility of a permission-slot pipeline middleware.
     const dataProvider = createMemoryDataProvider();
     const executor = createActionExecutor({ dataProvider });
     executor.registry.register(restrictedAction);
 
-    const aiActor: Actor = { type: "ai", id: "bot-1", groups: ["admin"] };
+    const aiActor: Actor = { type: "ai", id: "bot-1", groups: [] };
     const result = await executor.execute("approve_order", {}, aiActor);
 
-    expect(result.success).toBe(false);
-    expect((result.data as Record<string, unknown>).error).toContain(
-      'Actor type "ai" is not allowed',
-    );
-  });
-
-  it("rejects unauthorized role", async () => {
-    const dataProvider = createMemoryDataProvider();
-    const executor = createActionExecutor({ dataProvider });
-    executor.registry.register(restrictedAction);
-
-    const viewerActor: Actor = { type: "human", id: "user-2", groups: ["viewer"] };
-    const result = await executor.execute("approve_order", {}, viewerActor);
-
-    expect(result.success).toBe(false);
-    expect((result.data as Record<string, unknown>).error).toContain(
-      "does not belong to any of the required groups",
-    );
+    expect(result.success).toBe(true);
+    expect((result.data as Record<string, unknown>).approved).toBe(true);
   });
 
   it("rejects missing required input", async () => {

--- a/packages/core/__tests__/action-engine.test.ts
+++ b/packages/core/__tests__/action-engine.test.ts
@@ -282,17 +282,34 @@ describe("ActionExecutor", () => {
     expect(result.success).toBe(false);
   });
 
-  it("executor does not enforce action.permissions (pipeline-owned per #125)", async () => {
-    // Issue #125: Action Engine no longer runs any permission check. Even an
-    // actor whose type/groups would have previously been rejected now passes
-    // through the executor unchanged. Permission enforcement is the
-    // responsibility of a permission-slot pipeline middleware.
+  it("executor enforces action.permissions.actorTypes (Spec 10)", async () => {
+    // Issue #125 moved GROUP authorization to the CommandLayer permission slot,
+    // but Spec 10 still requires actor-type filtering to hold on every path —
+    // so an action declared with `actorTypes: ["human"]` rejects an AI actor
+    // even through a raw executor.execute() call that bypasses the pipeline.
     const dataProvider = createMemoryDataProvider();
     const executor = createActionExecutor({ dataProvider });
     executor.registry.register(restrictedAction);
 
     const aiActor: Actor = { type: "ai", id: "bot-1", groups: [] };
     const result = await executor.execute("approve_order", {}, aiActor);
+
+    expect(result.success).toBe(false);
+    expect((result.data as Record<string, unknown>).error).toMatch(/actor type/i);
+  });
+
+  it("executor no longer enforces action.permissions.groups (pipeline-owned per #125)", async () => {
+    // Group authorization belongs to cap-permission via the CommandLayer
+    // permission slot. The executor does not check groups, so an actor whose
+    // type is allowed but who lacks any "required" group still executes.
+    const dataProvider = createMemoryDataProvider();
+    const executor = createActionExecutor({ dataProvider });
+    executor.registry.register(restrictedAction);
+
+    // restrictedAction only declares actorTypes: ["human"] after #125; a human
+    // actor with zero groups must succeed (group checks are pipeline-only).
+    const humanWithoutGroups: Actor = { type: "human", id: "user-1", groups: [] };
+    const result = await executor.execute("approve_order", {}, humanWithoutGroups);
 
     expect(result.success).toBe(true);
     expect((result.data as Record<string, unknown>).approved).toBe(true);

--- a/packages/core/__tests__/action-helpers.test.ts
+++ b/packages/core/__tests__/action-helpers.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "bun:test";
 import {
-  checkPermissions,
   generateExecutionId,
   isExposed,
   resolveFieldExpression,
@@ -119,59 +118,6 @@ describe("isExposed", () => {
     for (const ch of channels) {
       expect(isExposed("all", ch)).toBe(true);
     }
-  });
-});
-
-// ── checkPermissions ──────────────────────────────────────
-
-describe("checkPermissions", () => {
-  it("returns null when no permissions defined", () => {
-    const action = makeAction({ permissions: undefined });
-    expect(checkPermissions(action, defaultActor)).toBeNull();
-  });
-
-  it("returns null when actor type is in allowedTypes", () => {
-    const action = makeAction({
-      permissions: { actorTypes: ["human", "ai"] },
-    });
-    expect(checkPermissions(action, defaultActor)).toBeNull();
-  });
-
-  it("returns error message when actor type is not allowed", () => {
-    const action = makeAction({
-      permissions: { actorTypes: ["ai"] },
-    });
-    const result = checkPermissions(action, defaultActor);
-    expect(result).toContain("human");
-  });
-
-  it("returns null when actor belongs to required group", () => {
-    const action = makeAction({
-      permissions: { groups: ["manager"] },
-    });
-    expect(checkPermissions(action, defaultActor)).toBeNull();
-  });
-
-  it("returns error message when actor lacks required group", () => {
-    const action = makeAction({
-      permissions: { groups: ["admin"] },
-    });
-    const result = checkPermissions(action, defaultActor);
-    expect(result).toContain("admin");
-  });
-
-  it("returns null when actor is in at least one required group", () => {
-    const action = makeAction({
-      permissions: { groups: ["admin", "employee"] },
-    });
-    expect(checkPermissions(action, defaultActor)).toBeNull();
-  });
-
-  it("returns null for empty actorTypes list (no restriction)", () => {
-    const action = makeAction({
-      permissions: { actorTypes: [] },
-    });
-    expect(checkPermissions(action, defaultActor)).toBeNull();
   });
 });
 

--- a/packages/core/__tests__/command-layer-helpers.ts
+++ b/packages/core/__tests__/command-layer-helpers.ts
@@ -94,7 +94,6 @@ export function createTestSetup(opts?: TestSetupOptions): {
     label: "Admin Action",
     policy: { mode: "sync", transaction: false },
     exposure: "all",
-    permissions: { groups: ["admin"] },
     handler: async () => {
       return { admin: true };
     },

--- a/packages/core/__tests__/command-layer-integration.test.ts
+++ b/packages/core/__tests__/command-layer-integration.test.ts
@@ -111,13 +111,30 @@ describe("Command Layer: Integration", () => {
     });
   });
 
-  describe("Granular permission skip", () => {
-    test("executor skips permission when pipeline has permission middleware", async () => {
+  describe("Permission is pipeline-owned", () => {
+    // Unified permission model (#125): the Action Engine no longer performs
+    // any permission check. Permission enforcement is owned by the pipeline
+    // (permission-slot middleware, typically provided by a permission
+    // capability such as cap-permission). Without a permission middleware,
+    // all actions pass the permission stage.
+
+    test("action executes when no permission middleware is registered", async () => {
       const { layer } = createTestSetup();
 
-      // admin_action requires group "admin"
-      // Anonymous actor has no groups
-      // Pipeline permission middleware intentionally passes
+      // admin_action used to be rejected by the executor's built-in check.
+      // Under the new model, the pipeline is the sole authority, so the
+      // action proceeds when no permission middleware is wired.
+      const result = await layer.execute({
+        command: "admin_action",
+        input: {},
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    test("permission middleware can allow requests", async () => {
+      const { layer } = createTestSetup();
+
       layer.use({
         name: "lenient_perm",
         slot: "permission",
@@ -131,29 +148,12 @@ describe("Command Layer: Integration", () => {
         input: {},
       });
 
-      // Permission middleware is registered, so executor trusts the pipeline's decision
       expect(result.success).toBe(true);
-    });
-
-    test("executor runs its own permission check when no permission middleware registered", async () => {
-      const { layer } = createTestSetup();
-
-      // No permission middleware — executor's built-in check should reject
-      // admin_action requires groups: ["admin"], anonymous has none
-      const result = await layer.execute({
-        command: "admin_action",
-        input: {},
-      });
-
-      expect(result.success).toBe(false);
-      const data = result.data as Record<string, unknown>;
-      expect(data.error as string).toContain("required groups");
     });
 
     test("action without permission restrictions works without permission middleware", async () => {
       const { layer } = createTestSetup();
 
-      // create_item has no permissions defined — should work fine
       const result = await layer.execute({
         command: "create_item",
         input: { name: "test" },

--- a/packages/core/__tests__/command-layer-permission.test.ts
+++ b/packages/core/__tests__/command-layer-permission.test.ts
@@ -169,19 +169,19 @@ describe("Command Layer + Permission Engine Integration", () => {
     expect(result.success).toBe(true);
   });
 
-  test("no permission middleware = executor built-in check still runs (fail-closed)", async () => {
+  test("no permission middleware = pipeline is open (per issue #125)", async () => {
     const { layer } = createTestSetup();
 
-    // No permission middleware registered — executor's built-in permission check runs
-    // admin_action requires groups: ["admin"], anonymous has none → rejected
+    // Issue #125 unified the permission model: the Action Engine no longer
+    // performs any check. Without a permission-slot middleware, the pipeline
+    // has no gate and the action executes. Apps that want access control
+    // must plug in a permission capability (e.g. cap-permission).
     const result = await layer.execute({
       command: "admin_action",
       input: {},
     });
 
-    expect(result.success).toBe(false);
-    const data = result.data as Record<string, unknown>;
-    expect(data.error as string).toContain("required groups");
+    expect(result.success).toBe(true);
   });
 
   test("no permission middleware + unrestricted action = allow", async () => {

--- a/packages/core/__tests__/command-layer-permission.test.ts
+++ b/packages/core/__tests__/command-layer-permission.test.ts
@@ -187,7 +187,8 @@ describe("Command Layer + Permission Engine Integration", () => {
   test("no permission middleware + unrestricted action = allow", async () => {
     const { layer } = createTestSetup();
 
-    // create_item has no permissions defined — passes executor's built-in check
+    // create_item is unrestricted and no permission-slot middleware is installed,
+    // so the pipeline is open by default (issue #125 — Spec 10 §7.8).
     const result = await layer.execute({
       command: "create_item",
       input: { name: "test" },

--- a/packages/core/__tests__/command-layer.test.ts
+++ b/packages/core/__tests__/command-layer.test.ts
@@ -144,6 +144,13 @@ describe("Command Layer: Core Pipeline", () => {
   });
 
   describe("Permission slot", () => {
+    // Test-scoped allowlist map: action name -> required groups (any-of).
+    // This simulates a permission capability that maintains its own policy
+    // store instead of reading from action.permissions.groups.
+    const requiredGroups: Record<string, string[]> = {
+      admin_action: ["admin"],
+    };
+
     test("permission middleware blocks unauthorized requests", async () => {
       const { layer } = createTestSetup();
 
@@ -151,9 +158,9 @@ describe("Command Layer: Core Pipeline", () => {
         name: "perm_check",
         slot: "permission",
         handler: async (ctx, next) => {
-          const action = ctx.action;
-          if (action?.permissions?.groups) {
-            const hasGroup = ctx.actor.groups.some((g) => action.permissions?.groups?.includes(g));
+          const groups = requiredGroups[ctx.command];
+          if (groups && groups.length > 0) {
+            const hasGroup = ctx.actor.groups.some((g) => groups.includes(g));
             if (!hasGroup) {
               throw new PipelineError("Insufficient permissions", "PERMISSION.DENIED");
             }
@@ -188,9 +195,9 @@ describe("Command Layer: Core Pipeline", () => {
         name: "perm_check",
         slot: "permission",
         handler: async (ctx, next) => {
-          const action = ctx.action;
-          if (action?.permissions?.groups) {
-            const hasGroup = ctx.actor.groups.some((g) => action.permissions?.groups?.includes(g));
+          const groups = requiredGroups[ctx.command];
+          if (groups && groups.length > 0) {
+            const hasGroup = ctx.actor.groups.some((g) => groups.includes(g));
             if (!hasGroup) {
               throw new PipelineError("Insufficient permissions", "PERMISSION.DENIED");
             }

--- a/packages/core/__tests__/documentation.test.ts
+++ b/packages/core/__tests__/documentation.test.ts
@@ -67,7 +67,7 @@ const submitAction: ActionDefinition = {
   policy: { mode: "sync", transaction: true },
   stateTransition: { from: "draft", to: "pending" },
   exposure: { http: true, mcp: true, ui: true },
-  permissions: { groups: ["purchaser"], actorTypes: ["human"] },
+  permissions: { actorTypes: ["human"] },
 };
 
 const approveAction: ActionDefinition = {
@@ -240,7 +240,6 @@ describe("actionToDoc", () => {
 
   test("preserves permissions", () => {
     const doc = actionToDoc(submitAction);
-    expect(doc.permissions?.groups).toEqual(["purchaser"]);
     expect(doc.permissions?.actorTypes).toEqual(["human"]);
   });
 
@@ -393,7 +392,6 @@ describe("renderActionDoc", () => {
     expect(md).toContain("**Input:**");
     expect(md).toContain("| title | string | yes |");
     expect(md).toContain("**Output:**");
-    expect(md).toContain("**Required groups:** purchaser");
   });
 });
 

--- a/packages/core/__tests__/e2e-full-flow.test.ts
+++ b/packages/core/__tests__/e2e-full-flow.test.ts
@@ -616,7 +616,9 @@ describe("E2E: Full LinchKit Runtime Flow", () => {
 
       expect(approveResult.success).toBe(false);
       const data = approveResult.data as Record<string, unknown>;
-      expect((data.error as string) || "").toContain("groups");
+      // Assert on the machine-readable code set by the permission middleware,
+      // not a substring of the human-facing message (which may change wording).
+      expect(data.code).toBe("PERMISSION.DENIED");
     });
 
     test("2e. Reject transitions submitted → rejected", async () => {

--- a/packages/core/__tests__/e2e-full-flow.test.ts
+++ b/packages/core/__tests__/e2e-full-flow.test.ts
@@ -35,6 +35,7 @@ import {
   evaluateRules,
   InMemoryApprovalStore,
   InMemoryExecutionLogger,
+  PipelineError,
 } from "@linchkit/core/server";
 
 // ── Schema ───────────────────────────────────────────────
@@ -289,7 +290,6 @@ const approveExpenseAction: ActionDefinition = {
   name: "approve_expense",
   entity: "expense_report",
   label: "Approve Expense Report",
-  permissions: { groups: ["manager", "admin"] },
   stateTransition: { from: "submitted", to: "approved" },
   policy: { mode: "sync", transaction: false },
   exposure: "all",
@@ -317,7 +317,6 @@ const rejectExpenseAction: ActionDefinition = {
   name: "reject_expense",
   entity: "expense_report",
   label: "Reject Expense Report",
-  permissions: { groups: ["manager", "admin"] },
   stateTransition: { from: "submitted", to: "rejected" },
   policy: { mode: "sync", transaction: false },
   exposure: "all",
@@ -411,6 +410,31 @@ beforeAll(() => {
     executor,
     verifyApproval: async (approvalId: string) => {
       return verifyApproval(approvalId);
+    },
+  });
+
+  // Simulated permission capability: in-test allowlist keyed by action name.
+  // Replaces the previous ActionEngine-embedded permission check that read
+  // action.permissions.groups — now permissions belong to a capability.
+  const requiredGroupsByAction: Record<string, string[]> = {
+    approve_expense: ["manager", "admin"],
+    reject_expense: ["manager", "admin"],
+  };
+  layer.use({
+    name: "test_permission_check",
+    slot: "permission",
+    handler: async (ctx, next) => {
+      const required = requiredGroupsByAction[ctx.command];
+      if (required && required.length > 0) {
+        const hasGroup = ctx.actor.groups.some((g) => required.includes(g));
+        if (!hasGroup) {
+          throw new PipelineError(
+            `Requires one of groups: ${required.join(", ")}`,
+            "PERMISSION.DENIED",
+          );
+        }
+      }
+      await next();
     },
   });
 

--- a/packages/core/__tests__/e2e-tooling-integration.test.ts
+++ b/packages/core/__tests__/e2e-tooling-integration.test.ts
@@ -131,7 +131,6 @@ const approveAction: ActionDefinition = {
   input: {
     timesheet_id: { type: "string", required: true, label: "Timesheet ID" },
   },
-  permissions: { groups: ["manager"] },
   handler: async () => ({}),
 };
 

--- a/packages/core/__tests__/execution-logger.test.ts
+++ b/packages/core/__tests__/execution-logger.test.ts
@@ -39,17 +39,6 @@ const failingAction: ActionDefinition = {
   },
 };
 
-const restrictedAction: ActionDefinition = {
-  name: "restricted_action",
-  entity: "order",
-  label: "Restricted",
-  permissions: {
-    groups: ["superadmin"],
-  },
-  policy: { mode: "sync", transaction: true },
-  handler: async () => ({ ok: true }),
-};
-
 const parentAction: ActionDefinition = {
   name: "parent_action",
   entity: "order",
@@ -248,24 +237,11 @@ describe("ActionExecutor with ExecutionLogger", () => {
     expect(entry.error?.message).toBe("Something went wrong");
   });
 
-  it("should log blocked actions (permission denied)", async () => {
-    const logger = new InMemoryExecutionLogger();
-    const executor = createActionExecutor({
-      dataProvider: createMockDataProvider(),
-      executionLogger: logger,
-    });
-
-    executor.registry.register(restrictedAction);
-    const lowPrivActor: Actor = { type: "human", id: "user-2", groups: ["viewer"] };
-    const result = await executor.execute("restricted_action", {}, lowPrivActor);
-
-    expect(result.success).toBe(false);
-    expect(logger.size).toBe(1);
-
-    const entry = logger.getAll()[0];
-    expect(entry.status).toBe("blocked");
-    expect(entry.error?.message).toContain("does not belong to any of the required groups");
-  });
+  // Removed: "should log blocked actions (permission denied)" — the Action
+  // Engine no longer performs permission checks (issue #125). Permission
+  // denial is now emitted by the CommandLayer pipeline as a PipelineError,
+  // which the execution logger records via its own path (covered by
+  // command-layer-permission.test.ts).
 
   it("should log when action is not found", async () => {
     const logger = new InMemoryExecutionLogger();

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -22,7 +22,6 @@ import { canTransition, getAvailableActions } from "./state-machine";
 export { ActionRegistry } from "./action-registry";
 
 import {
-  checkPermissions,
   generateExecutionId,
   isExposed,
   resolveFieldExpression,
@@ -293,12 +292,14 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
       };
     }
 
-    // Step 2 & 3: Exposure + Permission checks
-    // Granular flags allow CommandLayer to skip only the checks it has handled
+    // Step 2: Exposure check
+    // Granular flag allows CommandLayer to skip the check it has already handled.
+    // Note: skipPermissionCheck is accepted for backwards compatibility but is a
+    // no-op — group-based authorization now lives exclusively in cap-permission
+    // via the CommandLayer "permission" slot (issue #125).
     const skipExposure = execOptions?.skipExposureCheck ?? false;
-    const skipPermission = execOptions?.skipPermissionCheck ?? false;
 
-    // Step 2: Exposure check — default channel to "internal" so the check always runs
+    // Exposure check — default channel to "internal" so the check always runs
     const channel: ExecutionChannel = execOptions?.channel ?? "internal";
     if (!skipExposure) {
       if (!isExposed(action.exposure, channel)) {
@@ -331,29 +332,8 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
       }
     }
 
-    // Step 3: Permission check
-    if (!skipPermission) {
-      const permError = checkPermissions(action, actor);
-      if (permError) {
-        await logExecution({
-          id: executionId,
-          action: actionName,
-          entity: action.entity,
-          actor,
-          input,
-          status: "blocked",
-          error: { message: permError },
-          startedAt,
-        });
-        return {
-          success: false,
-          data: { error: permError } as T,
-          executionId,
-        };
-      }
-    }
-
-    // Step 4: Input validation
+    // Step 3: Input validation
+    // (Permission enforcement happens in the CommandLayer "permission" slot.)
     const inputValidation = validateInput(action, input);
     if (!inputValidation.valid) {
       const firstError = inputValidation.errors?.[0];
@@ -455,7 +435,7 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
       },
     };
 
-    // Step 5: Pre-validation
+    // Step 4: Pre-validation
     const preValidation = runPreValidation(action, ctx);
     if (!preValidation.valid) {
       const firstError = preValidation.errors?.[0];
@@ -489,7 +469,7 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
       };
     }
 
-    // Step 6: State transition check
+    // Step 5: State transition check
     let stateTransitionRecord: { from: string; to: string } | undefined;
 
     if (action.stateTransition && stateMachine) {

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -74,7 +74,12 @@ export interface ExecuteOptions {
   channel?: ExecutionChannel;
   /** Skip exposure check (already handled by CommandLayer built-in exposure slot) */
   skipExposureCheck?: boolean;
-  /** Skip permission check (already handled by CommandLayer permission middleware) */
+  /**
+   * @deprecated Group authorization no longer runs inside the Action Engine
+   * (issue #125). The executor ignores this flag; permissions are enforced
+   * exclusively by the CommandLayer "permission" slot. Retained for source
+   * compatibility with older CommandLayer middleware that still sets it.
+   */
   skipPermissionCheck?: boolean;
   /** Tenant ID resolved by CommandLayer */
   tenantId?: string;
@@ -293,14 +298,14 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
       };
     }
 
-    // Step 2: Exposure check
+    // Step 2: Exposure check.
     // Granular flag allows CommandLayer to skip the check it has already handled.
     //
-    // Note: `skipPermissionCheck` only suppresses GROUP enforcement. Group
+    // Note: `skipPermissionCheck` is a no-op on the executor after #125 — group
     // authorization lives exclusively in cap-permission via the CommandLayer
-    // "permission" slot (issue #125). Actor-type enforcement (Spec 10 §5) is
-    // still applied below on every execution path so callers that bypass the
-    // pipeline (GraphQL, internal execute) still honor actor-type gating.
+    // "permission" slot. Actor-type enforcement (Spec 10 §5) is applied in
+    // Step 3 below and runs on every execution path (REST, GraphQL, MCP,
+    // direct internal execute) so actor-type gating can't be bypassed.
     const skipExposure = execOptions?.skipExposureCheck ?? false;
 
     // Exposure check — default channel to "internal" so the check always runs
@@ -359,8 +364,7 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
       };
     }
 
-    // Step 4: Input validation
-    // (Group-level authorization happens in the CommandLayer "permission" slot.)
+    // Step 4: Input validation.
     const inputValidation = validateInput(action, input);
     if (!inputValidation.valid) {
       const firstError = inputValidation.errors?.[0];
@@ -462,7 +466,7 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
       },
     };
 
-    // Step 4: Pre-validation
+    // Step 5: Pre-validation
     const preValidation = runPreValidation(action, ctx);
     if (!preValidation.valid) {
       const firstError = preValidation.errors?.[0];
@@ -496,7 +500,7 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
       };
     }
 
-    // Step 5: State transition check
+    // Step 6: State transition check
     let stateTransitionRecord: { from: string; to: string } | undefined;
 
     if (action.stateTransition && stateMachine) {

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -22,6 +22,7 @@ import { canTransition, getAvailableActions } from "./state-machine";
 export { ActionRegistry } from "./action-registry";
 
 import {
+  checkActorType,
   generateExecutionId,
   isExposed,
   resolveFieldExpression,
@@ -294,9 +295,12 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
 
     // Step 2: Exposure check
     // Granular flag allows CommandLayer to skip the check it has already handled.
-    // Note: skipPermissionCheck is accepted for backwards compatibility but is a
-    // no-op — group-based authorization now lives exclusively in cap-permission
-    // via the CommandLayer "permission" slot (issue #125).
+    //
+    // Note: `skipPermissionCheck` only suppresses GROUP enforcement. Group
+    // authorization lives exclusively in cap-permission via the CommandLayer
+    // "permission" slot (issue #125). Actor-type enforcement (Spec 10 §5) is
+    // still applied below on every execution path so callers that bypass the
+    // pipeline (GraphQL, internal execute) still honor actor-type gating.
     const skipExposure = execOptions?.skipExposureCheck ?? false;
 
     // Exposure check — default channel to "internal" so the check always runs
@@ -332,8 +336,31 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
       }
     }
 
-    // Step 3: Input validation
-    // (Permission enforcement happens in the CommandLayer "permission" slot.)
+    // Step 3: Actor-type check — Spec 10 authorization field declared on the
+    // action itself. Group enforcement moved to the CommandLayer "permission"
+    // slot (cap-permission) in #125, but actor-type filtering must hold on
+    // every entry point, including GraphQL and direct executor callers.
+    const actorTypeError = checkActorType(action, actor);
+    if (actorTypeError) {
+      await logExecution({
+        id: executionId,
+        action: actionName,
+        entity: action.entity,
+        actor,
+        input,
+        status: "blocked",
+        error: { message: actorTypeError },
+        startedAt,
+      });
+      return {
+        success: false,
+        data: { error: actorTypeError } as T,
+        executionId,
+      };
+    }
+
+    // Step 4: Input validation
+    // (Group-level authorization happens in the CommandLayer "permission" slot.)
     const inputValidation = validateInput(action, input);
     if (!inputValidation.valid) {
       const firstError = inputValidation.errors?.[0];

--- a/packages/core/src/engine/action-helpers.ts
+++ b/packages/core/src/engine/action-helpers.ts
@@ -62,7 +62,6 @@ export function generateExecutionId(): string {
   return `exec_${crypto.randomUUID()}`;
 }
 
-/** Check if the action is exposed for the given channel */
 /**
  * Enforce `permissions.actorTypes` — the only authorization field still owned
  * by the Action Engine after issue #125. Returns an error string (for logging
@@ -82,6 +81,7 @@ export function checkActorType(action: ActionDefinition, actor: Actor): string |
   return null;
 }
 
+/** Check if the action is exposed for the given channel */
 export function isExposed(
   exposure: ActionExposure | "all" | undefined,
   channel: ExecutionChannel,

--- a/packages/core/src/engine/action-helpers.ts
+++ b/packages/core/src/engine/action-helpers.ts
@@ -15,10 +15,14 @@ import type {
 import type { ExecutionChannel } from "./action-engine";
 
 // NOTE: Group-based permission enforcement lives exclusively in cap-permission
-// via the CommandLayer "permission" slot. Action Engine no longer performs any
-// group check — see Spec 10 §7.8 (open-by-default when no cap-permission).
-// Actor-type filtering (permissions.actorTypes) is a UI/exposure hint, not
-// an authorization decision, and is handled by consumers (e.g. GraphQL build).
+// via the CommandLayer "permission" slot — the executor no longer performs any
+// group check (Spec 10 §7.8: open-by-default when cap-permission is absent).
+//
+// Actor-type filtering (`permissions.actorTypes`) is a different concern: it's
+// a first-order authorization gate declared on the action itself (e.g. a
+// system-only dispatch primitive, an AI-only tool). Spec 10 requires it to be
+// enforced on every execution path, so the executor keeps this check. See
+// `checkActorType` below.
 
 /**
  * Resolve a `$`-prefixed expression in declarative `setFields`.
@@ -59,6 +63,25 @@ export function generateExecutionId(): string {
 }
 
 /** Check if the action is exposed for the given channel */
+/**
+ * Enforce `permissions.actorTypes` — the only authorization field still owned
+ * by the Action Engine after issue #125. Returns an error string (for logging
+ * + response) or `null` when the actor type is allowed.
+ *
+ * Group-based checks live in the CommandLayer "permission" slot; this one
+ * stays here because it's declared on the action itself and must hold for
+ * every entry point (REST, GraphQL, MCP, internal execute), not just the
+ * pipeline-aware callers.
+ */
+export function checkActorType(action: ActionDefinition, actor: Actor): string | null {
+  const allowed = action.permissions?.actorTypes;
+  if (!allowed || allowed.length === 0) return null;
+  if (!allowed.includes(actor.type)) {
+    return `Actor type "${actor.type}" is not allowed for action "${action.name}"`;
+  }
+  return null;
+}
+
 export function isExposed(
   exposure: ActionExposure | "all" | undefined,
   channel: ExecutionChannel,

--- a/packages/core/src/engine/action-helpers.ts
+++ b/packages/core/src/engine/action-helpers.ts
@@ -14,6 +14,12 @@ import type {
 } from "../types/action";
 import type { ExecutionChannel } from "./action-engine";
 
+// NOTE: Group-based permission enforcement lives exclusively in cap-permission
+// via the CommandLayer "permission" slot. Action Engine no longer performs any
+// group check — see Spec 10 §7.8 (open-by-default when no cap-permission).
+// Actor-type filtering (permissions.actorTypes) is a UI/exposure hint, not
+// an authorization decision, and is handled by consumers (e.g. GraphQL build).
+
 /**
  * Resolve a `$`-prefixed expression in declarative `setFields`.
  *
@@ -73,31 +79,6 @@ export function isExposed(
   const key = mapping[channel];
   // If not explicitly set, default to true
   return exposure[key] !== false;
-}
-
-/** Check if the actor has permission to execute the action */
-export function checkPermissions(action: ActionDefinition, actor: Actor): string | null {
-  const perms = action.permissions;
-  if (!perms) {
-    return null; // No restrictions
-  }
-
-  // Check actor type
-  if (perms.actorTypes && perms.actorTypes.length > 0) {
-    if (!perms.actorTypes.includes(actor.type)) {
-      return `Actor type "${actor.type}" is not allowed for action "${action.name}"`;
-    }
-  }
-
-  // Check permission groups
-  if (perms.groups && perms.groups.length > 0) {
-    const hasGroup = actor.groups.some((g) => perms.groups?.includes(g));
-    if (!hasGroup) {
-      return `Actor does not belong to any of the required groups: ${perms.groups.join(", ")}`;
-    }
-  }
-
-  return null;
 }
 
 /** Validate required input fields */

--- a/packages/core/src/engine/command-layer.ts
+++ b/packages/core/src/engine/command-layer.ts
@@ -150,6 +150,13 @@ export interface CommandExecuteOptions {
   skipRules?: string[];
   /** External trace ID — when provided, the pipeline reuses this instead of generating a new one */
   traceId?: string;
+  /**
+   * Include soft-deleted records when the action reads the target row.
+   * Used by `restore_*` actions so they can locate the row before writing.
+   * Forwarded to the executor; the permission slot still runs — callers must
+   * be authorized to read/restore the deleted row.
+   */
+  includeDeleted?: boolean;
 }
 
 /**
@@ -334,6 +341,9 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
     }
     if (execOptions.skipRules) {
       executorOptions.skipRules = execOptions.skipRules;
+    }
+    if (execOptions.includeDeleted) {
+      executorOptions.includeDeleted = execOptions.includeDeleted;
     }
 
     // Action execution as the innermost handler in the compose chain (#2).

--- a/packages/core/src/types/action.ts
+++ b/packages/core/src/types/action.ts
@@ -186,7 +186,6 @@ export interface IntentResolution {
 // ── Action permissions ─────────────────────────────────────
 
 export interface ActionPermissions {
-  groups?: string[];
   actorTypes?: ActorType[];
 }
 

--- a/packages/devtools/src/documentation/api-doc-generator.ts
+++ b/packages/devtools/src/documentation/api-doc-generator.ts
@@ -42,7 +42,7 @@ export interface ActionDoc {
   output: FieldDoc[];
   stateTransition?: { from: string | string[]; to: string };
   exposure: ActionExposure;
-  permissions?: { groups?: string[]; actorTypes?: string[] };
+  permissions?: { actorTypes?: string[] };
   policy: { mode: string; transaction: boolean; idempotent?: boolean };
 }
 
@@ -128,9 +128,7 @@ export function actionToDoc(action: ActionDefinition): ActionDoc {
     output: outputFields,
     stateTransition: action.stateTransition,
     exposure,
-    permissions: action.permissions
-      ? { groups: action.permissions.groups, actorTypes: action.permissions.actorTypes }
-      : undefined,
+    permissions: action.permissions ? { actorTypes: action.permissions.actorTypes } : undefined,
     policy: {
       mode: action.policy.mode,
       transaction: action.policy.transaction,

--- a/packages/devtools/src/documentation/markdown-renderer.ts
+++ b/packages/devtools/src/documentation/markdown-renderer.ts
@@ -186,9 +186,6 @@ export function renderActionDoc(action: ActionDoc): string {
 
   // Permissions
   if (action.permissions) {
-    if (action.permissions.groups?.length) {
-      lines.push(`- **Required groups:** ${action.permissions.groups.join(", ")}`);
-    }
     if (action.permissions.actorTypes?.length) {
       lines.push(`- **Actor types:** ${action.permissions.actorTypes.join(", ")}`);
     }


### PR DESCRIPTION
## Summary

- Removes `ActionDefinition.permissions.groups` and the executor's `checkPermissions()` path — group authorization is now owned exclusively by `cap-permission` via the CommandLayer `permission` slot (Spec 10 §7.8: open-by-default).
- Keeps `permissions.actorTypes` as a first-order authorization gate enforced on every execution path (fixed in the review-response commit after codex flagged the regression).

## Breaking change

`defineAction({ permissions: { groups: [...] } })` is **removed**. Migrate by moving group requirements to `definePermissionGroup()` declarations consumed by `cap-permission`.

## Codex review — addressed

| ID | Severity | Action |
| --- | --- | --- |
| A-1 | P1 — GraphQL mutations bypass CommandLayer, so cap-permission doesn't guard them | **Deferred to follow-up issue** (see below). `actorTypes` check partly mitigates. |
| A-2 | P2 — `actorTypes` dropped | Fixed — `checkActorType()` re-added; runs unconditionally on every executor path. New contract tests assert enforcement. |

## Follow-ups

- New issue: **Route GraphQL mutations through CommandLayer** so cap-permission actually protects `buildGraphQLSchema()` generated mutations (7 direct `executor.execute()` call sites).
- `cap-purchase-demo`: three demo actions lost their group guards; no PermissionGroup wiring was added. Host apps either install `cap-permission` or run the demo open.
- `cap-permission`: its own admin actions (create_group, assign_user, etc.) lost their `["system_admin"]` guard. Should be protected via a self-registered PermissionGroup.

## Test plan

- [x] `bun run check` / `typecheck` / `test` — 4206 pass / 0 fail / 3 skip
- [x] `command-layer-permission.test.ts` — 9/9 open-by-default + middleware-driven cases pass
- [x] `action-engine.test.ts` — new contract tests: actorTypes enforced on direct executor calls; groups NOT enforced (pipeline-owned)
- [x] `e2e-auth.test.ts` + `rest-actions.test.ts` — CommandLayer + permission middleware wired into test setup; 403 paths still covered end-to-end

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Permission enforcement moved from action declarations to pipeline middleware; action definitions no longer list required permission groups
  * Actor-type validation is still enforced at the action level

* **Documentation**
  * Generated docs and rendered action docs no longer show required permission groups

* **Tests**
  * Test suites updated to reflect the pipeline-owned permission model and adjusted failure/success expectations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->