### PR TITLE
fix(core): harden command-layer skipActionSlots dispatch (closes #193)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/onchange-api.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/onchange-api.test.ts
@@ -81,6 +81,16 @@ function buildServer(options: { permissionDeny?: boolean; withEvaluator?: boolea
         throw new PipelineError("Actor lacks read permission on entity", "authz.action.denied");
       },
     });
+  } else {
+    // Non-action dispatch (`skipActionSlots`) requires a permission middleware
+    // (fail-closed guard). Register a no-op allow-all stub for the happy path.
+    commandLayer.use({
+      name: "allow_all",
+      slot: "permission",
+      handler: async (_ctx, next) => {
+        await next();
+      },
+    });
   }
 
   const evaluator = options.withEvaluator

--- a/addons/adapter-server/cap-adapter-server/src/dev.ts
+++ b/addons/adapter-server/cap-adapter-server/src/dev.ts
@@ -148,6 +148,29 @@ function extractCapabilities(capabilities: CapabilityDefinition[] = []): {
 
 const capContributions = extractCapabilities(config.capabilities);
 
+// Dev-only allow-all permission middleware. The CommandLayer now hard-fails
+// when the `permission` slot is empty (even with `skipActionSlots: true`) to
+// prevent accidental production deploys without RBAC. `dev.ts` does not wire
+// cap-permission, so inject a stub at `order: 999` that simply calls `next()`.
+// Any real permission middleware registered by a capability will run first
+// (lower order) and take precedence.
+const hasPermissionMiddleware = capContributions.middlewares.some(
+  (mw: MiddlewareRegistration) => mw.slot === "permission",
+);
+if (!hasPermissionMiddleware) {
+  capContributions.middlewares.push({
+    name: "dev:allow_all_permission",
+    slot: "permission",
+    order: 999,
+    handler: async (_ctx, next) => {
+      await next();
+    },
+  });
+  consoleLogger.warn(
+    "[permission] no permission middleware registered — dev server is running with an allow-all stub. Register cap-permission (or an equivalent) before deploying to production.",
+  );
+}
+
 // ── Merge capability entities and actions ────────────────
 
 const allEntities = capContributions.entities;

--- a/packages/core/__tests__/command-layer-skip-action-slots.test.ts
+++ b/packages/core/__tests__/command-layer-skip-action-slots.test.ts
@@ -13,10 +13,29 @@ import { createActionExecutor } from "../src/engine/action-engine";
 import { createCommandLayer } from "../src/engine/command-layer";
 import { createTestDataProvider } from "./command-layer-helpers";
 
+/**
+ * Register a no-op permission middleware on the given layer. The fail-closed
+ * guard for `skipActionSlots` requires at least one permission middleware —
+ * tests that focus on other behaviors need this stub to pass the guard.
+ */
+function registerNoopPermissionMiddleware(
+  layer: ReturnType<typeof createCommandLayer>,
+  name = "test_permission",
+): void {
+  layer.use({
+    name,
+    slot: "permission",
+    handler: async (_ctx, next) => {
+      await next();
+    },
+  });
+}
+
 describe("Command Layer: skipActionSlots synthetic result", () => {
   test("carries tenantId and locale resolved by middleware, plus skipped marker", async () => {
     const executor = createActionExecutor({ dataProvider: createTestDataProvider() });
     const layer = createCommandLayer({ executor });
+    registerNoopPermissionMiddleware(layer);
 
     // Tenant middleware mutates `ctx.tenantId` — the synthetic result must
     // reflect the middleware-resolved value, not whatever the caller passed.
@@ -46,6 +65,7 @@ describe("Command Layer: skipActionSlots synthetic result", () => {
   test("tenantId defaults to undefined when no middleware sets it", async () => {
     const executor = createActionExecutor({ dataProvider: createTestDataProvider() });
     const layer = createCommandLayer({ executor });
+    registerNoopPermissionMiddleware(layer);
 
     const result = await layer.execute({
       command: "customer.onchange",
@@ -63,6 +83,7 @@ describe("Command Layer: skipActionSlots synthetic result", () => {
   test("initial tenantId from execute options survives if middleware does not override", async () => {
     const executor = createActionExecutor({ dataProvider: createTestDataProvider() });
     const layer = createCommandLayer({ executor });
+    registerNoopPermissionMiddleware(layer);
 
     const result = await layer.execute({
       command: "customer.onchange",
@@ -76,5 +97,70 @@ describe("Command Layer: skipActionSlots synthetic result", () => {
     const data = result.data as Record<string, unknown>;
     expect(data.tenantId).toBe("tenant_from_caller");
     expect(data.locale).toBe("en");
+  });
+});
+
+describe("Command Layer: skipActionSlots hardening guards", () => {
+  test("returns PERMISSION.MIDDLEWARE_MISSING when skipActionSlots is true and no permission middleware is registered", async () => {
+    const executor = createActionExecutor({ dataProvider: createTestDataProvider() });
+    const layer = createCommandLayer({ executor });
+    // Intentionally NO permission middleware registered.
+
+    const result = await layer.execute({
+      command: "customer.onchange",
+      input: { entity: "customer", changedField: "name" },
+      skipActionSlots: true,
+    });
+
+    expect(result.success).toBe(false);
+    const data = result.data as Record<string, unknown>;
+    expect(data.code).toBe("PERMISSION.MIDDLEWARE_MISSING");
+    expect(typeof data.error).toBe("string");
+  });
+
+  test("returns COMMAND.INVALID_OPTIONS when skipActionSlots and approvalId are both set", async () => {
+    const executor = createActionExecutor({ dataProvider: createTestDataProvider() });
+    // verifyApproval is configured so approvalId would otherwise be honored —
+    // the guard must reject the combination BEFORE verifyApproval runs.
+    let verifyCalled = false;
+    const layer = createCommandLayer({
+      executor,
+      verifyApproval: async () => {
+        verifyCalled = true;
+        return true;
+      },
+    });
+    // Permission middleware registered so Finding 1 doesn't fire first.
+    registerNoopPermissionMiddleware(layer);
+
+    const result = await layer.execute({
+      command: "customer.onchange",
+      input: {},
+      skipActionSlots: true,
+      approvalId: "appr_test",
+    });
+
+    expect(result.success).toBe(false);
+    const data = result.data as Record<string, unknown>;
+    expect(data.code).toBe("COMMAND.INVALID_OPTIONS");
+    expect(typeof data.error).toBe("string");
+    // Guard must short-circuit before verifyApproval is consulted.
+    expect(verifyCalled).toBe(false);
+  });
+
+  test("skipActionSlots succeeds when permission middleware is registered and no approvalId", async () => {
+    const executor = createActionExecutor({ dataProvider: createTestDataProvider() });
+    const layer = createCommandLayer({ executor });
+    registerNoopPermissionMiddleware(layer);
+
+    const result = await layer.execute({
+      command: "customer.onchange",
+      input: { entity: "customer", changedField: "name" },
+      skipActionSlots: true,
+    });
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.skipped).toBe(true);
   });
 });

--- a/packages/core/src/engine/command-layer.ts
+++ b/packages/core/src/engine/command-layer.ts
@@ -316,6 +316,40 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
     // Determine if permission middleware is registered (#1 — fail-closed)
     const hasPermissionMiddleware = getSlotMiddlewares("permission").length > 0;
 
+    // Fail-closed guard: non-action dispatch (`skipActionSlots`) bypasses the
+    // ActionExecutor entirely, so the executor's built-in permission check —
+    // documented at the top of this file as the fallback when no permission
+    // middleware is registered — never fires. Without a registered permission
+    // middleware, an onchange-style request would run with zero authorization.
+    // Reject the request explicitly instead of silently running unguarded.
+    if (skipActionSlots && !hasPermissionMiddleware) {
+      return {
+        success: false,
+        data: {
+          error:
+            "Non-action dispatch (skipActionSlots) requires a permission middleware — built-in executor fallback does not apply.",
+          code: "PERMISSION.MIDDLEWARE_MISSING",
+        },
+        executionId: generatePipelineId(),
+      };
+    }
+
+    // Reject the `approvalId` + `skipActionSlots` combination. Approval
+    // re-execution skips {auth, exposure, permission}; non-action dispatch
+    // skips {exposure, pre-action, post-action}. Combined, auth AND permission
+    // would silently drop — contradicting the `skipActionSlots` contract that
+    // auth/permission/tenant still run. No legitimate flow needs this pair.
+    if (execOptions.approvalId && skipActionSlots) {
+      return {
+        success: false,
+        data: {
+          error: "approvalId is not supported with skipActionSlots.",
+          code: "COMMAND.INVALID_OPTIONS",
+        },
+        executionId: generatePipelineId(),
+      };
+    }
+
     // Approval re-execution: skip auth, exposure, permission slots ONLY when
     // a verifyApproval callback is configured AND it confirms the approvalId is valid.
     // Fail-closed: without verifyApproval, approvalId is ignored and all slots run.

--- a/packages/core/src/engine/command-layer.ts
+++ b/packages/core/src/engine/command-layer.ts
@@ -318,8 +318,10 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
       ctx.action = action;
     }
 
-    // Determine if permission middleware is registered (#1 — fail-closed)
-    const hasPermissionMiddleware = getSlotMiddlewares("permission").length > 0;
+    // Determine if permission middleware is registered (#1 — fail-closed).
+    // Use `.some()` rather than `getSlotMiddlewares().length > 0` to avoid
+    // filtering+sorting the middleware array on every request.
+    const hasPermissionMiddleware = middlewares.some((m) => m.slot === "permission");
 
     // Fail-closed guard: non-action dispatch (`skipActionSlots`) bypasses the
     // ActionExecutor entirely, so the executor's built-in permission check —

--- a/packages/core/src/engine/command-layer.ts
+++ b/packages/core/src/engine/command-layer.ts
@@ -3,8 +3,11 @@
  *
  * All entry points (HTTP / MCP / CLI / UI) go through the same pipeline.
  * Capabilities fill slots by registering middlewares (e.g. cap-auth fills "auth").
- * Unfilled slots are automatically skipped — except permission: when no permission
- * middleware is registered, the executor's built-in permission check still runs (fail-closed).
+ * Unfilled slots are automatically skipped — except permission: for normal
+ * action dispatch, if no permission middleware is registered, the executor's
+ * built-in permission check still runs (fail-closed). For non-action dispatch
+ * (`skipActionSlots: true`), the executor is never invoked, so an empty
+ * permission slot is rejected explicitly with `PERMISSION.MIDDLEWARE_MISSING`.
  *
  * Pipeline order: pre → auth → exposure → permission → tenant → pre-action → [action] → post-action
  *
@@ -15,7 +18,9 @@
  * entity onchange endpoint (Spec 64 §4.3). The pipeline runs pre / auth / permission /
  * tenant but skips exposure / pre-action / post-action and does not invoke the
  * ActionExecutor; a synthetic success result is returned so downstream code can
- * produce the actual response payload.
+ * produce the actual response payload. Requires a registered permission middleware
+ * (see guard above). Cannot be combined with `approvalId` — the combination would
+ * silently drop auth+permission and is rejected with `COMMAND.INVALID_OPTIONS`.
  *
  * See spec 16_command_layer_and_api.md §2.2 and 20_extension_mechanism.md §8.
  */


### PR DESCRIPTION
Closes #193.

## Problem

Follow-up review findings from PR #191 flagged two fail-closed gaps on the `skipActionSlots` code path introduced for the entity onchange endpoint (Spec 64 §4.3):

1. **[Major]** In `skipActionSlots` mode the ActionExecutor is never invoked. The executor's built-in permission check — documented as the fail-closed fallback when no permission middleware is registered — doesn't fire. Result: a deployment shipped without a permission middleware would accept onchange requests from any caller with zero authorization enforcement.

2. **[Minor]** Setting both `approvalId` (valid) and `skipActionSlots: true` combines two skip sets into `{auth, exposure, permission, pre-action, post-action}` — silently dropping auth AND permission, contradicting the `skipActionSlots` JSDoc contract. No legitimate flow needs approval re-execution of non-action dispatch.

## Fix

`packages/core/src/engine/command-layer.ts` — two early-return guards placed after `skipActionSlots` / `hasPermissionMiddleware` are computed, before approval verification and pipeline construction:

- `skipActionSlots && !hasPermissionMiddleware` → `{success: false, code: "PERMISSION.MIDDLEWARE_MISSING"}`
- `execOptions.approvalId && skipActionSlots` → `{success: false, code: "COMMAND.INVALID_OPTIONS"}`

Top-of-file docstring updated to reflect the new contract.

### Dev-mode stub

`addons/adapter-server/cap-adapter-server/src/dev.ts` doesn't wire cap-permission, so the new guard would 100% break onchange in local dev. Added a dev-only allow-all permission stub: registered at `order: 999` only when no permission middleware is already present, so real permission middlewares take precedence. Emits the same style of warning as the existing `[onchange] no checkReadPermission configured` log. Production deployments without RBAC now fail loudly as intended.

## Test plan

- [x] `bun test command-layer-skip-action-slots.test.ts` — 6 pass / 0 fail (3 new cases: MIDDLEWARE_MISSING, INVALID_OPTIONS+approvalId-short-circuit, happy path)
- [x] `bun run check` — clean
- [x] `bun run typecheck` — clean
- [x] `bun test` — 4318 pass / 3 skip / 0 fail across 255 files
- [x] Cross-model review (Codex) — PASS-with-non-blocking-suggestions; doc-drift suggestion applied, others follow-up material

## Not in scope

Codex also flagged a pre-existing issue: `verifyApproval` exceptions aren't caught, so approval-backend failures surface as unhandled 500s rather than structured denials. Unrelated to this fix; worth a separate follow-up.

Generated with Claude Code.
