### PR TITLE
chore: ignore .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ Thumbs.db
 # Claude local settings (user-specific)
 .claude/settings.local.json
 .claude/projects/
+.claude/scheduled_tasks.lock
 
 # Test
 coverage/


### PR DESCRIPTION
## Summary
- Adds `.claude/scheduled_tasks.lock` to `.gitignore` — local lock file from Claude Code's `/loop` scheduler, runtime state only, not meant to be tracked.
- Sits in the existing `# Claude local settings (user-specific)` block alongside `settings.local.json` and `projects/`.

## Test plan
- [x] `bun run check` — clean
- [x] `bun run typecheck` — clean
- [x] `bun test` — 4315 pass, 3 skip, 0 fail
- [x] Cross-model review (Codex) — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)