### PR TITLE
feat(cap-file-storage): file storage capability with local adapter (closes #139)

### DIFF
--- a/addons/file-storage/cap-file-storage/__tests__/capability.test.ts
+++ b/addons/file-storage/cap-file-storage/__tests__/capability.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LocalStorageAdapter } from "../src/adapters/local-adapter";
+import { createCapFileStorage } from "../src/capability";
+import { resetStorageAdapter } from "../src/storage-registry";
+
+describe("cap-file-storage capability", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "cap-file-storage-cap-"));
+    resetStorageAdapter();
+  });
+
+  afterEach(async () => {
+    resetStorageAdapter();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("has correct metadata", () => {
+    const cap = createCapFileStorage({
+      adapter: new LocalStorageAdapter({ rootDir: root }),
+    });
+    expect(cap.name).toBe("cap-file-storage");
+    expect(cap.type).toBe("standard");
+    expect(cap.category).toBe("system");
+    expect(cap.version).toBe("0.0.1");
+    expect(cap.group).toBe("file-storage");
+  });
+
+  it("registers the file entity", () => {
+    const cap = createCapFileStorage({
+      adapter: new LocalStorageAdapter({ rootDir: root }),
+    });
+    const names = cap.entities?.map((e) => e.name) ?? [];
+    expect(names).toEqual(["file"]);
+  });
+
+  it("registers the 3 actions with verb_noun naming", () => {
+    const cap = createCapFileStorage({
+      adapter: new LocalStorageAdapter({ rootDir: root }),
+    });
+    const names = cap.actions?.map((a) => a.name) ?? [];
+    expect(names).toContain("upload_file");
+    expect(names).toContain("download_file");
+    expect(names).toContain("delete_file");
+    expect(names).toHaveLength(3);
+  });
+
+  it("exposes the adapter as a 'storage' service", () => {
+    const adapter = new LocalStorageAdapter({ rootDir: root });
+    const cap = createCapFileStorage({ adapter });
+    const storageService = cap.extensions?.services?.find((s) => s.name === "storage");
+    expect(storageService).toBeDefined();
+    expect(storageService?.factory()).toBe(adapter);
+  });
+
+  it("declares system permissions with dot notation", () => {
+    const cap = createCapFileStorage({
+      adapter: new LocalStorageAdapter({ rootDir: root }),
+    });
+    expect(cap.systemPermissions).toContain("database.read");
+    expect(cap.systemPermissions).toContain("database.write");
+    expect(cap.systemPermissions).toContain("event.emit");
+  });
+
+  it("falls back to a LocalStorageAdapter when no adapter is supplied", () => {
+    const cap = createCapFileStorage({ rootDir: root });
+    expect(cap.adapter).toBeInstanceOf(LocalStorageAdapter);
+    expect(cap.adapter.name).toBe("local");
+  });
+});

--- a/addons/file-storage/cap-file-storage/__tests__/file-entity.test.ts
+++ b/addons/file-storage/cap-file-storage/__tests__/file-entity.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+import { fileEntity } from "../src/entities/file";
+
+describe("file entity", () => {
+  it("uses snake_case singular noun", () => {
+    expect(fileEntity.name).toBe("file");
+  });
+
+  it("has the required metadata fields", () => {
+    const fields = fileEntity.fields;
+    expect(fields.name?.type).toBe("string");
+    expect(fields.name?.required).toBe(true);
+    expect(fields.size?.type).toBe("number");
+    expect(fields.size?.required).toBe(true);
+    expect(fields.mime?.type).toBe("string");
+    expect(fields.mime?.required).toBe(true);
+    expect(fields.path?.type).toBe("string");
+    expect(fields.path?.required).toBe(true);
+    expect(fields.adapter?.type).toBe("string");
+    expect(fields.adapter?.required).toBe(true);
+    expect(fields.uploaded_by?.type).toBe("string");
+    expect(fields.uploaded_by?.required).toBe(true);
+  });
+
+  it("does not redeclare system-managed fields", () => {
+    // created_at, updated_at, id, tenant_id, created_by, updated_by, _version
+    // are injected by the core runtime and must NOT appear in user fields.
+    const forbidden = [
+      "id",
+      "tenant_id",
+      "created_at",
+      "updated_at",
+      "created_by",
+      "updated_by",
+      "_version",
+    ];
+    for (const key of forbidden) {
+      expect(fileEntity.fields[key]).toBeUndefined();
+    }
+  });
+
+  it("declares sensible presentation metadata", () => {
+    expect(fileEntity.presentation?.titleField).toBe("name");
+    expect(fileEntity.presentation?.icon).toBe("file");
+  });
+
+  it("constrains size to be non-negative", () => {
+    const size = fileEntity.fields.size;
+    expect(size?.type).toBe("number");
+    if (size?.type === "number") {
+      expect(size.min).toBe(0);
+    }
+  });
+});

--- a/addons/file-storage/cap-file-storage/__tests__/local-adapter.test.ts
+++ b/addons/file-storage/cap-file-storage/__tests__/local-adapter.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LocalStorageAdapter } from "../src/adapters/local-adapter";
+
+describe("LocalStorageAdapter", () => {
+  let root: string;
+  let adapter: LocalStorageAdapter;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "cap-file-storage-"));
+    adapter = new LocalStorageAdapter({ rootDir: root });
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("exposes a default adapter name of 'local'", () => {
+    expect(adapter.name).toBe("local");
+  });
+
+  it("honors a custom adapter name", () => {
+    const named = new LocalStorageAdapter({ rootDir: root, name: "custom" });
+    expect(named.name).toBe("custom");
+  });
+
+  it("rejects construction without rootDir", () => {
+    // biome-ignore lint/suspicious/noExplicitAny: intentional invalid input for test
+    expect(() => new LocalStorageAdapter({} as any)).toThrow(/rootDir/);
+  });
+
+  it("write() persists payload, returns size + sha256 checksum", async () => {
+    const data = new TextEncoder().encode("hello, file storage");
+    const result = await adapter.write({ path: "greeting.txt", data, mime: "text/plain" });
+
+    expect(result.path).toBe("greeting.txt");
+    expect(result.size).toBe(data.byteLength);
+    // sha256("hello, file storage")
+    expect(result.checksum).toBe(
+      "7de5f25d87840d5a6214a0ec7334b26b07a81c95d9f4789155dc88b65e14519a",
+    );
+  });
+
+  it("read() round-trips the exact bytes", async () => {
+    const data = new Uint8Array([0, 1, 2, 3, 4, 5, 255]);
+    await adapter.write({ path: "nested/dir/bin.dat", data });
+    const out = await adapter.read("nested/dir/bin.dat");
+    expect(out.byteLength).toBe(data.byteLength);
+    expect(Array.from(out)).toEqual(Array.from(data));
+  });
+
+  it("exists() reflects write and delete", async () => {
+    expect(await adapter.exists("a.txt")).toBe(false);
+    await adapter.write({ path: "a.txt", data: new Uint8Array([1]) });
+    expect(await adapter.exists("a.txt")).toBe(true);
+    await adapter.delete("a.txt");
+    expect(await adapter.exists("a.txt")).toBe(false);
+  });
+
+  it("delete() is idempotent for missing files", async () => {
+    await expect(adapter.delete("does-not-exist")).resolves.toBeUndefined();
+  });
+
+  it("read() throws for missing file", async () => {
+    await expect(adapter.read("missing")).rejects.toThrow();
+  });
+
+  it("rejects absolute paths (path-traversal guard)", async () => {
+    await expect(adapter.write({ path: "/etc/passwd", data: new Uint8Array() })).rejects.toThrow(
+      /relative/,
+    );
+  });
+
+  it("rejects parent-directory escapes", async () => {
+    await expect(adapter.write({ path: "../escape.txt", data: new Uint8Array() })).rejects.toThrow(
+      /escapes/,
+    );
+  });
+
+  it("rejects null bytes in path", async () => {
+    await expect(adapter.write({ path: "bad\0path", data: new Uint8Array() })).rejects.toThrow(
+      /null bytes/,
+    );
+  });
+
+  it("rejects non-Uint8Array data", async () => {
+    await expect(
+      // biome-ignore lint/suspicious/noExplicitAny: intentional invalid input for test
+      adapter.write({ path: "x.txt", data: "not bytes" as any }),
+    ).rejects.toThrow(/Uint8Array/);
+  });
+});

--- a/addons/file-storage/cap-file-storage/package.json
+++ b/addons/file-storage/cap-file-storage/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@linchkit/cap-file-storage",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "files": [
+    "src/",
+    "package.json",
+    "README.md"
+  ],
+  "exports": {
+    ".": "./src/index.ts",
+    "./capability": "./src/capability.ts",
+    "./adapters": "./src/adapters/index.ts"
+  },
+  "scripts": {
+    "test": "bun test"
+  },
+  "peerDependencies": {
+    "@linchkit/core": "^0.2.0"
+  },
+  "devDependencies": {
+    "@linchkit/core": "workspace:*",
+    "typescript": "^6.0.2"
+  },
+  "linchkit": {
+    "minCoreVersion": "^0.1.0",
+    "type": "standard",
+    "category": "system"
+  }
+}

--- a/addons/file-storage/cap-file-storage/src/actions/delete_file.ts
+++ b/addons/file-storage/cap-file-storage/src/actions/delete_file.ts
@@ -51,9 +51,13 @@ export const deleteFileAction = defineAction({
       );
     }
 
-    // Delete payload first, then metadata. Adapter delete is idempotent.
-    await adapter.delete(record.path as string);
+    // Delete metadata first, then the payload. If adapter.delete fails the
+    // record is already gone — the leftover blob is a harmless orphan that
+    // a storage GC can reclaim. The reverse order (blob first, row second)
+    // can leave an orphan row pointing at a missing blob, which breaks
+    // download_file for every future request.
     await ctx.delete("file", id);
+    await adapter.delete(record.path as string);
 
     ctx.emit("file.deleted", {
       file_id: id,

--- a/addons/file-storage/cap-file-storage/src/actions/delete_file.ts
+++ b/addons/file-storage/cap-file-storage/src/actions/delete_file.ts
@@ -32,12 +32,15 @@ export const deleteFileAction = defineAction({
       throw new Error("File id is required");
     }
 
-    let record: Record<string, unknown> | undefined;
-    try {
-      record = await ctx.get("file", id);
-    } catch {
-      // Idempotent: record already gone — nothing to delete.
-      return { deleted: false, id };
+    // Idempotency: use `query` rather than `get` so a missing record is a
+    // zero-length array instead of an exception. Transient errors
+    // (DB unavailable, tenant-isolation reject, permission error, etc.) still
+    // throw, which is what we want — callers must not see `deleted: false`
+    // for a real failure.
+    const rows = await ctx.query("file", { id });
+    const [record] = rows;
+    if (!record) {
+      return { deleted: false, id, reason: "not-found" };
     }
 
     const adapter = getStorageAdapter();

--- a/addons/file-storage/cap-file-storage/src/actions/delete_file.ts
+++ b/addons/file-storage/cap-file-storage/src/actions/delete_file.ts
@@ -1,0 +1,62 @@
+/**
+ * delete_file action — remove both the file record and its payload.
+ *
+ * Idempotent: deleting a missing file succeeds. The adapter `delete()`
+ * contract also requires idempotency.
+ */
+
+import { defineAction } from "@linchkit/core";
+import { getStorageAdapter } from "../storage-registry";
+
+export const deleteFileAction = defineAction({
+  name: "delete_file",
+  entity: "file",
+  label: "Delete File",
+  description: "Delete a file's record and payload",
+  input: {
+    id: {
+      type: "string",
+      label: "File ID",
+      required: true,
+    },
+  },
+  policy: {
+    mode: "sync",
+    transaction: true,
+    idempotent: true,
+  },
+  exposure: { http: true, ui: true, cli: true, mcp: false },
+  async handler(ctx) {
+    const id = String(ctx.input.id ?? "").trim();
+    if (!id) {
+      throw new Error("File id is required");
+    }
+
+    let record: Record<string, unknown> | undefined;
+    try {
+      record = await ctx.get("file", id);
+    } catch {
+      // Idempotent: record already gone — nothing to delete.
+      return { deleted: false, id };
+    }
+
+    const adapter = getStorageAdapter();
+    const recordAdapter = record.adapter as string | undefined;
+    if (recordAdapter && recordAdapter !== adapter.name) {
+      throw new Error(
+        `File record was stored by adapter "${recordAdapter}" but active adapter is "${adapter.name}"`,
+      );
+    }
+
+    // Delete payload first, then metadata. Adapter delete is idempotent.
+    await adapter.delete(record.path as string);
+    await ctx.delete("file", id);
+
+    ctx.emit("file.deleted", {
+      file_id: id,
+      deleted_by: ctx.actor.id,
+    });
+
+    return { deleted: true, id };
+  },
+});

--- a/addons/file-storage/cap-file-storage/src/actions/download_file.ts
+++ b/addons/file-storage/cap-file-storage/src/actions/download_file.ts
@@ -12,16 +12,14 @@
  *   id, name, mime, size, data_base64
  */
 
+import { Buffer } from "node:buffer";
 import { defineAction } from "@linchkit/core";
 import { getStorageAdapter } from "../storage-registry";
 
 function encodeBase64(bytes: Uint8Array): string {
-  let binary = "";
-  for (let i = 0; i < bytes.length; i++) {
-    binary += String.fromCharCode(bytes[i] as number);
-  }
-  // Bun/Node both ship globalThis.btoa.
-  return btoa(binary);
+  // Native base64 encoding — O(n) single-pass vs. the prior character-by-character
+  // `btoa(String.fromCharCode(...))` loop (slow + allocates the intermediate string).
+  return Buffer.from(bytes).toString("base64");
 }
 
 export const downloadFileAction = defineAction({

--- a/addons/file-storage/cap-file-storage/src/actions/download_file.ts
+++ b/addons/file-storage/cap-file-storage/src/actions/download_file.ts
@@ -1,0 +1,71 @@
+/**
+ * download_file action — read a file's payload via the active StorageAdapter.
+ *
+ * NOTE: Actions are the sole write entry, but are also used as the canonical
+ * invocation for non-GraphQL reads that need side-channel work (permission
+ * checks, audit logs). This action does not mutate state.
+ *
+ * Input:
+ *   id — file record id (required)
+ *
+ * Output:
+ *   id, name, mime, size, data_base64
+ */
+
+import { defineAction } from "@linchkit/core";
+import { getStorageAdapter } from "../storage-registry";
+
+function encodeBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i] as number);
+  }
+  // Bun/Node both ship globalThis.btoa.
+  return btoa(binary);
+}
+
+export const downloadFileAction = defineAction({
+  name: "download_file",
+  entity: "file",
+  label: "Download File",
+  description: "Read a file's payload via its storage adapter",
+  input: {
+    id: {
+      type: "string",
+      label: "File ID",
+      required: true,
+    },
+  },
+  policy: {
+    mode: "sync",
+    transaction: false,
+    idempotent: true,
+  },
+  exposure: { http: true, ui: true, cli: true, mcp: false },
+  async handler(ctx) {
+    const id = String(ctx.input.id ?? "").trim();
+    if (!id) {
+      throw new Error("File id is required");
+    }
+
+    const record = await ctx.get("file", id);
+
+    const adapter = getStorageAdapter();
+    const recordAdapter = record.adapter as string | undefined;
+    if (recordAdapter && recordAdapter !== adapter.name) {
+      throw new Error(
+        `File record was stored by adapter "${recordAdapter}" but active adapter is "${adapter.name}"`,
+      );
+    }
+
+    const data = await adapter.read(record.path as string);
+
+    return {
+      id: record.id,
+      name: record.name,
+      mime: record.mime,
+      size: record.size,
+      data_base64: encodeBase64(data),
+    };
+  },
+});

--- a/addons/file-storage/cap-file-storage/src/actions/upload_file.ts
+++ b/addons/file-storage/cap-file-storage/src/actions/upload_file.ts
@@ -1,0 +1,113 @@
+/**
+ * upload_file action — persist a file payload via the active StorageAdapter
+ * and create a `file` entity record holding its metadata.
+ *
+ * Input:
+ *   name        — original filename (required, non-empty)
+ *   mime        — MIME type (required, non-empty)
+ *   data_base64 — payload encoded as base64 (required, non-empty)
+ *   path        — optional relative path hint; when omitted, a random key
+ *                 under the current tenant prefix is generated
+ *
+ * Output: the created `file` record (with adapter-computed size + checksum).
+ */
+
+import { randomUUID } from "node:crypto";
+import { defineAction } from "@linchkit/core";
+import { getStorageAdapter } from "../storage-registry";
+
+function decodeBase64(input: string): Uint8Array {
+  // Reject whitespace/newlines and non-base64 chars explicitly — atob is lenient.
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(input)) {
+    throw new Error("data_base64 must be valid base64 without whitespace");
+  }
+  // Bun/Node both ship globalThis.atob.
+  const binary = atob(input);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    out[i] = binary.charCodeAt(i);
+  }
+  return out;
+}
+
+export const uploadFileAction = defineAction({
+  name: "upload_file",
+  entity: "file",
+  label: "Upload File",
+  description: "Store a file payload and create its metadata record",
+  input: {
+    name: {
+      type: "string",
+      label: "File Name",
+      required: true,
+    },
+    mime: {
+      type: "string",
+      label: "MIME Type",
+      required: true,
+    },
+    data_base64: {
+      type: "text",
+      label: "Payload (base64)",
+      required: true,
+      description: "File bytes encoded as base64 (no whitespace)",
+    },
+    path: {
+      type: "string",
+      label: "Storage Path Hint",
+      description: "Optional relative path for the adapter. A safe key is generated when omitted.",
+    },
+  },
+  policy: {
+    mode: "sync",
+    transaction: true,
+    idempotent: false,
+  },
+  exposure: { http: true, ui: true, cli: true, mcp: false },
+  async handler(ctx) {
+    const name = String(ctx.input.name ?? "").trim();
+    const mime = String(ctx.input.mime ?? "").trim();
+    const dataBase64 = String(ctx.input.data_base64 ?? "");
+    const pathHint =
+      typeof ctx.input.path === "string" && ctx.input.path.length > 0 ? ctx.input.path : undefined;
+
+    if (!name) {
+      throw new Error("File name is required");
+    }
+    if (!mime) {
+      throw new Error("MIME type is required");
+    }
+    if (!dataBase64) {
+      throw new Error("File payload (data_base64) is required");
+    }
+
+    const data = decodeBase64(dataBase64);
+
+    // Build a safe default relative path. The adapter re-validates it.
+    const tenantPrefix = ctx.tenantId ? `${ctx.tenantId}/` : "";
+    const relPath = pathHint ?? `${tenantPrefix}${randomUUID()}`;
+
+    const adapter = getStorageAdapter();
+    const written = await adapter.write({ path: relPath, data, mime });
+
+    const record = await ctx.create("file", {
+      name,
+      size: written.size,
+      mime,
+      path: written.path,
+      adapter: adapter.name,
+      checksum: written.checksum ?? "",
+      uploaded_by: ctx.actor.id,
+    });
+
+    ctx.emit("file.uploaded", {
+      file_id: record.id,
+      name,
+      size: written.size,
+      mime,
+      uploaded_by: ctx.actor.id,
+    });
+
+    return record;
+  },
+});

--- a/addons/file-storage/cap-file-storage/src/actions/upload_file.ts
+++ b/addons/file-storage/cap-file-storage/src/actions/upload_file.ts
@@ -6,10 +6,12 @@
  *   name        — original filename (required, non-empty)
  *   mime        — MIME type (required, non-empty)
  *   data_base64 — payload encoded as base64 (required, non-empty)
- *   path        — optional relative path hint; when omitted, a random key
- *                 under the current tenant prefix is generated
  *
  * Output: the created `file` record (with adapter-computed size + checksum).
+ *
+ * Storage key is ALWAYS generated server-side under the current tenant prefix.
+ * Client-supplied path hints are not accepted — allowing callers to pick keys
+ * enables cross-tenant blob overwrites and collision attacks.
  */
 
 import { randomUUID } from "node:crypto";
@@ -52,11 +54,6 @@ export const uploadFileAction = defineAction({
       required: true,
       description: "File bytes encoded as base64 (no whitespace)",
     },
-    path: {
-      type: "string",
-      label: "Storage Path Hint",
-      description: "Optional relative path for the adapter. A safe key is generated when omitted.",
-    },
   },
   policy: {
     mode: "sync",
@@ -68,8 +65,6 @@ export const uploadFileAction = defineAction({
     const name = String(ctx.input.name ?? "").trim();
     const mime = String(ctx.input.mime ?? "").trim();
     const dataBase64 = String(ctx.input.data_base64 ?? "");
-    const pathHint =
-      typeof ctx.input.path === "string" && ctx.input.path.length > 0 ? ctx.input.path : undefined;
 
     if (!name) {
       throw new Error("File name is required");
@@ -83,22 +78,37 @@ export const uploadFileAction = defineAction({
 
     const data = decodeBase64(dataBase64);
 
-    // Build a safe default relative path. The adapter re-validates it.
+    // Generate a safe server-side key scoped by tenant. Not accepting caller
+    // input here prevents cross-tenant overwrites and guessing attacks.
     const tenantPrefix = ctx.tenantId ? `${ctx.tenantId}/` : "";
-    const relPath = pathHint ?? `${tenantPrefix}${randomUUID()}`;
+    const relPath = `${tenantPrefix}${randomUUID()}`;
 
     const adapter = getStorageAdapter();
     const written = await adapter.write({ path: relPath, data, mime });
 
-    const record = await ctx.create("file", {
-      name,
-      size: written.size,
-      mime,
-      path: written.path,
-      adapter: adapter.name,
-      checksum: written.checksum ?? "",
-      uploaded_by: ctx.actor.id,
-    });
+    // Compensate: if the metadata write fails (transaction rollback, validation,
+    // uniqueness, etc.), we must remove the blob we just persisted — otherwise
+    // the backend accumulates orphaned payloads with no entity row pointing to
+    // them.
+    let record: Record<string, unknown>;
+    try {
+      record = await ctx.create("file", {
+        name,
+        size: written.size,
+        mime,
+        path: written.path,
+        adapter: adapter.name,
+        checksum: written.checksum ?? "",
+        uploaded_by: ctx.actor.id,
+      });
+    } catch (err) {
+      try {
+        await adapter.delete(written.path);
+      } catch {
+        // Best-effort compensation; surface the original error either way.
+      }
+      throw err;
+    }
 
     ctx.emit("file.uploaded", {
       file_id: record.id,

--- a/addons/file-storage/cap-file-storage/src/actions/upload_file.ts
+++ b/addons/file-storage/cap-file-storage/src/actions/upload_file.ts
@@ -14,22 +14,22 @@
  * enables cross-tenant blob overwrites and collision attacks.
  */
 
+import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
 import { defineAction } from "@linchkit/core";
 import { getStorageAdapter } from "../storage-registry";
 
 function decodeBase64(input: string): Uint8Array {
-  // Reject whitespace/newlines and non-base64 chars explicitly — atob is lenient.
+  // Reject whitespace/newlines and non-base64 chars up front — native
+  // `Buffer.from` is lenient and silently drops garbage, which would make
+  // checksum/size numbers diverge from what the caller sent.
   if (!/^[A-Za-z0-9+/]+={0,2}$/.test(input)) {
     throw new Error("data_base64 must be valid base64 without whitespace");
   }
-  // Bun/Node both ship globalThis.atob.
-  const binary = atob(input);
-  const out = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    out[i] = binary.charCodeAt(i);
-  }
-  return out;
+  // Native base64 decode — O(n) vs. the prior `atob` + per-char loop.
+  // The `new Uint8Array(buf)` wrap promotes the Node Buffer (a Uint8Array
+  // subclass, but usually backed by a shared pool) to a standalone array.
+  return new Uint8Array(Buffer.from(input, "base64"));
 }
 
 export const uploadFileAction = defineAction({

--- a/addons/file-storage/cap-file-storage/src/adapters/index.ts
+++ b/addons/file-storage/cap-file-storage/src/adapters/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Storage adapter exports
+ */
+
+export { LocalStorageAdapter, type LocalStorageAdapterOptions } from "./local-adapter";
+export type { StorageAdapter, StorageWriteInput, StorageWriteResult } from "./storage-adapter";

--- a/addons/file-storage/cap-file-storage/src/adapters/local-adapter.ts
+++ b/addons/file-storage/cap-file-storage/src/adapters/local-adapter.ts
@@ -1,0 +1,105 @@
+/**
+ * LocalStorageAdapter — stores files on the local filesystem.
+ *
+ * Intended for development and single-node deployments. Production multi-node
+ * setups should use a cloud adapter (S3, GCS, etc.) which will be delivered
+ * in a follow-up PR — see TODO at bottom.
+ *
+ * All paths are resolved relative to `rootDir` and validated to reject
+ * path-traversal attempts (`..`, absolute paths, null bytes).
+ */
+
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { isAbsolute, resolve, sep } from "node:path";
+import type { StorageAdapter, StorageWriteInput, StorageWriteResult } from "./storage-adapter";
+
+export interface LocalStorageAdapterOptions {
+  /** Root directory on disk under which all files are stored */
+  rootDir: string;
+  /** Adapter identifier (defaults to "local") */
+  name?: string;
+}
+
+/**
+ * Normalize and guard a caller-supplied relative path. Throws on:
+ * - absolute paths
+ * - null bytes
+ * - `..` segments that would escape `rootDir`
+ * Returns an absolute resolved path safe to pass to fs APIs.
+ */
+function resolveSafe(rootDir: string, path: string): string {
+  if (typeof path !== "string" || path.length === 0) {
+    throw new Error("Storage path must be a non-empty string");
+  }
+  if (path.includes("\0")) {
+    throw new Error("Storage path must not contain null bytes");
+  }
+  if (isAbsolute(path)) {
+    throw new Error("Storage path must be relative");
+  }
+  const absRoot = resolve(rootDir);
+  const absPath = resolve(absRoot, path);
+  const withSep = absRoot.endsWith(sep) ? absRoot : absRoot + sep;
+  if (absPath !== absRoot && !absPath.startsWith(withSep)) {
+    throw new Error("Storage path escapes root directory");
+  }
+  return absPath;
+}
+
+export class LocalStorageAdapter implements StorageAdapter {
+  readonly name: string;
+  readonly #rootDir: string;
+
+  constructor(options: LocalStorageAdapterOptions) {
+    if (!options?.rootDir) {
+      throw new Error("LocalStorageAdapter requires rootDir");
+    }
+    this.name = options.name ?? "local";
+    this.#rootDir = resolve(options.rootDir);
+  }
+
+  async write(input: StorageWriteInput): Promise<StorageWriteResult> {
+    if (!(input?.data instanceof Uint8Array)) {
+      throw new Error("write() requires Uint8Array data");
+    }
+    const abs = resolveSafe(this.#rootDir, input.path);
+    const dir = abs.slice(0, abs.lastIndexOf(sep));
+    await mkdir(dir, { recursive: true });
+    await writeFile(abs, input.data);
+
+    const hash = createHash("sha256").update(input.data).digest("hex");
+
+    return {
+      path: input.path,
+      size: input.data.byteLength,
+      checksum: hash,
+    };
+  }
+
+  async read(path: string): Promise<Uint8Array> {
+    const abs = resolveSafe(this.#rootDir, path);
+    const buf = await readFile(abs);
+    // Copy underlying buffer slice into a fresh Uint8Array for a stable view
+    return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+  }
+
+  async delete(path: string): Promise<void> {
+    const abs = resolveSafe(this.#rootDir, path);
+    await rm(abs, { force: true });
+  }
+
+  async exists(path: string): Promise<boolean> {
+    try {
+      const abs = resolveSafe(this.#rootDir, path);
+      const st = await stat(abs);
+      return st.isFile();
+    } catch {
+      return false;
+    }
+  }
+}
+
+// TODO(#139 follow-up): S3StorageAdapter — AWS SDK v3 client, bucket + prefix options.
+// TODO(#139 follow-up): GCSStorageAdapter, AzureBlobStorageAdapter.
+// TODO(#139 follow-up): Signed URL support on StorageAdapter for direct browser upload/download.

--- a/addons/file-storage/cap-file-storage/src/adapters/local-adapter.ts
+++ b/addons/file-storage/cap-file-storage/src/adapters/local-adapter.ts
@@ -80,8 +80,12 @@ export class LocalStorageAdapter implements StorageAdapter {
   async read(path: string): Promise<Uint8Array> {
     const abs = resolveSafe(this.#rootDir, path);
     const buf = await readFile(abs);
-    // Copy underlying buffer slice into a fresh Uint8Array for a stable view
-    return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+    // `readFile` returns a Buffer backed by Node's shared allocation pool
+    // (`buf.buffer` can be larger than this file). Construct a fresh
+    // Uint8Array from the Buffer directly — this copies the bytes and
+    // detaches the result from the pool, preventing callers from reading
+    // neighbor data or having their view invalidated later.
+    return new Uint8Array(buf);
   }
 
   async delete(path: string): Promise<void> {

--- a/addons/file-storage/cap-file-storage/src/adapters/storage-adapter.ts
+++ b/addons/file-storage/cap-file-storage/src/adapters/storage-adapter.ts
@@ -1,0 +1,55 @@
+/**
+ * StorageAdapter — pluggable backend contract for cap-file-storage.
+ *
+ * Adapters own the binary payload while the `file` entity tracks metadata.
+ * A single capability instance can be configured with exactly one adapter;
+ * the adapter `name` is recorded on every file record so that the right
+ * backend can be chosen when reading/deleting.
+ *
+ * Implementations MUST:
+ * - Sanitize incoming `path` values and reject absolute / parent-traversal paths.
+ * - Return a stable locator from `write()` that round-trips through `read()`.
+ * - Treat `read()` of a missing file as an error, not an empty payload.
+ */
+
+export interface StorageWriteInput {
+  /**
+   * Relative storage path the caller would like to use. Adapter MAY rewrite
+   * this (for example to scope under a tenant prefix) but MUST return the
+   * final locator as the `path` of `StorageWriteResult`.
+   */
+  path: string;
+  /** Raw payload bytes */
+  data: Uint8Array;
+  /** MIME type hint (adapters MAY persist this as metadata) */
+  mime?: string;
+}
+
+export interface StorageWriteResult {
+  /** Final locator to store on the `file` record. Opaque to callers. */
+  path: string;
+  /** Size in bytes of what was actually written */
+  size: number;
+  /** Optional SHA-256 hex digest if the adapter computed one */
+  checksum?: string;
+}
+
+export interface StorageAdapter {
+  /** Short adapter identifier (e.g. "local", "s3") stored on each `file` record */
+  readonly name: string;
+
+  /** Write a payload and return its locator + size (+ optional checksum). */
+  write(input: StorageWriteInput): Promise<StorageWriteResult>;
+
+  /** Read the payload for a locator previously returned by `write()`. */
+  read(path: string): Promise<Uint8Array>;
+
+  /**
+   * Delete the payload. MUST be idempotent — deleting a missing file
+   * resolves without throwing.
+   */
+  delete(path: string): Promise<void>;
+
+  /** Check existence without reading the payload. */
+  exists(path: string): Promise<boolean>;
+}

--- a/addons/file-storage/cap-file-storage/src/capability.ts
+++ b/addons/file-storage/cap-file-storage/src/capability.ts
@@ -1,0 +1,83 @@
+/**
+ * cap-file-storage capability definition + factory.
+ *
+ * Provides:
+ * - `file` entity (metadata for stored files)
+ * - Actions: upload_file, download_file, delete_file
+ * - A pluggable StorageAdapter contract, with a LocalStorageAdapter reference impl
+ *
+ * The factory wires the supplied adapter into the module-level storage registry
+ * that the actions read from. A follow-up PR will add a `file` field type and
+ * an S3/cloud adapter (see TODOs).
+ */
+
+import { type CapabilityDefinition, defineCapability } from "@linchkit/core";
+import { deleteFileAction } from "./actions/delete_file";
+import { downloadFileAction } from "./actions/download_file";
+import { uploadFileAction } from "./actions/upload_file";
+import { LocalStorageAdapter } from "./adapters/local-adapter";
+import type { StorageAdapter } from "./adapters/storage-adapter";
+import { fileEntity } from "./entities/file";
+import { setStorageAdapter } from "./storage-registry";
+
+export interface CapFileStorageOptions {
+  /**
+   * Pre-built StorageAdapter. When omitted, a LocalStorageAdapter is created
+   * at `rootDir` (defaults to `./.data/files`).
+   */
+  adapter?: StorageAdapter;
+  /** Root directory for the default LocalStorageAdapter (ignored if `adapter` is provided) */
+  rootDir?: string;
+}
+
+/**
+ * Create a fully-wired cap-file-storage capability.
+ *
+ * @example
+ * ```ts
+ * import { createCapFileStorage } from "@linchkit/cap-file-storage"
+ * const capFileStorage = createCapFileStorage({ rootDir: "./.data/files" })
+ * ```
+ */
+export function createCapFileStorage(
+  options?: CapFileStorageOptions,
+): CapabilityDefinition & { adapter: StorageAdapter } {
+  const adapter: StorageAdapter =
+    options?.adapter ?? new LocalStorageAdapter({ rootDir: options?.rootDir ?? "./.data/files" });
+
+  setStorageAdapter(adapter);
+
+  const capability = defineCapability({
+    name: "cap-file-storage",
+    label: "File Storage",
+    description:
+      "File storage capability — file metadata entity, pluggable StorageAdapter " +
+      "(local implementation included), and upload/download/delete actions.",
+    type: "standard",
+    category: "system",
+    version: "0.0.1",
+    group: "file-storage",
+
+    entities: [fileEntity],
+    actions: [uploadFileAction, downloadFileAction, deleteFileAction],
+
+    extensions: {
+      services: [
+        {
+          name: "storage",
+          factory: () => adapter,
+        },
+      ],
+    },
+
+    systemPermissions: ["database.read", "database.write", "event.emit"],
+  });
+
+  return Object.assign(capability, { adapter });
+}
+
+/**
+ * Static capability export for registries that only need the definition shape.
+ * Uses the default LocalStorageAdapter rooted at `./.data/files`.
+ */
+export const capFileStorage: CapabilityDefinition = createCapFileStorage();

--- a/addons/file-storage/cap-file-storage/src/entities/file.ts
+++ b/addons/file-storage/cap-file-storage/src/entities/file.ts
@@ -1,0 +1,70 @@
+/**
+ * File entity definition
+ *
+ * Represents a stored file's metadata. The binary payload is managed by
+ * a StorageAdapter (local disk, S3, etc.); this entity only tracks the
+ * metadata needed to locate and describe the file.
+ *
+ * System-managed fields (id, tenant_id, created_at, updated_at, created_by,
+ * updated_by, _version) are injected by the core runtime and must not be
+ * set by clients.
+ */
+
+import { defineEntity } from "@linchkit/core";
+
+export const fileEntity = defineEntity({
+  name: "file",
+  label: "File",
+  description: "Stored file metadata (binary payload is held by a StorageAdapter)",
+  fields: {
+    name: {
+      type: "string",
+      label: "File Name",
+      required: true,
+      description: "Original file name supplied at upload time",
+    },
+    size: {
+      type: "number",
+      label: "Size (bytes)",
+      required: true,
+      min: 0,
+      description: "File size in bytes",
+    },
+    mime: {
+      type: "string",
+      label: "MIME Type",
+      required: true,
+      description: "MIME type (e.g. 'image/png', 'application/pdf')",
+    },
+    path: {
+      type: "string",
+      label: "Storage Path",
+      required: true,
+      description:
+        "Adapter-specific storage locator (relative path, object key, URL, etc.). Opaque to consumers.",
+    },
+    adapter: {
+      type: "string",
+      label: "Storage Adapter",
+      required: true,
+      description: "Name of the StorageAdapter that owns this file (e.g. 'local', 's3')",
+    },
+    checksum: {
+      type: "string",
+      label: "Checksum",
+      description: "SHA-256 hex digest of the stored payload (empty if not computed)",
+    },
+    uploaded_by: {
+      type: "string",
+      label: "Uploaded By",
+      required: true,
+      description: "Actor id that uploaded the file (mirrors created_by for convenience)",
+    },
+  },
+  presentation: {
+    titleField: "name",
+    subtitleField: "mime",
+    summaryFields: ["name", "size", "mime"],
+    icon: "file",
+  },
+});

--- a/addons/file-storage/cap-file-storage/src/index.ts
+++ b/addons/file-storage/cap-file-storage/src/index.ts
@@ -1,0 +1,33 @@
+/**
+ * @linchkit/cap-file-storage — File storage capability
+ *
+ * Provides the `file` entity, a pluggable StorageAdapter contract, a
+ * LocalStorageAdapter reference implementation, and the upload/download/delete
+ * actions. A `file` field type and cloud adapters are planned follow-ups.
+ */
+
+// Actions
+export { deleteFileAction } from "./actions/delete_file";
+export { downloadFileAction } from "./actions/download_file";
+export { uploadFileAction } from "./actions/upload_file";
+// Adapters
+export { LocalStorageAdapter, type LocalStorageAdapterOptions } from "./adapters/local-adapter";
+export type {
+  StorageAdapter,
+  StorageWriteInput,
+  StorageWriteResult,
+} from "./adapters/storage-adapter";
+// Capability
+export {
+  type CapFileStorageOptions,
+  capFileStorage,
+  createCapFileStorage,
+} from "./capability";
+// Entities
+export { fileEntity } from "./entities/file";
+// Storage registry (primarily for tests / advanced wiring)
+export {
+  getStorageAdapter,
+  resetStorageAdapter,
+  setStorageAdapter,
+} from "./storage-registry";

--- a/addons/file-storage/cap-file-storage/src/storage-registry.ts
+++ b/addons/file-storage/cap-file-storage/src/storage-registry.ts
@@ -1,0 +1,33 @@
+/**
+ * StorageRegistry — module-level holder for the active StorageAdapter.
+ *
+ * The capability factory sets the adapter at construction time; actions
+ * resolve it via `getStorageAdapter()` at execution time. Tests may swap
+ * adapters with `setStorageAdapter()` / `resetStorageAdapter()`.
+ *
+ * This indirection exists because the current `ActionContext` does not yet
+ * expose a generic service-injection slot (see TODO). When core adds one,
+ * this module can delegate to `ctx.service("storage")` and be removed.
+ */
+
+import type { StorageAdapter } from "./adapters/storage-adapter";
+
+let activeAdapter: StorageAdapter | undefined;
+
+export function setStorageAdapter(adapter: StorageAdapter): void {
+  activeAdapter = adapter;
+}
+
+export function getStorageAdapter(): StorageAdapter {
+  if (!activeAdapter) {
+    throw new Error(
+      "cap-file-storage: no StorageAdapter configured. " +
+        "Use createCapFileStorage({ adapter }) or call setStorageAdapter() before executing file actions.",
+    );
+  }
+  return activeAdapter;
+}
+
+export function resetStorageAdapter(): void {
+  activeAdapter = undefined;
+}

--- a/addons/file-storage/cap-file-storage/tsconfig.json
+++ b/addons/file-storage/cap-file-storage/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun-types"]
+  },
+  "include": ["src"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -233,6 +233,17 @@
         "@linchkit/core": "workspace:*",
       },
     },
+    "addons/file-storage/cap-file-storage": {
+      "name": "@linchkit/cap-file-storage",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@linchkit/core": "workspace:*",
+        "typescript": "^6.0.2",
+      },
+      "peerDependencies": {
+        "@linchkit/core": "^0.2.0",
+      },
+    },
     "addons/flow-restate/cap-flow-restate": {
       "name": "@linchkit/cap-flow-restate",
       "version": "1.0.0",
@@ -613,6 +624,8 @@
     "@linchkit/cap-chatter": ["@linchkit/cap-chatter@workspace:addons/chatter/cap-chatter"],
 
     "@linchkit/cap-chatter-ui": ["@linchkit/cap-chatter-ui@workspace:addons/chatter/cap-chatter-ui"],
+
+    "@linchkit/cap-file-storage": ["@linchkit/cap-file-storage@workspace:addons/file-storage/cap-file-storage"],
 
     "@linchkit/cap-flow-restate": ["@linchkit/cap-flow-restate@workspace:addons/flow-restate/cap-flow-restate"],
 


### PR DESCRIPTION
## Summary

- New addon `@linchkit/cap-file-storage` — first concrete file storage capability. Split from parent issue #121 (Spec 14).
- `file` entity (name, size, mime, path, uploaded_by, checksum), pluggable `StorageAdapter` interface, built-in `LocalStorageAdapter` (path-traversal guarded), and three actions: upload_file / download_file / delete_file.
- All writes flow through the CommandLayer — no permission bypass.

## Codex review — addressed

| ID | Severity | Action |
| --- | --- | --- |
| B-1 | P1 — client-supplied path allowed cross-tenant overwrites | Fixed — `path` input removed; key is always `<tenantPrefix>/<uuid>` server-side |
| B-2 | P2 — orphaned blob if ctx.create fails after adapter.write | Fixed — try/catch around create with best-effort `adapter.delete(path)` compensation |
| B-3 | P2 — delete_file swallowed every lookup error as "not found" | Fixed — switched to `ctx.query("file", {id})`; empty array = not-found, any throw surfaces |

## Scope — deferred to follow-ups

- S3 / cloud storage adapters
- `file` field type on defineEntity (native FileRef fields)
- UI widgets for upload/preview

## Test plan

- [x] `bun run check` / `typecheck` / `test` — all green
- [x] Addon tests: 23/23 pass (entity + capability + local adapter contract, including path-traversal rejection, null-byte guard, parent-directory escape guard)
- [x] Full repo test suite: 4237 pass / 0 fail

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)