### PR TITLE
fix(test): skip Volcengine E2E tests on subscription/auth errors

### DIFF
--- a/packages/core/__tests__/ai-service-e2e.test.ts
+++ b/packages/core/__tests__/ai-service-e2e.test.ts
@@ -23,14 +23,35 @@ const config: AIServiceConfig = {
   },
 };
 
+/**
+ * Return true if the error looks like a Volcengine subscription/auth/payment
+ * failure that should cause the test to skip rather than fail.
+ * Re-throws anything else so real bugs still surface.
+ */
+function isSubscriptionError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /subscription|coding plan|unauthorized|401|403|payment|billing|quota|insufficient/i.test(
+    msg,
+  );
+}
+
 describe.skipIf(!apiKey)("AI Service E2E — Volcengine", () => {
   const ai = createAIService(config);
 
   it("text completion returns a response", async () => {
-    const result = await ai.complete({
-      messages: [{ role: "user", content: "Reply with exactly: hello" }],
-      maxTokens: 50,
-    });
+    let result: Awaited<ReturnType<typeof ai.complete>>;
+    try {
+      result = await ai.complete({
+        messages: [{ role: "user", content: "Reply with exactly: hello" }],
+        maxTokens: 50,
+      });
+    } catch (err) {
+      if (isSubscriptionError(err)) {
+        console.warn("[e2e] skipped: Volcengine subscription/auth error:", err);
+        return;
+      }
+      throw err;
+    }
 
     expect(result.content).toBeTruthy();
     expect(result.content.toLowerCase()).toContain("hello");
@@ -65,10 +86,19 @@ describe.skipIf(!apiKey)("AI Service E2E — Volcengine", () => {
   }, 30_000);
 
   it("respects maxTokens limit", async () => {
-    const result = await ai.complete({
-      messages: [{ role: "user", content: "Count from 1 to 1000" }],
-      maxTokens: 20,
-    });
+    let result: Awaited<ReturnType<typeof ai.complete>>;
+    try {
+      result = await ai.complete({
+        messages: [{ role: "user", content: "Count from 1 to 1000" }],
+        maxTokens: 20,
+      });
+    } catch (err) {
+      if (isSubscriptionError(err)) {
+        console.warn("[e2e] skipped: Volcengine subscription/auth error:", err);
+        return;
+      }
+      throw err;
+    }
 
     // Should be truncated — output tokens near the limit
     expect(result.usage.outputTokens).toBeLessThanOrEqual(30);

--- a/packages/core/__tests__/ai-service-e2e.test.ts
+++ b/packages/core/__tests__/ai-service-e2e.test.ts
@@ -27,11 +27,32 @@ const config: AIServiceConfig = {
  * Return true if the error looks like a Volcengine subscription/auth/payment
  * failure that should cause the test to skip rather than fail.
  * Re-throws anything else so real bugs still surface.
+ *
+ * Volcengine returns phrases like:
+ *   "does not have a valid coding plan subscription"
+ *   "your subscription has expired"
+ *   HTTP 401/403 for invalid/expired keys
+ * Match those specifically — don't swallow generic errors like
+ * "insufficient context length".
  */
 function isSubscriptionError(err: unknown): boolean {
-  const msg = err instanceof Error ? err.message : String(err);
-  return /subscription|coding plan|unauthorized|401|403|payment|billing|quota|insufficient/i.test(
-    msg,
+  const messages: string[] = [];
+  let current: unknown = err;
+  // Walk up to 2 levels of `cause` chain.
+  for (let i = 0; i < 3 && current != null; i++) {
+    if (current instanceof Error) {
+      messages.push(current.message);
+      const code = (current as { code?: unknown }).code;
+      if (typeof code === "string") messages.push(code);
+      current = (current as { cause?: unknown }).cause;
+    } else {
+      messages.push(String(current));
+      break;
+    }
+  }
+  const haystack = messages.join(" | ");
+  return /subscription|coding plan|\b(unauthorized|forbidden)\b|\b40[13]\b|payment required|billing/i.test(
+    haystack,
   );
 }
 
@@ -47,7 +68,8 @@ describe.skipIf(!apiKey)("AI Service E2E — Volcengine", () => {
       });
     } catch (err) {
       if (isSubscriptionError(err)) {
-        console.warn("[e2e] skipped: Volcengine subscription/auth error:", err);
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn("[e2e] skipped: Volcengine subscription/auth error:", msg);
         return;
       }
       throw err;
@@ -94,7 +116,8 @@ describe.skipIf(!apiKey)("AI Service E2E — Volcengine", () => {
       });
     } catch (err) {
       if (isSubscriptionError(err)) {
-        console.warn("[e2e] skipped: Volcengine subscription/auth error:", err);
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn("[e2e] skipped: Volcengine subscription/auth error:", msg);
         return;
       }
       throw err;

--- a/packages/core/__tests__/ai-service-e2e.test.ts
+++ b/packages/core/__tests__/ai-service-e2e.test.ts
@@ -43,7 +43,7 @@ function isSubscriptionError(err: unknown): boolean {
     if (current instanceof Error) {
       messages.push(current.message);
       const code = (current as { code?: unknown }).code;
-      if (typeof code === "string") messages.push(code);
+      if (code != null) messages.push(String(code));
       current = (current as { cause?: unknown }).cause;
     } else {
       messages.push(String(current));
@@ -56,24 +56,34 @@ function isSubscriptionError(err: unknown): boolean {
   );
 }
 
+/**
+ * Run an AI completion and skip the test (by returning undefined) if the
+ * error is a Volcengine subscription/auth failure. Re-throws other errors.
+ */
+async function runWithSubscriptionSkip<T>(fn: () => Promise<T>): Promise<T | undefined> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (isSubscriptionError(err)) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn("[e2e] skipped: Volcengine subscription/auth error:", msg);
+      return undefined;
+    }
+    throw err;
+  }
+}
+
 describe.skipIf(!apiKey)("AI Service E2E — Volcengine", () => {
   const ai = createAIService(config);
 
   it("text completion returns a response", async () => {
-    let result: Awaited<ReturnType<typeof ai.complete>>;
-    try {
-      result = await ai.complete({
+    const result = await runWithSubscriptionSkip(() =>
+      ai.complete({
         messages: [{ role: "user", content: "Reply with exactly: hello" }],
         maxTokens: 50,
-      });
-    } catch (err) {
-      if (isSubscriptionError(err)) {
-        const msg = err instanceof Error ? err.message : String(err);
-        console.warn("[e2e] skipped: Volcengine subscription/auth error:", msg);
-        return;
-      }
-      throw err;
-    }
+      }),
+    );
+    if (!result) return;
 
     expect(result.content).toBeTruthy();
     expect(result.content.toLowerCase()).toContain("hello");
@@ -108,20 +118,13 @@ describe.skipIf(!apiKey)("AI Service E2E — Volcengine", () => {
   }, 30_000);
 
   it("respects maxTokens limit", async () => {
-    let result: Awaited<ReturnType<typeof ai.complete>>;
-    try {
-      result = await ai.complete({
+    const result = await runWithSubscriptionSkip(() =>
+      ai.complete({
         messages: [{ role: "user", content: "Count from 1 to 1000" }],
         maxTokens: 20,
-      });
-    } catch (err) {
-      if (isSubscriptionError(err)) {
-        const msg = err instanceof Error ? err.message : String(err);
-        console.warn("[e2e] skipped: Volcengine subscription/auth error:", msg);
-        return;
-      }
-      throw err;
-    }
+      }),
+    );
+    if (!result) return;
 
     // Should be truncated — output tokens near the limit
     expect(result.usage.outputTokens).toBeLessThanOrEqual(30);


### PR DESCRIPTION
Closes #195.

## Problem

`packages/core/__tests__/ai-service-e2e.test.ts` uses `describe.skipIf(!apiKey)` to skip when `VOLCENGINE_API_KEY` is unset. If the key **is** set but the Volcengine subscription has expired, the API returns a subscription-expired error and the tests fail. The repo's pre-commit hook enforces full `bun test` green, so this blocks **all** local commits until the key is removed from `.env` or the subscription is renewed.

Subscription status is not a local-development concern — the gate should not depend on a paid external service's billing state.

## Fix

Introduces `isSubscriptionError(err)` in the test file. Each of the two live tests wraps the API call in try/catch; when the caught error matches a set of Volcengine subscription/auth/payment phrases, the test logs a `[e2e] skipped: ...` warning and returns early (passes without asserting). Other errors re-throw, so real bugs still surface.

The detection walks up to 2 levels of the `cause` chain and also inspects a string `code` property, so structured SDK errors without a useful `.message` still get caught. Regex is word-bounded on `unauthorized`/`forbidden`/`40[13]` to avoid matching digits in URLs or response bodies.

## Test plan

- [x] `bun run check` — clean
- [x] `bun run typecheck` — clean
- [x] `bun test` — 4315 pass, 3 skip, 0 fail
- [x] Targeted run with real key (subscription expired) — both live tests hit the subscription-skip path; no failures
- [x] Cross-model review (Codex) — PASS-with-suggestions, all 3 applied in a follow-up commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test resilience with enhanced error handling for subscription, billing, and authentication-related scenarios. Tests now intelligently detect and gracefully handle these specific error patterns by emitting console warnings and skipping affected assertions rather than causing complete test failures, ensuring tests remain functional across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->