### PR TITLE
feat(cap-notification): notification center with in-app channel (closes #140)

### DIFF
--- a/addons/notification/cap-notification/README.md
+++ b/addons/notification/cap-notification/README.md
@@ -1,0 +1,48 @@
+# @linchkit/cap-notification
+
+Notification center capability for LinchKit. Provides the `notification` entity,
+three write actions (`send_notification`, `mark_notification_read`,
+`mark_all_read`), and a pluggable `NotificationChannel` interface with a
+built-in in-app channel. Email and webhook channels are stubs — wire in real
+transports as follow-up work.
+
+## Install
+
+```ts
+import { capNotification } from "@linchkit/cap-notification";
+
+// Register alongside your other capabilities
+export const capabilities = [
+  // ...
+  capNotification,
+];
+```
+
+## Exports
+
+| Export | Purpose |
+| --- | --- |
+| `capNotification` | Capability definition (register it with the core runtime). |
+| `notificationSchema` | `defineEntity` output for `notification`. |
+| `sendNotificationAction` | Dispatch a notification on the chosen channel. |
+| `markNotificationReadAction` | Mark a single notification read. |
+| `markAllReadAction` | Mark every unread notification for a recipient. |
+| `NotificationChannel` (type) | Interface every channel implements. |
+| `InAppNotificationChannel`, `createInAppChannel` | In-app channel (persists to the `notification` entity). |
+| `EmailNotificationChannel`, `WebhookNotificationChannel` | Stubs — replace or subclass. |
+
+## Channel contract
+
+`NotificationChannel.send(request, context)` returns
+`{ channel, delivered, id, reason? }`. Channels MUST NOT throw for expected
+business failures (opted-out recipient, bad input) — return
+`{ delivered: false, reason }` instead so the calling action can log and
+continue.
+
+## Follow-ups
+
+- `cap-notification: implement email channel (SMTP/Resend/SES adapter)`
+- `cap-notification: implement webhook channel (signed HTTP POST + retry + DLQ)`
+- `cap-notification: add NotificationPreferences entity (opt-in/out per channel)`
+- `cap-notification-ui: notification center panel + unread badge count`
+- `cap-notification: batch dispatch action (send_bulk_notification)`

--- a/addons/notification/cap-notification/__tests__/actions.test.ts
+++ b/addons/notification/cap-notification/__tests__/actions.test.ts
@@ -152,10 +152,7 @@ describe("send_notification", () => {
     await expect(
       callHandler(
         sendNotificationAction,
-        store.ctx(
-          { recipient_id: "user-1", message: "hi", channel: "sms" },
-          { type: "system" },
-        ),
+        store.ctx({ recipient_id: "user-1", message: "hi", channel: "sms" }, { type: "system" }),
       ),
     ).rejects.toThrow(/channel/i);
   });
@@ -243,9 +240,9 @@ describe("mark_all_read", () => {
     const result = (await callHandler(
       markAllReadAction,
       store.ctx({ recipient_id: "user-2" }, { id: "user-1", type: "human" }),
-    )) as { updated: number; recipient_id: string };
+    )) as { updated: number; recipient_id: string; hasMore: boolean };
 
-    expect(result).toEqual({ updated: 2, recipient_id: "user-1" });
+    expect(result).toEqual({ updated: 2, recipient_id: "user-1", hasMore: false });
     expect((store.rows.get("n-1") as Row).read_at).toBeTypeOf("string");
     expect((store.rows.get("n-2") as Row).read_at).toBeTypeOf("string");
     expect((store.rows.get("n-3") as Row).read_at).toBeNull(); // protected
@@ -253,7 +250,7 @@ describe("mark_all_read", () => {
     expect(store.emitted).toContainEqual(
       expect.objectContaining({
         type: "notification.all_read",
-        payload: expect.objectContaining({ updated: 2 }),
+        payload: expect.objectContaining({ updated: 2, has_more: false }),
       }),
     );
   });
@@ -265,9 +262,9 @@ describe("mark_all_read", () => {
     const result = (await callHandler(
       markAllReadAction,
       store.ctx({ recipient_id: "user-2" }, { id: "housekeeper", type: "system" }),
-    )) as { updated: number; recipient_id: string };
+    )) as { updated: number; recipient_id: string; hasMore: boolean };
 
-    expect(result).toEqual({ updated: 1, recipient_id: "user-2" });
+    expect(result).toEqual({ updated: 1, recipient_id: "user-2", hasMore: false });
     expect((store.rows.get("n-2") as Row).read_at).toBeNull();
   });
 

--- a/addons/notification/cap-notification/__tests__/actions.test.ts
+++ b/addons/notification/cap-notification/__tests__/actions.test.ts
@@ -1,0 +1,232 @@
+/**
+ * cap-notification action handler tests.
+ *
+ * Each action is invoked through a minimal fake ActionContext so the tests
+ * exercise handler logic (validation, data-provider calls, emitted events)
+ * without pulling in the full command-layer pipeline.
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import type { ActionDefinition } from "@linchkit/core";
+import { markAllReadAction, markNotificationReadAction, sendNotificationAction } from "../src";
+
+type Row = Record<string, unknown> & { id: string };
+
+interface EmittedEvent {
+  type: string;
+  payload: Record<string, unknown>;
+}
+
+class FakeStore {
+  public rows = new Map<string, Row>();
+  public emitted: EmittedEvent[] = [];
+  private seq = 0;
+
+  ctx(input: Record<string, unknown>) {
+    return {
+      input,
+      actor: { id: "actor-1", type: "user", groups: [] },
+      tenantId: "t-1",
+      executionId: "exec-1",
+      timestamp: new Date(),
+      logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+      ai: {} as never,
+      config: { get: () => undefined } as never,
+      hasCapability: () => false,
+      emit: (type: string, payload: Record<string, unknown>) => {
+        this.emitted.push({ type, payload });
+      },
+      get: async (_entity: string, id: string) => {
+        const row = this.rows.get(id);
+        if (!row) throw new Error(`not found: ${id}`);
+        return row;
+      },
+      query: async (_entity: string, filter: Record<string, unknown>) => {
+        return [...this.rows.values()].filter((row) =>
+          Object.entries(filter).every(([k, v]) => row[k] === v),
+        );
+      },
+      create: async (_entity: string, data: Record<string, unknown>) => {
+        this.seq += 1;
+        const row: Row = { id: `n-${this.seq}`, ...data };
+        this.rows.set(row.id, row);
+        return row;
+      },
+      update: async (_entity: string, id: string, patch: Record<string, unknown>) => {
+        const row = this.rows.get(id);
+        if (!row) throw new Error(`not found: ${id}`);
+        const updated: Row = { ...row, ...patch };
+        this.rows.set(id, updated);
+        return updated;
+      },
+      delete: async () => {},
+      execute: async () => ({}),
+    };
+  }
+}
+
+function callHandler(action: ActionDefinition, ctxLike: unknown): Promise<unknown> {
+  if (!action.handler) throw new Error(`action ${action.name} has no handler`);
+  return action.handler(ctxLike as never);
+}
+
+describe("send_notification", () => {
+  let store: FakeStore;
+
+  beforeEach(() => {
+    store = new FakeStore();
+  });
+
+  it("creates an in-app notification row and emits notification.sent", async () => {
+    const result = await callHandler(
+      sendNotificationAction,
+      store.ctx({ recipient_id: "user-1", message: "hi", channel: "in_app" }),
+    );
+
+    expect(result).toMatchObject({ channel: "in_app", delivered: true });
+    expect(store.rows.size).toBe(1);
+    const [row] = store.rows.values();
+    expect(row).toMatchObject({
+      recipient_id: "user-1",
+      message: "hi",
+      channel: "in_app",
+      read_at: null,
+    });
+    expect(store.emitted).toContainEqual(
+      expect.objectContaining({
+        type: "notification.sent",
+        payload: expect.objectContaining({ recipient_id: "user-1" }),
+      }),
+    );
+  });
+
+  it("defaults to the in_app channel when channel is omitted", async () => {
+    const result = (await callHandler(
+      sendNotificationAction,
+      store.ctx({ recipient_id: "user-1", message: "hi" }),
+    )) as { channel: string; delivered: boolean };
+    expect(result.channel).toBe("in_app");
+    expect(result.delivered).toBe(true);
+  });
+
+  it("does NOT emit notification.sent for stub email channel (delivered=false)", async () => {
+    const result = (await callHandler(
+      sendNotificationAction,
+      store.ctx({ recipient_id: "user-1", message: "hi", channel: "email" }),
+    )) as { channel: string; delivered: boolean };
+    expect(result.channel).toBe("email");
+    expect(result.delivered).toBe(false);
+    expect(store.emitted).toHaveLength(0);
+  });
+
+  it("rejects empty recipient_id", async () => {
+    await expect(
+      callHandler(sendNotificationAction, store.ctx({ recipient_id: "   ", message: "hi" })),
+    ).rejects.toThrow(/recipient_id/);
+  });
+
+  it("rejects empty message", async () => {
+    await expect(
+      callHandler(sendNotificationAction, store.ctx({ recipient_id: "user-1", message: "" })),
+    ).rejects.toThrow(/message/);
+  });
+
+  it("rejects an unsupported channel name", async () => {
+    await expect(
+      callHandler(
+        sendNotificationAction,
+        store.ctx({ recipient_id: "user-1", message: "hi", channel: "sms" }),
+      ),
+    ).rejects.toThrow(/channel/i);
+  });
+});
+
+describe("mark_notification_read", () => {
+  let store: FakeStore;
+
+  beforeEach(() => {
+    store = new FakeStore();
+  });
+
+  it("sets read_at on an unread notification and emits notification.read", async () => {
+    store.rows.set("n-1", { id: "n-1", recipient_id: "user-1", read_at: null });
+
+    const result = (await callHandler(
+      markNotificationReadAction,
+      store.ctx({ notification_id: "n-1" }),
+    )) as Row;
+
+    expect(result.read_at).toBeTypeOf("string");
+    expect(store.emitted).toContainEqual(expect.objectContaining({ type: "notification.read" }));
+  });
+
+  it("is a no-op on an already-read notification", async () => {
+    const existingReadAt = new Date(0).toISOString();
+    store.rows.set("n-1", { id: "n-1", recipient_id: "user-1", read_at: existingReadAt });
+
+    const result = (await callHandler(
+      markNotificationReadAction,
+      store.ctx({ notification_id: "n-1" }),
+    )) as Row;
+
+    expect(result.read_at).toBe(existingReadAt);
+    expect(store.emitted).toHaveLength(0);
+  });
+
+  it("rejects empty notification_id", async () => {
+    await expect(
+      callHandler(markNotificationReadAction, store.ctx({ notification_id: "" })),
+    ).rejects.toThrow(/notification_id/);
+  });
+});
+
+describe("mark_all_read", () => {
+  let store: FakeStore;
+
+  beforeEach(() => {
+    store = new FakeStore();
+  });
+
+  it("marks every unread notification for the recipient and emits notification.all_read", async () => {
+    store.rows.set("n-1", { id: "n-1", recipient_id: "user-1", read_at: null });
+    store.rows.set("n-2", { id: "n-2", recipient_id: "user-1", read_at: null });
+    store.rows.set("n-3", { id: "n-3", recipient_id: "user-2", read_at: null }); // other recipient
+    store.rows.set("n-4", {
+      id: "n-4",
+      recipient_id: "user-1",
+      read_at: "2024-01-01T00:00:00.000Z",
+    }); // already read
+
+    const result = (await callHandler(
+      markAllReadAction,
+      store.ctx({ recipient_id: "user-1" }),
+    )) as { updated: number; recipient_id: string };
+
+    expect(result).toEqual({ updated: 2, recipient_id: "user-1" });
+    expect((store.rows.get("n-1") as Row).read_at).toBeTypeOf("string");
+    expect((store.rows.get("n-2") as Row).read_at).toBeTypeOf("string");
+    expect((store.rows.get("n-3") as Row).read_at).toBeNull();
+    expect((store.rows.get("n-4") as Row).read_at).toBe("2024-01-01T00:00:00.000Z");
+    expect(store.emitted).toContainEqual(
+      expect.objectContaining({
+        type: "notification.all_read",
+        payload: expect.objectContaining({ updated: 2 }),
+      }),
+    );
+  });
+
+  it("is a no-op when recipient has no unread rows", async () => {
+    const result = (await callHandler(markAllReadAction, store.ctx({ recipient_id: "ghost" }))) as {
+      updated: number;
+    };
+
+    expect(result.updated).toBe(0);
+    expect(store.emitted).toHaveLength(0);
+  });
+
+  it("rejects empty recipient_id", async () => {
+    await expect(callHandler(markAllReadAction, store.ctx({ recipient_id: "" }))).rejects.toThrow(
+      /recipient_id/,
+    );
+  });
+});

--- a/addons/notification/cap-notification/__tests__/actions.test.ts
+++ b/addons/notification/cap-notification/__tests__/actions.test.ts
@@ -17,15 +17,17 @@ interface EmittedEvent {
   payload: Record<string, unknown>;
 }
 
+type ActorOverride = { id?: string; type?: string };
+
 class FakeStore {
   public rows = new Map<string, Row>();
   public emitted: EmittedEvent[] = [];
   private seq = 0;
 
-  ctx(input: Record<string, unknown>) {
+  ctx(input: Record<string, unknown>, actor: ActorOverride = {}) {
     return {
       input,
-      actor: { id: "actor-1", type: "user", groups: [] },
+      actor: { id: actor.id ?? "actor-1", type: actor.type ?? "system", groups: [] },
       tenantId: "t-1",
       executionId: "exec-1",
       timestamp: new Date(),
@@ -77,10 +79,10 @@ describe("send_notification", () => {
     store = new FakeStore();
   });
 
-  it("creates an in-app notification row and emits notification.sent", async () => {
+  it("creates an in-app notification row and emits notification.sent (system actor)", async () => {
     const result = await callHandler(
       sendNotificationAction,
-      store.ctx({ recipient_id: "user-1", message: "hi", channel: "in_app" }),
+      store.ctx({ recipient_id: "user-1", message: "hi", channel: "in_app" }, { type: "system" }),
     );
 
     expect(result).toMatchObject({ channel: "in_app", delivered: true });
@@ -103,7 +105,7 @@ describe("send_notification", () => {
   it("defaults to the in_app channel when channel is omitted", async () => {
     const result = (await callHandler(
       sendNotificationAction,
-      store.ctx({ recipient_id: "user-1", message: "hi" }),
+      store.ctx({ recipient_id: "user-1", message: "hi" }, { type: "worker" }),
     )) as { channel: string; delivered: boolean };
     expect(result.channel).toBe("in_app");
     expect(result.delivered).toBe(true);
@@ -112,30 +114,48 @@ describe("send_notification", () => {
   it("does NOT emit notification.sent for stub email channel (delivered=false)", async () => {
     const result = (await callHandler(
       sendNotificationAction,
-      store.ctx({ recipient_id: "user-1", message: "hi", channel: "email" }),
+      store.ctx({ recipient_id: "user-1", message: "hi", channel: "email" }, { type: "system" }),
     )) as { channel: string; delivered: boolean };
     expect(result.channel).toBe("email");
     expect(result.delivered).toBe(false);
     expect(store.emitted).toHaveLength(0);
   });
 
-  it("rejects empty recipient_id", async () => {
-    await expect(
-      callHandler(sendNotificationAction, store.ctx({ recipient_id: "   ", message: "hi" })),
-    ).rejects.toThrow(/recipient_id/);
-  });
-
-  it("rejects empty message", async () => {
-    await expect(
-      callHandler(sendNotificationAction, store.ctx({ recipient_id: "user-1", message: "" })),
-    ).rejects.toThrow(/message/);
-  });
-
-  it("rejects an unsupported channel name", async () => {
+  it("rejects human / non-privileged actor types", async () => {
     await expect(
       callHandler(
         sendNotificationAction,
-        store.ctx({ recipient_id: "user-1", message: "hi", channel: "sms" }),
+        store.ctx({ recipient_id: "user-1", message: "hi" }, { type: "human" }),
+      ),
+    ).rejects.toThrow(/system dispatch primitive/i);
+  });
+
+  it("rejects empty recipient_id (system actor)", async () => {
+    await expect(
+      callHandler(
+        sendNotificationAction,
+        store.ctx({ recipient_id: "   ", message: "hi" }, { type: "system" }),
+      ),
+    ).rejects.toThrow(/recipient_id/);
+  });
+
+  it("rejects empty message (system actor)", async () => {
+    await expect(
+      callHandler(
+        sendNotificationAction,
+        store.ctx({ recipient_id: "user-1", message: "" }, { type: "system" }),
+      ),
+    ).rejects.toThrow(/message/);
+  });
+
+  it("rejects an unsupported channel name (system actor)", async () => {
+    await expect(
+      callHandler(
+        sendNotificationAction,
+        store.ctx(
+          { recipient_id: "user-1", message: "hi", channel: "sms" },
+          { type: "system" },
+        ),
       ),
     ).rejects.toThrow(/channel/i);
   });
@@ -148,12 +168,12 @@ describe("mark_notification_read", () => {
     store = new FakeStore();
   });
 
-  it("sets read_at on an unread notification and emits notification.read", async () => {
+  it("sets read_at on an unread notification owned by the actor and emits notification.read", async () => {
     store.rows.set("n-1", { id: "n-1", recipient_id: "user-1", read_at: null });
 
     const result = (await callHandler(
       markNotificationReadAction,
-      store.ctx({ notification_id: "n-1" }),
+      store.ctx({ notification_id: "n-1" }, { id: "user-1", type: "human" }),
     )) as Row;
 
     expect(result.read_at).toBeTypeOf("string");
@@ -166,16 +186,38 @@ describe("mark_notification_read", () => {
 
     const result = (await callHandler(
       markNotificationReadAction,
-      store.ctx({ notification_id: "n-1" }),
+      store.ctx({ notification_id: "n-1" }, { id: "user-1", type: "human" }),
     )) as Row;
 
     expect(result.read_at).toBe(existingReadAt);
     expect(store.emitted).toHaveLength(0);
   });
 
+  it("rejects non-owner human callers", async () => {
+    store.rows.set("n-1", { id: "n-1", recipient_id: "user-1", read_at: null });
+    await expect(
+      callHandler(
+        markNotificationReadAction,
+        store.ctx({ notification_id: "n-1" }, { id: "user-2", type: "human" }),
+      ),
+    ).rejects.toThrow(/does not belong/i);
+  });
+
+  it("lets system actors mark anyone's notification read", async () => {
+    store.rows.set("n-1", { id: "n-1", recipient_id: "user-1", read_at: null });
+    const result = (await callHandler(
+      markNotificationReadAction,
+      store.ctx({ notification_id: "n-1" }, { id: "housekeeper", type: "system" }),
+    )) as Row;
+    expect(result.read_at).toBeTypeOf("string");
+  });
+
   it("rejects empty notification_id", async () => {
     await expect(
-      callHandler(markNotificationReadAction, store.ctx({ notification_id: "" })),
+      callHandler(
+        markNotificationReadAction,
+        store.ctx({ notification_id: "" }, { id: "user-1", type: "human" }),
+      ),
     ).rejects.toThrow(/notification_id/);
   });
 });
@@ -187,25 +229,26 @@ describe("mark_all_read", () => {
     store = new FakeStore();
   });
 
-  it("marks every unread notification for the recipient and emits notification.all_read", async () => {
+  it("marks every unread notification for the CURRENT actor (input recipient_id ignored for humans)", async () => {
     store.rows.set("n-1", { id: "n-1", recipient_id: "user-1", read_at: null });
     store.rows.set("n-2", { id: "n-2", recipient_id: "user-1", read_at: null });
-    store.rows.set("n-3", { id: "n-3", recipient_id: "user-2", read_at: null }); // other recipient
+    store.rows.set("n-3", { id: "n-3", recipient_id: "user-2", read_at: null });
     store.rows.set("n-4", {
       id: "n-4",
       recipient_id: "user-1",
       read_at: "2024-01-01T00:00:00.000Z",
-    }); // already read
+    });
 
+    // Human supplies user-2 as recipient — must be IGNORED. Actor's own queue clears only.
     const result = (await callHandler(
       markAllReadAction,
-      store.ctx({ recipient_id: "user-1" }),
+      store.ctx({ recipient_id: "user-2" }, { id: "user-1", type: "human" }),
     )) as { updated: number; recipient_id: string };
 
     expect(result).toEqual({ updated: 2, recipient_id: "user-1" });
     expect((store.rows.get("n-1") as Row).read_at).toBeTypeOf("string");
     expect((store.rows.get("n-2") as Row).read_at).toBeTypeOf("string");
-    expect((store.rows.get("n-3") as Row).read_at).toBeNull();
+    expect((store.rows.get("n-3") as Row).read_at).toBeNull(); // protected
     expect((store.rows.get("n-4") as Row).read_at).toBe("2024-01-01T00:00:00.000Z");
     expect(store.emitted).toContainEqual(
       expect.objectContaining({
@@ -215,18 +258,32 @@ describe("mark_all_read", () => {
     );
   });
 
-  it("is a no-op when recipient has no unread rows", async () => {
-    const result = (await callHandler(markAllReadAction, store.ctx({ recipient_id: "ghost" }))) as {
-      updated: number;
-    };
+  it("lets privileged actors operate on an explicit recipient_id", async () => {
+    store.rows.set("n-1", { id: "n-1", recipient_id: "user-2", read_at: null });
+    store.rows.set("n-2", { id: "n-2", recipient_id: "user-3", read_at: null });
+
+    const result = (await callHandler(
+      markAllReadAction,
+      store.ctx({ recipient_id: "user-2" }, { id: "housekeeper", type: "system" }),
+    )) as { updated: number; recipient_id: string };
+
+    expect(result).toEqual({ updated: 1, recipient_id: "user-2" });
+    expect((store.rows.get("n-2") as Row).read_at).toBeNull();
+  });
+
+  it("is a no-op when the actor has no unread rows", async () => {
+    const result = (await callHandler(
+      markAllReadAction,
+      store.ctx({}, { id: "ghost", type: "human" }),
+    )) as { updated: number };
 
     expect(result.updated).toBe(0);
     expect(store.emitted).toHaveLength(0);
   });
 
-  it("rejects empty recipient_id", async () => {
-    await expect(callHandler(markAllReadAction, store.ctx({ recipient_id: "" }))).rejects.toThrow(
-      /recipient_id/,
-    );
+  it("requires an authenticated actor (empty actor.id rejected)", async () => {
+    await expect(
+      callHandler(markAllReadAction, store.ctx({}, { id: "", type: "human" })),
+    ).rejects.toThrow(/authenticated actor/i);
   });
 });

--- a/addons/notification/cap-notification/__tests__/capability.test.ts
+++ b/addons/notification/cap-notification/__tests__/capability.test.ts
@@ -1,0 +1,33 @@
+/**
+ * cap-notification capability shape tests.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { capNotification } from "../src";
+
+describe("capNotification", () => {
+  it("declares the expected identity fields", () => {
+    expect(capNotification.name).toBe("cap-notification");
+    expect(capNotification.type).toBe("standard");
+    expect(capNotification.category).toBe("system");
+    expect(capNotification.version).toBe("0.0.1");
+  });
+
+  it("registers the notification entity", () => {
+    const names = capNotification.entities?.map((e) => e.name);
+    expect(names).toContain("notification");
+  });
+
+  it("registers all three write actions", () => {
+    const names = capNotification.actions?.map((a) => a.name);
+    expect(names).toEqual(
+      expect.arrayContaining(["send_notification", "mark_notification_read", "mark_all_read"]),
+    );
+  });
+
+  it("requests the system permissions needed to persist and emit", () => {
+    expect(capNotification.systemPermissions).toEqual(
+      expect.arrayContaining(["database.read", "database.write", "event.emit"]),
+    );
+  });
+});

--- a/addons/notification/cap-notification/__tests__/channels.test.ts
+++ b/addons/notification/cap-notification/__tests__/channels.test.ts
@@ -1,0 +1,104 @@
+/**
+ * NotificationChannel unit tests.
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import {
+  EmailNotificationChannel,
+  InAppNotificationChannel,
+  type NotificationChannelContext,
+  type NotificationDispatchRequest,
+  type NotificationStore,
+  WebhookNotificationChannel,
+} from "../src";
+
+const ctx: NotificationChannelContext = { actorId: "actor-1", tenantId: "t-1" };
+
+class InMemoryStore implements NotificationStore {
+  public rows: Array<Record<string, unknown>> = [];
+  private seq = 0;
+  async create(
+    _entity: "notification",
+    data: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    this.seq += 1;
+    const row = { id: `n-${this.seq}`, ...data };
+    this.rows.push(row);
+    return row;
+  }
+}
+
+function request(
+  overrides: Partial<NotificationDispatchRequest> = {},
+): NotificationDispatchRequest {
+  return {
+    recipientId: "user-1",
+    message: "hello",
+    ...overrides,
+  };
+}
+
+describe("InAppNotificationChannel", () => {
+  let store: InMemoryStore;
+  let channel: InAppNotificationChannel;
+
+  beforeEach(() => {
+    store = new InMemoryStore();
+    channel = new InAppNotificationChannel({ store });
+  });
+
+  it("persists a notification row and returns delivered=true with the new id", async () => {
+    const result = await channel.send(
+      request({ title: "hi", link: "/x", metadata: { a: 1 } }),
+      ctx,
+    );
+
+    expect(result).toEqual({ channel: "in_app", delivered: true, id: "n-1" });
+    expect(store.rows).toHaveLength(1);
+    expect(store.rows[0]).toMatchObject({
+      recipient_id: "user-1",
+      channel: "in_app",
+      message: "hello",
+      title: "hi",
+      link: "/x",
+      metadata: { a: 1 },
+      read_at: null,
+    });
+  });
+
+  it("returns delivered=false without writing when recipient_id is empty", async () => {
+    const result = await channel.send(request({ recipientId: "" }), ctx);
+
+    expect(result.delivered).toBe(false);
+    expect(result.reason).toMatch(/recipient/i);
+    expect(store.rows).toHaveLength(0);
+  });
+
+  it("returns delivered=false without writing when message is empty", async () => {
+    const result = await channel.send(request({ message: "   " }), ctx);
+
+    expect(result.delivered).toBe(false);
+    expect(result.reason).toMatch(/message/i);
+    expect(store.rows).toHaveLength(0);
+  });
+});
+
+describe("Stub channels", () => {
+  it("email channel returns delivered=false with a reason", async () => {
+    const channel = new EmailNotificationChannel();
+    const result = await channel.send(request(), ctx);
+    expect(result.channel).toBe("email");
+    expect(result.delivered).toBe(false);
+    expect(result.id).toBeNull();
+    expect(result.reason).toMatch(/email/i);
+  });
+
+  it("webhook channel returns delivered=false with a reason", async () => {
+    const channel = new WebhookNotificationChannel();
+    const result = await channel.send(request(), ctx);
+    expect(result.channel).toBe("webhook");
+    expect(result.delivered).toBe(false);
+    expect(result.id).toBeNull();
+    expect(result.reason).toMatch(/webhook/i);
+  });
+});

--- a/addons/notification/cap-notification/package.json
+++ b/addons/notification/cap-notification/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@linchkit/cap-notification",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "files": [
+    "src/",
+    "package.json",
+    "README.md"
+  ],
+  "exports": {
+    ".": "./src/index.ts",
+    "./capability": "./src/capability.ts"
+  },
+  "scripts": {
+    "test": "bun test"
+  },
+  "peerDependencies": {
+    "@linchkit/core": "^0.2.0"
+  },
+  "devDependencies": {
+    "@linchkit/core": "workspace:*",
+    "typescript": "^6.0.2"
+  },
+  "linchkit": {
+    "minCoreVersion": "^0.1.0",
+    "type": "standard",
+    "category": "system"
+  }
+}

--- a/addons/notification/cap-notification/src/actions/mark_all_read.ts
+++ b/addons/notification/cap-notification/src/actions/mark_all_read.ts
@@ -1,8 +1,11 @@
 /**
  * mark_all_read action
  *
- * Marks every unread notification owned by the given recipient as read.
- * Idempotent: running against a recipient with no unread rows is a no-op.
+ * Marks every unread notification for the CURRENT actor as read. The recipient
+ * is derived from `ctx.actor.id` — callers cannot mass-mark another user's
+ * notifications. Privileged actors (system/worker/ai) may pass an explicit
+ * `recipient_id` to operate on someone else's queue (used by housekeeping).
+ * Idempotent: running with no unread rows is a no-op.
  */
 
 import { defineAction } from "@linchkit/core";
@@ -11,12 +14,12 @@ export const markAllReadAction = defineAction({
   name: "mark_all_read",
   entity: "notification",
   label: "Mark All Notifications Read",
-  description: "Mark every unread notification for the given recipient as read",
+  description: "Mark every unread notification for the current actor as read",
   input: {
     recipient_id: {
       type: "string",
-      label: "Recipient",
-      required: true,
+      label: "Recipient (privileged only)",
+      description: "Optional — only honored when the caller is system/worker/ai",
     },
   },
   policy: {
@@ -26,9 +29,19 @@ export const markAllReadAction = defineAction({
   },
   exposure: { http: true, ui: true, cli: true, mcp: true },
   async handler(ctx) {
-    const recipientId = ctx.input.recipient_id;
-    if (typeof recipientId !== "string" || !recipientId.trim()) {
-      throw new Error("recipient_id is required");
+    const actorType = ctx.actor.type;
+    const isPrivilegedActor = actorType === "system" || actorType === "worker" || actorType === "ai";
+    const explicitRecipient = ctx.input.recipient_id;
+
+    let recipientId: string;
+    if (isPrivilegedActor && typeof explicitRecipient === "string" && explicitRecipient.trim()) {
+      recipientId = explicitRecipient.trim();
+    } else {
+      // Anyone else is locked to their own queue; explicit recipient_id is ignored.
+      if (!ctx.actor.id) {
+        throw new Error("An authenticated actor is required");
+      }
+      recipientId = ctx.actor.id;
     }
 
     const unread = await ctx.query("notification", {

--- a/addons/notification/cap-notification/src/actions/mark_all_read.ts
+++ b/addons/notification/cap-notification/src/actions/mark_all_read.ts
@@ -3,12 +3,23 @@
  *
  * Marks every unread notification for the CURRENT actor as read. The recipient
  * is derived from `ctx.actor.id` — callers cannot mass-mark another user's
- * notifications. Privileged actors (system/worker/ai) may pass an explicit
- * `recipient_id` to operate on someone else's queue (used by housekeeping).
- * Idempotent: running with no unread rows is a no-op.
+ * notifications. Privileged actors (system/worker/ai/timer) may pass an
+ * explicit `recipient_id` to operate on someone else's queue (used by
+ * housekeeping). Idempotent: running with no unread rows is a no-op.
  */
 
 import { defineAction } from "@linchkit/core";
+
+/**
+ * Safety cap on how many rows this action touches in a single call. A normal
+ * user's unread queue is much smaller than this; the cap exists so a pathological
+ * queue (e.g. runaway producer) cannot load unbounded rows into memory. Callers
+ * seeing `updated === MARK_ALL_READ_BATCH_SIZE` should re-invoke to finish.
+ *
+ * TODO(#140 follow-up): once `ctx.query` grows a native `limit`/`offset`, push
+ * the cap into the DataProvider instead of slicing post-fetch.
+ */
+const MARK_ALL_READ_BATCH_SIZE = 1000;
 
 export const markAllReadAction = defineAction({
   name: "mark_all_read",
@@ -19,7 +30,7 @@ export const markAllReadAction = defineAction({
     recipient_id: {
       type: "string",
       label: "Recipient (privileged only)",
-      description: "Optional — only honored when the caller is system/worker/ai",
+      description: "Optional — only honored when the caller is system/worker/ai/timer",
     },
   },
   policy: {
@@ -30,7 +41,11 @@ export const markAllReadAction = defineAction({
   exposure: { http: true, ui: true, cli: true, mcp: true },
   async handler(ctx) {
     const actorType = ctx.actor.type;
-    const isPrivilegedActor = actorType === "system" || actorType === "worker" || actorType === "ai";
+    const isPrivilegedActor =
+      actorType === "system" ||
+      actorType === "worker" ||
+      actorType === "ai" ||
+      actorType === "timer";
     const explicitRecipient = ctx.input.recipient_id;
 
     let recipientId: string;
@@ -44,29 +59,34 @@ export const markAllReadAction = defineAction({
       recipientId = ctx.actor.id;
     }
 
-    const unread = await ctx.query("notification", {
+    const allUnread = await ctx.query("notification", {
       recipient_id: recipientId,
       read_at: null,
     });
 
-    if (unread.length === 0) {
-      return { updated: 0, recipient_id: recipientId };
+    if (allUnread.length === 0) {
+      return { updated: 0, recipient_id: recipientId, hasMore: false };
     }
 
+    // Cap the batch size so a pathological queue doesn't OOM the action worker.
+    const batch = allUnread.slice(0, MARK_ALL_READ_BATCH_SIZE);
+    const hasMore = allUnread.length > batch.length;
+
     const readAt = new Date().toISOString();
-    let updated = 0;
-    for (const row of unread) {
-      const id = typeof row.id === "string" ? row.id : null;
-      if (!id) continue;
-      await ctx.update("notification", id, { read_at: readAt });
-      updated += 1;
-    }
+    const ids = batch
+      .map((row) => (typeof row.id === "string" ? row.id : null))
+      .filter((id): id is string => id !== null);
+
+    // Run updates in parallel — each is an independent row write. The underlying
+    // DataProvider is expected to either pool connections or serialize as needed.
+    await Promise.all(ids.map((id) => ctx.update("notification", id, { read_at: readAt })));
 
     ctx.emit("notification.all_read", {
       recipient_id: recipientId,
-      updated,
+      updated: ids.length,
+      has_more: hasMore,
     });
 
-    return { updated, recipient_id: recipientId };
+    return { updated: ids.length, recipient_id: recipientId, hasMore };
   },
 });

--- a/addons/notification/cap-notification/src/actions/mark_all_read.ts
+++ b/addons/notification/cap-notification/src/actions/mark_all_read.ts
@@ -1,0 +1,59 @@
+/**
+ * mark_all_read action
+ *
+ * Marks every unread notification owned by the given recipient as read.
+ * Idempotent: running against a recipient with no unread rows is a no-op.
+ */
+
+import { defineAction } from "@linchkit/core";
+
+export const markAllReadAction = defineAction({
+  name: "mark_all_read",
+  entity: "notification",
+  label: "Mark All Notifications Read",
+  description: "Mark every unread notification for the given recipient as read",
+  input: {
+    recipient_id: {
+      type: "string",
+      label: "Recipient",
+      required: true,
+    },
+  },
+  policy: {
+    mode: "sync",
+    transaction: true,
+    idempotent: true,
+  },
+  exposure: { http: true, ui: true, cli: true, mcp: true },
+  async handler(ctx) {
+    const recipientId = ctx.input.recipient_id;
+    if (typeof recipientId !== "string" || !recipientId.trim()) {
+      throw new Error("recipient_id is required");
+    }
+
+    const unread = await ctx.query("notification", {
+      recipient_id: recipientId,
+      read_at: null,
+    });
+
+    if (unread.length === 0) {
+      return { updated: 0, recipient_id: recipientId };
+    }
+
+    const readAt = new Date().toISOString();
+    let updated = 0;
+    for (const row of unread) {
+      const id = typeof row.id === "string" ? row.id : null;
+      if (!id) continue;
+      await ctx.update("notification", id, { read_at: readAt });
+      updated += 1;
+    }
+
+    ctx.emit("notification.all_read", {
+      recipient_id: recipientId,
+      updated,
+    });
+
+    return { updated, recipient_id: recipientId };
+  },
+});

--- a/addons/notification/cap-notification/src/actions/mark_notification_read.ts
+++ b/addons/notification/cap-notification/src/actions/mark_notification_read.ts
@@ -1,0 +1,53 @@
+/**
+ * mark_notification_read action
+ *
+ * Sets `read_at` on a single notification record owned by the calling actor.
+ * Idempotent: re-running on an already-read notification is a no-op that
+ * returns the existing record unchanged.
+ */
+
+import { defineAction } from "@linchkit/core";
+
+export const markNotificationReadAction = defineAction({
+  name: "mark_notification_read",
+  entity: "notification",
+  label: "Mark Notification Read",
+  description: "Mark a single notification as read for the current recipient",
+  input: {
+    notification_id: {
+      type: "string",
+      label: "Notification ID",
+      required: true,
+    },
+  },
+  policy: {
+    mode: "sync",
+    transaction: true,
+    idempotent: true,
+  },
+  exposure: { http: true, ui: true, cli: true, mcp: true },
+  async handler(ctx) {
+    const notificationId = ctx.input.notification_id;
+    if (typeof notificationId !== "string" || !notificationId.trim()) {
+      throw new Error("notification_id is required");
+    }
+
+    const record = await ctx.get("notification", notificationId);
+
+    // Already read — return current record without a pointless write.
+    if (record.read_at != null) {
+      return record;
+    }
+
+    const updated = await ctx.update("notification", notificationId, {
+      read_at: new Date().toISOString(),
+    });
+
+    ctx.emit("notification.read", {
+      notification_id: notificationId,
+      recipient_id: record.recipient_id,
+    });
+
+    return updated;
+  },
+});

--- a/addons/notification/cap-notification/src/actions/mark_notification_read.ts
+++ b/addons/notification/cap-notification/src/actions/mark_notification_read.ts
@@ -34,6 +34,15 @@ export const markNotificationReadAction = defineAction({
 
     const record = await ctx.get("notification", notificationId);
 
+    // Ownership guard — a notification may only be marked read by its recipient.
+    // System/worker/ai actors are allowed to mark any record (used by housekeeping
+    // flows); human actors must match record.recipient_id.
+    const actorType = ctx.actor.type;
+    const isPrivilegedActor = actorType === "system" || actorType === "worker" || actorType === "ai";
+    if (!isPrivilegedActor && record.recipient_id !== ctx.actor.id) {
+      throw new Error("Notification does not belong to the current actor");
+    }
+
     // Already read — return current record without a pointless write.
     if (record.read_at != null) {
       return record;

--- a/addons/notification/cap-notification/src/actions/mark_notification_read.ts
+++ b/addons/notification/cap-notification/src/actions/mark_notification_read.ts
@@ -35,10 +35,14 @@ export const markNotificationReadAction = defineAction({
     const record = await ctx.get("notification", notificationId);
 
     // Ownership guard — a notification may only be marked read by its recipient.
-    // System/worker/ai actors are allowed to mark any record (used by housekeeping
-    // flows); human actors must match record.recipient_id.
+    // System/worker/ai/timer actors are allowed to mark any record (used by
+    // housekeeping flows); human actors must match record.recipient_id.
     const actorType = ctx.actor.type;
-    const isPrivilegedActor = actorType === "system" || actorType === "worker" || actorType === "ai";
+    const isPrivilegedActor =
+      actorType === "system" ||
+      actorType === "worker" ||
+      actorType === "ai" ||
+      actorType === "timer";
     if (!isPrivilegedActor && record.recipient_id !== ctx.actor.id) {
       throw new Error("Notification does not belong to the current actor");
     }

--- a/addons/notification/cap-notification/src/actions/send_notification.ts
+++ b/addons/notification/cap-notification/src/actions/send_notification.ts
@@ -106,7 +106,12 @@ export const sendNotificationAction = defineAction({
     // Defensive check — `permissions.actorTypes` is a hint in some code paths,
     // so also enforce in-handler to guarantee no human actor can dispatch.
     const actorType = ctx.actor.type;
-    if (actorType !== "system" && actorType !== "worker" && actorType !== "ai" && actorType !== "timer") {
+    if (
+      actorType !== "system" &&
+      actorType !== "worker" &&
+      actorType !== "ai" &&
+      actorType !== "timer"
+    ) {
       throw new Error(
         "send_notification is a system dispatch primitive — invoke it from a Rule, EventHandler, or another privileged action",
       );

--- a/addons/notification/cap-notification/src/actions/send_notification.ts
+++ b/addons/notification/cap-notification/src/actions/send_notification.ts
@@ -95,8 +95,23 @@ export const sendNotificationAction = defineAction({
     transaction: true,
     idempotent: false,
   },
+  // send_notification is a system-side dispatch primitive. It is declared with
+  // the HTTP/UI/CLI/MCP exposures so system actors and AI agents can invoke it
+  // over any transport, but the handler hard-gates human callers so business
+  // users cannot spoof notifications to arbitrary recipients. Trigger this
+  // action from a Rule, EventHandler, or another privileged action.
   exposure: { http: true, ui: true, cli: true, mcp: true },
+  permissions: { actorTypes: ["system", "worker", "ai", "timer"] },
   async handler(ctx): Promise<NotificationDispatchResult> {
+    // Defensive check — `permissions.actorTypes` is a hint in some code paths,
+    // so also enforce in-handler to guarantee no human actor can dispatch.
+    const actorType = ctx.actor.type;
+    if (actorType !== "system" && actorType !== "worker" && actorType !== "ai" && actorType !== "timer") {
+      throw new Error(
+        "send_notification is a system dispatch primitive — invoke it from a Rule, EventHandler, or another privileged action",
+      );
+    }
+
     const recipientId = ctx.input.recipient_id;
     const message = ctx.input.message;
     const rawChannel = ctx.input.channel ?? "in_app";

--- a/addons/notification/cap-notification/src/actions/send_notification.ts
+++ b/addons/notification/cap-notification/src/actions/send_notification.ts
@@ -1,0 +1,150 @@
+/**
+ * send_notification action
+ *
+ * Sole write entry for dispatching a notification. Routes the request to the
+ * requested channel (default: in_app). The channel is responsible for the
+ * actual persistence / transport; this action is the stable external contract.
+ */
+
+import { defineAction } from "@linchkit/core";
+import type {
+  NotificationChannel,
+  NotificationChannelContext,
+  NotificationChannelName,
+  NotificationDispatchRequest,
+  NotificationDispatchResult,
+} from "../channels/channel";
+import { EmailNotificationChannel } from "../channels/email";
+import { createInAppChannel, type NotificationStore } from "../channels/in-app";
+import { WebhookNotificationChannel } from "../channels/webhook";
+
+const SUPPORTED_CHANNELS: readonly NotificationChannelName[] = ["in_app", "email", "webhook"];
+
+function isChannelName(value: unknown): value is NotificationChannelName {
+  return typeof value === "string" && (SUPPORTED_CHANNELS as readonly string[]).includes(value);
+}
+
+/**
+ * Resolve a channel implementation from an ActionContext.
+ *
+ * The `in_app` channel is built directly from `ctx.create`; other channels
+ * are stubs and return `{ delivered: false, reason }`. This keeps the action
+ * self-contained so the capability can function without an explicit channel
+ * registry while still allowing real implementations to be wired in later.
+ */
+function resolveChannel(
+  name: NotificationChannelName,
+  store: NotificationStore,
+): NotificationChannel {
+  switch (name) {
+    case "in_app":
+      return createInAppChannel({ store });
+    case "email":
+      return new EmailNotificationChannel();
+    case "webhook":
+      return new WebhookNotificationChannel();
+    default: {
+      // Exhaustiveness check — unreachable when SUPPORTED_CHANNELS is honored
+      const exhaustive: never = name;
+      throw new Error(`Unsupported notification channel: ${String(exhaustive)}`);
+    }
+  }
+}
+
+export const sendNotificationAction = defineAction({
+  name: "send_notification",
+  entity: "notification",
+  label: "Send Notification",
+  description: "Dispatch a notification to a recipient on the requested channel",
+  input: {
+    recipient_id: {
+      type: "string",
+      label: "Recipient",
+      required: true,
+    },
+    channel: {
+      type: "enum",
+      label: "Channel",
+      options: [
+        { value: "in_app", label: "In-App" },
+        { value: "email", label: "Email" },
+        { value: "webhook", label: "Webhook" },
+      ],
+      default: "in_app",
+    },
+    title: {
+      type: "string",
+      label: "Title",
+    },
+    message: {
+      type: "text",
+      label: "Message",
+      required: true,
+    },
+    link: {
+      type: "string",
+      label: "Link",
+    },
+    metadata: {
+      type: "json",
+      label: "Metadata",
+    },
+  },
+  policy: {
+    mode: "sync",
+    transaction: true,
+    idempotent: false,
+  },
+  exposure: { http: true, ui: true, cli: true, mcp: true },
+  async handler(ctx): Promise<NotificationDispatchResult> {
+    const recipientId = ctx.input.recipient_id;
+    const message = ctx.input.message;
+    const rawChannel = ctx.input.channel ?? "in_app";
+    const title = ctx.input.title;
+    const link = ctx.input.link;
+    const metadata = ctx.input.metadata;
+
+    if (typeof recipientId !== "string" || !recipientId.trim()) {
+      throw new Error("recipient_id is required");
+    }
+    if (typeof message !== "string" || !message.trim()) {
+      throw new Error("message is required");
+    }
+    if (!isChannelName(rawChannel)) {
+      throw new Error(`Unsupported channel: ${String(rawChannel)}`);
+    }
+
+    const request: NotificationDispatchRequest = {
+      recipientId,
+      message,
+      title: typeof title === "string" ? title : undefined,
+      link: typeof link === "string" ? link : undefined,
+      metadata:
+        metadata && typeof metadata === "object" && !Array.isArray(metadata)
+          ? (metadata as Record<string, unknown>)
+          : undefined,
+      tenantId: ctx.tenantId,
+    };
+
+    const channelContext: NotificationChannelContext = {
+      actorId: ctx.actor.id,
+      tenantId: ctx.tenantId,
+    };
+
+    const channel = resolveChannel(rawChannel, {
+      create: (entity, data) => ctx.create(entity, data),
+    });
+
+    const result = await channel.send(request, channelContext);
+
+    if (result.delivered) {
+      ctx.emit("notification.sent", {
+        recipient_id: recipientId,
+        channel: result.channel,
+        notification_id: result.id,
+      });
+    }
+
+    return result;
+  },
+});

--- a/addons/notification/cap-notification/src/capability.ts
+++ b/addons/notification/cap-notification/src/capability.ts
@@ -1,0 +1,27 @@
+/**
+ * cap-notification capability definition
+ *
+ * Multi-channel notification dispatch. Ships with an in-app channel that
+ * persists to the `notification` entity; email and webhook channels are stubs
+ * reserved for follow-up work.
+ */
+
+import { defineCapability } from "@linchkit/core";
+import { markAllReadAction } from "./actions/mark_all_read";
+import { markNotificationReadAction } from "./actions/mark_notification_read";
+import { sendNotificationAction } from "./actions/send_notification";
+import { notificationSchema } from "./entities/notification";
+
+export const capNotification = defineCapability({
+  name: "cap-notification",
+  label: "Notification Center",
+  description: "Multi-channel notification dispatch with in-app channel built in",
+  type: "standard",
+  category: "system",
+  version: "0.0.1",
+
+  entities: [notificationSchema],
+  actions: [sendNotificationAction, markNotificationReadAction, markAllReadAction],
+
+  systemPermissions: ["database.read", "database.write", "event.emit"],
+});

--- a/addons/notification/cap-notification/src/channels/channel.ts
+++ b/addons/notification/cap-notification/src/channels/channel.ts
@@ -1,0 +1,64 @@
+/**
+ * NotificationChannel — dispatch interface for a single delivery channel.
+ *
+ * Every channel implementation (in-app, email, webhook, ...) implements this
+ * contract. The default in-app channel persists to the `notification` entity;
+ * other channels are stubs for now.
+ */
+
+// ── Domain types ────────────────────────────────────────────
+
+/** Supported channel identifiers. Extend this union when new channels ship. */
+export type NotificationChannelName = "in_app" | "email" | "webhook";
+
+/**
+ * Request payload passed to a channel's `send()` method.
+ * The channel is responsible for interpreting fields it understands
+ * (subject for email, url for webhook, etc.) and ignoring the rest.
+ */
+export interface NotificationDispatchRequest {
+  recipientId: string;
+  title?: string;
+  message: string;
+  link?: string;
+  metadata?: Record<string, unknown>;
+  tenantId?: string;
+}
+
+/**
+ * Outcome of a single channel dispatch.
+ * `id` is the persisted notification id when the channel stores a record
+ * (in_app); transport-only channels (email/webhook) MAY return `null`.
+ */
+export interface NotificationDispatchResult {
+  channel: NotificationChannelName;
+  delivered: boolean;
+  id: string | null;
+  /** When delivered = false, an explanation suitable for logs/UI */
+  reason?: string;
+}
+
+/**
+ * Minimal context a channel needs to perform its work. Concrete channels
+ * receive this from the capability factory at dispatch time.
+ */
+export interface NotificationChannelContext {
+  /** Actor id to record as created_by on any persisted row */
+  actorId: string;
+  /** Current tenant id, if any */
+  tenantId?: string;
+}
+
+export interface NotificationChannel {
+  /** Stable channel identifier (must match NotificationChannelName) */
+  readonly name: NotificationChannelName;
+  /**
+   * Dispatch a single notification. Implementations MUST be non-throwing for
+   * expected business failures (e.g. recipient opted out) and instead return
+   * `{ delivered: false, reason }`. Unexpected errors may throw.
+   */
+  send(
+    request: NotificationDispatchRequest,
+    context: NotificationChannelContext,
+  ): Promise<NotificationDispatchResult>;
+}

--- a/addons/notification/cap-notification/src/channels/email.ts
+++ b/addons/notification/cap-notification/src/channels/email.ts
@@ -1,0 +1,31 @@
+/**
+ * Email notification channel — STUB.
+ *
+ * TODO(#follow-up): wire to a real mail transport (SMTP / SES / Resend).
+ * Kept as a stub so the channel interface has a second concrete reference
+ * implementation and callers can wire it in without branching on channel name.
+ */
+
+import type {
+  NotificationChannel,
+  NotificationChannelContext,
+  NotificationDispatchRequest,
+  NotificationDispatchResult,
+} from "./channel";
+
+export class EmailNotificationChannel implements NotificationChannel {
+  readonly name = "email" as const;
+
+  async send(
+    _request: NotificationDispatchRequest,
+    _context: NotificationChannelContext,
+  ): Promise<NotificationDispatchResult> {
+    // TODO: implement SMTP / provider dispatch; see issue #140 follow-ups.
+    return {
+      channel: this.name,
+      delivered: false,
+      id: null,
+      reason: "email channel not implemented",
+    };
+  }
+}

--- a/addons/notification/cap-notification/src/channels/in-app.ts
+++ b/addons/notification/cap-notification/src/channels/in-app.ts
@@ -1,0 +1,67 @@
+/**
+ * In-app notification channel.
+ *
+ * Persists notifications to the `notification` entity. The UI layer queries
+ * this entity via GraphQL (read-only) to render the notification center;
+ * writes always flow through Actions.
+ */
+
+import type {
+  NotificationChannel,
+  NotificationChannelContext,
+  NotificationDispatchRequest,
+  NotificationDispatchResult,
+} from "./channel";
+
+/**
+ * Minimal persistence contract the in-app channel needs.
+ *
+ * Action handlers receive an `ActionContext` whose `create()` matches this
+ * shape, so the channel can be driven directly by `ctx.create` without any
+ * extra adapter. Tests may provide their own in-memory implementation.
+ */
+export interface NotificationStore {
+  create(entity: "notification", data: Record<string, unknown>): Promise<Record<string, unknown>>;
+}
+
+export interface InAppChannelOptions {
+  /** Store used to persist the notification record */
+  store: NotificationStore;
+}
+
+export class InAppNotificationChannel implements NotificationChannel {
+  readonly name = "in_app" as const;
+
+  constructor(private readonly options: InAppChannelOptions) {}
+
+  async send(
+    request: NotificationDispatchRequest,
+    _context: NotificationChannelContext,
+  ): Promise<NotificationDispatchResult> {
+    if (!request.recipientId?.trim()) {
+      return { channel: this.name, delivered: false, id: null, reason: "recipient_id is required" };
+    }
+    if (!request.message?.trim()) {
+      return { channel: this.name, delivered: false, id: null, reason: "message is required" };
+    }
+
+    const record = await this.options.store.create("notification", {
+      recipient_id: request.recipientId,
+      channel: this.name,
+      title: request.title,
+      message: request.message,
+      link: request.link,
+      metadata: request.metadata,
+      read_at: null,
+    });
+
+    const id = typeof record.id === "string" ? record.id : null;
+
+    return { channel: this.name, delivered: true, id };
+  }
+}
+
+/** Factory helper, mirrors the style used by other cap-* addons. */
+export function createInAppChannel(options: InAppChannelOptions): InAppNotificationChannel {
+  return new InAppNotificationChannel(options);
+}

--- a/addons/notification/cap-notification/src/channels/webhook.ts
+++ b/addons/notification/cap-notification/src/channels/webhook.ts
@@ -1,0 +1,30 @@
+/**
+ * Webhook notification channel — STUB.
+ *
+ * TODO(#follow-up): perform signed HTTP POST to a configured target URL
+ * with retry + DLQ semantics. Kept as a stub for now.
+ */
+
+import type {
+  NotificationChannel,
+  NotificationChannelContext,
+  NotificationDispatchRequest,
+  NotificationDispatchResult,
+} from "./channel";
+
+export class WebhookNotificationChannel implements NotificationChannel {
+  readonly name = "webhook" as const;
+
+  async send(
+    _request: NotificationDispatchRequest,
+    _context: NotificationChannelContext,
+  ): Promise<NotificationDispatchResult> {
+    // TODO: implement outbound webhook dispatch; see issue #140 follow-ups.
+    return {
+      channel: this.name,
+      delivered: false,
+      id: null,
+      reason: "webhook channel not implemented",
+    };
+  }
+}

--- a/addons/notification/cap-notification/src/entities/notification.ts
+++ b/addons/notification/cap-notification/src/entities/notification.ts
@@ -1,0 +1,69 @@
+/**
+ * Notification entity definition
+ *
+ * Stores a single notification addressed to a recipient on a given channel.
+ * System fields (id, tenant_id, created_at, updated_at, created_by, updated_by,
+ * _version) are managed by the framework and are intentionally not declared here.
+ *
+ * Spec reference: docs/specs/14_system_capabilities.md section 4.4
+ */
+
+import { defineEntity } from "@linchkit/core";
+
+export const notificationSchema = defineEntity({
+  name: "notification",
+  label: "Notification",
+  description: "A single notification addressed to a recipient on a given channel",
+  fields: {
+    recipient_id: {
+      type: "string",
+      label: "Recipient",
+      required: true,
+      description: "User (or actor) who should receive this notification",
+    },
+    channel: {
+      type: "enum",
+      label: "Channel",
+      required: true,
+      description: "Dispatch channel name (in_app is the only implemented channel for now)",
+      options: [
+        { value: "in_app", label: "In-App" },
+        { value: "email", label: "Email" },
+        { value: "webhook", label: "Webhook" },
+      ],
+      default: "in_app",
+    },
+    title: {
+      type: "string",
+      label: "Title",
+      description: "Optional short headline shown in notification center",
+    },
+    message: {
+      type: "text",
+      label: "Message",
+      required: true,
+      description: "Human-readable notification body",
+    },
+    link: {
+      type: "string",
+      label: "Link",
+      description: "Optional deep link for the UI to navigate to on click",
+    },
+    metadata: {
+      type: "json",
+      label: "Metadata",
+      description: "Free-form structured payload (entity/record references, counters, etc.)",
+    },
+    read_at: {
+      type: "datetime",
+      label: "Read At",
+      description: "Timestamp the recipient marked this notification read. Null = unread.",
+    },
+  },
+  presentation: {
+    titleField: "title",
+    subtitleField: "message",
+    summaryFields: ["recipient_id", "channel", "read_at"],
+    icon: "bell",
+  },
+});

--- a/addons/notification/cap-notification/src/index.ts
+++ b/addons/notification/cap-notification/src/index.ts
@@ -1,0 +1,25 @@
+/**
+ * @linchkit/cap-notification — public exports.
+ */
+
+export { markAllReadAction } from "./actions/mark_all_read";
+export { markNotificationReadAction } from "./actions/mark_notification_read";
+export { sendNotificationAction } from "./actions/send_notification";
+export { capNotification } from "./capability";
+export type {
+  NotificationChannel,
+  NotificationChannelContext,
+  NotificationChannelName,
+  NotificationDispatchRequest,
+  NotificationDispatchResult,
+} from "./channels/channel";
+export { EmailNotificationChannel } from "./channels/email";
+
+export {
+  createInAppChannel,
+  type InAppChannelOptions,
+  InAppNotificationChannel,
+  type NotificationStore,
+} from "./channels/in-app";
+export { WebhookNotificationChannel } from "./channels/webhook";
+export { notificationSchema } from "./entities/notification";

--- a/addons/notification/cap-notification/tsconfig.json
+++ b/addons/notification/cap-notification/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun-types"]
+  },
+  "include": ["src", "__tests__"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -258,6 +258,17 @@
         "drizzle-orm": "*",
       },
     },
+    "addons/notification/cap-notification": {
+      "name": "@linchkit/cap-notification",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@linchkit/core": "workspace:*",
+        "typescript": "^6.0.2",
+      },
+      "peerDependencies": {
+        "@linchkit/core": "^0.2.0",
+      },
+    },
     "addons/permission/cap-permission": {
       "name": "@linchkit/cap-permission",
       "version": "1.0.0",
@@ -619,6 +630,8 @@
     "@linchkit/cap-mcp-ui": ["@linchkit/cap-mcp-ui@workspace:addons/adapter-mcp/cap-mcp-ui"],
 
     "@linchkit/cap-migration": ["@linchkit/cap-migration@workspace:addons/migration/cap-migration"],
+
+    "@linchkit/cap-notification": ["@linchkit/cap-notification@workspace:addons/notification/cap-notification"],
 
     "@linchkit/cap-permission": ["@linchkit/cap-permission@workspace:addons/permission/cap-permission"],
 


### PR DESCRIPTION
## Summary

- New addon `@linchkit/cap-notification` — notification dispatch. Split from parent issue #121 (Spec 14).
- `notification` entity, `NotificationChannel` interface, built-in `InAppNotificationChannel` (persists via `ctx.create`), and three actions: send_notification / mark_notification_read / mark_all_read.
- Email + webhook channels are stubs returning `{ delivered: false, reason }` — real transports deferred to follow-ups.

## Codex review — addressed (all P1/P2 were real security holes)

| ID | Severity | Action |
| --- | --- | --- |
| C-1 | P1 — mark_notification_read didn't check ownership | Fixed — human actors must match `record.recipient_id`; system/worker/ai bypass for housekeeping |
| C-2 | P1 — mark_all_read trusted caller-supplied recipient_id | Fixed — human callers operate only on their own queue (derived from `ctx.actor.id`); privileged actors may still pass explicit recipient_id |
| C-3 | P2 — send_notification exposed to any authenticated user | Fixed — declared with `permissions.actorTypes: ["system", "worker", "ai", "timer"]` AND hard-gated in handler (belt-and-braces). Business notifications must be dispatched from Rule / EventHandler / another privileged action |

## Scope — deferred to follow-ups

- Real email transport (SMTP / Resend / SES)
- Webhook channel (signed HTTP POST + retry + DLQ)
- `NotificationPreferences` entity (per-user opt-in/out per channel)
- `cap-notification-ui`: notification center panel + unread badge count

## Test plan

- [x] `bun run check` / `typecheck` / `test` — all green
- [x] Addon tests: 25/25 pass — includes non-owner rejection, privileged bypass, human-dispatch refusal on send_notification
- [x] Full repo test suite: all passing

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)