### PR TITLE
feat(core): interactive onchange endpoint + evaluator (refs #148)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/onchange-api.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/onchange-api.test.ts
@@ -198,6 +198,19 @@ describe("POST /api/entities/:name/onchange", () => {
     expect(body.success).toBe(false);
   });
 
+  test("404 when changedField exists on entity but has no onchange hook", async () => {
+    // `description` is defined on purchase_line but no hook is registered
+    // against it. Spec 64 §4.1 mandates this returns 404 (not an empty 200).
+    const { status, body } = await postOnchange(happyPort, "purchase_line", {
+      changedField: "description",
+      values: { description: "x" },
+    });
+    expect(status).toBe(404);
+    expect(body.success).toBe(false);
+    const err = body.error as Record<string, unknown>;
+    expect(err.message as string).toContain("no onchange hook");
+  });
+
   test("403 when permission middleware denies the request", async () => {
     const { status, body } = await postOnchange(denyPort, "purchase_line", {
       changedField: "product_id",
@@ -218,5 +231,39 @@ describe("POST /api/entities/:name/onchange", () => {
     expect(body).toHaveProperty("warnings");
     expect(typeof body.updates).toBe("object");
     expect(Array.isArray(body.warnings)).toBe(true);
+  });
+});
+
+describe("onchange evaluator wiring via runtime context", () => {
+  // Smoke-test: construct the evaluator the same way dev.ts / capability.ts do
+  // — from runtime `entityRegistry` + `dataProvider`. A stock install that
+  // forgets to pass `onchangeEvaluator` should still wire correctly when this
+  // code path is used.
+  test("createOnchangeEvaluator can be built from a shared runtime registry + data provider", async () => {
+    const { createRuntimeContext } = await import("../src/runtime-context");
+    const runtime = createRuntimeContext({
+      entities: [lineEntity, plainEntity],
+    });
+    // Seed the same product fixture into the shared store
+    if (runtime.dataProvider instanceof InMemoryStore) {
+      await runtime.dataProvider.create("product", {
+        id: "p2",
+        price: 7,
+        description: "Gadget",
+      });
+    }
+    const evaluator = createOnchangeEvaluator({
+      entityRegistry: runtime.entityRegistry,
+      dataProvider: runtime.dataProvider,
+    });
+    const result = await evaluator.evaluate({
+      entityName: "purchase_line",
+      changedField: "product_id",
+      values: { product_id: "p2", quantity: 3 },
+      actor: { type: "human", id: "u1", groups: ["user"] },
+    });
+    expect(result.updates.unit_price).toBe(7);
+    expect(result.updates.description).toBe("Gadget");
+    expect(result.updates.subtotal).toBe(21);
   });
 });

--- a/addons/adapter-server/cap-adapter-server/__tests__/onchange-api.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/onchange-api.test.ts
@@ -1,0 +1,222 @@
+/**
+ * REST onchange endpoint integration tests (Spec 64).
+ *
+ * Verifies the full request flow:
+ *   - CommandLayer pipeline with skipActionSlots
+ *   - Entity + onchange definition lookup
+ *   - Permission middleware denial surfacing as 403
+ *   - Request body validation (400 / 404)
+ *   - Happy-path response shape { updates, warnings }
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import type { EntityDefinition } from "@linchkit/core";
+import {
+  createActionExecutor,
+  createCommandLayer,
+  createEntityRegistry,
+  createOnchangeEvaluator,
+  InMemoryStore,
+  PipelineError,
+} from "@linchkit/core/server";
+import { buildGraphQLSchema } from "../src/graphql/build-schema";
+import { createServer } from "../src/server";
+
+// ── Fixtures ──────────────────────────────────────────────
+
+const lineEntity: EntityDefinition = {
+  name: "purchase_line",
+  fields: {
+    product_id: { type: "string", label: "Product" },
+    unit_price: { type: "number", label: "Unit Price" },
+    description: { type: "string", label: "Description" },
+    quantity: { type: "number", label: "Quantity" },
+    subtotal: { type: "number", label: "Subtotal" },
+  },
+  onchange: {
+    product_id: {
+      updates: ["unit_price", "description"],
+      compute: async (ctx) => ({
+        unit_price: await ctx.lookup("product", ctx.value as string, "price"),
+        description: await ctx.lookup("product", ctx.value as string, "description"),
+      }),
+    },
+    "quantity,unit_price": {
+      updates: ["subtotal"],
+      compute: (ctx) => ({
+        subtotal: ((ctx.values.quantity as number) ?? 0) * ((ctx.values.unit_price as number) ?? 0),
+      }),
+    },
+  },
+};
+
+const plainEntity: EntityDefinition = {
+  name: "plain",
+  fields: {
+    title: { type: "string" },
+  },
+};
+
+// Onchange evaluator uses this data provider for lookups.
+const store = new InMemoryStore();
+
+// Seed a product used by lookups.
+await store.create("product", { id: "p1", price: 29.99, description: "Widget" });
+
+// ── Servers ───────────────────────────────────────────────
+
+function buildServer(options: { permissionDeny?: boolean; withEvaluator?: boolean; port: number }) {
+  const entityRegistry = createEntityRegistry();
+  entityRegistry.register(lineEntity);
+  entityRegistry.register(plainEntity);
+
+  const executor = createActionExecutor({ dataProvider: store });
+  const commandLayer = createCommandLayer({ executor });
+
+  if (options.permissionDeny) {
+    commandLayer.use({
+      name: "deny_all",
+      slot: "permission",
+      handler: async () => {
+        throw new PipelineError("Actor lacks read permission on entity", "authz.action.denied");
+      },
+    });
+  }
+
+  const evaluator = options.withEvaluator
+    ? createOnchangeEvaluator({ entityRegistry, dataProvider: store })
+    : undefined;
+
+  const graphqlSchema = buildGraphQLSchema([lineEntity, plainEntity]);
+  const app = createServer(graphqlSchema, {
+    executor,
+    commandLayer,
+    entityRegistry,
+    onchangeEvaluator: evaluator,
+  });
+  app.listen(options.port);
+  return app;
+}
+
+const happyPort = 4210;
+const denyPort = 4211;
+let happyApp: ReturnType<typeof buildServer>;
+let denyApp: ReturnType<typeof buildServer>;
+
+beforeAll(() => {
+  happyApp = buildServer({ port: happyPort, withEvaluator: true });
+  denyApp = buildServer({ port: denyPort, withEvaluator: true, permissionDeny: true });
+});
+
+afterAll(() => {
+  happyApp.stop();
+  denyApp.stop();
+});
+
+async function postOnchange(
+  port: number,
+  entityName: string,
+  body: unknown,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const res = await fetch(`http://localhost:${port}/api/entities/${entityName}/onchange`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const json = (await res.json()) as Record<string, unknown>;
+  return { status: res.status, body: json };
+}
+
+// ── Tests ─────────────────────────────────────────────────
+
+describe("POST /api/entities/:name/onchange", () => {
+  test("happy path returns { updates, warnings } with chained subtotal cascade", async () => {
+    const { status, body } = await postOnchange(happyPort, "purchase_line", {
+      changedField: "product_id",
+      values: { product_id: "p1", quantity: 2 },
+    });
+    expect(status).toBe(200);
+    // product_id -> unit_price, description (29.99, "Widget")
+    // unit_price triggers quantity,unit_price -> subtotal (2 * 29.99)
+    const updates = body.updates as Record<string, unknown>;
+    expect(updates.unit_price).toBe(29.99);
+    expect(updates.description).toBe("Widget");
+    expect(updates.subtotal).toBeCloseTo(59.98, 5);
+    expect(Array.isArray(body.warnings)).toBe(true);
+  });
+
+  test("comma-separated trigger (quantity,unit_price) updates subtotal", async () => {
+    const { status, body } = await postOnchange(happyPort, "purchase_line", {
+      changedField: "quantity",
+      values: { quantity: 4, unit_price: 5 },
+    });
+    expect(status).toBe(200);
+    expect(body.updates).toEqual({ subtotal: 20 });
+  });
+
+  test("400 when changedField is missing", async () => {
+    const { status, body } = await postOnchange(happyPort, "purchase_line", {
+      values: { product_id: "p1" },
+    });
+    expect(status).toBe(400);
+    expect(body.success).toBe(false);
+  });
+
+  test("400 when changedField is not a known field on the entity", async () => {
+    const { status, body } = await postOnchange(happyPort, "purchase_line", {
+      changedField: "does_not_exist",
+      values: {},
+    });
+    expect(status).toBe(400);
+    expect(body.success).toBe(false);
+  });
+
+  test("400 when changedField is not a string", async () => {
+    const { status, body } = await postOnchange(happyPort, "purchase_line", {
+      changedField: 42,
+      values: {},
+    });
+    expect(status).toBe(400);
+    expect(body.success).toBe(false);
+  });
+
+  test("404 when entity does not exist", async () => {
+    const { status, body } = await postOnchange(happyPort, "ghost", {
+      changedField: "x",
+      values: {},
+    });
+    expect(status).toBe(404);
+    expect(body.success).toBe(false);
+  });
+
+  test("404 when entity has no onchange definition", async () => {
+    const { status, body } = await postOnchange(happyPort, "plain", {
+      changedField: "title",
+      values: { title: "hi" },
+    });
+    expect(status).toBe(404);
+    expect(body.success).toBe(false);
+  });
+
+  test("403 when permission middleware denies the request", async () => {
+    const { status, body } = await postOnchange(denyPort, "purchase_line", {
+      changedField: "product_id",
+      values: { product_id: "p1" },
+    });
+    expect(status).toBe(403);
+    expect(body.success).toBe(false);
+    const err = body.error as Record<string, unknown>;
+    expect(err.message as string).toContain("read permission");
+  });
+
+  test("response shape includes updates (record) and warnings (array)", async () => {
+    const { body } = await postOnchange(happyPort, "purchase_line", {
+      changedField: "product_id",
+      values: { product_id: "p1" },
+    });
+    expect(body).toHaveProperty("updates");
+    expect(body).toHaveProperty("warnings");
+    expect(typeof body.updates).toBe("object");
+    expect(Array.isArray(body.warnings)).toBe(true);
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/src/capability.ts
+++ b/addons/adapter-server/cap-adapter-server/src/capability.ts
@@ -6,6 +6,7 @@
 
 import type { CliCommandContext, TransportContext } from "@linchkit/core";
 import { defineCapability, serverConfig } from "@linchkit/core";
+import { consoleLogger, createOnchangeEvaluator } from "@linchkit/core/server";
 
 export const capAdapterServer = defineCapability({
   name: "cap-adapter-server",
@@ -105,6 +106,26 @@ export const capAdapterServer = defineCapability({
           // Collect rule definitions from all capabilities for /api/rules endpoint
           const allRules = (ctx.capabilities ?? []).flatMap((c) => c.rules ?? []);
 
+          // Construct the onchange evaluator (Spec 64). Use the same data
+          // provider chain that the rest of the server uses (system-wrapped
+          // when available) so lookups from onchange hooks honor internal
+          // schema handling and tenant isolation. No permission callback is
+          // wired here either — emit a single structured warning so operators
+          // understand entity-level read gating is not active until a
+          // permission capability wires a `checkReadPermission`.
+          const onchangeDataProvider = systemDataProvider ?? ctx.dataProvider;
+          const onchangeEvaluator = onchangeDataProvider
+            ? createOnchangeEvaluator({
+                entityRegistry: ctx.entityRegistry,
+                dataProvider: onchangeDataProvider,
+              })
+            : undefined;
+          if (onchangeEvaluator) {
+            consoleLogger.warn(
+              "[onchange] no checkReadPermission configured — lookup/query helpers return data without permission enforcement. Wire cap-permission (or an equivalent) to gate entity reads inside onchange hooks.",
+            );
+          }
+
           // Use the shared runtime from CLI — no duplicate executor/commandLayer
           const app = createServer(graphqlSchema, {
             port,
@@ -125,6 +146,7 @@ export const capAdapterServer = defineCapability({
             aiService: ctx.aiService,
             aiConfig: ctx.aiConfig,
             ontologyRegistry: ctx.ontologyRegistry,
+            onchangeEvaluator,
             // Extract tenant ID from verified actor (set by auth middleware) first,
             // then fall back to X-Tenant-Id header for unauthenticated/dev scenarios.
             // Never decode JWT directly — that bypasses signature verification.

--- a/addons/adapter-server/cap-adapter-server/src/dev.ts
+++ b/addons/adapter-server/cap-adapter-server/src/dev.ts
@@ -17,6 +17,7 @@ import type {
   StateDefinition,
   ViewDefinition,
 } from "@linchkit/core";
+import { consoleLogger, createOnchangeEvaluator } from "@linchkit/core/server";
 import { loadConfig } from "./config-loader";
 import { buildGraphQLSchema, generateCrudActions } from "./graphql/build-schema";
 import { createRuntimeContext } from "./runtime-context";
@@ -212,6 +213,19 @@ const graphqlSchema = buildGraphQLSchema(allEntities, {
 const port = config.server?.port ?? 3001;
 const host = config.server?.host ?? "0.0.0.0";
 
+// Construct the onchange evaluator (Spec 64). No permission capability is wired
+// into `dev.ts`, so reads from within onchange hooks are ALL ALLOWED by default.
+// Log a structured warning once at startup so operators know the evaluator has
+// no permission gate; a production install should inject a `checkReadPermission`
+// callback (e.g. from cap-permission) that consults the real RBAC graph.
+const onchangeEvaluator = createOnchangeEvaluator({
+  entityRegistry: runtime.entityRegistry,
+  dataProvider: runtime.dataProvider,
+});
+consoleLogger.warn(
+  "[onchange] no checkReadPermission configured — lookup/query helpers return data without permission enforcement. Wire cap-permission (or an equivalent) to gate entity reads inside onchange hooks.",
+);
+
 const server = createServer(graphqlSchema, {
   port,
   host,
@@ -226,6 +240,8 @@ const server = createServer(graphqlSchema, {
   linchKitConfig: config,
   states: capContributions.states,
   flows: [],
+  dataProvider: runtime.dataProvider,
+  onchangeEvaluator,
 });
 
 server.listen(port);

--- a/addons/adapter-server/cap-adapter-server/src/routes/onchange-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/onchange-api.ts
@@ -9,9 +9,12 @@
  * wholly separate from the Action Engine write path.
  *
  * Pipeline: passes through CommandLayer with `skipActionSlots = true` so that
- * auth / exposure (no-op) / permission / tenant still run but pre-action and
- * post-action slots are skipped. The permission slot is scoped to entity-level
- * read access via `ctx.meta.onchange.entity` (see Spec 64 §4.3).
+ * auth / permission / tenant still run but exposure / pre-action / post-action
+ * slots are skipped. The synthetic command name is `"<entityName>.onchange"`
+ * (exists only for metrics/tracing labels) and `meta.onchange = { entity,
+ * changedField }` carries the permission target so middlewares can perform an
+ * entity-level READ check rather than looking up an action named `onchange`.
+ * See Spec 64 §4.3.
  */
 
 import type { OnchangeEvaluator } from "@linchkit/core/server";
@@ -27,8 +30,14 @@ import {
   serviceUnavailable,
 } from "./shared";
 
-/** Synthetic command name used for the non-action CommandLayer dispatch. */
-export const ONCHANGE_COMMAND_NAME = "entity_onchange";
+/**
+ * Build the synthetic command name for a given entity. Permission middleware
+ * SHOULD NOT match on this name — the authoritative target is
+ * `ctx.meta.onchange.entity`. The name is stable enough for metrics labels.
+ */
+export function buildOnchangeCommandName(entityName: string): string {
+  return `${entityName}.onchange`;
+}
 
 export function mountOnchangeRoutes(
   app: Elysia,
@@ -80,7 +89,7 @@ export function mountOnchangeRoutes(
     const incomingTraceId = request.headers.get("x-trace-id") ?? undefined;
 
     const commandResult = await commandLayer.execute({
-      command: ONCHANGE_COMMAND_NAME,
+      command: buildOnchangeCommandName(entityName),
       input: { entity: entityName, changedField },
       actor,
       channel: "http",
@@ -126,7 +135,11 @@ export function mountOnchangeRoutes(
       };
     } catch (err) {
       if (err instanceof OnchangeEvaluatorError) {
-        if (err.code === "ENTITY_NOT_FOUND" || err.code === "ENTITY_HAS_NO_ONCHANGE") {
+        if (
+          err.code === "ENTITY_NOT_FOUND" ||
+          err.code === "ENTITY_HAS_NO_ONCHANGE" ||
+          err.code === "NO_HOOK_FOR_FIELD"
+        ) {
           return notFound(set, err.message);
         }
         // FIELD_UNKNOWN

--- a/addons/adapter-server/cap-adapter-server/src/routes/onchange-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/onchange-api.ts
@@ -118,16 +118,22 @@ export function mountOnchangeRoutes(
     // Now run the evaluator. The CommandLayer has already authorized this
     // request; the evaluator only handles pure computation + permission-scoped
     // lookups via the DataProvider.
+    //
+    // The synthetic success result from `skipActionSlots` carries the resolved
+    // `tenantId` / `locale` read from the command context after the tenant +
+    // auth middlewares ran, so downstream handlers pick up whatever the
+    // pipeline decided rather than whatever the caller initially sent.
+    const resolvedContext =
+      commandResult.data && typeof commandResult.data === "object"
+        ? (commandResult.data as { tenantId?: string; locale?: string })
+        : undefined;
     try {
       const result = await onchangeEvaluator.evaluate({
         entityName,
         changedField,
         values,
         actor,
-        tenantId:
-          commandResult.data && typeof commandResult.data === "object"
-            ? (commandResult.data as { tenantId?: string }).tenantId
-            : undefined,
+        tenantId: resolvedContext?.tenantId,
       });
       return {
         updates: result.updates,

--- a/addons/adapter-server/cap-adapter-server/src/routes/onchange-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/onchange-api.ts
@@ -1,0 +1,139 @@
+/**
+ * Entity onchange REST endpoint (Spec 64).
+ *
+ * POST /api/entities/:entityName/onchange
+ *
+ * Interactive pre-save form computation. Given a triggering field change and
+ * the current form values, return a suggested set of updates the UI can apply
+ * to the unsaved form state. Onchange NEVER writes to the database and is
+ * wholly separate from the Action Engine write path.
+ *
+ * Pipeline: passes through CommandLayer with `skipActionSlots = true` so that
+ * auth / exposure (no-op) / permission / tenant still run but pre-action and
+ * post-action slots are skipped. The permission slot is scoped to entity-level
+ * read access via `ctx.meta.onchange.entity` (see Spec 64 §4.3).
+ */
+
+import type { OnchangeEvaluator } from "@linchkit/core/server";
+import { OnchangeEvaluatorError } from "@linchkit/core/server";
+import type { Elysia } from "elysia";
+import type { ServerOptions } from "../server";
+import {
+  badRequest,
+  notFound,
+  resolveActor,
+  resolveStatusCode,
+  serverError,
+  serviceUnavailable,
+} from "./shared";
+
+/** Synthetic command name used for the non-action CommandLayer dispatch. */
+export const ONCHANGE_COMMAND_NAME = "entity_onchange";
+
+export function mountOnchangeRoutes(
+  app: Elysia,
+  options: ServerOptions,
+  onchangeEvaluator: OnchangeEvaluator | undefined,
+): void {
+  const { entityRegistry, commandLayer } = options;
+
+  app.post("/api/entities/:name/onchange", async ({ params, body, set, request }) => {
+    if (!entityRegistry || !commandLayer || !onchangeEvaluator) {
+      return serviceUnavailable(
+        set,
+        "Onchange evaluator, entity registry, or command layer not configured.",
+      );
+    }
+
+    const entityName = params.name;
+    const entity = entityRegistry.get(entityName);
+    if (!entity) {
+      return notFound(set, `Entity "${entityName}" not found.`);
+    }
+    if (!entity.onchange || Object.keys(entity.onchange).length === 0) {
+      return notFound(set, `Entity "${entityName}" has no onchange definition.`);
+    }
+
+    // Parse body
+    const payload = (body ?? {}) as Record<string, unknown>;
+    const changedField = payload.changedField;
+    const rawValues = payload.values;
+
+    if (typeof changedField !== "string" || changedField.length === 0) {
+      return badRequest(set, "Request body must include a non-empty string `changedField`.");
+    }
+    if (!(changedField in entity.fields)) {
+      return badRequest(set, `Field "${changedField}" is not defined on entity "${entityName}".`);
+    }
+    const values =
+      rawValues && typeof rawValues === "object" && !Array.isArray(rawValues)
+        ? (rawValues as Record<string, unknown>)
+        : {};
+
+    // Dispatch through CommandLayer with skipActionSlots. The synthetic command
+    // name exists only so metrics / tracing have a stable label.
+    const actor = await resolveActor(request, options.resolveRequestActor);
+    const headers: Record<string, string> = {};
+    for (const [key, value] of request.headers.entries()) {
+      headers[key] = value;
+    }
+    const incomingTraceId = request.headers.get("x-trace-id") ?? undefined;
+
+    const commandResult = await commandLayer.execute({
+      command: ONCHANGE_COMMAND_NAME,
+      input: { entity: entityName, changedField },
+      actor,
+      channel: "http",
+      headers,
+      traceId: incomingTraceId,
+      meta: {
+        onchange: {
+          entity: entityName,
+          changedField,
+        },
+      },
+      skipActionSlots: true,
+    });
+
+    if (!commandResult.success) {
+      set.status = resolveStatusCode(commandResult);
+      const errData = commandResult.data as Record<string, unknown> | undefined;
+      const message = (errData?.error as string) ?? "Onchange request blocked";
+      const code = (errData?.code as string) ?? "ONCHANGE.BLOCKED";
+      return {
+        success: false,
+        error: { code, message },
+      };
+    }
+
+    // Now run the evaluator. The CommandLayer has already authorized this
+    // request; the evaluator only handles pure computation + permission-scoped
+    // lookups via the DataProvider.
+    try {
+      const result = await onchangeEvaluator.evaluate({
+        entityName,
+        changedField,
+        values,
+        actor,
+        tenantId:
+          commandResult.data && typeof commandResult.data === "object"
+            ? (commandResult.data as { tenantId?: string }).tenantId
+            : undefined,
+      });
+      return {
+        updates: result.updates,
+        warnings: result.warnings,
+      };
+    } catch (err) {
+      if (err instanceof OnchangeEvaluatorError) {
+        if (err.code === "ENTITY_NOT_FOUND" || err.code === "ENTITY_HAS_NO_ONCHANGE") {
+          return notFound(set, err.message);
+        }
+        // FIELD_UNKNOWN
+        return badRequest(set, err.message);
+      }
+      const message = err instanceof Error ? err.message : "Onchange evaluation failed";
+      return serverError(set, message);
+    }
+  });
+}

--- a/addons/adapter-server/cap-adapter-server/src/server.ts
+++ b/addons/adapter-server/cap-adapter-server/src/server.ts
@@ -35,6 +35,7 @@ import type {
   CacheManager,
   HealthCheckRegistry,
   InMemoryMetricsCollector,
+  OnchangeEvaluator,
 } from "@linchkit/core/server";
 import { createTenantAwareDataProvider, getCurrentTrace } from "@linchkit/core/server";
 import { Elysia } from "elysia";
@@ -50,6 +51,7 @@ import { mountConfigRoutes } from "./routes/config-api";
 import { mountConfigStoreRoutes } from "./routes/config-store-api";
 import { mountEntityRoutes } from "./routes/entity-api";
 import { mountImportRoutes } from "./routes/import-api";
+import { mountOnchangeRoutes } from "./routes/onchange-api";
 import { mountOverlayRoutes } from "./routes/overlay-api";
 import { ANONYMOUS_ACTOR, NO_AUTH_ACTOR, resolveRequestLocale } from "./routes/shared";
 import { mountSubscriptionRoutes } from "./routes/subscription-api";
@@ -142,6 +144,11 @@ export interface ServerOptions {
   cacheManager?: CacheManager;
   /** Overlay registry — when provided, enables /api/overlays REST endpoints */
   overlayRegistry?: import("@linchkit/core/server").OverlayRegistry;
+  /**
+   * Onchange evaluator (Spec 64) — when provided, enables
+   * `POST /api/entities/:name/onchange` for interactive form computation.
+   */
+  onchangeEvaluator?: OnchangeEvaluator;
   /**
    * Callback to rebuild GraphQL schema after overlay changes.
    * Receives the current yoga instance and triggers schema replacement.
@@ -251,6 +258,7 @@ export function createServer(
   mountConfigStoreRoutes(app, opts);
   mountAIRoutes(app, opts);
   mountTranslationRoutes(app, opts);
+  mountOnchangeRoutes(app, opts, opts.onchangeEvaluator);
 
   // Mount overlay management endpoints when overlay registry is available
   if (options?.overlayRegistry) {

--- a/packages/core/__tests__/command-layer-skip-action-slots.test.ts
+++ b/packages/core/__tests__/command-layer-skip-action-slots.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Command Layer — non-action dispatch (`skipActionSlots`) tests.
+ *
+ * Covers the synthetic success result produced when the pipeline runs auth /
+ * permission / tenant middlewares without executing an action (used by the
+ * entity onchange REST route, Spec 64 §4.3). The result must expose the
+ * resolved `tenantId` and `locale` read from the final command context so
+ * downstream handlers can propagate them without re-parsing the request.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createActionExecutor } from "../src/engine/action-engine";
+import { createCommandLayer } from "../src/engine/command-layer";
+import { createTestDataProvider } from "./command-layer-helpers";
+
+describe("Command Layer: skipActionSlots synthetic result", () => {
+  test("carries tenantId and locale resolved by middleware, plus skipped marker", async () => {
+    const executor = createActionExecutor({ dataProvider: createTestDataProvider() });
+    const layer = createCommandLayer({ executor });
+
+    // Tenant middleware mutates `ctx.tenantId` — the synthetic result must
+    // reflect the middleware-resolved value, not whatever the caller passed.
+    layer.use({
+      name: "test_tenant",
+      slot: "tenant",
+      handler: async (ctx, next) => {
+        ctx.tenantId = "tenant_from_middleware";
+        ctx.locale = "zh-CN";
+        await next();
+      },
+    });
+
+    const result = await layer.execute({
+      command: "customer.onchange",
+      input: { entity: "customer", changedField: "name" },
+      skipActionSlots: true,
+    });
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.skipped).toBe(true);
+    expect(data.tenantId).toBe("tenant_from_middleware");
+    expect(data.locale).toBe("zh-CN");
+  });
+
+  test("tenantId defaults to undefined when no middleware sets it", async () => {
+    const executor = createActionExecutor({ dataProvider: createTestDataProvider() });
+    const layer = createCommandLayer({ executor });
+
+    const result = await layer.execute({
+      command: "customer.onchange",
+      input: {},
+      skipActionSlots: true,
+    });
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.skipped).toBe(true);
+    expect(data.tenantId).toBeUndefined();
+    expect(data.locale).toBeUndefined();
+  });
+
+  test("initial tenantId from execute options survives if middleware does not override", async () => {
+    const executor = createActionExecutor({ dataProvider: createTestDataProvider() });
+    const layer = createCommandLayer({ executor });
+
+    const result = await layer.execute({
+      command: "customer.onchange",
+      input: {},
+      tenantId: "tenant_from_caller",
+      locale: "en",
+      skipActionSlots: true,
+    });
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.tenantId).toBe("tenant_from_caller");
+    expect(data.locale).toBe("en");
+  });
+});

--- a/packages/core/__tests__/onchange-evaluator.test.ts
+++ b/packages/core/__tests__/onchange-evaluator.test.ts
@@ -604,4 +604,233 @@ describe("createOnchangeEvaluator — checkReadPermission", () => {
     const denials = result.warnings.filter((w) => w.includes('Access to "product" denied'));
     expect(denials.length).toBe(1);
   });
+
+  // E2-2 regression: warnings from `checkReadPermission` must dedup across
+  // chained hooks, not just within a single hook invocation.
+  test("collapses repeated denials across chained hooks into a single warning", async () => {
+    const entity: EntityDefinition = {
+      name: "chain",
+      fields: {
+        a: { type: "string" },
+        b: { type: "string" },
+        c: { type: "string" },
+      },
+      onchange: {
+        // Hook A triggers and produces `b`, which then triggers hook B.
+        // Both hooks try to lookup on `product` and both are denied.
+        a: {
+          updates: ["b"],
+          compute: async (ctx) => {
+            await ctx.lookup("product", "x", "price");
+            return { b: "from-a" };
+          },
+        },
+        b: {
+          updates: ["c"],
+          compute: async (ctx) => {
+            await ctx.lookup("product", "y", "price");
+            return { c: "from-b" };
+          },
+        },
+      },
+    };
+    const evaluator = createOnchangeEvaluator({
+      entityRegistry: registerEntity(entity),
+      dataProvider: createStubDataProvider({
+        records: { product: { x: { id: "x", price: 1 } } },
+      }),
+      checkReadPermission: () => false,
+    });
+
+    const result = await evaluator.evaluate({
+      entityName: "chain",
+      changedField: "a",
+      values: { a: "v" },
+      actor: ACTOR,
+    });
+    expect(result.updates).toEqual({ b: "from-a", c: "from-b" });
+    const denials = result.warnings.filter((w) => w.includes('Access to "product" denied'));
+    expect(denials.length).toBe(1);
+  });
+});
+
+// E2-3 regression: lookup / query must never throw from the hook author's
+// perspective, but errors swallowed silently are dangerous. Surface them as
+// structured warnings instead.
+describe("createOnchangeEvaluator — lookup/query error surfacing", () => {
+  /** Stub provider whose get/query always throw the same error. */
+  function createFailingDataProvider(message: string): DataProvider {
+    return {
+      async get() {
+        throw new Error(message);
+      },
+      async query() {
+        throw new Error(message);
+      },
+      async create() {
+        throw new Error("not used");
+      },
+      async update() {
+        throw new Error("not used");
+      },
+      async delete() {
+        throw new Error("not used");
+      },
+      async count() {
+        throw new Error("not used");
+      },
+    };
+  }
+
+  test("DataProvider error surfaces as a warning but hook still completes", async () => {
+    const entity: EntityDefinition = {
+      name: "line",
+      fields: {
+        product_id: { type: "string" },
+        unit_price: { type: "number" },
+        status: { type: "string" },
+      },
+      onchange: {
+        product_id: {
+          updates: ["unit_price", "status"],
+          compute: async (ctx) => {
+            // lookup fails, but the hook continues and still returns a value
+            // for `status`, proving the rejection did not propagate as a throw.
+            const price = await ctx.lookup("product", ctx.value as string, "price");
+            return {
+              unit_price: price,
+              status: "ok",
+            };
+          },
+        },
+      },
+    };
+    const evaluator = createOnchangeEvaluator({
+      entityRegistry: registerEntity(entity),
+      dataProvider: createFailingDataProvider("DB connection reset"),
+    });
+
+    const result = await evaluator.evaluate({
+      entityName: "line",
+      changedField: "product_id",
+      values: { product_id: "p1" },
+      actor: ACTOR,
+    });
+    expect(result.updates.status).toBe("ok");
+    expect(result.updates.unit_price).toBeUndefined();
+    const lookupWarnings = result.warnings.filter((w) => w.includes('Lookup on "product" failed'));
+    expect(lookupWarnings.length).toBe(1);
+    expect(lookupWarnings[0]).toContain("DB connection reset");
+  });
+
+  test("query error surfaces as a warning and returns []", async () => {
+    const entity: EntityDefinition = {
+      name: "line",
+      fields: {
+        product_id: { type: "string" },
+        unit_price: { type: "number" },
+      },
+      onchange: {
+        product_id: {
+          updates: ["unit_price"],
+          compute: async (ctx) => {
+            const list = await ctx.query("product", { kind: "widget" });
+            return { unit_price: list.length };
+          },
+        },
+      },
+    };
+    const evaluator = createOnchangeEvaluator({
+      entityRegistry: registerEntity(entity),
+      dataProvider: createFailingDataProvider("timeout"),
+    });
+
+    const result = await evaluator.evaluate({
+      entityName: "line",
+      changedField: "product_id",
+      values: { product_id: "p1" },
+      actor: ACTOR,
+    });
+    expect(result.updates.unit_price).toBe(0);
+    const queryWarnings = result.warnings.filter((w) => w.includes('Query on "product" failed'));
+    expect(queryWarnings.length).toBe(1);
+    expect(queryWarnings[0]).toContain("timeout");
+  });
+
+  test("permission denial stays as a permission-warning (not a lookup-warning)", async () => {
+    const entity: EntityDefinition = {
+      name: "line",
+      fields: {
+        product_id: { type: "string" },
+        unit_price: { type: "number" },
+      },
+      onchange: {
+        product_id: {
+          updates: ["unit_price"],
+          compute: async (ctx) => ({
+            unit_price: await ctx.lookup("product", ctx.value as string, "price"),
+          }),
+        },
+      },
+    };
+    const evaluator = createOnchangeEvaluator({
+      entityRegistry: registerEntity(entity),
+      dataProvider: createStubDataProvider({
+        records: { product: { p1: { id: "p1", price: 42 } } },
+      }),
+      checkReadPermission: () => false,
+    });
+
+    const result = await evaluator.evaluate({
+      entityName: "line",
+      changedField: "product_id",
+      values: { product_id: "p1" },
+      actor: ACTOR,
+    });
+    // Permission path is taken (not the try/catch fallback) — so we see the
+    // access-denied warning and NOT a lookup-failed warning.
+    expect(result.warnings.some((w) => w.includes('Access to "product" denied'))).toBe(true);
+    expect(result.warnings.some((w) => w.includes('Lookup on "product" failed'))).toBe(false);
+  });
+
+  test("collapses repeated identical lookup errors across chained hooks", async () => {
+    const entity: EntityDefinition = {
+      name: "chain",
+      fields: {
+        a: { type: "string" },
+        b: { type: "string" },
+        c: { type: "string" },
+      },
+      onchange: {
+        a: {
+          updates: ["b"],
+          compute: async (ctx) => {
+            await ctx.lookup("product", "x", "price");
+            return { b: "next" };
+          },
+        },
+        b: {
+          updates: ["c"],
+          compute: async (ctx) => {
+            await ctx.lookup("product", "y", "price");
+            return { c: "done" };
+          },
+        },
+      },
+    };
+    const evaluator = createOnchangeEvaluator({
+      entityRegistry: registerEntity(entity),
+      dataProvider: createFailingDataProvider("DB connection reset"),
+    });
+
+    const result = await evaluator.evaluate({
+      entityName: "chain",
+      changedField: "a",
+      values: { a: "start" },
+      actor: ACTOR,
+    });
+    expect(result.updates).toEqual({ b: "next", c: "done" });
+    const lookupWarnings = result.warnings.filter((w) => w.includes('Lookup on "product" failed'));
+    expect(lookupWarnings.length).toBe(1);
+  });
 });

--- a/packages/core/__tests__/onchange-evaluator.test.ts
+++ b/packages/core/__tests__/onchange-evaluator.test.ts
@@ -1,0 +1,463 @@
+/**
+ * Onchange evaluator unit tests (Spec 64 §5).
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { DataProvider } from "../src/engine/action-engine";
+import {
+  createOnchangeEvaluator,
+  MAX_CHAIN_DEPTH,
+  OnchangeEvaluatorError,
+} from "../src/engine/onchange-evaluator";
+import { createEntityRegistry } from "../src/entity/entity-registry";
+import type { Actor } from "../src/types/action";
+import type { EntityDefinition } from "../src/types/entity";
+
+// ── Fixtures ────────────────────────────────────────────────
+
+const ACTOR: Actor = { type: "human", id: "u1", groups: ["user"] };
+
+/** Minimal in-memory data provider for lookup/query tests. */
+function createStubDataProvider(seed?: {
+  records?: Record<string, Record<string, Record<string, unknown>>>;
+}): DataProvider {
+  const store = seed?.records ?? {};
+  return {
+    async get(entity, id) {
+      const rec = store[entity]?.[id];
+      if (!rec) throw new Error(`Record ${entity}/${id} not found`);
+      return rec;
+    },
+    async query(entity, filter) {
+      const table = store[entity];
+      if (!table) return [];
+      return Object.values(table).filter((r) =>
+        Object.entries(filter).every(([k, v]) => r[k] === v),
+      );
+    },
+    async create() {
+      throw new Error("DataProvider.create must not be called from onchange");
+    },
+    async update() {
+      throw new Error("DataProvider.update must not be called from onchange");
+    },
+    async delete() {
+      throw new Error("DataProvider.delete must not be called from onchange");
+    },
+    async count() {
+      throw new Error("not used");
+    },
+  };
+}
+
+function registerEntity(entity: EntityDefinition) {
+  const reg = createEntityRegistry();
+  reg.register(entity);
+  return reg;
+}
+
+// ── Tests ───────────────────────────────────────────────────
+
+describe("createOnchangeEvaluator — single hook", () => {
+  test("evaluates a single-field hook", async () => {
+    const entity: EntityDefinition = {
+      name: "line",
+      fields: {
+        product_id: { type: "string" },
+        unit_price: { type: "number" },
+      },
+      onchange: {
+        product_id: {
+          updates: ["unit_price"],
+          compute: () => ({ unit_price: 9.99 }),
+        },
+      },
+    };
+    const evaluator = createOnchangeEvaluator({
+      entityRegistry: registerEntity(entity),
+      dataProvider: createStubDataProvider(),
+    });
+
+    const result = await evaluator.evaluate({
+      entityName: "line",
+      changedField: "product_id",
+      values: { product_id: "p1" },
+      actor: ACTOR,
+    });
+
+    expect(result.updates).toEqual({ unit_price: 9.99 });
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("fires comma-separated multi-trigger hook when either field changes", async () => {
+    const entity: EntityDefinition = {
+      name: "line",
+      fields: {
+        quantity: { type: "number" },
+        unit_price: { type: "number" },
+        subtotal: { type: "number" },
+      },
+      onchange: {
+        "quantity,unit_price": {
+          updates: ["subtotal"],
+          compute: (ctx) => ({
+            subtotal:
+              ((ctx.values.quantity as number) ?? 0) * ((ctx.values.unit_price as number) ?? 0),
+          }),
+        },
+      },
+    };
+    const evaluator = createOnchangeEvaluator({
+      entityRegistry: registerEntity(entity),
+      dataProvider: createStubDataProvider(),
+    });
+
+    const r1 = await evaluator.evaluate({
+      entityName: "line",
+      changedField: "quantity",
+      values: { quantity: 3, unit_price: 2 },
+      actor: ACTOR,
+    });
+    expect(r1.updates).toEqual({ subtotal: 6 });
+
+    const r2 = await evaluator.evaluate({
+      entityName: "line",
+      changedField: "unit_price",
+      values: { quantity: 5, unit_price: 7 },
+      actor: ACTOR,
+    });
+    expect(r2.updates).toEqual({ subtotal: 35 });
+  });
+
+  test("runs async compute with DataProvider lookup", async () => {
+    const entity: EntityDefinition = {
+      name: "line",
+      fields: {
+        product_id: { type: "string" },
+        unit_price: { type: "number" },
+      },
+      onchange: {
+        product_id: {
+          updates: ["unit_price"],
+          compute: async (ctx) => ({
+            unit_price: await ctx.lookup("product", ctx.value as string, "price"),
+          }),
+        },
+      },
+    };
+    const evaluator = createOnchangeEvaluator({
+      entityRegistry: registerEntity(entity),
+      dataProvider: createStubDataProvider({
+        records: { product: { p1: { id: "p1", price: 42 } } },
+      }),
+    });
+
+    const result = await evaluator.evaluate({
+      entityName: "line",
+      changedField: "product_id",
+      values: { product_id: "p1" },
+      actor: ACTOR,
+    });
+    expect(result.updates).toEqual({ unit_price: 42 });
+  });
+
+  test("returns undefined from lookup when record is missing (no throw)", async () => {
+    const entity: EntityDefinition = {
+      name: "line",
+      fields: {
+        product_id: { type: "string" },
+        unit_price: { type: "number" },
+      },
+      onchange: {
+        product_id: {
+          updates: ["unit_price"],
+          compute: async (ctx) => ({
+            unit_price: await ctx.lookup("product", "missing", "price"),
+          }),
+        },
+      },
+    };
+    const evaluator = createOnchangeEvaluator({
+      entityRegistry: registerEntity(entity),
+      dataProvider: createStubDataProvider(),
+    });
+
+    const result = await evaluator.evaluate({
+      entityName: "line",
+      changedField: "product_id",
+      values: { product_id: "x" },
+      actor: ACTOR,
+    });
+    expect(result.updates).toEqual({ unit_price: undefined });
+  });
+});
+
+describe("createOnchangeEvaluator — chaining", () => {
+  test("cascades A → B → C in BFS order", async () => {
+    const entity: EntityDefinition = {
+      name: "chain",
+      fields: {
+        a: { type: "number" },
+        b: { type: "number" },
+        c: { type: "number" },
+      },
+      onchange: {
+        a: {
+          updates: ["b"],
+          compute: (ctx) => ({ b: (ctx.value as number) + 1 }),
+        },
+        b: {
+          updates: ["c"],
+          compute: (ctx) => ({ c: (ctx.value as number) + 1 }),
+        },
+      },
+    };
+    const evaluator = createOnchangeEvaluator({
+      entityRegistry: registerEntity(entity),
+      dataProvider: createStubDataProvider(),
+    });
+
+    const result = await evaluator.evaluate({
+      entityName: "chain",
+      changedField: "a",
+      values: { a: 1 },
+      actor: ACTOR,
+    });
+    expect(result.updates).toEqual({ b: 2, c: 3 });
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("detects cycles via visited set (A → B → A short-circuits)", async () => {
+    const entity: EntityDefinition = {
+      name: "cycle",
+      fields: {
+        a: { type: "number" },
+        b: { type: "number" },
+      },
+      onchange: {
+        a: { updates: ["b"], compute: () => ({ b: 10 }) },
+        b: { updates: ["a"], compute: () => ({ a: 20 }) },
+      },
+    };
+    const evaluator = createOnchangeEvaluator({
+      entityRegistry: registerEntity(entity),
+      dataProvider: createStubDataProvider(),
+    });
+
+    const result = await evaluator.evaluate({
+      entityName: "cycle",
+      changedField: "a",
+      values: { a: 0 },
+      actor: ACTOR,
+    });
+    // a-hook fires -> b=10; b enqueued; b-hook fires -> a=20; a already visited -> stop.
+    expect(result.updates).toEqual({ b: 10, a: 20 });
+  });
+
+  test("caps chain depth at MAX_CHAIN_DEPTH with a warning", async () => {
+    const fields: Record<string, { type: "number" }> = {};
+    const onchange: Record<string, { updates: string[]; compute: () => Record<string, number> }> =
+      {};
+    // Build 10 fields f0..f9 where f_n updates f_{n+1}.
+    for (let i = 0; i < 10; i++) {
+      fields[`f${i}`] = { type: "number" };
+    }
+    for (let i = 0; i < 9; i++) {
+      onchange[`f${i}`] = {
+        updates: [`f${i + 1}`],
+        compute: () => ({ [`f${i + 1}`]: i + 1 }),
+      };
+    }
+
+    const entity: EntityDefinition = {
+      name: "deep",
+      fields,
+      onchange,
+    };
+    const evaluator = createOnchangeEvaluator({
+      entityRegistry: registerEntity(entity),
+      dataProvider: createStubDataProvider(),
+    });
+
+    const result = await evaluator.evaluate({
+      entityName: "deep",
+      changedField: "f0",
+      values: { f0: 0 },
+      actor: ACTOR,
+    });
+
+    // Exactly MAX_CHAIN_DEPTH hook evaluations allowed; so f1..f5 get updated, f6..f9 do not.
+    expect(Object.keys(result.updates).length).toBe(MAX_CHAIN_DEPTH);
+    expect(result.warnings.some((w) => w.includes("chain depth limit reached"))).toBe(true);
+  });
+});
+
+describe("createOnchangeEvaluator — allowlist filtering", () => {
+  test("drops fields outside the hook's updates list with a warning", async () => {
+    const entity: EntityDefinition = {
+      name: "line",
+      fields: {
+        product_id: { type: "string" },
+        unit_price: { type: "number" },
+        description: { type: "string" },
+      },
+      onchange: {
+        product_id: {
+          updates: ["unit_price"],
+          // description is NOT in updates — must be filtered out.
+          compute: () => ({ unit_price: 5, description: "sneaky" }),
+        },
+      },
+    };
+    const evaluator = createOnchangeEvaluator({
+      entityRegistry: registerEntity(entity),
+      dataProvider: createStubDataProvider(),
+    });
+
+    const result = await evaluator.evaluate({
+      entityName: "line",
+      changedField: "product_id",
+      values: { product_id: "p1" },
+      actor: ACTOR,
+    });
+    expect(result.updates).toEqual({ unit_price: 5 });
+    expect(result.warnings.some((w) => w.includes("description"))).toBe(true);
+    expect(result.warnings.some((w) => w.includes("allowlist"))).toBe(true);
+  });
+});
+
+describe("createOnchangeEvaluator — failures", () => {
+  test("captures thrown errors into warnings, does not propagate", async () => {
+    const entity: EntityDefinition = {
+      name: "line",
+      fields: {
+        product_id: { type: "string" },
+        unit_price: { type: "number" },
+      },
+      onchange: {
+        product_id: {
+          updates: ["unit_price"],
+          compute: () => {
+            throw new Error("boom");
+          },
+        },
+      },
+    };
+    const evaluator = createOnchangeEvaluator({
+      entityRegistry: registerEntity(entity),
+      dataProvider: createStubDataProvider(),
+    });
+
+    const result = await evaluator.evaluate({
+      entityName: "line",
+      changedField: "product_id",
+      values: { product_id: "p1" },
+      actor: ACTOR,
+    });
+    expect(result.updates).toEqual({});
+    expect(result.warnings.some((w) => w.includes("boom"))).toBe(true);
+  });
+
+  test("per-hook timeout resolves with warning and empty updates", async () => {
+    const entity: EntityDefinition = {
+      name: "line",
+      fields: {
+        product_id: { type: "string" },
+        unit_price: { type: "number" },
+      },
+      onchange: {
+        product_id: {
+          updates: ["unit_price"],
+          timeout: 20,
+          compute: () =>
+            new Promise((resolve) => {
+              setTimeout(() => resolve({ unit_price: 99 }), 200);
+            }),
+        },
+      },
+    };
+    const evaluator = createOnchangeEvaluator({
+      entityRegistry: registerEntity(entity),
+      dataProvider: createStubDataProvider(),
+    });
+
+    const result = await evaluator.evaluate({
+      entityName: "line",
+      changedField: "product_id",
+      values: { product_id: "p1" },
+      actor: ACTOR,
+    });
+    expect(result.updates).toEqual({});
+    expect(result.warnings.some((w) => w.includes("timeout"))).toBe(true);
+  });
+});
+
+describe("createOnchangeEvaluator — validation errors", () => {
+  test("throws ENTITY_NOT_FOUND when entity is unknown", async () => {
+    const evaluator = createOnchangeEvaluator({
+      entityRegistry: createEntityRegistry(),
+      dataProvider: createStubDataProvider(),
+    });
+    try {
+      await evaluator.evaluate({
+        entityName: "ghost",
+        changedField: "x",
+        values: {},
+        actor: ACTOR,
+      });
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(OnchangeEvaluatorError);
+      expect((err as OnchangeEvaluatorError).code).toBe("ENTITY_NOT_FOUND");
+    }
+  });
+
+  test("throws ENTITY_HAS_NO_ONCHANGE when entity has no onchange map", async () => {
+    const entity: EntityDefinition = {
+      name: "plain",
+      fields: { x: { type: "string" } },
+    };
+    const evaluator = createOnchangeEvaluator({
+      entityRegistry: registerEntity(entity),
+      dataProvider: createStubDataProvider(),
+    });
+    try {
+      await evaluator.evaluate({
+        entityName: "plain",
+        changedField: "x",
+        values: { x: "v" },
+        actor: ACTOR,
+      });
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(OnchangeEvaluatorError);
+      expect((err as OnchangeEvaluatorError).code).toBe("ENTITY_HAS_NO_ONCHANGE");
+    }
+  });
+
+  test("throws FIELD_UNKNOWN when changedField is not on the entity", async () => {
+    const entity: EntityDefinition = {
+      name: "line",
+      fields: { a: { type: "string" } },
+      onchange: {
+        a: { updates: [], compute: () => ({}) },
+      },
+    };
+    const evaluator = createOnchangeEvaluator({
+      entityRegistry: registerEntity(entity),
+      dataProvider: createStubDataProvider(),
+    });
+    try {
+      await evaluator.evaluate({
+        entityName: "line",
+        changedField: "nope",
+        values: {},
+        actor: ACTOR,
+      });
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(OnchangeEvaluatorError);
+      expect((err as OnchangeEvaluatorError).code).toBe("FIELD_UNKNOWN");
+    }
+  });
+});

--- a/packages/core/__tests__/onchange-evaluator.test.ts
+++ b/packages/core/__tests__/onchange-evaluator.test.ts
@@ -460,4 +460,148 @@ describe("createOnchangeEvaluator — validation errors", () => {
       expect((err as OnchangeEvaluatorError).code).toBe("FIELD_UNKNOWN");
     }
   });
+
+  test("throws NO_HOOK_FOR_FIELD when field exists on entity but has no onchange hook", async () => {
+    // Entity has an onchange map covering `a`, but the caller triggers on `b`.
+    // Spec 64 §4.1 says this is a 404 case — the evaluator must surface it as
+    // a distinct, typed error so the REST layer maps it to the right status.
+    const entity: EntityDefinition = {
+      name: "line",
+      fields: {
+        a: { type: "string" },
+        b: { type: "string" },
+      },
+      onchange: {
+        a: { updates: [], compute: () => ({}) },
+      },
+    };
+    const evaluator = createOnchangeEvaluator({
+      entityRegistry: registerEntity(entity),
+      dataProvider: createStubDataProvider(),
+    });
+    try {
+      await evaluator.evaluate({
+        entityName: "line",
+        changedField: "b",
+        values: { b: "v" },
+        actor: ACTOR,
+      });
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(OnchangeEvaluatorError);
+      expect((err as OnchangeEvaluatorError).code).toBe("NO_HOOK_FOR_FIELD");
+    }
+  });
+});
+
+describe("createOnchangeEvaluator — checkReadPermission", () => {
+  test("drops lookup result and emits warning when read is denied", async () => {
+    const entity: EntityDefinition = {
+      name: "line",
+      fields: {
+        product_id: { type: "string" },
+        unit_price: { type: "number" },
+      },
+      onchange: {
+        product_id: {
+          updates: ["unit_price"],
+          compute: async (ctx) => ({
+            unit_price: await ctx.lookup("product", ctx.value as string, "price"),
+          }),
+        },
+      },
+    };
+    const evaluator = createOnchangeEvaluator({
+      entityRegistry: registerEntity(entity),
+      dataProvider: createStubDataProvider({
+        records: { product: { p1: { id: "p1", price: 42 } } },
+      }),
+      checkReadPermission: ({ entity: target }) => target !== "product",
+    });
+
+    const result = await evaluator.evaluate({
+      entityName: "line",
+      changedField: "product_id",
+      values: { product_id: "p1" },
+      actor: ACTOR,
+    });
+    // Lookup was denied; the hook still ran but received `undefined` from lookup,
+    // so unit_price ends up as undefined after filterByAllowlist.
+    expect(result.updates).toEqual({ unit_price: undefined });
+    expect(result.warnings.some((w) => w.includes('Access to "product" denied'))).toBe(true);
+  });
+
+  test("allows data access when checkReadPermission returns true", async () => {
+    const entity: EntityDefinition = {
+      name: "line",
+      fields: {
+        product_id: { type: "string" },
+        unit_price: { type: "number" },
+      },
+      onchange: {
+        product_id: {
+          updates: ["unit_price"],
+          compute: async (ctx) => ({
+            unit_price: await ctx.lookup("product", ctx.value as string, "price"),
+          }),
+        },
+      },
+    };
+    const evaluator = createOnchangeEvaluator({
+      entityRegistry: registerEntity(entity),
+      dataProvider: createStubDataProvider({
+        records: { product: { p1: { id: "p1", price: 42 } } },
+      }),
+      checkReadPermission: () => true,
+    });
+
+    const result = await evaluator.evaluate({
+      entityName: "line",
+      changedField: "product_id",
+      values: { product_id: "p1" },
+      actor: ACTOR,
+    });
+    expect(result.updates).toEqual({ unit_price: 42 });
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("collapses repeated denials of the same entity into a single warning", async () => {
+    const entity: EntityDefinition = {
+      name: "line",
+      fields: {
+        a: { type: "string" },
+        b: { type: "string" },
+      },
+      onchange: {
+        a: {
+          updates: ["b"],
+          compute: async (ctx) => {
+            // Two consecutive denied lookups should produce only ONE warning
+            // about `product`.
+            await ctx.lookup("product", "x", "price");
+            await ctx.lookup("product", "y", "price");
+            const list = await ctx.query("product", { kind: "widget" });
+            return { b: `${list.length}` };
+          },
+        },
+      },
+    };
+    const evaluator = createOnchangeEvaluator({
+      entityRegistry: registerEntity(entity),
+      dataProvider: createStubDataProvider({
+        records: { product: { x: { id: "x", price: 1 } } },
+      }),
+      checkReadPermission: () => false,
+    });
+
+    const result = await evaluator.evaluate({
+      entityName: "line",
+      changedField: "a",
+      values: { a: "v" },
+      actor: ACTOR,
+    });
+    expect(result.updates).toEqual({ b: "0" });
+    const denials = result.warnings.filter((w) => w.includes('Access to "product" denied'));
+    expect(denials.length).toBe(1);
+  });
 });

--- a/packages/core/src/engine/command-layer.ts
+++ b/packages/core/src/engine/command-layer.ts
@@ -158,18 +158,34 @@ export interface CommandExecuteOptions {
   traceId?: string;
   /**
    * Non-action dispatch mode (Spec 64 §4.3). When true, the pipeline:
-   * - RUNS pre, auth, exposure (no-op when no action), permission, tenant slots
-   * - SKIPS pre-action and post-action slots
+   * - RUNS pre, auth, permission, tenant slots
+   * - SKIPS exposure (no action to expose), pre-action and post-action slots
    * - SKIPS action execution (returns a synthetic success result with `data.skipped = true`)
    *
-   * This is used by endpoints that need to pass through the CommandLayer for
+   * Post-action is deliberately skipped: notification, cache-invalidation and
+   * event-fan-out middlewares run after write side effects — a non-action
+   * dispatch has no writes so firing them would be semantically wrong.
+   *
+   * Used by endpoints that need to pass through the CommandLayer for
    * auth/permission/tenant enforcement WITHOUT executing a write action —
    * currently the entity onchange endpoint (interactive form computation).
    *
-   * The caller must still supply a synthetic `command` name (e.g. `"entity_onchange"`)
-   * because the pipeline identifies dispatches by command name for metrics and tracing.
-   * Permission checks in this mode should be scoped to the target entity (via `meta`),
-   * not to an action.
+   * ### `meta.onchange` contract (for permission middleware)
+   *
+   * Callers MUST populate `meta.onchange = { entity, changedField }` so the
+   * permission slot can perform an entity-level READ check instead of looking
+   * up an action. The synthetic command name is typically
+   * `"<entityName>.onchange"` and is intended for metrics/tracing only —
+   * permission middleware should NOT match on `ctx.action` or on the command
+   * name when `meta.onchange` is present.
+   *
+   * Example (permission middleware):
+   * ```ts
+   * if (ctx.meta.onchange) {
+   *   const { entity } = ctx.meta.onchange as { entity: string };
+   *   assertCanRead(ctx.actor, entity);
+   * }
+   * ```
    */
   skipActionSlots?: boolean;
 }
@@ -470,8 +486,14 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
       };
     }
 
-    // Run post-action middlewares individually to track critical failures
-    const postMiddlewares = getSlotMiddlewares("post-action");
+    // Run post-action middlewares individually to track critical failures.
+    // Non-action dispatches (`skipActionSlots = true`, e.g. onchange) must NOT
+    // trigger post-action side effects — cache invalidation, event fan-out and
+    // notifications are only correct after a real write. Honor the same
+    // `skippedSlots` set the pre/post pipeline uses to stay consistent.
+    const postMiddlewares = skippedSlots.has("post-action")
+      ? []
+      : getSlotMiddlewares("post-action");
     if (postMiddlewares.length > 0) {
       for (const mw of postMiddlewares) {
         try {

--- a/packages/core/src/engine/command-layer.ts
+++ b/packages/core/src/engine/command-layer.ts
@@ -417,10 +417,17 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
       // Non-action dispatch: set a synthetic success result so downstream code
       // knows the pipeline completed without error. The caller is responsible
       // for producing the actual response payload (e.g. onchange updates).
+      // Include the resolved tenantId / locale (read from the final ctx after
+      // middleware runs) so downstream handlers like the onchange REST route
+      // can propagate them without having to re-derive from the request.
       pipeline.push(async (c: CommandContext, _next: () => Promise<void>) => {
         c.result = {
           success: true,
-          data: { skipped: true },
+          data: {
+            skipped: true,
+            tenantId: c.tenantId,
+            locale: c.locale,
+          },
           executionId: generatePipelineId(),
         };
       });

--- a/packages/core/src/engine/command-layer.ts
+++ b/packages/core/src/engine/command-layer.ts
@@ -11,6 +11,12 @@
  * Action execution is placed inside the compose chain so that any middleware not calling
  * next() will block the action from running.
  *
+ * Non-action dispatches (`CommandExecuteOptions.skipActionSlots = true`): used by the
+ * entity onchange endpoint (Spec 64 §4.3). The pipeline runs pre / auth / permission /
+ * tenant but skips exposure / pre-action / post-action and does not invoke the
+ * ActionExecutor; a synthetic success result is returned so downstream code can
+ * produce the actual response payload.
+ *
  * See spec 16_command_layer_and_api.md §2.2 and 20_extension_mechanism.md §8.
  */
 
@@ -150,6 +156,22 @@ export interface CommandExecuteOptions {
   skipRules?: string[];
   /** External trace ID — when provided, the pipeline reuses this instead of generating a new one */
   traceId?: string;
+  /**
+   * Non-action dispatch mode (Spec 64 §4.3). When true, the pipeline:
+   * - RUNS pre, auth, exposure (no-op when no action), permission, tenant slots
+   * - SKIPS pre-action and post-action slots
+   * - SKIPS action execution (returns a synthetic success result with `data.skipped = true`)
+   *
+   * This is used by endpoints that need to pass through the CommandLayer for
+   * auth/permission/tenant enforcement WITHOUT executing a write action —
+   * currently the entity onchange endpoint (interactive form computation).
+   *
+   * The caller must still supply a synthetic `command` name (e.g. `"entity_onchange"`)
+   * because the pipeline identifies dispatches by command name for metrics and tracing.
+   * Permission checks in this mode should be scoped to the target entity (via `meta`),
+   * not to an action.
+   */
+  skipActionSlots?: boolean;
 }
 
 /**
@@ -252,16 +274,21 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
       traceId: trace?.traceId,
     };
 
-    // Resolve action definition for exposure check
-    const action = executor.registry.get(ctx.command);
-    if (!action) {
-      return {
-        success: false,
-        data: { error: `Action "${ctx.command}" not found` },
-        executionId: generatePipelineId(),
-      };
+    const skipActionSlots = execOptions.skipActionSlots === true;
+
+    // Resolve action definition for exposure check (only when an action will run)
+    let action: ActionDefinition | undefined;
+    if (!skipActionSlots) {
+      action = executor.registry.get(ctx.command);
+      if (!action) {
+        return {
+          success: false,
+          data: { error: `Action "${ctx.command}" not found` },
+          executionId: generatePipelineId(),
+        };
+      }
+      ctx.action = action;
     }
-    ctx.action = action;
 
     // Determine if permission middleware is registered (#1 — fail-closed)
     const hasPermissionMiddleware = getSlotMiddlewares("permission").length > 0;
@@ -291,6 +318,14 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
     const skippedSlots: Set<SlotName> = isApprovalReExecution
       ? new Set(["auth", "exposure", "permission"])
       : new Set();
+    // Non-action dispatch: skip exposure + pre-action + post-action slots.
+    // The exposure slot has nothing to check (no action); pre/post-action hooks
+    // only apply to write actions. Auth / permission / tenant still run.
+    if (skipActionSlots) {
+      skippedSlots.add("exposure");
+      skippedSlots.add("pre-action");
+      skippedSlots.add("post-action");
+    }
 
     // Build the pipeline: collect handlers from each slot in order
     const pipeline: Array<(ctx: CommandContext, next: () => Promise<void>) => Promise<void>> = [];
@@ -302,15 +337,18 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
       }
 
       if (slot === "exposure") {
-        // Built-in exposure check
-        pipeline.push(async (c, next) => {
-          if (!checkExposure(action, c.channel)) {
-            throw new ExposureError(
-              `Action "${c.command}" is not exposed for channel "${c.channel}"`,
-            );
-          }
-          await next();
-        });
+        // Built-in exposure check — only applicable when an action is resolved.
+        if (action) {
+          const resolvedAction = action;
+          pipeline.push(async (c, next) => {
+            if (!checkExposure(resolvedAction, c.channel)) {
+              throw new ExposureError(
+                `Action "${c.command}" is not exposed for channel "${c.channel}"`,
+              );
+            }
+            await next();
+          });
+        }
       } else if (slot === "post-action") {
         // Handled separately after action execution
       } else {
@@ -340,23 +378,37 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
     // If any middleware does not call next(), the action will NOT run.
     // Use `action.name` (resolved before pipeline) instead of `c.command` to prevent
     // middleware from swapping the command after exposure/permission checks ran.
-    pipeline.push(async (c: CommandContext, _next: () => Promise<void>) => {
-      try {
-        const result = await executor.execute(action.name, c.input, c.actor, {
-          ...executorOptions,
-          tenantId: c.tenantId, // Use latest tenantId (tenant middleware may have set it)
-          locale: c.locale, // Use latest locale (middleware may have set it)
-        });
-        c.result = result;
-      } catch (_err) {
-        // Executor should return ActionResult, but guard against unexpected throws (#4)
+    if (action && !skipActionSlots) {
+      const resolvedAction = action;
+      pipeline.push(async (c: CommandContext, _next: () => Promise<void>) => {
+        try {
+          const result = await executor.execute(resolvedAction.name, c.input, c.actor, {
+            ...executorOptions,
+            tenantId: c.tenantId, // Use latest tenantId (tenant middleware may have set it)
+            locale: c.locale, // Use latest locale (middleware may have set it)
+          });
+          c.result = result;
+        } catch (_err) {
+          // Executor should return ActionResult, but guard against unexpected throws (#4)
+          c.result = {
+            success: false,
+            data: { error: "Action execution failed" },
+            executionId: generatePipelineId(),
+          };
+        }
+      });
+    } else {
+      // Non-action dispatch: set a synthetic success result so downstream code
+      // knows the pipeline completed without error. The caller is responsible
+      // for producing the actual response payload (e.g. onchange updates).
+      pipeline.push(async (c: CommandContext, _next: () => Promise<void>) => {
         c.result = {
-          success: false,
-          data: { error: "Action execution failed" },
+          success: true,
+          data: { skipped: true },
           executionId: generatePipelineId(),
         };
-      }
-    });
+      });
+    }
 
     // Execute the full pipeline (pre → auth → exposure → permission → tenant → pre-action → action)
     try {

--- a/packages/core/src/engine/index.ts
+++ b/packages/core/src/engine/index.ts
@@ -53,7 +53,9 @@ export {
   type OnchangeEvaluationResult,
   type OnchangeEvaluator,
   OnchangeEvaluatorError,
+  type OnchangeEvaluatorErrorCode,
   type OnchangeEvaluatorOptions,
+  type OnchangeReadPermissionCheck,
 } from "./onchange-evaluator";
 // Overlay proposal executor
 export {

--- a/packages/core/src/engine/index.ts
+++ b/packages/core/src/engine/index.ts
@@ -44,6 +44,17 @@ export {
 } from "./command-layer";
 // Condition evaluator
 export { type ConditionContext, evaluateCondition, resolveField } from "./condition-evaluator";
+// Onchange evaluator (Spec 64)
+export {
+  createOnchangeEvaluator,
+  DEFAULT_COMPUTE_TIMEOUT_MS,
+  MAX_CHAIN_DEPTH,
+  type OnchangeEvaluateArgs,
+  type OnchangeEvaluationResult,
+  type OnchangeEvaluator,
+  OnchangeEvaluatorError,
+  type OnchangeEvaluatorOptions,
+} from "./onchange-evaluator";
 // Overlay proposal executor
 export {
   canAutoApproveOverlayChange,

--- a/packages/core/src/engine/onchange-evaluator.ts
+++ b/packages/core/src/engine/onchange-evaluator.ts
@@ -33,6 +33,21 @@ export const DEFAULT_COMPUTE_TIMEOUT_MS = 2000;
 /** Structured result returned by the evaluator. */
 export type OnchangeEvaluationResult = Required<OnchangeResult>;
 
+/**
+ * Callback evaluated before each `lookup` / `query` to decide whether the
+ * current actor can read from the target entity. Returning `false` drops the
+ * call and appends a structured warning to the evaluation result.
+ *
+ * The callback is intentionally minimal — it takes only the fields the
+ * evaluator knows about. Full permission engines can capture additional state
+ * in a closure when they construct the callback.
+ */
+export type OnchangeReadPermissionCheck = (args: {
+  actor: Actor;
+  tenantId: string | undefined;
+  entity: string;
+}) => Promise<boolean> | boolean;
+
 /** Options for creating an onchange evaluator. */
 export interface OnchangeEvaluatorOptions {
   entityRegistry: EntityRegistry;
@@ -41,6 +56,16 @@ export interface OnchangeEvaluatorOptions {
   defaultTimeoutMs?: number;
   /** Override the default max chain depth (primarily for tests). */
   maxChainDepth?: number;
+  /**
+   * Optional read-permission check applied inside `lookup`/`query`. When the
+   * check returns false, the data-provider call is skipped, the field is left
+   * unset, and a structured warning is appended to the result.
+   *
+   * When omitted, ALL reads are allowed. The REST route is responsible for
+   * logging a structured warning at startup so operators know permission
+   * enforcement is not active (Spec 64 §4.3 — permission layer responsibility).
+   */
+  checkReadPermission?: OnchangeReadPermissionCheck;
 }
 
 /** Public evaluator interface. */
@@ -167,6 +192,11 @@ function filterByAllowlist(
 /**
  * Build the context object passed to `hook.compute`. The context exposes only
  * read-level helpers; it MUST NOT leak any DataProvider write methods.
+ *
+ * When `checkReadPermission` is supplied, each `lookup`/`query` first asks the
+ * caller whether the current actor may read the target entity. On denial the
+ * data-provider call is skipped and a structured warning is pushed into
+ * `warningSink`, which the evaluator merges into the final result.
  */
 function buildContext(options: {
   changedField: string;
@@ -174,9 +204,37 @@ function buildContext(options: {
   actor: Actor;
   tenantId: string | undefined;
   dataProvider: DataProvider;
+  checkReadPermission?: OnchangeReadPermissionCheck;
+  warningSink: string[];
 }): OnchangeContext {
-  const { changedField, values, actor, tenantId, dataProvider } = options;
+  const { changedField, values, actor, tenantId, dataProvider, checkReadPermission, warningSink } =
+    options;
   const queryOptions: DataQueryOptions = tenantId ? { tenantId } : {};
+  const deniedEntities = new Set<string>();
+
+  async function ensureReadable(entity: string): Promise<boolean> {
+    if (!checkReadPermission) return true;
+    try {
+      const allowed = await checkReadPermission({ actor, tenantId, entity });
+      if (!allowed) {
+        // Collapse repeated denials of the same entity into a single warning
+        // so chained hooks don't spam the UI with identical messages.
+        if (!deniedEntities.has(entity)) {
+          deniedEntities.add(entity);
+          warningSink.push(`Access to "${entity}" denied for current actor`);
+        }
+      }
+      return allowed;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (!deniedEntities.has(entity)) {
+        deniedEntities.add(entity);
+        warningSink.push(`Read-permission check for "${entity}" failed: ${message}`);
+      }
+      return false;
+    }
+  }
+
   return {
     changedField,
     value: values[changedField],
@@ -184,6 +242,7 @@ function buildContext(options: {
     actor,
     tenantId,
     async lookup(entity, id, field) {
+      if (!(await ensureReadable(entity))) return undefined;
       try {
         const record = await dataProvider.get(entity, id, queryOptions);
         if (!record) return undefined;
@@ -194,6 +253,7 @@ function buildContext(options: {
       }
     },
     async query(entity, filter) {
+      if (!(await ensureReadable(entity))) return [];
       try {
         return await dataProvider.query(entity, filter, queryOptions);
       } catch {
@@ -218,6 +278,7 @@ export function createOnchangeEvaluator(options: OnchangeEvaluatorOptions): Onch
     dataProvider,
     defaultTimeoutMs = DEFAULT_COMPUTE_TIMEOUT_MS,
     maxChainDepth = MAX_CHAIN_DEPTH,
+    checkReadPermission,
   } = options;
 
   async function evaluate(args: OnchangeEvaluateArgs): Promise<OnchangeEvaluationResult> {
@@ -241,6 +302,17 @@ export function createOnchangeEvaluator(options: OnchangeEvaluatorOptions): Onch
     }
 
     const hookIndex = indexHooks(entity);
+
+    // Spec 64 §4.1 — 404 case: entity has an onchange map but nothing registered
+    // for the triggering field. Surface as a typed error so the REST layer can
+    // distinguish this from a successful "no-op" and return the correct status.
+    if (!hookIndex.has(changedField)) {
+      throw new OnchangeEvaluatorError(
+        `Entity "${entityName}" has no onchange hook for field "${changedField}"`,
+        "NO_HOOK_FOR_FIELD",
+      );
+    }
+
     // Start with a mutable copy so chained hooks can observe prior updates.
     const mergedValues: Record<string, unknown> = { ...values };
     const accumulated: Record<string, unknown> = {};
@@ -273,6 +345,8 @@ export function createOnchangeEvaluator(options: OnchangeEvaluatorOptions): Onch
           actor,
           tenantId,
           dataProvider,
+          checkReadPermission,
+          warningSink: warnings,
         });
 
         let result: OnchangeResult;
@@ -312,12 +386,16 @@ export function createOnchangeEvaluator(options: OnchangeEvaluatorOptions): Onch
  * bad input (unknown entity / field, no onchange map, etc.). The REST route
  * maps each `code` to an HTTP status.
  */
+/** Discriminator for all structured evaluator errors. */
+export type OnchangeEvaluatorErrorCode =
+  | "ENTITY_NOT_FOUND"
+  | "ENTITY_HAS_NO_ONCHANGE"
+  | "FIELD_UNKNOWN"
+  | "NO_HOOK_FOR_FIELD";
+
 export class OnchangeEvaluatorError extends Error {
-  readonly code: "ENTITY_NOT_FOUND" | "ENTITY_HAS_NO_ONCHANGE" | "FIELD_UNKNOWN";
-  constructor(
-    message: string,
-    code: "ENTITY_NOT_FOUND" | "ENTITY_HAS_NO_ONCHANGE" | "FIELD_UNKNOWN",
-  ) {
+  readonly code: OnchangeEvaluatorErrorCode;
+  constructor(message: string, code: OnchangeEvaluatorErrorCode) {
     super(message);
     this.name = "OnchangeEvaluatorError";
     this.code = code;

--- a/packages/core/src/engine/onchange-evaluator.ts
+++ b/packages/core/src/engine/onchange-evaluator.ts
@@ -1,0 +1,325 @@
+/**
+ * Onchange evaluator (Spec 64).
+ *
+ * Runs a per-entity onchange map for a single triggering field change. Handles:
+ * - Comma-separated trigger keys (`"a,b"` fires when either `a` or `b` changes).
+ * - Chained evaluation: when a hook updates field B, B's own hook fires next
+ *   (breadth-first, visited-set short-circuits cycles).
+ * - Depth cap: at most MAX_CHAIN_DEPTH hook evaluations per call, with a warning
+ *   when the cap is reached.
+ * - Strict `updates` allowlist: fields returned outside the hook's declared
+ *   `updates` list are silently dropped with a structured warning.
+ * - Per-hook timeout: default 2 s (Spec 64 §9.4); on timeout the hook is skipped
+ *   with a warning and the chain continues.
+ * - Pure read-only context: `lookup` and `query` delegate to the caller-provided
+ *   DataProvider — tenant scope + permissions are preserved by the caller.
+ *
+ * This module does NOT mutate any data and is unrelated to the Action Engine
+ * write path.
+ */
+
+import type { EntityRegistry } from "../entity/entity-registry";
+import type { Actor } from "../types/action";
+import type { EntityDefinition } from "../types/entity";
+import type { OnchangeContext, OnchangeDefinition, OnchangeResult } from "../types/onchange";
+import type { DataProvider, DataQueryOptions } from "./action-engine";
+
+/** Maximum number of hook evaluations per onchange call (Spec 64 §5.2). */
+export const MAX_CHAIN_DEPTH = 5;
+
+/** Default per-hook timeout in milliseconds (Spec 64 §9.4). */
+export const DEFAULT_COMPUTE_TIMEOUT_MS = 2000;
+
+/** Structured result returned by the evaluator. */
+export type OnchangeEvaluationResult = Required<OnchangeResult>;
+
+/** Options for creating an onchange evaluator. */
+export interface OnchangeEvaluatorOptions {
+  entityRegistry: EntityRegistry;
+  dataProvider: DataProvider;
+  /** Override the default 2000 ms per-hook timeout (primarily for tests). */
+  defaultTimeoutMs?: number;
+  /** Override the default max chain depth (primarily for tests). */
+  maxChainDepth?: number;
+}
+
+/** Public evaluator interface. */
+export interface OnchangeEvaluator {
+  evaluate(args: OnchangeEvaluateArgs): Promise<OnchangeEvaluationResult>;
+}
+
+/** Arguments for a single evaluate() call. */
+export interface OnchangeEvaluateArgs {
+  entityName: string;
+  changedField: string;
+  values: Record<string, unknown>;
+  actor: Actor;
+  tenantId?: string;
+}
+
+// ── Internal helpers ─────────────────────────────────────────
+
+/** Split a comma-key like `"a , b"` into `["a", "b"]`. */
+function parseTriggerKey(key: string): string[] {
+  return key
+    .split(",")
+    .map((k) => k.trim())
+    .filter((k) => k.length > 0);
+}
+
+/**
+ * Build a map from trigger field → OnchangeDefinition[] for a given entity.
+ * When multiple comma-keys include the same field, all matching hooks fire.
+ */
+function indexHooks(entity: EntityDefinition): Map<string, OnchangeDefinition[]> {
+  const index = new Map<string, OnchangeDefinition[]>();
+  const onchange = entity.onchange;
+  if (!onchange) return index;
+  for (const [key, def] of Object.entries(onchange)) {
+    for (const field of parseTriggerKey(key)) {
+      const list = index.get(field) ?? [];
+      list.push(def);
+      index.set(field, list);
+    }
+  }
+  return index;
+}
+
+/** Normalize a hook return value into a full OnchangeResult. */
+function normalizeHookReturn(raw: OnchangeResult | Record<string, unknown>): OnchangeResult {
+  if (
+    raw !== null &&
+    typeof raw === "object" &&
+    "updates" in raw &&
+    typeof (raw as OnchangeResult).updates === "object"
+  ) {
+    const full = raw as OnchangeResult;
+    return {
+      updates: full.updates ?? {},
+      warnings: Array.isArray(full.warnings) ? full.warnings : [],
+    };
+  }
+  return { updates: raw as Record<string, unknown>, warnings: [] };
+}
+
+/**
+ * Run the hook with a deadline. When the hook does not settle before the
+ * deadline, resolve with an empty update set plus a timeout warning.
+ */
+async function runHookWithTimeout(
+  hook: OnchangeDefinition,
+  ctx: OnchangeContext,
+  timeoutMs: number,
+): Promise<OnchangeResult> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<OnchangeResult>((resolve) => {
+    timer = setTimeout(() => {
+      resolve({
+        updates: {},
+        warnings: [
+          `Onchange hook for "${ctx.changedField}" exceeded ${timeoutMs} ms timeout and was skipped`,
+        ],
+      });
+    }, timeoutMs);
+  });
+
+  const hookPromise = (async () => {
+    const raw = await hook.compute(ctx);
+    return normalizeHookReturn(raw);
+  })();
+
+  try {
+    return await Promise.race([hookPromise, timeoutPromise]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+/**
+ * Apply the hook's declared `updates` allowlist to the returned record. Any
+ * field not in the allowlist is dropped; a structured warning is emitted when
+ * fields are dropped so UIs / logs can surface the discrepancy.
+ */
+function filterByAllowlist(
+  hook: OnchangeDefinition,
+  result: OnchangeResult,
+  triggerField: string,
+): OnchangeResult {
+  const allowed = new Set(hook.updates);
+  const filtered: Record<string, unknown> = {};
+  const dropped: string[] = [];
+  for (const [field, value] of Object.entries(result.updates ?? {})) {
+    if (allowed.has(field)) {
+      filtered[field] = value;
+    } else {
+      dropped.push(field);
+    }
+  }
+  const warnings = [...(result.warnings ?? [])];
+  if (dropped.length > 0) {
+    warnings.push(
+      `Onchange hook for "${triggerField}" returned fields outside its updates allowlist and they were dropped: ${dropped.join(", ")}`,
+    );
+  }
+  return { updates: filtered, warnings };
+}
+
+/**
+ * Build the context object passed to `hook.compute`. The context exposes only
+ * read-level helpers; it MUST NOT leak any DataProvider write methods.
+ */
+function buildContext(options: {
+  changedField: string;
+  values: Record<string, unknown>;
+  actor: Actor;
+  tenantId: string | undefined;
+  dataProvider: DataProvider;
+}): OnchangeContext {
+  const { changedField, values, actor, tenantId, dataProvider } = options;
+  const queryOptions: DataQueryOptions = tenantId ? { tenantId } : {};
+  return {
+    changedField,
+    value: values[changedField],
+    values,
+    actor,
+    tenantId,
+    async lookup(entity, id, field) {
+      try {
+        const record = await dataProvider.get(entity, id, queryOptions);
+        if (!record) return undefined;
+        return record[field];
+      } catch {
+        // Permission denied / record missing — return undefined per Spec 64 §9.1
+        return undefined;
+      }
+    },
+    async query(entity, filter) {
+      try {
+        return await dataProvider.query(entity, filter, queryOptions);
+      } catch {
+        return [];
+      }
+    },
+  };
+}
+
+// ── Factory ─────────────────────────────────────────────────
+
+/**
+ * Create an onchange evaluator bound to an EntityRegistry + DataProvider.
+ *
+ * The returned `evaluate()` runs the BFS algorithm from Spec 64 §5 and returns
+ * the final accumulated updates plus any warnings (including depth-cap,
+ * timeout, and allowlist warnings).
+ */
+export function createOnchangeEvaluator(options: OnchangeEvaluatorOptions): OnchangeEvaluator {
+  const {
+    entityRegistry,
+    dataProvider,
+    defaultTimeoutMs = DEFAULT_COMPUTE_TIMEOUT_MS,
+    maxChainDepth = MAX_CHAIN_DEPTH,
+  } = options;
+
+  async function evaluate(args: OnchangeEvaluateArgs): Promise<OnchangeEvaluationResult> {
+    const { entityName, changedField, values, actor, tenantId } = args;
+
+    const entity = entityRegistry.get(entityName);
+    if (!entity) {
+      throw new OnchangeEvaluatorError(`Entity "${entityName}" not found`, "ENTITY_NOT_FOUND");
+    }
+    if (!entity.onchange || Object.keys(entity.onchange).length === 0) {
+      throw new OnchangeEvaluatorError(
+        `Entity "${entityName}" has no onchange definition`,
+        "ENTITY_HAS_NO_ONCHANGE",
+      );
+    }
+    if (!(changedField in entity.fields)) {
+      throw new OnchangeEvaluatorError(
+        `Field "${changedField}" is not defined on entity "${entityName}"`,
+        "FIELD_UNKNOWN",
+      );
+    }
+
+    const hookIndex = indexHooks(entity);
+    // Start with a mutable copy so chained hooks can observe prior updates.
+    const mergedValues: Record<string, unknown> = { ...values };
+    const accumulated: Record<string, unknown> = {};
+    const warnings: string[] = [];
+    const visited = new Set<string>();
+    const queue: string[] = [changedField];
+    let evaluations = 0;
+
+    while (queue.length > 0) {
+      const field = queue.shift();
+      if (field === undefined) break;
+      if (visited.has(field)) continue;
+      visited.add(field);
+
+      const hooks = hookIndex.get(field);
+      if (!hooks || hooks.length === 0) continue;
+
+      for (const hook of hooks) {
+        if (evaluations >= maxChainDepth) {
+          warnings.push(
+            `Onchange chain depth limit reached (${maxChainDepth}). Some dependent fields may not be updated.`,
+          );
+          return { updates: accumulated, warnings };
+        }
+        evaluations++;
+
+        const ctx = buildContext({
+          changedField: field,
+          values: mergedValues,
+          actor,
+          tenantId,
+          dataProvider,
+        });
+
+        let result: OnchangeResult;
+        try {
+          const timeoutMs = hook.timeout ?? defaultTimeoutMs;
+          result = await runHookWithTimeout(hook, ctx, timeoutMs);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          warnings.push(`Onchange hook for "${field}" threw an error and was skipped: ${message}`);
+          continue;
+        }
+
+        const filtered = filterByAllowlist(hook, result, field);
+        for (const w of filtered.warnings ?? []) warnings.push(w);
+
+        for (const [updatedField, value] of Object.entries(filtered.updates)) {
+          accumulated[updatedField] = value;
+          mergedValues[updatedField] = value;
+          // Enqueue cascaded field only if it wasn't already processed (cycle safety).
+          if (!visited.has(updatedField)) {
+            queue.push(updatedField);
+          }
+        }
+      }
+    }
+
+    return { updates: accumulated, warnings };
+  }
+
+  return { evaluate };
+}
+
+// ── Errors ──────────────────────────────────────────────────
+
+/**
+ * Structured error emitted when an onchange evaluation cannot proceed due to
+ * bad input (unknown entity / field, no onchange map, etc.). The REST route
+ * maps each `code` to an HTTP status.
+ */
+export class OnchangeEvaluatorError extends Error {
+  readonly code: "ENTITY_NOT_FOUND" | "ENTITY_HAS_NO_ONCHANGE" | "FIELD_UNKNOWN";
+  constructor(
+    message: string,
+    code: "ENTITY_NOT_FOUND" | "ENTITY_HAS_NO_ONCHANGE" | "FIELD_UNKNOWN",
+  ) {
+    super(message);
+    this.name = "OnchangeEvaluatorError";
+    this.code = code;
+  }
+}

--- a/packages/core/src/engine/onchange-evaluator.ts
+++ b/packages/core/src/engine/onchange-evaluator.ts
@@ -190,6 +190,32 @@ function filterByAllowlist(
 }
 
 /**
+ * Deduping warning sink used across a single `evaluate()` call. Callers supply
+ * a dedup `key` plus the warning `message`; the first emission per key is
+ * pushed into the backing array, subsequent emissions with the same key are
+ * dropped. Used to collapse identical permission / lookup / query warnings
+ * that would otherwise repeat across chained hooks.
+ */
+interface DedupedWarningSink {
+  /** Push `message` unless `key` was already pushed during this call. */
+  push(key: string, message: string): void;
+  /** Raw warning array for evaluator-owned (non-deduped) warnings. */
+  readonly warnings: string[];
+}
+
+function createDedupedWarningSink(backing: string[]): DedupedWarningSink {
+  const seen = new Set<string>();
+  return {
+    push(key, message) {
+      if (seen.has(key)) return;
+      seen.add(key);
+      backing.push(message);
+    },
+    warnings: backing,
+  };
+}
+
+/**
  * Build the context object passed to `hook.compute`. The context exposes only
  * read-level helpers; it MUST NOT leak any DataProvider write methods.
  *
@@ -197,6 +223,10 @@ function filterByAllowlist(
  * caller whether the current actor may read the target entity. On denial the
  * data-provider call is skipped and a structured warning is pushed into
  * `warningSink`, which the evaluator merges into the final result.
+ *
+ * `warningSink` must be a shared `DedupedWarningSink` for the whole
+ * `evaluate()` call so that identical permission denials / lookup failures
+ * emitted by chained hooks collapse into a single warning (Spec 64 §9.1).
  */
 function buildContext(options: {
   changedField: string;
@@ -205,12 +235,11 @@ function buildContext(options: {
   tenantId: string | undefined;
   dataProvider: DataProvider;
   checkReadPermission?: OnchangeReadPermissionCheck;
-  warningSink: string[];
+  warningSink: DedupedWarningSink;
 }): OnchangeContext {
   const { changedField, values, actor, tenantId, dataProvider, checkReadPermission, warningSink } =
     options;
   const queryOptions: DataQueryOptions = tenantId ? { tenantId } : {};
-  const deniedEntities = new Set<string>();
 
   async function ensureReadable(entity: string): Promise<boolean> {
     if (!checkReadPermission) return true;
@@ -219,18 +248,18 @@ function buildContext(options: {
       if (!allowed) {
         // Collapse repeated denials of the same entity into a single warning
         // so chained hooks don't spam the UI with identical messages.
-        if (!deniedEntities.has(entity)) {
-          deniedEntities.add(entity);
-          warningSink.push(`Access to "${entity}" denied for current actor`);
-        }
+        warningSink.push(
+          `permission-denied:${entity}`,
+          `Access to "${entity}" denied for current actor`,
+        );
       }
       return allowed;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      if (!deniedEntities.has(entity)) {
-        deniedEntities.add(entity);
-        warningSink.push(`Read-permission check for "${entity}" failed: ${message}`);
-      }
+      warningSink.push(
+        `permission-check-failed:${entity}`,
+        `Read-permission check for "${entity}" failed: ${message}`,
+      );
       return false;
     }
   }
@@ -247,8 +276,17 @@ function buildContext(options: {
         const record = await dataProvider.get(entity, id, queryOptions);
         if (!record) return undefined;
         return record[field];
-      } catch {
-        // Permission denied / record missing — return undefined per Spec 64 §9.1
+      } catch (err) {
+        // Spec 64 §9.1 — `lookup` must never throw from the hook author's
+        // perspective. But silently swallowing DB / tenant / timeout errors is
+        // dangerous, so surface them as a structured warning. Dedup by
+        // (entity, message) so repeated identical failures across chained
+        // hooks collapse into a single warning.
+        const message = err instanceof Error ? err.message : String(err);
+        warningSink.push(
+          `lookup-failed:${entity}:${message}`,
+          `Lookup on "${entity}" failed: ${message}`,
+        );
         return undefined;
       }
     },
@@ -256,7 +294,13 @@ function buildContext(options: {
       if (!(await ensureReadable(entity))) return [];
       try {
         return await dataProvider.query(entity, filter, queryOptions);
-      } catch {
+      } catch (err) {
+        // Same contract as `lookup`: never throw, but emit a deduped warning.
+        const message = err instanceof Error ? err.message : String(err);
+        warningSink.push(
+          `query-failed:${entity}:${message}`,
+          `Query on "${entity}" failed: ${message}`,
+        );
         return [];
       }
     },
@@ -317,6 +361,10 @@ export function createOnchangeEvaluator(options: OnchangeEvaluatorOptions): Onch
     const mergedValues: Record<string, unknown> = { ...values };
     const accumulated: Record<string, unknown> = {};
     const warnings: string[] = [];
+    // Single deduping sink shared across every hook in this evaluate() call.
+    // Permission denials and lookup/query failures dedup by entity + message
+    // so chained hooks collapse repeated warnings into one.
+    const warningSink = createDedupedWarningSink(warnings);
     const visited = new Set<string>();
     const queue: string[] = [changedField];
     let evaluations = 0;
@@ -346,7 +394,7 @@ export function createOnchangeEvaluator(options: OnchangeEvaluatorOptions): Onch
           tenantId,
           dataProvider,
           checkReadPermission,
-          warningSink: warnings,
+          warningSink,
         });
 
         let result: OnchangeResult;

--- a/packages/core/src/server-entry.ts
+++ b/packages/core/src/server-entry.ts
@@ -64,7 +64,9 @@ export {
   type OnchangeEvaluationResult,
   type OnchangeEvaluator,
   OnchangeEvaluatorError,
+  type OnchangeEvaluatorErrorCode,
   type OnchangeEvaluatorOptions,
+  type OnchangeReadPermissionCheck,
 } from "./engine/onchange-evaluator";
 export {
   checkActionPermission,

--- a/packages/core/src/server-entry.ts
+++ b/packages/core/src/server-entry.ts
@@ -56,21 +56,28 @@ export {
   PipelineError,
   type SlotName,
 } from "./engine/command-layer";
-
+export {
+  createOnchangeEvaluator,
+  DEFAULT_COMPUTE_TIMEOUT_MS,
+  MAX_CHAIN_DEPTH,
+  type OnchangeEvaluateArgs,
+  type OnchangeEvaluationResult,
+  type OnchangeEvaluator,
+  OnchangeEvaluatorError,
+  type OnchangeEvaluatorOptions,
+} from "./engine/onchange-evaluator";
 export {
   checkActionPermission,
   PermissionRegistry,
   resolveConditionVariables,
   resolveDataAccess,
 } from "./engine/permission-engine";
-
 export {
   bumpVersion,
   type CreateProposalOptions,
   createProposalEngine,
   ProposalEngine,
 } from "./engine/proposal-engine";
-
 export {
   createProposalGenerator,
   ProposalGenerationError,

--- a/packages/core/src/types/entity.ts
+++ b/packages/core/src/types/entity.ts
@@ -5,6 +5,8 @@
  * Define once, auto-generate Zod / Drizzle / TypeScript / GraphQL / JSON Schema.
  */
 
+import type { OnchangeDefinition } from "./onchange";
+
 // ── Field types ──────────────────────────────────────────
 
 export type FieldType =
@@ -277,6 +279,13 @@ export interface EntityDefinition<
   fieldExposure?: FieldExposureMap;
   /** AI behavior configuration for this entity (spec 52 §8.2) */
   ai?: EntityAIConfig;
+
+  /**
+   * Interactive form computation hooks (Spec 64).
+   * Keys are either a single field name or a comma-separated list of field names.
+   * A hook fires while the user is editing a form; it never runs on the write path.
+   */
+  onchange?: Record<string, OnchangeDefinition>;
 }
 
 // ── Schema extension and override ─────────────────────────────────

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -30,6 +30,7 @@ export type * from "./execution-log";
 export type * from "./flow";
 export type * from "./life-system";
 export type * from "./logger";
+export type * from "./onchange";
 export type * from "./overlay";
 export type * from "./page";
 export type * from "./permission";

--- a/packages/core/src/types/onchange.ts
+++ b/packages/core/src/types/onchange.ts
@@ -1,0 +1,102 @@
+/**
+ * Onchange type definitions (Spec 64).
+ *
+ * Onchange hooks compute suggested field values while the user is still editing
+ * a form — BEFORE any Action is submitted. They are triggered by the form UI
+ * (via `POST /api/entities/:name/onchange`) and return a partial record the
+ * client can apply to the unsaved form state.
+ *
+ * Onchange is NOT part of the Action Engine write path. It requires read-level
+ * permission only and never writes to the database.
+ *
+ * See: docs/specs/64_entity_onchange.md
+ */
+
+import type { Actor } from "./action";
+
+/**
+ * Runtime context passed to every onchange `compute` function.
+ *
+ * The only data-access helpers exposed are `lookup` and `query`. They must be
+ * backed by a permission-scoped DataProvider so the caller's tenant and
+ * read-permissions are enforced — no write methods are exposed.
+ */
+export interface OnchangeContext {
+  /** The field that triggered this onchange evaluation. */
+  changedField: string;
+
+  /** New value of the changed field (as supplied by the form). */
+  value: unknown;
+
+  /**
+   * All current form values, including prior onchange results merged in during
+   * chained evaluation. Safe to read, must not be mutated.
+   */
+  values: Record<string, unknown>;
+
+  /** Authenticated actor performing the edit. */
+  actor: Actor;
+
+  /** Tenant ID of the current session (when multi-tenant). */
+  tenantId?: string;
+
+  /**
+   * Fetch a single field value from another entity record.
+   * Equivalent to: SELECT `<field>` FROM `<entity>` WHERE id = `<id>`.
+   * Returns `undefined` when the record / field cannot be read (permission or
+   * not found) — it never throws.
+   */
+  lookup(entity: string, id: string, field: string): Promise<unknown>;
+
+  /**
+   * Fetch a list of records from another entity.
+   * Results are read-only and permission-scoped via the DataProvider.
+   */
+  query(entity: string, filter: Record<string, unknown>): Promise<Array<Record<string, unknown>>>;
+}
+
+/**
+ * Structured result produced by a single onchange hook and returned to the UI.
+ */
+export interface OnchangeResult {
+  /** Field values to apply to the form. Only fields in the hook's `updates` allowlist survive. */
+  updates: Record<string, unknown>;
+
+  /** Optional non-blocking warnings surfaced to the UI. */
+  warnings?: string[];
+}
+
+/**
+ * Declarative onchange hook attached to an entity definition.
+ *
+ * Keys on `EntityDefinition.onchange` are either a single field name (e.g.
+ * `"product_id"`) or a comma-separated list of field names (e.g.
+ * `"quantity,unit_price"`). A comma-key hook fires when ANY listed field is
+ * the triggering change.
+ */
+export interface OnchangeDefinition {
+  /**
+   * Field names this hook is allowed to update. Any field returned outside of
+   * this allowlist is silently dropped (Spec 64 §9.3).
+   */
+  updates: string[];
+
+  /**
+   * Per-hook timeout in milliseconds. When omitted the evaluator default
+   * (2000 ms, Spec 64 §9.4) applies. Exceeding the timeout produces a warning
+   * and an empty update set for this hook.
+   */
+  timeout?: number;
+
+  /**
+   * Pure read-only computation. May return either a plain record (treated as
+   * `{ updates: <record> }`) or a full `OnchangeResult` with warnings.
+   */
+  compute: (
+    ctx: OnchangeContext,
+  ) =>
+    | OnchangeResult
+    | Promise<OnchangeResult>
+    | Record<string, unknown>
+    | Promise<Record<string, unknown>>;
+}


### PR DESCRIPTION
## Summary

Implements Spec 64 **Phase 1**: server-side form computation via a stateless HTTP endpoint. Addresses the interactive-form use case that `derived (store)` and `Rule (pre)` can't cover (user is still editing — no Action has been submitted yet).

**Note on history:** an earlier commit on issue #148 misread the spec and built a write-time hook. That work was discarded before any PR was opened (see issue #148 comment trail). This PR is the fresh, spec-aligned implementation.

## What it does

Users edit a form → UI calls `POST /api/entities/:name/onchange` with the changed field + current form values → the evaluator runs the hook, follows chained onchange dependencies (BFS, depth-5 cap, cycle detection), and returns suggested updates + warnings for the UI to apply. Nothing is written to the database — onchange is a read-only helper.

## Module

- **Types** (`packages/core/src/types/onchange.ts`): `OnchangeContext`, `OnchangeResult`, `OnchangeDefinition`, extended `EntityDefinition.onchange`.
- **Evaluator** (`engine/onchange-evaluator.ts`): BFS with cycle + depth cap + per-hook 2s timeout + strict `updates` allowlist + optional `checkReadPermission` callback for lookup/query.
- **CommandLayer** (`engine/command-layer.ts`): new `skipActionSlots` flag. When set, pipeline runs pre/auth/exposure/permission/tenant and skips pre-action / action / post-action. Populates `meta.onchange` so permission middlewares can do entity-level read checks.
- **REST route** (`routes/onchange-api.ts`): `POST /api/entities/:name/onchange`. Error mapping: 400 bad field, 404 entity/field has no onchange, 403 denied, 503 misconfigured.
- **Wiring**: `dev.ts` and `capability.ts` construct the evaluator from the shared registry + provider and pass it to `createServer`.

## Codex review — all addressed

| ID | Severity | Finding | Fix |
| --- | --- | --- | --- |
| E-1 | P1 | Evaluator not wired into default server startup — every request 503 | Constructed in `dev.ts` + `capability.ts` |
| E-2 | P1 | Synthetic `entity_onchange` command name → cap-permission denies every caller | Switched to `<entity>.onchange` + `meta.onchange` contract |
| E-3 | P1 | Post-action middleware ran on synthetic success result (cache invalidation etc. firing on read-only path) | `skippedSlots` now includes `post-action` |
| E-4 | P1 | `lookup`/`query` on context bypassed related-entity read checks | Added `checkReadPermission` callback on evaluator options; denies collapse into a warning |
| E-5 | P2 | Missing hook for `changedField` returned empty object instead of 404 | Evaluator throws `OnchangeEvaluatorError(NO_HOOK_FOR_FIELD)`; route maps to 404 |

## Test plan

- [x] 17 evaluator unit tests (single hook, multi-trigger, chained, cycle, depth cap, allowlist, async, timeout, permission allow/deny, warning-collapse, NO_HOOK_FOR_FIELD).
- [x] 11 REST integration tests (happy, 400, 404 entity, 404 field, 403, misconfigured, permission denial).
- [x] `bun run check` / `typecheck` / `test` — 4242 pass / 0 fail / 3 skip.

## Scope deferred to follow-ups

- **cap-permission onchange read-check branch** — consult `ctx.meta.onchange.entity` when `skipActionSlots` is set (contract lives here; the capability itself is untouched in this PR).
- GraphQL auto-generated `<entity>_onchange` mutation (Spec 64 §4.2).
- React `useOnchange` hook + AutoForm auto-trigger / loading state (Spec 64 §6).
- Per-actor + per-entity rate limiter (Spec 64 §9.4).
- Ontology exposure of `triggersOnchange` / `updatedByOnchange` (Spec 64 §7).
- Wire `linchkit.config.ts.onchange` config through to evaluator (Spec 64 §11).
- cap-permission factory that builds the `OnchangeReadPermissionCheck` callback from its internal graph (removes the startup warning).

Refs #148 (Phase 1 — types + evaluator + REST + wiring; GraphQL + UI + rate limiter follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onchange evaluator engine for computing chained form field updates and automatic value suggestions.
  * REST API endpoint to run onchange computations for interactive pre-save form behavior.
  * Permission-aware data lookups during form computation and startup warning when permission gating is not configured.

* **Tests**
  * Comprehensive tests covering onchange evaluation, chaining, timeouts, permission/lookup handling, error responses, and REST endpoint validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->