### PR TITLE
feat(core): ExecutionMeta propagation (Spec 65 Phase 1, refs #149)

### DIFF
--- a/packages/core/__tests__/action-engine-meta-propagation.test.ts
+++ b/packages/core/__tests__/action-engine-meta-propagation.test.ts
@@ -1,0 +1,369 @@
+/**
+ * ActionEngine — ExecutionMeta propagation through nested ctx.execute (Spec 65 Phase 1).
+ *
+ * Covers:
+ * - Parent's meta keys visible in child action.
+ * - Child's `options.meta` extensions visible to child, but parent keys win on collision.
+ * - `_depth` bumps: root=0, child=1, grandchild=2.
+ * - `_source_action` on the child equals the parent action's name.
+ * - `_execution_id` stays the same across the chain (root id preserved).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createActionExecutor } from "../src/engine/action-engine";
+import { createCommandLayer } from "../src/engine/command-layer";
+import type { ActionContext, ActionDefinition, Actor } from "../src/types/action";
+import { createExecutionMeta } from "../src/types/execution-meta";
+import { createTestDataProvider } from "./command-layer-helpers";
+
+const defaultActor: Actor = {
+  type: "human",
+  id: "user-1",
+  groups: ["admin"],
+};
+
+/** Captured snapshots from handler ctx — one per action invocation. */
+interface Capture {
+  action: string;
+  meta: Record<string, unknown>;
+  executionId: string;
+}
+
+describe("ActionEngine — ExecutionMeta propagation via ctx.execute", () => {
+  test("parent meta keys visible in child; parent wins on override attempt", async () => {
+    const captures: Capture[] = [];
+    const dp = createTestDataProvider();
+    const executor = createActionExecutor({ dataProvider: dp });
+
+    const recordCapture = (ctx: ActionContext, name: string) => {
+      captures.push({
+        action: name,
+        meta: ctx.meta.toJSON(),
+        executionId: ctx.executionId,
+      });
+    };
+
+    const parent: ActionDefinition = {
+      name: "parent_action",
+      entity: "item",
+      label: "Parent",
+      policy: { mode: "sync", transaction: false },
+      exposure: "all",
+      handler: async (ctx) => {
+        recordCapture(ctx, "parent_action");
+        // Child tries to override `bulk` (parent set to true) and also adds a new key.
+        await ctx.execute(
+          "child_action",
+          {},
+          {
+            meta: { bulk: false, validation_mode: "strict" },
+          },
+        );
+        return { ok: true };
+      },
+    };
+
+    const child: ActionDefinition = {
+      name: "child_action",
+      entity: "item",
+      label: "Child",
+      policy: { mode: "sync", transaction: false },
+      exposure: "all",
+      handler: async (ctx) => {
+        recordCapture(ctx, "child_action");
+        return { child: true };
+      },
+    };
+
+    executor.registry.register(parent);
+    executor.registry.register(child);
+
+    const layer = createCommandLayer({ executor });
+    const result = await layer.execute({
+      command: "parent_action",
+      input: {},
+      meta: { bulk: true, source: "import" },
+      actor: defaultActor,
+      channel: "internal",
+    });
+
+    expect(result.success).toBe(true);
+    expect(captures.length).toBe(2);
+
+    const [parentCap, childCap] = captures;
+    // Parent sees its original meta.
+    expect(parentCap.meta.bulk).toBe(true);
+    expect(parentCap.meta.source).toBe("import");
+
+    // Child sees parent's keys — parent wins on override attempt.
+    expect(childCap.meta.bulk).toBe(true); // NOT false
+    expect(childCap.meta.source).toBe("import");
+    // Child gets a new key it added that didn't collide.
+    expect(childCap.meta.validation_mode).toBe("strict");
+  });
+
+  test("_depth bumps across nested calls: 0 -> 1 -> 2", async () => {
+    const captures: Capture[] = [];
+    const dp = createTestDataProvider();
+    const executor = createActionExecutor({ dataProvider: dp });
+
+    const record = (ctx: ActionContext, name: string) => {
+      captures.push({
+        action: name,
+        meta: ctx.meta.toJSON(),
+        executionId: ctx.executionId,
+      });
+    };
+
+    const root: ActionDefinition = {
+      name: "root_action",
+      entity: "item",
+      label: "Root",
+      policy: { mode: "sync", transaction: false },
+      exposure: "all",
+      handler: async (ctx) => {
+        record(ctx, "root_action");
+        await ctx.execute("mid_action", {});
+        return { ok: true };
+      },
+    };
+
+    const mid: ActionDefinition = {
+      name: "mid_action",
+      entity: "item",
+      label: "Mid",
+      policy: { mode: "sync", transaction: false },
+      exposure: "all",
+      handler: async (ctx) => {
+        record(ctx, "mid_action");
+        await ctx.execute("leaf_action", {});
+        return { mid: true };
+      },
+    };
+
+    const leaf: ActionDefinition = {
+      name: "leaf_action",
+      entity: "item",
+      label: "Leaf",
+      policy: { mode: "sync", transaction: false },
+      exposure: "all",
+      handler: async (ctx) => {
+        record(ctx, "leaf_action");
+        return { leaf: true };
+      },
+    };
+
+    executor.registry.register(root);
+    executor.registry.register(mid);
+    executor.registry.register(leaf);
+
+    const layer = createCommandLayer({ executor });
+    await layer.execute({
+      command: "root_action",
+      input: {},
+      meta: {},
+      actor: defaultActor,
+      channel: "internal",
+    });
+
+    expect(captures.length).toBe(3);
+    const byAction = Object.fromEntries(captures.map((c) => [c.action, c]));
+
+    expect(byAction.root_action.meta._depth).toBe(0);
+    expect(byAction.mid_action.meta._depth).toBe(1);
+    expect(byAction.leaf_action.meta._depth).toBe(2);
+  });
+
+  test("_source_action on child equals the parent action name", async () => {
+    const captures: Capture[] = [];
+    const dp = createTestDataProvider();
+    const executor = createActionExecutor({ dataProvider: dp });
+
+    const record = (ctx: ActionContext, name: string) => {
+      captures.push({
+        action: name,
+        meta: ctx.meta.toJSON(),
+        executionId: ctx.executionId,
+      });
+    };
+
+    const parent: ActionDefinition = {
+      name: "alpha",
+      entity: "item",
+      label: "Alpha",
+      policy: { mode: "sync", transaction: false },
+      exposure: "all",
+      handler: async (ctx) => {
+        record(ctx, "alpha");
+        await ctx.execute("beta", {});
+        return { ok: true };
+      },
+    };
+
+    const child: ActionDefinition = {
+      name: "beta",
+      entity: "item",
+      label: "Beta",
+      policy: { mode: "sync", transaction: false },
+      exposure: "all",
+      handler: async (ctx) => {
+        record(ctx, "beta");
+        return { beta: true };
+      },
+    };
+
+    executor.registry.register(parent);
+    executor.registry.register(child);
+
+    const layer = createCommandLayer({ executor });
+    await layer.execute({
+      command: "alpha",
+      input: {},
+      actor: defaultActor,
+    });
+
+    const byAction = Object.fromEntries(captures.map((c) => [c.action, c]));
+    // Root action has no _source_action.
+    expect(byAction.alpha.meta._source_action).toBeUndefined();
+    expect(byAction.beta.meta._source_action).toBe("alpha");
+  });
+
+  test("_execution_id stays the same across the chain", async () => {
+    // When the CommandLayer sets `_execution_id` from the traceId, all nested
+    // calls inherit the same root id because `extend` preserves parent keys.
+    const captures: Capture[] = [];
+    const dp = createTestDataProvider();
+    const executor = createActionExecutor({ dataProvider: dp });
+
+    const record = (ctx: ActionContext, name: string) => {
+      captures.push({
+        action: name,
+        meta: ctx.meta.toJSON(),
+        executionId: ctx.executionId,
+      });
+    };
+
+    const root: ActionDefinition = {
+      name: "root_x",
+      entity: "item",
+      label: "Root X",
+      policy: { mode: "sync", transaction: false },
+      exposure: "all",
+      handler: async (ctx) => {
+        record(ctx, "root_x");
+        await ctx.execute("mid_x", {});
+        return { ok: true };
+      },
+    };
+
+    const mid: ActionDefinition = {
+      name: "mid_x",
+      entity: "item",
+      label: "Mid X",
+      policy: { mode: "sync", transaction: false },
+      exposure: "all",
+      handler: async (ctx) => {
+        record(ctx, "mid_x");
+        await ctx.execute("leaf_x", {});
+        return { ok: true };
+      },
+    };
+
+    const leaf: ActionDefinition = {
+      name: "leaf_x",
+      entity: "item",
+      label: "Leaf X",
+      policy: { mode: "sync", transaction: false },
+      exposure: "all",
+      handler: async (ctx) => {
+        record(ctx, "leaf_x");
+        return { leaf: true };
+      },
+    };
+
+    executor.registry.register(root);
+    executor.registry.register(mid);
+    executor.registry.register(leaf);
+
+    const layer = createCommandLayer({ executor });
+    // Force a traceId so the CommandLayer stamps `_execution_id` from it.
+    await layer.execute({
+      command: "root_x",
+      input: {},
+      meta: {},
+      actor: defaultActor,
+      traceId: "root_trace_abc",
+    });
+
+    const ids = captures.map((c) => c.meta._execution_id);
+    expect(ids).toEqual(["root_trace_abc", "root_trace_abc", "root_trace_abc"]);
+  });
+
+  test("direct executor call (no CommandLayer) synthesizes meta with system keys", async () => {
+    // When the ActionEngine is invoked directly with no ExecuteOptions.meta,
+    // it must still expose a valid ctx.meta populated with system keys.
+    const captures: Capture[] = [];
+    const dp = createTestDataProvider();
+    const executor = createActionExecutor({ dataProvider: dp });
+
+    const action: ActionDefinition = {
+      name: "lone",
+      entity: "item",
+      label: "Lone",
+      policy: { mode: "sync", transaction: false },
+      exposure: "all",
+      handler: async (ctx) => {
+        captures.push({
+          action: "lone",
+          meta: ctx.meta.toJSON(),
+          executionId: ctx.executionId,
+        });
+        return { ok: true };
+      },
+    };
+    executor.registry.register(action);
+
+    const result = await executor.execute("lone", {}, defaultActor);
+    expect(result.success).toBe(true);
+    expect(captures.length).toBe(1);
+    expect(captures[0].meta._channel).toBe("internal");
+    expect(captures[0].meta._depth).toBe(0);
+    expect(captures[0].meta._execution_id).toBe(captures[0].executionId);
+  });
+
+  test("caller-supplied ExecuteOptions.meta is honored by the engine", async () => {
+    // When ExecutionMeta is passed directly via ExecuteOptions.meta (e.g., a
+    // test or internal caller bypassing the CommandLayer), the engine uses it
+    // rather than synthesizing a fresh one.
+    const captures: Capture[] = [];
+    const dp = createTestDataProvider();
+    const executor = createActionExecutor({ dataProvider: dp });
+
+    const action: ActionDefinition = {
+      name: "preset",
+      entity: "item",
+      label: "Preset",
+      policy: { mode: "sync", transaction: false },
+      exposure: "all",
+      handler: async (ctx) => {
+        captures.push({
+          action: "preset",
+          meta: ctx.meta.toJSON(),
+          executionId: ctx.executionId,
+        });
+        return { ok: true };
+      },
+    };
+    executor.registry.register(action);
+
+    const preset = createExecutionMeta({
+      raw: { flow: "custom" },
+      systemKeys: { _channel: "mcp", _depth: 0, _execution_id: "trace_z" },
+    });
+    await executor.execute("preset", {}, defaultActor, { meta: preset });
+
+    expect(captures[0].meta.flow).toBe("custom");
+    expect(captures[0].meta._channel).toBe("mcp");
+    expect(captures[0].meta._execution_id).toBe("trace_z");
+  });
+});

--- a/packages/core/__tests__/action-engine-meta-propagation.test.ts
+++ b/packages/core/__tests__/action-engine-meta-propagation.test.ts
@@ -541,6 +541,42 @@ describe("ActionEngine — ExecutionMeta propagation via ctx.execute", () => {
     expect(captured.source_view).toBe("legit");
   });
 
+  // Codex round-4: direct-executor oversized meta returns a failed
+  // ActionResult (no unhandled throw) + logs the rejection.
+  test("direct executor with oversized plain meta returns failed ActionResult", async () => {
+    const dp = createTestDataProvider();
+    const logEntries: Array<{ id: string; status: string }> = [];
+    const executor = createActionExecutor({
+      dataProvider: dp,
+      executionLogger: {
+        log: async (e) => {
+          logEntries.push({ id: e.id, status: e.status });
+        },
+        getById: async () => null as never,
+      },
+    });
+
+    executor.registry.register({
+      name: "root_oversize",
+      entity: "item",
+      label: "Root Oversize",
+      policy: { mode: "sync", transaction: false },
+      exposure: "all",
+      handler: async () => ({ ok: true }),
+    });
+
+    const result = await executor.execute("root_oversize", {}, defaultActor, {
+      meta: { big: "x".repeat(DEFAULT_META_MAX_BYTES + 100) } as Record<string, unknown>,
+    });
+
+    expect(result.success).toBe(false);
+    expect((result.data as Record<string, unknown>).code).toBe("META.SIZE_EXCEEDED");
+    // Failure was logged (observability preserved).
+    expect(logEntries.length).toBe(1);
+    expect(logEntries[0].status).toBe("failed");
+    expect(logEntries[0].id).toBe(result.executionId);
+  });
+
   // Codex round-3 P3: don't record a fake child execution id when meta size
   // rejects the child before any log entry is written.
   test("child meta size rejection does NOT register a phantom execution id", async () => {

--- a/packages/core/__tests__/action-engine-meta-propagation.test.ts
+++ b/packages/core/__tests__/action-engine-meta-propagation.test.ts
@@ -229,8 +229,10 @@ describe("ActionEngine — ExecutionMeta propagation via ctx.execute", () => {
   });
 
   test("_execution_id stays the same across the chain", async () => {
-    // When the CommandLayer sets `_execution_id` from the traceId, all nested
-    // calls inherit the same root id because `extend` preserves parent keys.
+    // Spec 65 §4.4: `_execution_id` is the ROOT execution record id (not a
+    // tracing context). The ActionEngine stamps it from the root action's
+    // `executionId` at depth 0; `extend` preserves that same value through
+    // nested ctx.execute calls, so every level sees the root's id.
     const captures: Capture[] = [];
     const dp = createTestDataProvider();
     const executor = createActionExecutor({ dataProvider: dp });
@@ -286,17 +288,21 @@ describe("ActionEngine — ExecutionMeta propagation via ctx.execute", () => {
     executor.registry.register(leaf);
 
     const layer = createCommandLayer({ executor });
-    // Force a traceId so the CommandLayer stamps `_execution_id` from it.
     await layer.execute({
       command: "root_x",
       input: {},
       meta: {},
       actor: defaultActor,
-      traceId: "root_trace_abc",
     });
 
     const ids = captures.map((c) => c.meta._execution_id);
-    expect(ids).toEqual(["root_trace_abc", "root_trace_abc", "root_trace_abc"]);
+    const rootExecutionId = captures[0].executionId;
+    // All three levels carry the root action's executionId.
+    expect(ids).toEqual([rootExecutionId, rootExecutionId, rootExecutionId]);
+    // And each call still had its own per-action executionId distinct from
+    // the preserved root id (except for the root itself).
+    expect(captures[1].executionId).not.toBe(rootExecutionId);
+    expect(captures[2].executionId).not.toBe(rootExecutionId);
   });
 
   test("direct executor call (no CommandLayer) synthesizes meta with system keys", async () => {
@@ -466,5 +472,129 @@ describe("ActionEngine — ExecutionMeta propagation via ctx.execute", () => {
     expect("nested_date" in childMetaJson).toBe(false);
     expect("cb" in childMetaJson).toBe(false);
     expect(childMetaJson.ok_flag).toBe(true);
+  });
+
+  // Codex round-3 follow-up: ExecuteOptions.meta accepts a plain record
+  // (natural shape for direct-executor callers). Engine normalizes internally.
+  test("direct executor with plain record meta normalizes to ExecutionMeta", async () => {
+    const dp = createTestDataProvider();
+    const executor = createActionExecutor({ dataProvider: dp });
+
+    let captured: { meta: Record<string, unknown>; hasGet: boolean } | undefined;
+    executor.registry.register({
+      name: "plain_meta_consumer",
+      entity: "item",
+      label: "Plain Meta Consumer",
+      policy: { mode: "sync", transaction: false },
+      exposure: "all",
+      handler: async (ctx) => {
+        captured = {
+          meta: ctx.meta.toJSON(),
+          hasGet: typeof ctx.meta.get === "function",
+        };
+        return { ok: true };
+      },
+    });
+
+    // Pass a plain Record<string, unknown> (no createExecutionMeta).
+    await executor.execute("plain_meta_consumer", {}, defaultActor, {
+      meta: { source_view: "queue", bulk: true } as Record<string, unknown>,
+    });
+
+    expect(captured?.hasGet).toBe(true);
+    expect(captured?.meta.source_view).toBe("queue");
+    expect(captured?.meta.bulk).toBe(true);
+    // System keys still set by the engine.
+    expect(captured?.meta._channel).toBe("internal");
+    expect(typeof captured?.meta._execution_id).toBe("string");
+    expect(captured?.meta._depth).toBe(0);
+  });
+
+  test("direct executor with plain record meta strips _-prefixed external keys", async () => {
+    const dp = createTestDataProvider();
+    const executor = createActionExecutor({ dataProvider: dp });
+
+    let captured: Record<string, unknown> = {};
+    executor.registry.register({
+      name: "plain_stripped",
+      entity: "item",
+      label: "Plain Stripped",
+      policy: { mode: "sync", transaction: false },
+      exposure: "all",
+      handler: async (ctx) => {
+        captured = ctx.meta.toJSON();
+        return { ok: true };
+      },
+    });
+
+    await executor.execute("plain_stripped", {}, defaultActor, {
+      meta: {
+        _channel: "spoofed",
+        _execution_id: "hacked",
+        source_view: "legit",
+      } as Record<string, unknown>,
+    });
+
+    // Plain-record path goes through createExecutionMeta's _-prefix strip.
+    expect(captured._channel).toBe("internal");
+    expect(captured._execution_id).not.toBe("hacked");
+    expect(captured.source_view).toBe("legit");
+  });
+
+  // Codex round-3 P3: don't record a fake child execution id when meta size
+  // rejects the child before any log entry is written.
+  test("child meta size rejection does NOT register a phantom execution id", async () => {
+    const dp = createTestDataProvider();
+    // Simple in-memory executionLogger to observe childExecutionIds persistence.
+    const logEntries: Array<{ id: string }> = [];
+    const executor = createActionExecutor({
+      dataProvider: dp,
+      executionLogger: {
+        log: async (e) => {
+          logEntries.push({ id: e.id });
+        },
+        getById: async (id) => logEntries.find((x) => x.id === id) as never,
+      },
+    });
+
+    let parentResult: unknown;
+    executor.registry.register({
+      name: "child",
+      entity: "item",
+      label: "Child",
+      policy: { mode: "sync", transaction: false },
+      exposure: "all",
+      handler: async () => ({ ok: true }),
+    });
+
+    executor.registry.register({
+      name: "parent_oversize_child",
+      entity: "item",
+      label: "Parent",
+      policy: { mode: "sync", transaction: false },
+      exposure: "all",
+      handler: async (ctx) => {
+        parentResult = await ctx.execute(
+          "child",
+          {},
+          { meta: { huge: "x".repeat(DEFAULT_META_MAX_BYTES + 100) } },
+        );
+        return { ok: true };
+      },
+    });
+
+    await executor.execute("parent_oversize_child", {}, defaultActor);
+
+    // The child meta was rejected — one log entry exists (the parent).
+    expect(logEntries.length).toBe(1);
+    // The logged id is the parent's id, which is resolvable.
+    const parentLogId = logEntries[0].id;
+    const found = await executor.registry.get("parent_oversize_child");
+    expect(found).toBeDefined();
+    // And the failed "child" return data is META.SIZE_EXCEEDED, shaped for
+    // the parent handler to pattern-match on.
+    expect((parentResult as Record<string, unknown>).code).toBe("META.SIZE_EXCEEDED");
+    // parentLogId referenced as a sanity anchor.
+    expect(typeof parentLogId).toBe("string");
   });
 });

--- a/packages/core/__tests__/action-engine-meta-propagation.test.ts
+++ b/packages/core/__tests__/action-engine-meta-propagation.test.ts
@@ -337,10 +337,12 @@ describe("ActionEngine — ExecutionMeta propagation via ctx.execute", () => {
     expect(captures[0].meta._execution_id).toBe(captures[0].executionId);
   });
 
-  test("caller-supplied ExecuteOptions.meta is honored by the engine", async () => {
-    // When ExecutionMeta is passed directly via ExecuteOptions.meta (e.g., a
-    // test or internal caller bypassing the CommandLayer), the engine uses it
-    // rather than synthesizing a fresh one.
+  test("caller-supplied ExecuteOptions.meta: user keys flow through, system keys re-stamped", async () => {
+    // When a pre-built ExecutionMeta reaches the root executor, user-space
+    // keys flow through unchanged, but system keys are always re-stamped
+    // by the framework at root (Gemini PR #201 review — system keys must
+    // not be spoofable by any entry point). Nested calls preserve system
+    // keys; that's covered separately.
     const captures: Capture[] = [];
     const dp = createTestDataProvider();
     const executor = createActionExecutor({ dataProvider: dp });
@@ -363,14 +365,22 @@ describe("ActionEngine — ExecutionMeta propagation via ctx.execute", () => {
     executor.registry.register(action);
 
     const preset = createExecutionMeta({
-      raw: { flow: "custom" },
-      systemKeys: { _channel: "mcp", _depth: 0, _execution_id: "trace_z" },
+      raw: { flow: "custom", source_view: "queue" },
+      // Caller-attempted system keys — must be overridden by framework.
+      systemKeys: { _channel: "mcp", _depth: 99, _execution_id: "trace_z" },
     });
-    await executor.execute("preset", {}, defaultActor, { meta: preset });
+    const result = await executor.execute("preset", {}, defaultActor, { meta: preset });
 
+    // User-space keys preserved.
     expect(captures[0].meta.flow).toBe("custom");
-    expect(captures[0].meta._channel).toBe("mcp");
-    expect(captures[0].meta._execution_id).toBe("trace_z");
+    expect(captures[0].meta.source_view).toBe("queue");
+    // System keys re-stamped at root — `_channel` defaults to "internal"
+    // (no channel in ExecuteOptions), `_execution_id` is the real action id,
+    // `_depth` is 0.
+    expect(captures[0].meta._channel).toBe("internal");
+    expect(captures[0].meta._execution_id).toBe(result.executionId);
+    expect(captures[0].meta._execution_id).not.toBe("trace_z");
+    expect(captures[0].meta._depth).toBe(0);
   });
 
   // Codex follow-up: child ctx.execute must enforce the same size limit as
@@ -632,5 +642,92 @@ describe("ActionEngine — ExecutionMeta propagation via ctx.execute", () => {
     expect((parentResult as Record<string, unknown>).code).toBe("META.SIZE_EXCEEDED");
     // parentLogId referenced as a sanity anchor.
     expect(typeof parentLogId).toBe("string");
+  });
+
+  // Gemini PR #201 review: system keys are framework-owned. Even if a caller
+  // crafts a pre-built ExecutionMeta (or duck-typed equivalent) with spoofed
+  // `_`-prefixed entries, the root executor must strip and re-stamp.
+  test("root: ExecutionMeta with spoofed system keys is re-normalized", async () => {
+    const dp = createTestDataProvider();
+    const executor = createActionExecutor({ dataProvider: dp });
+
+    let captured: Record<string, unknown> = {};
+    executor.registry.register({
+      name: "spoofed_meta_consumer",
+      entity: "item",
+      label: "Spoof Consumer",
+      policy: { mode: "sync", transaction: false },
+      exposure: "all",
+      handler: async (ctx) => {
+        captured = ctx.meta.toJSON();
+        return { ok: true };
+      },
+    });
+
+    const spoofed = createExecutionMeta({
+      // createExecutionMeta strips `_` from raw automatically, so craft
+      // the spoofed keys via systemKeys — this simulates any adversarial
+      // code that bypasses the factory's strip step.
+      systemKeys: {
+        _channel: "spoofed",
+        _execution_id: "fake_root_id",
+        _depth: 999,
+        legit_key: "preserved",
+      },
+    });
+    const result = await executor.execute("spoofed_meta_consumer", {}, defaultActor, {
+      meta: spoofed,
+    });
+
+    expect(result.success).toBe(true);
+    // System keys were re-stamped by the engine.
+    expect(captured._channel).toBe("internal");
+    expect(captured._execution_id).toBe(result.executionId);
+    expect(captured._execution_id).not.toBe("fake_root_id");
+    expect(captured._depth).toBe(0);
+    // Non-system keys still flow through untouched.
+    expect(captured.legit_key).toBe("preserved");
+  });
+
+  test("root: duck-typed ExecutionMeta with spoofed toJSON cannot bypass stripping", async () => {
+    const dp = createTestDataProvider();
+    const executor = createActionExecutor({ dataProvider: dp });
+
+    let captured: Record<string, unknown> = {};
+    executor.registry.register({
+      name: "duck_typed_spoof",
+      entity: "item",
+      label: "Duck Typed",
+      policy: { mode: "sync", transaction: false },
+      exposure: "all",
+      handler: async (ctx) => {
+        captured = ctx.meta.toJSON();
+        return { ok: true };
+      },
+    });
+
+    // Craft a duck-typed ExecutionMeta whose toJSON hands out spoofed system keys.
+    const spoofedDuck = {
+      get: () => undefined,
+      has: () => false,
+      require: () => {
+        throw new Error("never");
+      },
+      toJSON: () => ({ _channel: "mcp_bypass", _depth: 42, user_key: "x" }),
+    };
+
+    // Cast required because the interface requires generic methods.
+    const result = await executor.execute(
+      "duck_typed_spoof",
+      {},
+      defaultActor,
+      // biome-ignore lint/suspicious/noExplicitAny: test-only adversarial cast
+      { meta: spoofedDuck as any },
+    );
+
+    expect(result.success).toBe(true);
+    expect(captured._channel).toBe("internal");
+    expect(captured._depth).toBe(0);
+    expect(captured.user_key).toBe("x");
   });
 });

--- a/packages/core/__tests__/action-engine-meta-propagation.test.ts
+++ b/packages/core/__tests__/action-engine-meta-propagation.test.ts
@@ -13,7 +13,7 @@ import { describe, expect, test } from "bun:test";
 import { createActionExecutor } from "../src/engine/action-engine";
 import { createCommandLayer } from "../src/engine/command-layer";
 import type { ActionContext, ActionDefinition, Actor } from "../src/types/action";
-import { createExecutionMeta } from "../src/types/execution-meta";
+import { createExecutionMeta, DEFAULT_META_MAX_BYTES } from "../src/types/execution-meta";
 import { createTestDataProvider } from "./command-layer-helpers";
 
 const defaultActor: Actor = {
@@ -365,5 +365,106 @@ describe("ActionEngine — ExecutionMeta propagation via ctx.execute", () => {
     expect(captures[0].meta.flow).toBe("custom");
     expect(captures[0].meta._channel).toBe("mcp");
     expect(captures[0].meta._execution_id).toBe("trace_z");
+  });
+
+  // Codex follow-up: child ctx.execute must enforce the same size limit as
+  // root meta construction. If `extend` throws MetaSizeError, ctx.execute
+  // surfaces it as a failed child result rather than bubbling the exception
+  // up and crashing the parent handler.
+  test("child ctx.execute with over-limit meta returns a failed result, not throws", async () => {
+    const dp = createTestDataProvider();
+    const executor = createActionExecutor({ dataProvider: dp });
+
+    let childRan = false;
+    let childReturn: unknown = null;
+
+    executor.registry.register({
+      name: "child",
+      entity: "item",
+      label: "Child",
+      policy: { mode: "sync", transaction: false },
+      exposure: "all",
+      handler: async () => {
+        childRan = true;
+        return { ok: true };
+      },
+    });
+
+    executor.registry.register({
+      name: "parent_with_oversize_child_meta",
+      entity: "item",
+      label: "Parent",
+      policy: { mode: "sync", transaction: false },
+      exposure: "all",
+      handler: async (ctx) => {
+        childReturn = await ctx.execute(
+          "child",
+          {},
+          { meta: { huge: "x".repeat(DEFAULT_META_MAX_BYTES + 100) } },
+        );
+        return { ok: true };
+      },
+    });
+
+    const result = await executor.execute("parent_with_oversize_child_meta", {}, defaultActor);
+
+    // Parent succeeds — its handler caught the failed child result and returned normally.
+    expect(result.success).toBe(true);
+    // Child never actually executed (size check failed before it could).
+    expect(childRan).toBe(false);
+    // ctx.execute returned the failed result's `data` — shaped like other
+    // action failures so handlers can pattern-match.
+    const childData = childReturn as Record<string, unknown>;
+    expect(childData.code).toBe("META.SIZE_EXCEEDED");
+  });
+
+  test("child ctx.execute drops non-serializable meta extras (mirrors root)", async () => {
+    // `extend` applies the same serializable filter as `createExecutionMeta`,
+    // so a child's attempt to stash a Date/function in meta is silently dropped
+    // rather than leaked to downstream handlers.
+    const dp = createTestDataProvider();
+    const executor = createActionExecutor({ dataProvider: dp });
+
+    let childMetaJson: Record<string, unknown> = {};
+
+    executor.registry.register({
+      name: "child_capture",
+      entity: "item",
+      label: "Child Capture",
+      policy: { mode: "sync", transaction: false },
+      exposure: "all",
+      handler: async (ctx) => {
+        childMetaJson = ctx.meta.toJSON();
+        return { ok: true };
+      },
+    });
+
+    executor.registry.register({
+      name: "parent_dirty_meta",
+      entity: "item",
+      label: "Parent",
+      policy: { mode: "sync", transaction: false },
+      exposure: "all",
+      handler: async (ctx) => {
+        await ctx.execute(
+          "child_capture",
+          {},
+          {
+            meta: {
+              nested_date: { when: new Date() }, // dropped (nested Date)
+              cb: () => 1, // dropped (function)
+              ok_flag: true, // kept
+            },
+          },
+        );
+        return { ok: true };
+      },
+    });
+
+    await executor.execute("parent_dirty_meta", {}, defaultActor);
+
+    expect("nested_date" in childMetaJson).toBe(false);
+    expect("cb" in childMetaJson).toBe(false);
+    expect(childMetaJson.ok_flag).toBe(true);
   });
 });

--- a/packages/core/__tests__/command-layer-meta.test.ts
+++ b/packages/core/__tests__/command-layer-meta.test.ts
@@ -75,9 +75,10 @@ describe("CommandLayer — ExecutionMeta integration", () => {
 
     // _channel is set by the framework from ctx.channel.
     expect(capturedCtx?.meta.get<string>("_channel")).toBe("http");
-    // _execution_id comes from the pipeline-assigned traceId when present
-    // (or is absent). Either way, not "spoofed_exec".
-    expect(capturedCtx?.meta.get<string>("_execution_id")).not.toBe("spoofed_exec");
+    // _execution_id is the ROOT execution record id (Spec 65 §4.4) — the
+    // ActionEngine fills it from the action's executionId. Never from
+    // external input.
+    expect(capturedCtx?.meta.get<string>("_execution_id")).toBe(capturedCtx?.executionId);
     // Legitimate user keys still pass through.
     expect(capturedCtx?.meta.get<string>("source_view")).toBe("legit");
   });

--- a/packages/core/__tests__/command-layer-meta.test.ts
+++ b/packages/core/__tests__/command-layer-meta.test.ts
@@ -132,6 +132,32 @@ describe("CommandLayer — ExecutionMeta integration", () => {
     expect(snapshot._channel).toBe("ui");
   });
 
+  // Codex follow-up: when meta construction rejects the request, post-action
+  // middleware MUST NOT fire — cache invalidation / notifications have
+  // write-side semantics and no write happened.
+  test("META.SIZE_EXCEEDED short-circuit suppresses post-action middleware", async () => {
+    const { layer } = setup();
+    let postActionRan = false;
+    layer.use({
+      name: "cache_invalidate",
+      slot: "post-action",
+      handler: async (_ctx, next) => {
+        postActionRan = true;
+        await next();
+      },
+    });
+
+    const result = await layer.execute({
+      command: "capture_meta",
+      input: {},
+      meta: { big: "x".repeat(DEFAULT_META_MAX_BYTES + 1024) },
+    });
+
+    expect(result.success).toBe(false);
+    expect((result.data as Record<string, unknown>).code).toBe("META.SIZE_EXCEEDED");
+    expect(postActionRan).toBe(false);
+  });
+
   test("middleware that mutates ctx.meta feeds the handler-visible meta", async () => {
     // Existing CommandContext.meta middleware-internal contract (Spec 65 §8.3):
     // middleware may add keys before the action handler runs; those should

--- a/packages/core/__tests__/command-layer-meta.test.ts
+++ b/packages/core/__tests__/command-layer-meta.test.ts
@@ -159,6 +159,37 @@ describe("CommandLayer — ExecutionMeta integration", () => {
     expect(postActionRan).toBe(false);
   });
 
+  // Codex round-6: near-limit meta where the CommandLayer's payload fits
+  // but adding `_execution_id` inside the ActionEngine tips it over. Must
+  // still suppress post-action — no action handler ever ran.
+  test("near-limit meta that ActionEngine rejects still suppresses post-action", async () => {
+    const { layer } = setup();
+    let postActionRan = false;
+    layer.use({
+      name: "cache_invalidate_edge",
+      slot: "post-action",
+      handler: async (_ctx, next) => {
+        postActionRan = true;
+        await next();
+      },
+    });
+
+    // Size calibration: the raw-object payload is just under 8 KB, but once
+    // the engine stamps `_channel`, `_depth`, and `_execution_id` onto it,
+    // the total exceeds the limit and only the engine's size check can
+    // catch it.
+    const nearLimit = "x".repeat(DEFAULT_META_MAX_BYTES - 20);
+    const result = await layer.execute({
+      command: "capture_meta",
+      input: {},
+      meta: { big: nearLimit },
+    });
+
+    expect(result.success).toBe(false);
+    expect((result.data as Record<string, unknown>).code).toBe("META.SIZE_EXCEEDED");
+    expect(postActionRan).toBe(false);
+  });
+
   test("middleware that mutates ctx.meta feeds the handler-visible meta", async () => {
     // Existing CommandContext.meta middleware-internal contract (Spec 65 §8.3):
     // middleware may add keys before the action handler runs; those should

--- a/packages/core/__tests__/command-layer-meta.test.ts
+++ b/packages/core/__tests__/command-layer-meta.test.ts
@@ -1,0 +1,162 @@
+/**
+ * CommandLayer — ExecutionMeta integration (Spec 65 Phase 1).
+ *
+ * Covers end-to-end flow of caller-provided meta into action handlers:
+ * - Caller meta reaches the handler via `ctx.meta.get(...)`.
+ * - `_`-prefixed keys in caller meta are stripped (system key wins).
+ * - Over-size meta (>8 KB) short-circuits with `META.SIZE_EXCEEDED`.
+ * - `ctx.meta` is always populated even when the caller supplies no meta.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createActionExecutor } from "../src/engine/action-engine";
+import { createCommandLayer } from "../src/engine/command-layer";
+import type { ActionContext, ActionDefinition } from "../src/types/action";
+import { DEFAULT_META_MAX_BYTES } from "../src/types/execution-meta";
+import { createTestDataProvider } from "./command-layer-helpers";
+
+/** Build a test setup with a handler that captures its ctx into `captured`. */
+function setup(onExecute?: (ctx: ActionContext) => void) {
+  const dp = createTestDataProvider();
+  const executor = createActionExecutor({ dataProvider: dp });
+
+  const captureAction: ActionDefinition = {
+    name: "capture_meta",
+    entity: "item",
+    label: "Capture Meta",
+    policy: { mode: "sync", transaction: false },
+    exposure: "all",
+    handler: async (ctx) => {
+      onExecute?.(ctx);
+      return { ok: true };
+    },
+  };
+  executor.registry.register(captureAction);
+  const layer = createCommandLayer({ executor });
+  return { layer };
+}
+
+describe("CommandLayer — ExecutionMeta integration", () => {
+  test("caller-provided meta reaches action handler via ctx.meta", async () => {
+    let capturedCtx: ActionContext | undefined;
+    const { layer } = setup((ctx) => {
+      capturedCtx = ctx;
+    });
+
+    const result = await layer.execute({
+      command: "capture_meta",
+      input: {},
+      meta: { source_view: "approval_queue", bulk: true },
+      channel: "http",
+    });
+
+    expect(result.success).toBe(true);
+    expect(capturedCtx).toBeDefined();
+    expect(capturedCtx?.meta.get<string>("source_view")).toBe("approval_queue");
+    expect(capturedCtx?.meta.get<boolean>("bulk")).toBe(true);
+  });
+
+  test("external `_channel` in caller meta is stripped — system key wins", async () => {
+    let capturedCtx: ActionContext | undefined;
+    const { layer } = setup((ctx) => {
+      capturedCtx = ctx;
+    });
+
+    await layer.execute({
+      command: "capture_meta",
+      input: {},
+      meta: {
+        _channel: "evil_override",
+        _execution_id: "spoofed_exec",
+        source_view: "legit",
+      },
+      channel: "http",
+    });
+
+    // _channel is set by the framework from ctx.channel.
+    expect(capturedCtx?.meta.get<string>("_channel")).toBe("http");
+    // _execution_id comes from the pipeline-assigned traceId when present
+    // (or is absent). Either way, not "spoofed_exec".
+    expect(capturedCtx?.meta.get<string>("_execution_id")).not.toBe("spoofed_exec");
+    // Legitimate user keys still pass through.
+    expect(capturedCtx?.meta.get<string>("source_view")).toBe("legit");
+  });
+
+  test("9 KB meta payload returns META.SIZE_EXCEEDED", async () => {
+    const { layer } = setup();
+
+    const big = "x".repeat(DEFAULT_META_MAX_BYTES + 1024);
+    const result = await layer.execute({
+      command: "capture_meta",
+      input: {},
+      meta: { big },
+    });
+
+    expect(result.success).toBe(false);
+    const data = result.data as Record<string, unknown>;
+    expect(data.code).toBe("META.SIZE_EXCEEDED");
+  });
+
+  test("ctx.meta is populated with system keys even when caller supplies no meta", async () => {
+    let capturedCtx: ActionContext | undefined;
+    const { layer } = setup((ctx) => {
+      capturedCtx = ctx;
+    });
+
+    await layer.execute({
+      command: "capture_meta",
+      input: {},
+      channel: "internal",
+    });
+
+    expect(capturedCtx?.meta).toBeDefined();
+    expect(capturedCtx?.meta.get<string>("_channel")).toBe("internal");
+    expect(capturedCtx?.meta.get<number>("_depth")).toBe(0);
+  });
+
+  test("ctx.meta.toJSON returns a plain object snapshot", async () => {
+    let capturedCtx: ActionContext | undefined;
+    const { layer } = setup((ctx) => {
+      capturedCtx = ctx;
+    });
+
+    await layer.execute({
+      command: "capture_meta",
+      input: {},
+      meta: { source_view: "queue" },
+      channel: "ui",
+    });
+
+    const snapshot = capturedCtx?.meta.toJSON() ?? {};
+    expect(snapshot.source_view).toBe("queue");
+    expect(snapshot._channel).toBe("ui");
+  });
+
+  test("middleware that mutates ctx.meta feeds the handler-visible meta", async () => {
+    // Existing CommandContext.meta middleware-internal contract (Spec 65 §8.3):
+    // middleware may add keys before the action handler runs; those should
+    // appear in ctx.meta.
+    let capturedCtx: ActionContext | undefined;
+    const { layer } = setup((ctx) => {
+      capturedCtx = ctx;
+    });
+
+    layer.use({
+      name: "inject_meta",
+      slot: "pre",
+      handler: async (ctx, next) => {
+        ctx.meta.injected_flag = true;
+        await next();
+      },
+    });
+
+    await layer.execute({
+      command: "capture_meta",
+      input: {},
+      meta: { source_view: "queue" },
+    });
+
+    expect(capturedCtx?.meta.get<boolean>("injected_flag")).toBe(true);
+    expect(capturedCtx?.meta.get<string>("source_view")).toBe("queue");
+  });
+});

--- a/packages/core/__tests__/execution-meta.test.ts
+++ b/packages/core/__tests__/execution-meta.test.ts
@@ -1,0 +1,248 @@
+/**
+ * ExecutionMeta — unit tests (Spec 65 Phase 1).
+ *
+ * Covers: get/require/has/toJSON, extend semantics (parent wins, system
+ * overrides, `_`-prefix stripping), createExecutionMeta factory
+ * (system-key merge, non-serializable filtering, 8 KB size limit),
+ * toJSON shallow-copy guarantee.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  createExecutionMeta,
+  DEFAULT_META_MAX_BYTES,
+  ExecutionMetaImpl,
+  extendExecutionMeta,
+  MetaSizeError,
+} from "../src/types/execution-meta";
+
+describe("ExecutionMetaImpl", () => {
+  describe("read accessors", () => {
+    test("get returns value for existing key", () => {
+      const meta = new ExecutionMetaImpl({ foo: "bar", num: 42 });
+      expect(meta.get<string>("foo")).toBe("bar");
+      expect(meta.get<number>("num")).toBe(42);
+    });
+
+    test("get returns undefined for missing key", () => {
+      const meta = new ExecutionMetaImpl({ foo: "bar" });
+      expect(meta.get("missing")).toBeUndefined();
+    });
+
+    test("has returns true for existing key, false otherwise", () => {
+      const meta = new ExecutionMetaImpl({ foo: "bar" });
+      expect(meta.has("foo")).toBe(true);
+      expect(meta.has("missing")).toBe(false);
+    });
+
+    test("require returns value for existing key", () => {
+      const meta = new ExecutionMetaImpl({ foo: "bar" });
+      expect(meta.require<string>("foo")).toBe("bar");
+    });
+
+    test("require throws for missing key", () => {
+      const meta = new ExecutionMetaImpl({ foo: "bar" });
+      expect(() => meta.require("missing")).toThrow(/Required meta key "missing" not found/);
+    });
+
+    test("toJSON returns all entries as a shallow copy", () => {
+      const meta = new ExecutionMetaImpl({ a: 1, b: "two" });
+      expect(meta.toJSON()).toEqual({ a: 1, b: "two" });
+    });
+
+    test("toJSON result is independent — mutating it does not affect meta", () => {
+      const meta = new ExecutionMetaImpl({ foo: "bar" });
+      const snapshot = meta.toJSON();
+      snapshot.foo = "mutated";
+      snapshot.extra = "added";
+      expect(meta.get("foo")).toBe("bar");
+      expect(meta.has("extra")).toBe(false);
+    });
+  });
+
+  describe("extend", () => {
+    test("parent keys always win over extra", () => {
+      const parent = new ExecutionMetaImpl({ bulk: true, source: "import" });
+      const child = parent.extend({ bulk: false, new_key: "added" });
+      expect(child.get("bulk")).toBe(true); // parent wins
+      expect(child.get("source")).toBe("import");
+      expect(child.get("new_key")).toBe("added");
+    });
+
+    test("systemOverrides always applied, even when key exists in parent", () => {
+      const parent = new ExecutionMetaImpl({ _depth: 0, user: "alice" });
+      const child = parent.extend({}, { _depth: 1, _source_action: "parent_action" });
+      expect(child.get<number>("_depth")).toBe(1);
+      expect(child.get<string>("_source_action")).toBe("parent_action");
+      expect(child.get<string>("user")).toBe("alice");
+    });
+
+    test("`_`-prefixed keys in extra are silently dropped", () => {
+      const parent = new ExecutionMetaImpl({ _channel: "rest" });
+      const child = parent.extend({
+        _channel: "evil", // dropped because `_`-prefixed
+        _mcp_client_id: "evil_client", // dropped
+        legitimate: "kept",
+      });
+      expect(child.get("_channel")).toBe("rest"); // parent preserved
+      expect(child.has("_mcp_client_id")).toBe(false);
+      expect(child.get("legitimate")).toBe("kept");
+    });
+
+    test("extend returns a new instance — parent unchanged", () => {
+      const parent = new ExecutionMetaImpl({ a: 1 });
+      const child = parent.extend({ b: 2 });
+      expect(parent.has("b")).toBe(false);
+      expect(child.get("a")).toBe(1);
+      expect(child.get("b")).toBe(2);
+    });
+
+    test("extend preserves all parent keys even when systemOverrides supplies same key", () => {
+      const parent = new ExecutionMetaImpl({ _depth: 0, _source_action: "root" });
+      const child = parent.extend({}, { _depth: 1 });
+      expect(child.get<number>("_depth")).toBe(1); // override applied
+      expect(child.get<string>("_source_action")).toBe("root"); // untouched
+    });
+  });
+});
+
+describe("extendExecutionMeta helper", () => {
+  test("delegates to ExecutionMetaImpl.extend when given an impl instance", () => {
+    const parent = new ExecutionMetaImpl({ a: 1 });
+    const child = extendExecutionMeta(parent, { b: 2 }, { _depth: 3 });
+    expect(child.get("a")).toBe(1);
+    expect(child.get("b")).toBe(2);
+    expect(child.get("_depth")).toBe(3);
+  });
+
+  test("reconstructs from toJSON for non-impl ExecutionMeta implementations", () => {
+    // Simulate a foreign ExecutionMeta that isn't an ExecutionMetaImpl.
+    const fake = {
+      get: <T>(k: string): T | undefined => (({ x: 1 }) as Record<string, unknown>)[k] as T,
+      require: <T>(k: string): T => (({ x: 1 }) as Record<string, unknown>)[k] as T,
+      has: (k: string) => k === "x",
+      toJSON: () => ({ x: 1 }),
+    };
+    const child = extendExecutionMeta(fake, { y: 2 });
+    expect(child.get("x")).toBe(1);
+    expect(child.get("y")).toBe(2);
+  });
+});
+
+describe("createExecutionMeta", () => {
+  test("strips `_`-prefixed keys from raw input", () => {
+    const meta = createExecutionMeta({
+      raw: {
+        _channel: "evil",
+        _execution_id: "spoofed",
+        source_view: "approval_queue",
+      },
+    });
+    expect(meta.has("_channel")).toBe(false);
+    expect(meta.has("_execution_id")).toBe(false);
+    expect(meta.get("source_view")).toBe("approval_queue");
+  });
+
+  test("merges systemKeys on top of raw (system wins)", () => {
+    const meta = createExecutionMeta({
+      raw: { source_view: "queue" },
+      systemKeys: {
+        _channel: "rest",
+        _execution_id: "exec_abc",
+        _depth: 0,
+      },
+    });
+    expect(meta.get("_channel")).toBe("rest");
+    expect(meta.get("_execution_id")).toBe("exec_abc");
+    expect(meta.get<number>("_depth")).toBe(0);
+    expect(meta.get("source_view")).toBe("queue");
+  });
+
+  test("external caller cannot set system key via raw", () => {
+    const meta = createExecutionMeta({
+      raw: { _channel: "spoofed" },
+      systemKeys: { _channel: "rest" },
+    });
+    expect(meta.get("_channel")).toBe("rest");
+  });
+
+  test("drops non-serializable values (function, Symbol)", () => {
+    const meta = createExecutionMeta({
+      raw: {
+        good: "value",
+        fn: () => 42,
+        sym: Symbol("x"),
+        bi: BigInt(1),
+      },
+    });
+    expect(meta.get("good")).toBe("value");
+    expect(meta.has("fn")).toBe(false);
+    expect(meta.has("sym")).toBe(false);
+    expect(meta.has("bi")).toBe(false);
+  });
+
+  test("drops circular references", () => {
+    const circular: Record<string, unknown> = { name: "x" };
+    circular.self = circular;
+    const meta = createExecutionMeta({
+      raw: { ok: "fine", bad: circular },
+    });
+    expect(meta.get("ok")).toBe("fine");
+    expect(meta.has("bad")).toBe(false);
+  });
+
+  test("drops class instances (non-plain objects)", () => {
+    class Thing {
+      x = 1;
+    }
+    const meta = createExecutionMeta({
+      raw: { instance: new Thing(), plain: { a: 1 } },
+    });
+    expect(meta.has("instance")).toBe(false);
+    expect(meta.get("plain")).toEqual({ a: 1 });
+  });
+
+  test("preserves arrays and nested plain objects", () => {
+    const meta = createExecutionMeta({
+      raw: {
+        list: [1, 2, 3],
+        nested: { a: { b: "c" } },
+      },
+    });
+    expect(meta.get("list")).toEqual([1, 2, 3]);
+    expect(meta.get("nested")).toEqual({ a: { b: "c" } });
+  });
+
+  test("throws MetaSizeError when payload exceeds 8 KB", () => {
+    const big = "x".repeat(DEFAULT_META_MAX_BYTES + 1);
+    expect(() => createExecutionMeta({ raw: { big } })).toThrow(MetaSizeError);
+  });
+
+  test("MetaSizeError carries size/max + `META.SIZE_EXCEEDED` code", () => {
+    const big = "x".repeat(DEFAULT_META_MAX_BYTES + 100);
+    try {
+      createExecutionMeta({ raw: { big } });
+      expect(true).toBe(false); // unreachable
+    } catch (err) {
+      expect(err).toBeInstanceOf(MetaSizeError);
+      const mse = err as MetaSizeError;
+      expect(mse.code).toBe("META.SIZE_EXCEEDED");
+      expect(mse.sizeBytes).toBeGreaterThan(DEFAULT_META_MAX_BYTES);
+      expect(mse.maxBytes).toBe(DEFAULT_META_MAX_BYTES);
+    }
+  });
+
+  test("accepts custom maxSizeBytes", () => {
+    expect(() =>
+      createExecutionMeta({
+        raw: { x: "ab".repeat(50) },
+        maxSizeBytes: 32,
+      }),
+    ).toThrow(MetaSizeError);
+  });
+
+  test("empty options produce an empty but valid meta", () => {
+    const meta = createExecutionMeta();
+    expect(meta.toJSON()).toEqual({});
+  });
+});

--- a/packages/core/__tests__/execution-meta.test.ts
+++ b/packages/core/__tests__/execution-meta.test.ts
@@ -395,3 +395,58 @@ describe("ExecutionMeta read-only + shared-ref handling", () => {
     expect(meta.get<number[]>("list")?.length).toBe(3);
   });
 });
+
+// Codex round-5: invariants must hold for any `new ExecutionMetaImpl(...)`
+// instantiation, not only the factory — the class is publicly exported.
+describe("ExecutionMetaImpl constructor self-enforcement", () => {
+  test("constructor enforces 8 KB size limit directly", () => {
+    expect(() => new ExecutionMetaImpl({ big: "x".repeat(DEFAULT_META_MAX_BYTES + 1) })).toThrow(
+      MetaSizeError,
+    );
+  });
+
+  test("constructor filters non-JSON-serializable values", () => {
+    const meta = new ExecutionMetaImpl({
+      good: "keep",
+      fn: () => 1,
+      date: new Date(),
+      nan: Number.NaN,
+    });
+    expect(meta.get("good")).toBe("keep");
+    expect(meta.has("fn")).toBe(false);
+    expect(meta.has("date")).toBe(false);
+    expect(meta.has("nan")).toBe(false);
+  });
+
+  test("constructor honors custom maxBytes", () => {
+    expect(() => new ExecutionMetaImpl({ text: "x".repeat(100) }, 32)).toThrow(MetaSizeError);
+  });
+
+  // Non-finite numbers (NaN, Infinity, -Infinity) serialize to `null`, which
+  // would diverge from what handlers read in memory.
+  test("createExecutionMeta drops NaN and Infinity", () => {
+    const meta = createExecutionMeta({
+      raw: {
+        n: Number.NaN,
+        p: Number.POSITIVE_INFINITY,
+        neg: Number.NEGATIVE_INFINITY,
+        ok: 42,
+      },
+    });
+    expect(meta.has("n")).toBe(false);
+    expect(meta.has("p")).toBe(false);
+    expect(meta.has("neg")).toBe(false);
+    expect(meta.get("ok")).toBe(42);
+  });
+
+  test("nested NaN causes the whole key to be dropped", () => {
+    const meta = createExecutionMeta({
+      raw: {
+        bad: { inner: Number.NaN },
+        okay: { inner: 1 },
+      },
+    });
+    expect(meta.has("bad")).toBe(false);
+    expect(meta.get("okay")).toEqual({ inner: 1 });
+  });
+});

--- a/packages/core/__tests__/execution-meta.test.ts
+++ b/packages/core/__tests__/execution-meta.test.ts
@@ -318,3 +318,80 @@ describe("ExecutionMetaImpl.extend safety", () => {
     expect(() => parent.extend({ big: "x".repeat(200) })).toThrow(MetaSizeError);
   });
 });
+
+// Codex round-2 follow-up: shared subobject references must not be classified
+// as circular, and nested values must be detached from caller + read-only to handlers.
+describe("ExecutionMeta read-only + shared-ref handling", () => {
+  test("shared sibling subobjects are accepted (not mis-detected as circular)", () => {
+    const shared = { s: "y" };
+    const meta = createExecutionMeta({
+      raw: {
+        payload: { a: shared, b: shared },
+        items: [shared, shared, shared],
+      },
+    });
+    expect(meta.has("payload")).toBe(true);
+    expect(meta.has("items")).toBe(true);
+    const items = meta.get<unknown[]>("items");
+    expect(items?.length).toBe(3);
+  });
+
+  test("true circular reference still rejected", () => {
+    const cyclic: Record<string, unknown> = { a: 1 };
+    cyclic.self = cyclic;
+    const meta = createExecutionMeta({
+      raw: {
+        bad: cyclic,
+        good: "kept",
+      },
+    });
+    expect(meta.has("bad")).toBe(false);
+    expect(meta.get("good")).toBe("kept");
+  });
+
+  test("construction detaches from caller's object graph", () => {
+    const raw = { nested: { count: 1 } };
+    const meta = createExecutionMeta({ raw });
+    // Mutating the caller's original does NOT affect the stored meta.
+    (raw.nested as { count: number }).count = 999;
+    const stored = meta.get<{ count: number }>("nested");
+    expect(stored?.count).toBe(1);
+  });
+
+  test("values returned from get() are frozen — handler mutation is rejected", () => {
+    const meta = createExecutionMeta({ raw: { nested: { count: 1 } } });
+    const view = meta.get<{ count: number }>("nested");
+    expect(view).toBeDefined();
+    expect(Object.isFrozen(view)).toBe(true);
+    // Strict-mode throws on write to frozen property (ES modules = strict mode).
+    expect(() => {
+      if (view) view.count = 999;
+    }).toThrow();
+    expect(meta.get<{ count: number }>("nested")?.count).toBe(1);
+  });
+
+  test("values inside toJSON() snapshot are frozen at nested levels", () => {
+    const meta = createExecutionMeta({ raw: { nested: { a: 1 } } });
+    const snap = meta.toJSON();
+    // Top level of snapshot is a fresh Object (from Object.fromEntries) —
+    // mutable; the existing "toJSON returns a shallow copy" test documents this.
+    snap.extra = "ok"; // allowed
+    expect("extra" in snap).toBe(true);
+    // Nested values remain frozen — cannot mutate through the snapshot either.
+    const nestedInSnap = snap.nested as { a: number };
+    expect(Object.isFrozen(nestedInSnap)).toBe(true);
+    expect(() => {
+      nestedInSnap.a = 999;
+    }).toThrow();
+    // And the meta itself is unchanged.
+    expect(meta.get<{ a: number }>("nested")?.a).toBe(1);
+  });
+
+  test("arrays in meta are frozen — push / index assignment rejected", () => {
+    const meta = createExecutionMeta({ raw: { list: [1, 2, 3] } });
+    const list = meta.get<number[]>("list");
+    expect(Object.isFrozen(list)).toBe(true);
+    expect(() => list?.push(4)).toThrow();
+    expect(meta.get<number[]>("list")?.length).toBe(3);
+  });
+});

--- a/packages/core/__tests__/execution-meta.test.ts
+++ b/packages/core/__tests__/execution-meta.test.ts
@@ -245,4 +245,76 @@ describe("createExecutionMeta", () => {
     const meta = createExecutionMeta();
     expect(meta.toJSON()).toEqual({});
   });
+
+  // Codex follow-up: nested values must be recursively validated. A Date or
+  // function embedded inside an otherwise-plain object was previously passing
+  // the filter because JSON.stringify tolerated it — handlers then observed
+  // a live Date/function that diverged from `meta.toJSON()`.
+  test("recursively drops keys containing nested Date / class instance", () => {
+    const meta = createExecutionMeta({
+      raw: {
+        nestedDate: { when: new Date() },
+        nestedClass: { inst: new (class {})() },
+        nestedFn: { cb: () => 1 },
+        nestedOk: { a: { b: "c" } },
+      },
+    });
+    expect(meta.has("nestedDate")).toBe(false);
+    expect(meta.has("nestedClass")).toBe(false);
+    expect(meta.has("nestedFn")).toBe(false);
+    expect(meta.get("nestedOk")).toEqual({ a: { b: "c" } });
+  });
+
+  test("recursively drops arrays whose elements are non-serializable", () => {
+    const meta = createExecutionMeta({
+      raw: {
+        arrWithFn: [1, () => 2, 3],
+        arrClean: [1, 2, 3],
+      },
+    });
+    expect(meta.has("arrWithFn")).toBe(false);
+    expect(meta.get("arrClean")).toEqual([1, 2, 3]);
+  });
+});
+
+// Codex follow-up: extend() must apply the same filter + size limit so nested
+// ctx.execute meta cannot smuggle non-serializable values or exceed 8 KB.
+describe("ExecutionMetaImpl.extend safety", () => {
+  test("extend drops non-serializable extra keys", () => {
+    const parent = new ExecutionMetaImpl({ a: 1 });
+    const child = parent.extend({ bad: () => 1, date: new Date(), ok: "yes" });
+    expect(child.has("bad")).toBe(false);
+    expect(child.has("date")).toBe(false);
+    expect(child.get("ok")).toBe("yes");
+  });
+
+  test("extend drops extras whose nested values are non-serializable", () => {
+    const parent = new ExecutionMetaImpl({ a: 1 });
+    const child = parent.extend({ nested: { when: new Date() } });
+    expect(child.has("nested")).toBe(false);
+  });
+
+  test("extend enforces size limit inherited from parent", () => {
+    const parent = new ExecutionMetaImpl({ a: 1 });
+    expect(() => parent.extend({ huge: "x".repeat(DEFAULT_META_MAX_BYTES + 1) })).toThrow(
+      MetaSizeError,
+    );
+  });
+
+  test("extendExecutionMeta enforces size on non-ExecutionMetaImpl parent", () => {
+    const fakeParent = {
+      get: () => undefined,
+      require: () => undefined,
+      has: () => false,
+      toJSON: () => ({ a: 1 }),
+    };
+    expect(() =>
+      extendExecutionMeta(fakeParent, { huge: "x".repeat(DEFAULT_META_MAX_BYTES + 1) }),
+    ).toThrow(MetaSizeError);
+  });
+
+  test("custom size limit from constructor is honored by extend", () => {
+    const parent = new ExecutionMetaImpl({ a: 1 }, 64);
+    expect(() => parent.extend({ big: "x".repeat(200) })).toThrow(MetaSizeError);
+  });
 });

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -109,13 +109,15 @@ export interface ExecuteOptions {
   /**
    * Execution metadata propagated through the execution chain (Spec 65).
    *
-   * Normally set by the CommandLayer from `CommandExecuteOptions.meta` +
-   * framework system keys, and by the ActionEngine itself on nested
-   * `ctx.execute` calls. When absent (direct internal executor calls), the
-   * ActionEngine synthesizes a default meta containing only system keys so
-   * `ctx.meta` is always populated.
+   * Accepts either a pre-built `ExecutionMeta` (how the CommandLayer and the
+   * ActionEngine itself pass meta across nested calls) OR a plain record of
+   * raw key-value pairs (the natural call shape from direct-executor tests
+   * and internal callers). Plain records are normalized with
+   * `createExecutionMeta` at ingestion. Without this normalization, passing
+   * `{ meta: { source_view: "queue" } }` would break `ctx.meta.get(...)` at
+   * runtime with "x is not a function".
    */
-  meta?: ExecutionMeta;
+  meta?: ExecutionMeta | Record<string, unknown>;
 }
 
 // ── ActionExecutor ──────────────────────────────────────────
@@ -189,6 +191,43 @@ export interface ActionExecutorOptions {
   eventBus?: EventBus;
   /** Names of registered capabilities — enables ctx.hasCapability() for weak dependency checks */
   capabilityNames?: ReadonlySet<string>;
+}
+
+/**
+ * Duck-type check: does `value` look like an {@link ExecutionMeta}? The
+ * public ExecuteOptions.meta accepts either a pre-built ExecutionMeta (how
+ * the CommandLayer + nested ctx.execute pass it) or a plain record (natural
+ * external call shape). We detect the former by the presence of the typed
+ * accessor methods rather than an `instanceof` check so third-party
+ * implementations (e.g., future Phase 2 subclasses) still work.
+ */
+function isExecutionMeta(value: unknown): value is ExecutionMeta {
+  if (value === null || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.get === "function" &&
+    typeof candidate.has === "function" &&
+    typeof candidate.require === "function" &&
+    typeof candidate.toJSON === "function"
+  );
+}
+
+/**
+ * Extend an incoming ExecutionMeta with system defaults ONLY for keys the
+ * parent has not already set. Prevents a child execution from clobbering
+ * root-level `_execution_id`, while still backfilling it when a parent meta
+ * happens to arrive without one.
+ */
+function fillMissingSystemKeys(
+  meta: ExecutionMeta,
+  systemDefaults: Record<string, unknown>,
+): ExecutionMeta {
+  const missing: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(systemDefaults)) {
+    if (!meta.has(k)) missing[k] = v;
+  }
+  if (Object.keys(missing).length === 0) return meta;
+  return extendExecutionMeta(meta, {}, missing);
 }
 
 /**
@@ -439,20 +478,34 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
     // so that ctx closures automatically use the transactional connection.
     let activeProvider: DataProvider = baseProvider;
 
-    // Resolve execution meta: CommandLayer-provided meta takes precedence.
-    // When absent (direct internal executor calls), synthesize a default meta
-    // with only system keys so `ctx.meta` is always populated (Spec 65 §2.2).
-    // Size-limit validation has already happened at construction time in the
-    // CommandLayer for external paths — this synthesized meta is tiny.
-    const resolvedMeta: ExecutionMeta =
-      execOptions?.meta ??
-      createExecutionMeta({
-        systemKeys: {
-          _channel: channel,
-          _execution_id: executionId,
-          _depth: currentDepth,
-        },
-      });
+    // Resolve execution meta. `execOptions.meta` is typed as
+    // `ExecutionMeta | Record<string, unknown>` so direct-executor callers can
+    // pass a plain record (e.g., `executor.execute(..., { meta: { foo: 1 } })`)
+    // without constructing an ExecutionMeta themselves — the natural call
+    // shape. Internally we always normalize to an ExecutionMeta before
+    // exposing on ctx.meta.
+    //
+    // `_execution_id` is the ROOT execution record id (Spec 65 §4.4 — keyed
+    // against ExecutionLogger.getById), NOT a tracing id. ActionEngine owns
+    // its assignment: set from `executionId` at the root (depth == 0) when
+    // not already carried from a parent (which uses extendExecutionMeta to
+    // preserve the parent's root id through the chain).
+    const rootSystemDefaults: Record<string, unknown> = {
+      _channel: channel,
+      _execution_id: executionId,
+      _depth: currentDepth,
+    };
+    const providedMeta = execOptions?.meta;
+    const resolvedMeta: ExecutionMeta = !providedMeta
+      ? createExecutionMeta({ systemKeys: rootSystemDefaults })
+      : isExecutionMeta(providedMeta)
+        ? fillMissingSystemKeys(providedMeta, rootSystemDefaults)
+        : // Plain record — wrap through createExecutionMeta so _-prefixed
+          // keys get stripped, non-serializable values filtered, size enforced.
+          createExecutionMeta({
+            raw: providedMeta as Record<string, unknown>,
+            systemKeys: rootSystemDefaults,
+          });
 
     const ctx: ActionContext = {
       input,
@@ -491,8 +544,10 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
           });
         } catch (err) {
           if (err instanceof MetaSizeError) {
-            const failedId = generateExecutionId();
-            childExecutionIds.push(failedId);
+            // The child never ran — no execution log entry exists for this
+            // rejection. Do NOT push a fake id onto childExecutionIds: that
+            // would break `ExecutionLogger.getById()` lookups from the parent
+            // log, since no record is ever written under it.
             return { error: err.message, code: err.code };
           }
           throw err;

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -15,6 +15,8 @@ import { createTenantAwareDataProvider } from "../security/tenant-isolation";
 import type { ActionContext, ActionResult, Actor } from "../types/action";
 import type { AIService } from "../types/ai";
 import type { ExecutionLogEntry, ExecutionLogger } from "../types/execution-log";
+import type { ExecutionMeta } from "../types/execution-meta";
+import { createExecutionMeta, extendExecutionMeta } from "../types/execution-meta";
 import type { Logger } from "../types/logger";
 import type { StateMachine } from "./state-machine";
 import { canTransition, getAvailableActions } from "./state-machine";
@@ -104,6 +106,16 @@ export interface ExecuteOptions {
   _txDataProvider?: DataProvider;
   /** Internal: parent's pending events array for shared transaction */
   _parentPendingEvents?: PendingEvent[];
+  /**
+   * Execution metadata propagated through the execution chain (Spec 65).
+   *
+   * Normally set by the CommandLayer from `CommandExecuteOptions.meta` +
+   * framework system keys, and by the ActionEngine itself on nested
+   * `ctx.execute` calls. When absent (direct internal executor calls), the
+   * ActionEngine synthesizes a default meta containing only system keys so
+   * `ctx.meta` is always populated.
+   */
+  meta?: ExecutionMeta;
 }
 
 // ── ActionExecutor ──────────────────────────────────────────
@@ -427,6 +439,21 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
     // so that ctx closures automatically use the transactional connection.
     let activeProvider: DataProvider = baseProvider;
 
+    // Resolve execution meta: CommandLayer-provided meta takes precedence.
+    // When absent (direct internal executor calls), synthesize a default meta
+    // with only system keys so `ctx.meta` is always populated (Spec 65 §2.2).
+    // Size-limit validation has already happened at construction time in the
+    // CommandLayer for external paths — this synthesized meta is tiny.
+    const resolvedMeta: ExecutionMeta =
+      execOptions?.meta ??
+      createExecutionMeta({
+        systemKeys: {
+          _channel: channel,
+          _execution_id: executionId,
+          _depth: currentDepth,
+        },
+      });
+
     const ctx: ActionContext = {
       input,
       actor,
@@ -437,17 +464,30 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
       config: configRegistry ?? ConfigRegistry.empty(),
       executionId,
       timestamp: startedAt,
+      meta: resolvedMeta,
       get: (entity, id) => activeProvider.get(entity, id, queryOptions),
       query: (entity, filter) => activeProvider.query(entity, filter, queryOptions),
       create: (entity, data) => activeProvider.create(entity, data),
       update: (entity, id, data) => activeProvider.update(entity, id, data, queryOptions),
       delete: (entity, id) => activeProvider.delete(entity, id, queryOptions),
-      execute: async (childActionName, childInput) => {
+      execute: async (childActionName, childInput, childOpts) => {
+        // Extend parent meta for the child call: parent keys always win (§4.3),
+        // framework updates _depth and _source_action unconditionally (§4.4),
+        // and the root _execution_id is preserved across the chain.
+        // Using the standalone extendExecutionMeta helper keeps the public
+        // ExecutionMeta interface read-only from the handler's perspective —
+        // handlers can't accidentally mutate meta by calling `.extend(...)`
+        // on `ctx.meta`.
+        const childMeta = extendExecutionMeta(resolvedMeta, childOpts?.meta ?? {}, {
+          _depth: currentDepth + 1,
+          _source_action: actionName,
+        });
         const childResult = await execute(childActionName, childInput, actor, {
           ...execOptions,
           _depth: currentDepth + 1,
           _txDataProvider: activeProvider,
           _parentPendingEvents: pendingEvents,
+          meta: childMeta,
         });
         childExecutionIds.push(childResult.executionId);
         return childResult.data;

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -496,16 +496,44 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
       _depth: currentDepth,
     };
     const providedMeta = execOptions?.meta;
-    const resolvedMeta: ExecutionMeta = !providedMeta
-      ? createExecutionMeta({ systemKeys: rootSystemDefaults })
-      : isExecutionMeta(providedMeta)
-        ? fillMissingSystemKeys(providedMeta, rootSystemDefaults)
-        : // Plain record — wrap through createExecutionMeta so _-prefixed
-          // keys get stripped, non-serializable values filtered, size enforced.
-          createExecutionMeta({
-            raw: providedMeta as Record<string, unknown>,
-            systemKeys: rootSystemDefaults,
-          });
+    // Meta construction can throw MetaSizeError (plain-record wrap + size
+    // enforcement, or an already-oversized ExecutionMeta reaching the limit
+    // after system keys are added). Direct-executor callers bypass the
+    // CommandLayer's catch, so without handling here the exception would
+    // escape as unhandled. Return a normal failed ActionResult and log it
+    // so callers see the same shape regardless of entry point.
+    let resolvedMeta: ExecutionMeta;
+    try {
+      resolvedMeta = !providedMeta
+        ? createExecutionMeta({ systemKeys: rootSystemDefaults })
+        : isExecutionMeta(providedMeta)
+          ? fillMissingSystemKeys(providedMeta, rootSystemDefaults)
+          : // Plain record — wrap through createExecutionMeta so _-prefixed
+            // keys get stripped, non-serializable values filtered, size enforced.
+            createExecutionMeta({
+              raw: providedMeta as Record<string, unknown>,
+              systemKeys: rootSystemDefaults,
+            });
+    } catch (err) {
+      if (err instanceof MetaSizeError) {
+        await logExecution({
+          id: executionId,
+          action: actionName,
+          entity: action.entity,
+          actor,
+          input,
+          status: "failed",
+          error: { message: err.message, code: err.code },
+          startedAt,
+        });
+        return {
+          success: false,
+          data: { error: err.message, code: err.code } as T,
+          executionId,
+        };
+      }
+      throw err;
+    }
 
     const ctx: ActionContext = {
       input,

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -309,6 +309,14 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
     // Step 0b: Idempotency check
     // Scope key by action name + tenant to prevent cross-action/cross-tenant collisions.
     // Only apply at top level — child executions (depth > 0) do not inherit idempotency.
+    //
+    // TODO(spec-65 Phase 2): If an action's `ctx.meta` participates in
+    // decision-making (e.g., `dry_run`, `skip_notifications`), a second
+    // request reusing the same `idempotencyKey` with different meta will
+    // receive the first execution's cached output without re-running. Either
+    // hash the normalized meta into the key or reject changed meta for an
+    // existing key. Deferred here because it requires a product decision on
+    // idempotency semantics (observational meta vs behavior-affecting meta).
     const rawIdempotencyKey = currentDepth === 0 ? execOptions?.idempotencyKey : undefined;
     const idempotencyKey = rawIdempotencyKey
       ? `${actionName}:${execOptions?.tenantId ?? ""}:${rawIdempotencyKey}`

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -16,7 +16,7 @@ import type { ActionContext, ActionResult, Actor } from "../types/action";
 import type { AIService } from "../types/ai";
 import type { ExecutionLogEntry, ExecutionLogger } from "../types/execution-log";
 import type { ExecutionMeta } from "../types/execution-meta";
-import { createExecutionMeta, extendExecutionMeta } from "../types/execution-meta";
+import { createExecutionMeta, extendExecutionMeta, MetaSizeError } from "../types/execution-meta";
 import type { Logger } from "../types/logger";
 import type { StateMachine } from "./state-machine";
 import { canTransition, getAvailableActions } from "./state-machine";
@@ -478,10 +478,25 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
         // ExecutionMeta interface read-only from the handler's perspective —
         // handlers can't accidentally mutate meta by calling `.extend(...)`
         // on `ctx.meta`.
-        const childMeta = extendExecutionMeta(resolvedMeta, childOpts?.meta ?? {}, {
-          _depth: currentDepth + 1,
-          _source_action: actionName,
-        });
+        // `extend` enforces the same filter + size limit as root meta
+        // construction. If the merged child payload exceeds 8 KB, surface the
+        // error as a failed ActionResult rather than letting the exception
+        // bubble up and crash the parent handler — consistent with how other
+        // child failures flow back to the caller (ctx.execute returns result.data).
+        let childMeta: ExecutionMeta;
+        try {
+          childMeta = extendExecutionMeta(resolvedMeta, childOpts?.meta ?? {}, {
+            _depth: currentDepth + 1,
+            _source_action: actionName,
+          });
+        } catch (err) {
+          if (err instanceof MetaSizeError) {
+            const failedId = generateExecutionId();
+            childExecutionIds.push(failedId);
+            return { error: err.message, code: err.code };
+          }
+          throw err;
+        }
         const childResult = await execute(childActionName, childInput, actor, {
           ...execOptions,
           _depth: currentDepth + 1,

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -495,9 +495,23 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
     //
     // `_execution_id` is the ROOT execution record id (Spec 65 §4.4 — keyed
     // against ExecutionLogger.getById), NOT a tracing id. ActionEngine owns
-    // its assignment: set from `executionId` at the root (depth == 0) when
-    // not already carried from a parent (which uses extendExecutionMeta to
-    // preserve the parent's root id through the chain).
+    // its assignment.
+    //
+    // ### Root-vs-nested trust boundary (Gemini PR #201 review)
+    //
+    // At `currentDepth === 0` the provided meta comes from an **untrusted**
+    // external surface — a direct-executor call, a CommandLayer forward, a
+    // duck-typed ExecutionMeta, whatever. We always re-run through
+    // `createExecutionMeta` with the raw snapshot so:
+    //  1. `_`-prefixed keys are stripped (external callers cannot spoof
+    //     `_channel`, `_execution_id`, etc.).
+    //  2. Non-JSON-serializable values are filtered.
+    //  3. Framework-owned `rootSystemDefaults` always win.
+    //
+    // At `currentDepth > 0` the provided meta was built by the engine itself
+    // via `extendExecutionMeta` in `ctx.execute`, so it is framework-trusted;
+    // passing it through unchanged preserves the parent's `_execution_id`
+    // and other system keys across the chain.
     const rootSystemDefaults: Record<string, unknown> = {
       _channel: channel,
       _execution_id: executionId,
@@ -512,16 +526,30 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
     // so callers see the same shape regardless of entry point.
     let resolvedMeta: ExecutionMeta;
     try {
-      resolvedMeta = !providedMeta
-        ? createExecutionMeta({ systemKeys: rootSystemDefaults })
-        : isExecutionMeta(providedMeta)
+      if (!providedMeta) {
+        resolvedMeta = createExecutionMeta({ systemKeys: rootSystemDefaults });
+      } else if (currentDepth === 0) {
+        // Root entry — treat any provided meta as external input. Extract
+        // its raw snapshot (handles both ExecutionMeta and plain records)
+        // and push it through the untrusted-input factory.
+        const rawSnapshot = isExecutionMeta(providedMeta)
+          ? providedMeta.toJSON()
+          : (providedMeta as Record<string, unknown>);
+        resolvedMeta = createExecutionMeta({
+          raw: rawSnapshot,
+          systemKeys: rootSystemDefaults,
+        });
+      } else {
+        // Nested call — provided meta is framework-built via extend.
+        // Trust it, only filling system keys that somehow went missing
+        // (defensive — expected to be a no-op in practice).
+        resolvedMeta = isExecutionMeta(providedMeta)
           ? fillMissingSystemKeys(providedMeta, rootSystemDefaults)
-          : // Plain record — wrap through createExecutionMeta so _-prefixed
-            // keys get stripped, non-serializable values filtered, size enforced.
-            createExecutionMeta({
+          : createExecutionMeta({
               raw: providedMeta as Record<string, unknown>,
               systemKeys: rootSystemDefaults,
             });
+      }
     } catch (err) {
       if (err instanceof MetaSizeError) {
         await logExecution({

--- a/packages/core/src/engine/approval-engine.ts
+++ b/packages/core/src/engine/approval-engine.ts
@@ -388,6 +388,13 @@ export function createApprovalEngine(options: ApprovalEngineOptions): ApprovalEn
     // Re-execute the original action.
     // Prefer CommandLayer (runs pre/tenant/pre-action/post-action, skips auth/exposure/permission).
     // Fall back to direct executor.execute() for backward compatibility.
+    //
+    // TODO(spec-65 Phase 2): Approval records do NOT persist the original
+    // `ctx.meta` — handlers relying on meta (e.g., `source_view`,
+    // `triggered_by`) see different context before and after approval.
+    // Needs an approval-store schema extension to carry meta through the
+    // suspend/resume boundary. Deferred here because it requires a
+    // storage-layer change.
     let result: ActionResult;
 
     if (commandLayer) {

--- a/packages/core/src/engine/command-layer.ts
+++ b/packages/core/src/engine/command-layer.ts
@@ -31,6 +31,7 @@ import type { MetricsCollector } from "../observability/metrics";
 import { noopMetricsCollector } from "../observability/metrics";
 import { getCurrentTrace, withTrace, withTraceId } from "../observability/trace-context";
 import type { ActionDefinition, ActionResult, Actor } from "../types/action";
+import { createExecutionMeta, MetaSizeError } from "../types/execution-meta";
 import type { Logger } from "../types/logger";
 import type { ActionExecutor, ExecuteOptions, ExecutionChannel } from "./action-engine";
 
@@ -448,11 +449,46 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
     if (action && !skipActionSlots) {
       const resolvedAction = action;
       pipeline.push(async (c: CommandContext, _next: () => Promise<void>) => {
+        // Build the typed ExecutionMeta from the raw pipeline dict.
+        // Constructed here (after middleware has run) so middleware that
+        // mutates `c.meta` for pipeline-internal state still feeds the final
+        // handler-visible meta (Spec 65 §8.3).
+        //
+        // `_execution_id` source: prefer the pipeline-assigned traceId when
+        // present so distributed traces share one root id. When no traceId
+        // was propagated, omit `_execution_id` here — the ActionEngine will
+        // not synthesize one either for CommandLayer-owned paths, and the
+        // actual per-action `executionId` remains on `ctx.executionId`.
+        // TODO(spec-65 Phase 2): The execution-log writer should record
+        // `meta.toJSON()` alongside the existing ExecutionLogEntry fields.
+        let meta: ReturnType<typeof createExecutionMeta>;
+        try {
+          const systemKeys: Record<string, unknown> = {
+            _channel: c.channel,
+            _depth: 0,
+          };
+          if (c.traceId) {
+            systemKeys._execution_id = c.traceId;
+          }
+          meta = createExecutionMeta({ raw: c.meta, systemKeys });
+        } catch (err) {
+          if (err instanceof MetaSizeError) {
+            c.result = {
+              success: false,
+              data: { error: err.message, code: err.code },
+              executionId: generatePipelineId(),
+            };
+            return;
+          }
+          throw err;
+        }
+
         try {
           const result = await executor.execute(resolvedAction.name, c.input, c.actor, {
             ...executorOptions,
             tenantId: c.tenantId, // Use latest tenantId (tenant middleware may have set it)
             locale: c.locale, // Use latest locale (middleware may have set it)
+            meta,
           });
           c.result = result;
         } catch (_err) {

--- a/packages/core/src/engine/command-layer.ts
+++ b/packages/core/src/engine/command-layer.ts
@@ -31,7 +31,6 @@ import type { MetricsCollector } from "../observability/metrics";
 import { noopMetricsCollector } from "../observability/metrics";
 import { getCurrentTrace, withTrace, withTraceId } from "../observability/trace-context";
 import type { ActionDefinition, ActionResult, Actor } from "../types/action";
-import { createExecutionMeta, MetaSizeError } from "../types/execution-meta";
 import type { Logger } from "../types/logger";
 import type { ActionExecutor, ExecuteOptions, ExecutionChannel } from "./action-engine";
 
@@ -449,56 +448,32 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
     if (action && !skipActionSlots) {
       const resolvedAction = action;
       pipeline.push(async (c: CommandContext, _next: () => Promise<void>) => {
-        // Build the typed ExecutionMeta from the raw pipeline dict.
-        // Constructed here (after middleware has run) so middleware that
-        // mutates `c.meta` for pipeline-internal state still feeds the final
-        // handler-visible meta (Spec 65 §8.3).
-        //
-        // `_execution_id` is intentionally NOT set here. Spec 65 §4.4 defines
-        // it as the ROOT execution record id (keyed against ExecutionLogger),
-        // not a tracing context. The ActionEngine owns executionId generation
-        // and fills the system key at root entry; nested calls preserve it
-        // via extendExecutionMeta. Setting it from traceId would collapse
-        // multiple executions under a single upstream trace onto the same
-        // "execution id" and break ExecutionLogger.getById() lookups.
+        // Pass `c.meta` through as a plain record and let ActionEngine be the
+        // single source of truth for meta normalization (strip _-prefix,
+        // filter non-serializable, enforce 8 KB including `_execution_id`).
+        // Any middleware that mutated `c.meta` for pipeline-internal state
+        // still feeds the final handler-visible meta via this handoff —
+        // Spec 65 §8.3.
         //
         // TODO(spec-65 Phase 2): The execution-log writer should record
         // `meta.toJSON()` alongside the existing ExecutionLogEntry fields.
-        let meta: ReturnType<typeof createExecutionMeta>;
-        try {
-          meta = createExecutionMeta({
-            raw: c.meta,
-            systemKeys: {
-              _channel: c.channel,
-              _depth: 0,
-            },
-          });
-        } catch (err) {
-          if (err instanceof MetaSizeError) {
-            // Meta is invalid → the action never runs. Post-action hooks
-            // (cache invalidation, event fan-out, notifications) are write-side
-            // semantics and MUST NOT fire when there were no writes. Add
-            // `post-action` to the skipped set so the loop below is a no-op,
-            // mirroring the skipActionSlots contract.
-            skippedSlots.add("post-action");
-            c.result = {
-              success: false,
-              data: { error: err.message, code: err.code },
-              executionId: generatePipelineId(),
-            };
-            return;
-          }
-          throw err;
-        }
-
         try {
           const result = await executor.execute(resolvedAction.name, c.input, c.actor, {
             ...executorOptions,
             tenantId: c.tenantId, // Use latest tenantId (tenant middleware may have set it)
             locale: c.locale, // Use latest locale (middleware may have set it)
-            meta,
+            meta: c.meta,
           });
           c.result = result;
+          // ActionEngine rejected the meta (oversized after all system keys
+          // applied). The action handler never ran → post-action hooks
+          // (cache invalidation, event fan-out, notifications) are
+          // write-side semantics and MUST NOT fire. Mirror the
+          // `skipActionSlots` contract by skipping post-action here.
+          const code = (result.data as { code?: unknown } | undefined)?.code;
+          if (!result.success && code === "META.SIZE_EXCEEDED") {
+            skippedSlots.add("post-action");
+          }
         } catch (_err) {
           // Executor should return ActionResult, but guard against unexpected throws (#4)
           c.result = {

--- a/packages/core/src/engine/command-layer.ts
+++ b/packages/core/src/engine/command-layer.ts
@@ -454,23 +454,25 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
         // mutates `c.meta` for pipeline-internal state still feeds the final
         // handler-visible meta (Spec 65 §8.3).
         //
-        // `_execution_id` source: prefer the pipeline-assigned traceId when
-        // present so distributed traces share one root id. When no traceId
-        // was propagated, omit `_execution_id` here — the ActionEngine will
-        // not synthesize one either for CommandLayer-owned paths, and the
-        // actual per-action `executionId` remains on `ctx.executionId`.
+        // `_execution_id` is intentionally NOT set here. Spec 65 §4.4 defines
+        // it as the ROOT execution record id (keyed against ExecutionLogger),
+        // not a tracing context. The ActionEngine owns executionId generation
+        // and fills the system key at root entry; nested calls preserve it
+        // via extendExecutionMeta. Setting it from traceId would collapse
+        // multiple executions under a single upstream trace onto the same
+        // "execution id" and break ExecutionLogger.getById() lookups.
+        //
         // TODO(spec-65 Phase 2): The execution-log writer should record
         // `meta.toJSON()` alongside the existing ExecutionLogEntry fields.
         let meta: ReturnType<typeof createExecutionMeta>;
         try {
-          const systemKeys: Record<string, unknown> = {
-            _channel: c.channel,
-            _depth: 0,
-          };
-          if (c.traceId) {
-            systemKeys._execution_id = c.traceId;
-          }
-          meta = createExecutionMeta({ raw: c.meta, systemKeys });
+          meta = createExecutionMeta({
+            raw: c.meta,
+            systemKeys: {
+              _channel: c.channel,
+              _depth: 0,
+            },
+          });
         } catch (err) {
           if (err instanceof MetaSizeError) {
             // Meta is invalid → the action never runs. Post-action hooks

--- a/packages/core/src/engine/command-layer.ts
+++ b/packages/core/src/engine/command-layer.ts
@@ -473,6 +473,12 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
           meta = createExecutionMeta({ raw: c.meta, systemKeys });
         } catch (err) {
           if (err instanceof MetaSizeError) {
+            // Meta is invalid → the action never runs. Post-action hooks
+            // (cache invalidation, event fan-out, notifications) are write-side
+            // semantics and MUST NOT fire when there were no writes. Add
+            // `post-action` to the skipped set so the loop below is a no-op,
+            // mirroring the skipActionSlots contract.
+            skippedSlots.add("post-action");
             c.result = {
               success: false,
               data: { error: err.message, code: err.code },

--- a/packages/core/src/types/action.ts
+++ b/packages/core/src/types/action.ts
@@ -8,6 +8,7 @@
 import type { ConfigRegistry } from "../config/config-registry";
 import type { AIService } from "./ai";
 import type { FieldDefinition } from "./entity";
+import type { ExecutionMeta } from "./execution-meta";
 import type { Logger } from "./logger";
 
 // ── Actor types ──────────────────────────────────────
@@ -125,7 +126,11 @@ export interface ActionContext {
   delete(schema: string, id: string): Promise<void>;
 
   // Trigger other Actions
-  execute(actionName: string, input: Record<string, unknown>): Promise<unknown>;
+  execute(
+    actionName: string,
+    input: Record<string, unknown>,
+    options?: { meta?: Record<string, unknown> },
+  ): Promise<unknown>;
 
   // Emit custom events
   emit(eventType: string, payload: Record<string, unknown>): void;
@@ -135,6 +140,13 @@ export interface ActionContext {
 
   /** Check whether a capability is installed (weak dependency degradation) */
   hasCapability(name: string): boolean;
+
+  /**
+   * Execution metadata — arbitrary key-value context that propagates through
+   * the entire execution chain (Action -> EventHandler -> nested Actions).
+   * Read-only after construction (Spec 65 §4.2).
+   */
+  meta: ExecutionMeta;
 
   // Current execution info
   executionId: string;

--- a/packages/core/src/types/execution-meta.ts
+++ b/packages/core/src/types/execution-meta.ts
@@ -162,12 +162,19 @@ function filterSerializable(input: Record<string, unknown>): Record<string, unkn
 }
 
 /**
+ * Module-level TextEncoder instance. UTF-8 encoder state is stateless, so one
+ * shared instance is safe across all calls and avoids per-size-check
+ * allocation in the hot path (Gemini PR #201 review).
+ */
+const META_ENCODER = new TextEncoder();
+
+/**
  * Enforce the serialized-size limit on an already-filtered meta payload.
  * Throws {@link MetaSizeError} when exceeded.
  */
 function assertSizeLimit(entries: Record<string, unknown>, maxBytes: number): void {
   const serialized = JSON.stringify(entries);
-  const sizeBytes = new TextEncoder().encode(serialized).length;
+  const sizeBytes = META_ENCODER.encode(serialized).length;
   if (sizeBytes > maxBytes) {
     throw new MetaSizeError(sizeBytes, maxBytes);
   }

--- a/packages/core/src/types/execution-meta.ts
+++ b/packages/core/src/types/execution-meta.ts
@@ -65,7 +65,12 @@ export interface ExecutionMeta {
 function isJsonSerializable(value: unknown, ancestors?: WeakSet<object>): boolean {
   if (value === null) return true;
   const t = typeof value;
-  if (t === "string" || t === "number" || t === "boolean") return true;
+  if (t === "string" || t === "boolean") return true;
+  // Reject non-finite numbers (NaN, Infinity, -Infinity) — JSON.stringify
+  // coerces them to `null`, so in-memory `ctx.meta.get("x") === NaN` would
+  // diverge from `meta.toJSON()` / the on-wire payload. Same principle as
+  // dropping Date / function values.
+  if (t === "number") return Number.isFinite(value);
   if (t === "function" || t === "symbol" || t === "undefined" || t === "bigint") return false;
   // object — arrays and plain objects only; walk recursively to catch
   // class instances / non-plain prototypes nested inside otherwise-plain
@@ -181,13 +186,24 @@ export class ExecutionMetaImpl implements ExecutionMeta {
   private readonly maxBytes: number;
 
   constructor(entries: Record<string, unknown>, maxBytes: number = DEFAULT_META_MAX_BYTES) {
+    // Self-enforcing invariants: the constructor itself filters non-JSON-
+    // serializable values AND asserts the size limit. This matters because
+    // ExecutionMetaImpl is a public export — any caller who does
+    // `new ExecutionMetaImpl(...)` directly (or crafts a custom
+    // ExecutionMeta that the engine normalizes via extend) must still get
+    // the same guarantees as the `createExecutionMeta` factory.
+    //
+    // System keys (`_`-prefixed) are NOT stripped here — that's the
+    // factory's job on external input. The constructor treats whatever it
+    // gets as already-merged and framework-trusted-for-system-keys.
+    const safe = filterSerializable(entries);
+    assertSizeLimit(safe, maxBytes);
     // Deep-clone + deep-freeze so the stored payload is fully detached from
     // caller-provided object graphs AND cannot be mutated through values
     // returned by `get` / `require` / `toJSON`. Spec 65 §4.2 — meta is
-    // read-only after construction. Silent freeze works in sloppy mode;
-    // strict-mode callers get a TypeError on mutation attempts, which is
-    // the desired surfacing behavior.
-    const frozen = cloneAndFreezeEntries(entries);
+    // read-only after construction. Strict-mode callers get a TypeError on
+    // mutation attempts, which is the desired surfacing behavior.
+    const frozen = cloneAndFreezeEntries(safe);
     this.data = new Map(Object.entries(frozen));
     this.maxBytes = maxBytes;
   }
@@ -237,19 +253,17 @@ export class ExecutionMetaImpl implements ExecutionMeta {
   ): ExecutionMetaImpl {
     const merged: Record<string, unknown> = { ...this.toJSON() };
     const strippedExtra = stripSystemKeys(extra);
-    const safeExtra = filterSerializable(strippedExtra);
-    for (const [k, v] of Object.entries(safeExtra)) {
-      // Parent always wins — child can only add new keys.
+    for (const [k, v] of Object.entries(strippedExtra)) {
+      // Parent always wins — child can only add new keys. The constructor
+      // will filter non-serializable values and size-check on the final
+      // payload, so we just propose keys here.
       if (!Object.hasOwn(merged, k)) {
         merged[k] = v;
       }
     }
     if (systemOverrides) {
-      // System overrides are framework-trusted but still filtered for
-      // serializability so a programmer error can't poison the chain.
-      Object.assign(merged, filterSerializable(systemOverrides));
+      Object.assign(merged, systemOverrides);
     }
-    assertSizeLimit(merged, this.maxBytes);
     return new ExecutionMetaImpl(merged, this.maxBytes);
   }
 }
@@ -301,16 +315,11 @@ export interface CreateExecutionMetaOptions {
 export function createExecutionMeta(options: CreateExecutionMetaOptions = {}): ExecutionMeta {
   const { raw = {}, systemKeys = {}, maxSizeBytes = DEFAULT_META_MAX_BYTES } = options;
 
-  const strippedRaw = stripSystemKeys(raw);
-  const safeRaw = filterSerializable(strippedRaw);
-  // System keys are framework-owned — trust them, but still filter non-
-  // serializable values so a bad `_` key (e.g., a class instance) can't poison
-  // the execution log downstream.
-  const safeSystemKeys = filterSerializable(systemKeys);
-
-  const merged: Record<string, unknown> = { ...safeRaw, ...safeSystemKeys };
-
-  assertSizeLimit(merged, maxSizeBytes);
+  // The factory's only unique responsibility is stripping `_`-prefixed keys
+  // from external `raw` (system-key namespace protection, §4.4). Serialization
+  // filtering and size-limit enforcement both live in the constructor —
+  // running them here too would just be duplicate work.
+  const merged: Record<string, unknown> = { ...stripSystemKeys(raw), ...systemKeys };
 
   return new ExecutionMetaImpl(merged, maxSizeBytes);
 }

--- a/packages/core/src/types/execution-meta.ts
+++ b/packages/core/src/types/execution-meta.ts
@@ -1,0 +1,225 @@
+/**
+ * ExecutionMeta — typed, immutable execution metadata propagation (Spec 65).
+ *
+ * ExecutionMeta carries arbitrary key-value context through the entire execution
+ * chain (Action -> EventHandler -> nested Actions). It is read-only once
+ * constructed; framework code extends it on nested calls via {@link ExecutionMetaImpl.extend}.
+ *
+ * System-only keys (prefixed with `_`) may only be set by the framework.
+ * External callers' `_`-prefixed keys are silently stripped.
+ */
+
+/** Default 8 KB size limit for the JSON-serialized meta payload (Spec 65 §10.2). */
+export const DEFAULT_META_MAX_BYTES = 8192;
+
+/**
+ * Error thrown when the serialized meta payload exceeds the configured size limit.
+ * Uses a plain Error subclass to avoid the `ErrorCode` "a.b.c" format constraint
+ * on LinchKitError — the `code` field here is the 2-part marker the CommandLayer
+ * surfaces in `ActionResult.data.code` (consistent with PIPELINE error codes).
+ */
+export class MetaSizeError extends Error {
+  readonly code = "META.SIZE_EXCEEDED";
+  readonly sizeBytes: number;
+  readonly maxBytes: number;
+
+  constructor(sizeBytes: number, maxBytes: number) {
+    super(`Execution meta size ${sizeBytes} bytes exceeds limit of ${maxBytes} bytes`);
+    this.name = "MetaSizeError";
+    this.sizeBytes = sizeBytes;
+    this.maxBytes = maxBytes;
+  }
+}
+
+/**
+ * Immutable execution metadata that propagates through the entire execution
+ * chain (Action -> EventHandler -> nested Actions).
+ * Used for cross-cutting concerns, caller hints, and integration metadata.
+ */
+export interface ExecutionMeta {
+  /** Get a metadata value by key */
+  get<T = unknown>(key: string): T | undefined;
+
+  /** Get a metadata value, throwing if not present */
+  require<T = unknown>(key: string): T;
+
+  /** Check if a key exists */
+  has(key: string): boolean;
+
+  /** Get all metadata as a plain object (shallow copy) */
+  toJSON(): Record<string, unknown>;
+}
+
+/**
+ * Check whether a value is safely JSON-serializable as a plain primitive /
+ * array / object. Drops functions, class instances, Symbols, and circular
+ * references (Spec 65 §10.4).
+ */
+function isJsonSerializable(value: unknown): boolean {
+  if (value === null) return true;
+  const t = typeof value;
+  if (t === "string" || t === "number" || t === "boolean") return true;
+  if (t === "function" || t === "symbol" || t === "undefined" || t === "bigint") return false;
+  // object — arrays and plain objects only; try a JSON round-trip as a
+  // cheap guard against circular refs / class instances with custom
+  // toJSON that throw.
+  try {
+    JSON.stringify(value);
+  } catch {
+    return false;
+  }
+  // Reject non-plain objects (class instances, Dates, Maps, etc.).
+  // Plain objects have Object.prototype or null prototype; arrays pass too.
+  if (Array.isArray(value)) return true;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/** Strip `_`-prefixed keys from an input object (returns a shallow copy). */
+function stripSystemKeys(input: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(input)) {
+    if (k.startsWith("_")) continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+/** Filter to JSON-serializable values only. */
+function filterSerializable(input: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(input)) {
+    if (isJsonSerializable(v)) out[k] = v;
+  }
+  return out;
+}
+
+/**
+ * Internal implementation of {@link ExecutionMeta}.
+ *
+ * Framework code uses {@link extend} to build child meta on nested `ctx.execute`
+ * calls. Handler code sees only the {@link ExecutionMeta} interface and cannot
+ * mutate the store.
+ */
+export class ExecutionMetaImpl implements ExecutionMeta {
+  private readonly data: ReadonlyMap<string, unknown>;
+
+  constructor(entries: Record<string, unknown>) {
+    this.data = new Map(Object.entries(entries));
+  }
+
+  get<T = unknown>(key: string): T | undefined {
+    return this.data.get(key) as T | undefined;
+  }
+
+  require<T = unknown>(key: string): T {
+    if (!this.data.has(key)) {
+      throw new Error(`Required meta key "${key}" not found`);
+    }
+    return this.data.get(key) as T;
+  }
+
+  has(key: string): boolean {
+    return this.data.has(key);
+  }
+
+  toJSON(): Record<string, unknown> {
+    return Object.fromEntries(this.data);
+  }
+
+  /**
+   * Create a child meta by merging `extra` into the current entries.
+   *
+   * Semantics (Spec 65 §4.3, §4.4):
+   * - `_`-prefixed keys in `extra` are silently dropped (system-only namespace).
+   * - For remaining keys, parent wins — `extra` keys only add new entries.
+   * - `systemOverrides` is applied unconditionally (framework-owned updates
+   *   like `_depth`, `_source_action`).
+   *
+   * Framework-only; not exposed on the {@link ExecutionMeta} interface so
+   * handler code cannot accidentally extend meta (use `ctx.execute(..., { meta })`
+   * instead).
+   */
+  extend(
+    extra: Record<string, unknown>,
+    systemOverrides?: Record<string, unknown>,
+  ): ExecutionMetaImpl {
+    const merged: Record<string, unknown> = { ...this.toJSON() };
+    const strippedExtra = stripSystemKeys(extra);
+    for (const [k, v] of Object.entries(strippedExtra)) {
+      // Parent always wins — child can only add new keys.
+      if (!Object.hasOwn(merged, k)) {
+        merged[k] = v;
+      }
+    }
+    if (systemOverrides) {
+      Object.assign(merged, systemOverrides);
+    }
+    return new ExecutionMetaImpl(merged);
+  }
+}
+
+/**
+ * Helper for framework code that only has access to the {@link ExecutionMeta}
+ * interface (e.g., when propagating through `ctx.execute` without widening the
+ * public type). Delegates to {@link ExecutionMetaImpl.extend} when the input is
+ * an `ExecutionMetaImpl`; otherwise reconstructs from `toJSON()`.
+ *
+ * Keeping `extend` off the public `ExecutionMeta` interface is a deliberate
+ * read-only affordance for handlers (Spec 65 §4.2 — handlers must not mutate
+ * meta; only the framework extends on nested calls).
+ */
+export function extendExecutionMeta(
+  parent: ExecutionMeta,
+  extra: Record<string, unknown>,
+  systemOverrides?: Record<string, unknown>,
+): ExecutionMetaImpl {
+  if (parent instanceof ExecutionMetaImpl) {
+    return parent.extend(extra, systemOverrides);
+  }
+  // Fallback for non-standard implementations: reconstruct via toJSON().
+  const impl = new ExecutionMetaImpl(parent.toJSON());
+  return impl.extend(extra, systemOverrides);
+}
+
+export interface CreateExecutionMetaOptions {
+  /** Caller-provided raw meta (external input). `_`-prefixed keys stripped. */
+  raw?: Record<string, unknown>;
+  /** Framework-set system keys (e.g., `_channel`, `_execution_id`, `_depth`). */
+  systemKeys?: Record<string, unknown>;
+  /** Max serialized size in bytes. Defaults to {@link DEFAULT_META_MAX_BYTES}. */
+  maxSizeBytes?: number;
+}
+
+/**
+ * Build a fresh {@link ExecutionMeta} from raw caller input + framework system keys.
+ *
+ * Merge order (later sources win for the same key, except `_`-prefixed keys
+ * which are always stripped from `raw`):
+ * 1. Strip `_` keys from `raw` (external callers cannot set system keys — §4.4).
+ * 2. Filter non-JSON-serializable values from the stripped raw (§10.4).
+ * 3. Apply `systemKeys` on top (framework keys always win).
+ * 4. Enforce {@link CreateExecutionMetaOptions.maxSizeBytes} on the JSON payload.
+ *
+ * @throws {MetaSizeError} When the serialized meta exceeds the size limit.
+ */
+export function createExecutionMeta(options: CreateExecutionMetaOptions = {}): ExecutionMeta {
+  const { raw = {}, systemKeys = {}, maxSizeBytes = DEFAULT_META_MAX_BYTES } = options;
+
+  const strippedRaw = stripSystemKeys(raw);
+  const safeRaw = filterSerializable(strippedRaw);
+  // System keys are framework-owned — trust them, but still filter non-
+  // serializable values so a bad `_` key (e.g., a class instance) can't poison
+  // the execution log downstream.
+  const safeSystemKeys = filterSerializable(systemKeys);
+
+  const merged: Record<string, unknown> = { ...safeRaw, ...safeSystemKeys };
+
+  const serialized = JSON.stringify(merged);
+  const sizeBytes = new TextEncoder().encode(serialized).length;
+  if (sizeBytes > maxSizeBytes) {
+    throw new MetaSizeError(sizeBytes, maxSizeBytes);
+  }
+
+  return new ExecutionMetaImpl(merged);
+}

--- a/packages/core/src/types/execution-meta.ts
+++ b/packages/core/src/types/execution-meta.ts
@@ -52,27 +52,36 @@ export interface ExecutionMeta {
 
 /**
  * Check whether a value is safely JSON-serializable as a plain primitive /
- * array / object. Drops functions, class instances, Symbols, and circular
- * references (Spec 65 §10.4).
+ * array / plain object **all the way down**. Drops functions, class instances
+ * (Date / Map / user classes), Symbols, BigInts, and circular references
+ * (Spec 65 §10.4).
+ *
+ * Nested validation matters: a raw `{ when: new Date() }` will serialize via
+ * `JSON.stringify` (Date has its own toJSON), but the live Date instance
+ * remains on the in-memory object the handler reads via `ctx.meta.get(...)`.
+ * Rejecting the key outright keeps the handler-visible view consistent with
+ * `meta.toJSON()`.
  */
-function isJsonSerializable(value: unknown): boolean {
+function isJsonSerializable(value: unknown, seen?: WeakSet<object>): boolean {
   if (value === null) return true;
   const t = typeof value;
   if (t === "string" || t === "number" || t === "boolean") return true;
   if (t === "function" || t === "symbol" || t === "undefined" || t === "bigint") return false;
-  // object — arrays and plain objects only; try a JSON round-trip as a
-  // cheap guard against circular refs / class instances with custom
-  // toJSON that throw.
-  try {
-    JSON.stringify(value);
-  } catch {
-    return false;
+  // object — arrays and plain objects only; walk recursively to catch
+  // class instances / non-plain prototypes nested inside otherwise-plain
+  // containers.
+  const tracker = seen ?? new WeakSet<object>();
+  if (tracker.has(value as object)) return false; // circular
+  tracker.add(value as object);
+  if (Array.isArray(value)) {
+    return value.every((v) => isJsonSerializable(v, tracker));
   }
-  // Reject non-plain objects (class instances, Dates, Maps, etc.).
-  // Plain objects have Object.prototype or null prototype; arrays pass too.
-  if (Array.isArray(value)) return true;
   const proto = Object.getPrototypeOf(value);
-  return proto === Object.prototype || proto === null;
+  if (proto !== Object.prototype && proto !== null) return false;
+  for (const v of Object.values(value as Record<string, unknown>)) {
+    if (!isJsonSerializable(v, tracker)) return false;
+  }
+  return true;
 }
 
 /** Strip `_`-prefixed keys from an input object (returns a shallow copy). */
@@ -95,6 +104,18 @@ function filterSerializable(input: Record<string, unknown>): Record<string, unkn
 }
 
 /**
+ * Enforce the serialized-size limit on an already-filtered meta payload.
+ * Throws {@link MetaSizeError} when exceeded.
+ */
+function assertSizeLimit(entries: Record<string, unknown>, maxBytes: number): void {
+  const serialized = JSON.stringify(entries);
+  const sizeBytes = new TextEncoder().encode(serialized).length;
+  if (sizeBytes > maxBytes) {
+    throw new MetaSizeError(sizeBytes, maxBytes);
+  }
+}
+
+/**
  * Internal implementation of {@link ExecutionMeta}.
  *
  * Framework code uses {@link extend} to build child meta on nested `ctx.execute`
@@ -103,9 +124,12 @@ function filterSerializable(input: Record<string, unknown>): Record<string, unkn
  */
 export class ExecutionMetaImpl implements ExecutionMeta {
   private readonly data: ReadonlyMap<string, unknown>;
+  /** Size limit carried through {@link extend} so nested calls enforce the same ceiling. */
+  private readonly maxBytes: number;
 
-  constructor(entries: Record<string, unknown>) {
+  constructor(entries: Record<string, unknown>, maxBytes: number = DEFAULT_META_MAX_BYTES) {
     this.data = new Map(Object.entries(entries));
+    this.maxBytes = maxBytes;
   }
 
   get<T = unknown>(key: string): T | undefined {
@@ -130,15 +154,22 @@ export class ExecutionMetaImpl implements ExecutionMeta {
   /**
    * Create a child meta by merging `extra` into the current entries.
    *
-   * Semantics (Spec 65 §4.3, §4.4):
+   * Semantics (Spec 65 §4.3, §4.4, §10):
    * - `_`-prefixed keys in `extra` are silently dropped (system-only namespace).
+   * - Non-JSON-serializable values in `extra` are dropped (same filter as
+   *   {@link createExecutionMeta}) — nested `ctx.execute` must not be a way
+   *   to smuggle Dates, class instances, or functions into meta.
    * - For remaining keys, parent wins — `extra` keys only add new entries.
    * - `systemOverrides` is applied unconditionally (framework-owned updates
    *   like `_depth`, `_source_action`).
+   * - The resulting serialized payload must stay under {@link maxBytes};
+   *   throws {@link MetaSizeError} otherwise. Inherits the parent's limit.
    *
    * Framework-only; not exposed on the {@link ExecutionMeta} interface so
    * handler code cannot accidentally extend meta (use `ctx.execute(..., { meta })`
    * instead).
+   *
+   * @throws {MetaSizeError} When the merged payload exceeds the size limit.
    */
   extend(
     extra: Record<string, unknown>,
@@ -146,16 +177,20 @@ export class ExecutionMetaImpl implements ExecutionMeta {
   ): ExecutionMetaImpl {
     const merged: Record<string, unknown> = { ...this.toJSON() };
     const strippedExtra = stripSystemKeys(extra);
-    for (const [k, v] of Object.entries(strippedExtra)) {
+    const safeExtra = filterSerializable(strippedExtra);
+    for (const [k, v] of Object.entries(safeExtra)) {
       // Parent always wins — child can only add new keys.
       if (!Object.hasOwn(merged, k)) {
         merged[k] = v;
       }
     }
     if (systemOverrides) {
-      Object.assign(merged, systemOverrides);
+      // System overrides are framework-trusted but still filtered for
+      // serializability so a programmer error can't poison the chain.
+      Object.assign(merged, filterSerializable(systemOverrides));
     }
-    return new ExecutionMetaImpl(merged);
+    assertSizeLimit(merged, this.maxBytes);
+    return new ExecutionMetaImpl(merged, this.maxBytes);
   }
 }
 
@@ -215,11 +250,7 @@ export function createExecutionMeta(options: CreateExecutionMetaOptions = {}): E
 
   const merged: Record<string, unknown> = { ...safeRaw, ...safeSystemKeys };
 
-  const serialized = JSON.stringify(merged);
-  const sizeBytes = new TextEncoder().encode(serialized).length;
-  if (sizeBytes > maxSizeBytes) {
-    throw new MetaSizeError(sizeBytes, maxSizeBytes);
-  }
+  assertSizeLimit(merged, maxSizeBytes);
 
-  return new ExecutionMetaImpl(merged);
+  return new ExecutionMetaImpl(merged, maxSizeBytes);
 }

--- a/packages/core/src/types/execution-meta.ts
+++ b/packages/core/src/types/execution-meta.ts
@@ -62,7 +62,7 @@ export interface ExecutionMeta {
  * Rejecting the key outright keeps the handler-visible view consistent with
  * `meta.toJSON()`.
  */
-function isJsonSerializable(value: unknown, seen?: WeakSet<object>): boolean {
+function isJsonSerializable(value: unknown, ancestors?: WeakSet<object>): boolean {
   if (value === null) return true;
   const t = typeof value;
   if (t === "string" || t === "number" || t === "boolean") return true;
@@ -70,18 +70,71 @@ function isJsonSerializable(value: unknown, seen?: WeakSet<object>): boolean {
   // object — arrays and plain objects only; walk recursively to catch
   // class instances / non-plain prototypes nested inside otherwise-plain
   // containers.
-  const tracker = seen ?? new WeakSet<object>();
-  if (tracker.has(value as object)) return false; // circular
-  tracker.add(value as object);
+  //
+  // `ancestors` tracks the *current recursion path* (objects we are inside),
+  // not every object seen anywhere in the tree. Using a per-subtree visited
+  // set would mis-classify a legitimately shared reference — e.g.,
+  // `{ a: shared, b: shared }` — as circular. Add on descent, remove on
+  // ascent so sibling branches start with a clean path view.
+  const path = ancestors ?? new WeakSet<object>();
+  if (path.has(value as object)) return false; // true circular reference
   if (Array.isArray(value)) {
-    return value.every((v) => isJsonSerializable(v, tracker));
+    path.add(value as object);
+    try {
+      for (const v of value) {
+        if (!isJsonSerializable(v, path)) return false;
+      }
+    } finally {
+      path.delete(value as object);
+    }
+    return true;
   }
   const proto = Object.getPrototypeOf(value);
   if (proto !== Object.prototype && proto !== null) return false;
-  for (const v of Object.values(value as Record<string, unknown>)) {
-    if (!isJsonSerializable(v, tracker)) return false;
+  path.add(value as object);
+  try {
+    for (const v of Object.values(value as Record<string, unknown>)) {
+      if (!isJsonSerializable(v, path)) return false;
+    }
+  } finally {
+    path.delete(value as object);
   }
   return true;
+}
+
+/**
+ * Recursively freeze an object graph. The graph is assumed to be acyclic and
+ * JSON-serializable (both already validated by {@link isJsonSerializable}
+ * before this runs), so a plain depth-first walk is sufficient — no visited
+ * tracking needed.
+ */
+function deepFreeze<T>(value: T): T {
+  if (value === null || typeof value !== "object") return value;
+  Object.freeze(value);
+  if (Array.isArray(value)) {
+    for (const v of value) deepFreeze(v);
+  } else {
+    for (const v of Object.values(value as Record<string, unknown>)) deepFreeze(v);
+  }
+  return value;
+}
+
+/**
+ * Detach `entries` from the caller's object graph and freeze the clone so
+ * handlers can neither affect our internal state by mutating their original
+ * object nor mutate values retrieved via `ctx.meta.get(...)` / `toJSON()`.
+ *
+ * Uses `structuredClone` when available (Bun / Node ≥ 17); falls back to a
+ * JSON round-trip otherwise — safe because `filterSerializable` already
+ * guaranteed JSON-serializability.
+ */
+function cloneAndFreezeEntries(entries: Record<string, unknown>): Record<string, unknown> {
+  const clone =
+    typeof structuredClone === "function"
+      ? structuredClone(entries)
+      : (JSON.parse(JSON.stringify(entries)) as Record<string, unknown>);
+  deepFreeze(clone);
+  return clone;
 }
 
 /** Strip `_`-prefixed keys from an input object (returns a shallow copy). */
@@ -128,7 +181,14 @@ export class ExecutionMetaImpl implements ExecutionMeta {
   private readonly maxBytes: number;
 
   constructor(entries: Record<string, unknown>, maxBytes: number = DEFAULT_META_MAX_BYTES) {
-    this.data = new Map(Object.entries(entries));
+    // Deep-clone + deep-freeze so the stored payload is fully detached from
+    // caller-provided object graphs AND cannot be mutated through values
+    // returned by `get` / `require` / `toJSON`. Spec 65 §4.2 — meta is
+    // read-only after construction. Silent freeze works in sloppy mode;
+    // strict-mode callers get a TypeError on mutation attempts, which is
+    // the desired surfacing behavior.
+    const frozen = cloneAndFreezeEntries(entries);
+    this.data = new Map(Object.entries(frozen));
     this.maxBytes = maxBytes;
   }
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -27,6 +27,18 @@ export type * from "./error";
 export { ERROR_STATUS_MAP } from "./error";
 export type * from "./event";
 export type * from "./execution-log";
+export type {
+  CreateExecutionMetaOptions,
+  ExecutionMeta,
+} from "./execution-meta";
+// Non-type exports: MetaSizeError class, factory + helpers, constant
+export {
+  createExecutionMeta,
+  DEFAULT_META_MAX_BYTES,
+  ExecutionMetaImpl,
+  extendExecutionMeta,
+  MetaSizeError,
+} from "./execution-meta";
 export type * from "./flow";
 export type * from "./life-system";
 export type * from "./logger";

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -31,12 +31,15 @@ export type {
   CreateExecutionMetaOptions,
   ExecutionMeta,
 } from "./execution-meta";
-// Non-type exports: MetaSizeError class, factory + helpers, constant
+// Non-type exports: MetaSizeError class, factory, constant.
+// `ExecutionMetaImpl` and `extendExecutionMeta` are deliberately NOT exported —
+// they are framework-internal. Making them public would let callers bypass
+// the `createExecutionMeta` factory's `_`-prefix stripping and spoof system
+// keys (Gemini review feedback on PR #201). Engine code imports directly from
+// the module. Downstream callers construct meta only via `createExecutionMeta`.
 export {
   createExecutionMeta,
   DEFAULT_META_MAX_BYTES,
-  ExecutionMetaImpl,
-  extendExecutionMeta,
   MetaSizeError,
 } from "./execution-meta";
 export type * from "./flow";


### PR DESCRIPTION
Refs #149. First of two phases for Spec 65 — typed, immutable execution metadata that flows transport → CommandLayer → Action → nested ctx.execute.

## Scope (M5, Spec 65 §14)

- [x] `ExecutionMeta` interface + `ExecutionMetaImpl` + `createExecutionMeta` factory
- [x] `ActionContext.meta` (read-only from handlers)
- [x] CommandLayer forwards `c.meta` to ActionEngine (single source of truth for normalization)
- [x] `ctx.execute(name, input, { meta })` — parent keys win, system keys framework-owned
- [x] System-key stripping (`_`-prefix) on external input
- [x] 8 KB JSON size limit → `META.SIZE_EXCEEDED`
- [x] Non-JSON-serializable filter (functions, Dates, class instances, Symbols, BigInts, non-finite numbers, circular refs)
- [x] Deep-clone + deep-freeze: nested values cannot be mutated via `get`/`toJSON`
- [x] Tests: 63 new cases

## Phase 2 (M6) — deliberately not in this PR

- REST `X-Linch-Meta` header, GraphQL `meta` arg, MCP `_mcp_client_id` injection, CLI `--meta` flag
- Execution-log meta recording + masking (`maskedKeys` config)
- Rule `meta.*` conditions
- `EventHandlerContext.meta`
- Approval replay persisting `ctx.meta` — filed as **#199** (needs approval-store schema change)
- Idempotency key accounting for `ctx.meta` — filed as **#200** (needs product decision on observational vs behavior-affecting meta)

## Design highlights

### Single source of truth for meta invariants
Earlier rounds had CommandLayer running its own 8 KB check before ActionEngine added `_execution_id`, creating a near-limit gap where post-action middleware could fire for a rejected request. Now CommandLayer just forwards `c.meta` as a plain record; ActionEngine owns all normalization (strip/filter/size) with `_execution_id` included, and CommandLayer mirrors post-action suppression by inspecting `result.data.code`.

### `_execution_id` = root execution record id (not traceId)
Spec 65 §4.4. The ActionEngine stamps `_execution_id` from the action's `executionId` at depth 0; `extend` preserves it across nested calls. Using traceId would collapse multiple actions under one upstream trace onto the same id and break `ExecutionLogger.getById()`.

### Read-only via clone + freeze
`structuredClone` + recursive `deepFreeze` in the constructor. Handlers that attempt to mutate `ctx.meta.get("x").y` get a TypeError in strict mode (ES modules) — surfaces bugs rather than silently swallowing them. Caller's original object graph is also fully detached.

### Recursive JSON-serializable check
Top-level `isJsonSerializable` was insufficient: `{ when: new Date() }` passed because `JSON.stringify` tolerates Date via `toJSON`, but the handler saw a live Date. Now walks arrays + plain objects with a path-based cycle tracker (add on descent, remove on ascent) so shared sibling refs like `{ a: shared, b: shared }` are accepted while true cycles are rejected.

### Constructor enforces invariants
`ExecutionMetaImpl` is a public export. Any `new ExecutionMetaImpl(...)` call — including the factory's and `extend`'s — runs through the same filter + size check. No way to bypass.

## Codex cross-model review

Seven rounds; each round's findings fixed and verified:

| Round | Findings | Status |
|-------|----------|--------|
| R1 | 3 P2 (nested sanitize / extend bypass / post-action on size-err) | Fixed |
| R2 | 2 P2 (shared-ref cycle detection / immutability of nested) | Fixed |
| R3 | 1 P1 + 1 P2 + 1 P3 (direct-exec plain meta / `_execution_id` source / phantom child id) | Fixed |
| R4 | 1 P2 (direct-exec oversized root throws) | Fixed |
| R5 | 2 P2 (ctor bypass / NaN-Infinity leak) | Fixed |
| R6 | 1 P1 (near-limit preflight gap) | Fixed |
| R7 | 1 P1 + 1 P2 (approval / idempotency) | Filed as #199/#200 Phase 2 work |

## Test plan

- [x] `bun test packages/core/__tests__/execution-meta.test.ts` — 38 pass / 0 fail
- [x] `bun test packages/core/__tests__/command-layer-meta.test.ts` — 7 pass / 0 fail
- [x] `bun test packages/core/__tests__/action-engine-meta-propagation.test.ts` — 18 pass / 0 fail
- [x] `bun run check` — clean
- [x] `bun run typecheck` — clean
- [x] `bun test` — 4401 pass / 3 skip / 0 fail across 263 files (net +63 cases vs main)
- [x] 7 rounds of Codex cross-model review — final round clean of in-scope findings

Generated with Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Actions can now propagate custom metadata across nested action calls via `ctx.execute` options.
  * Access execution metadata inside actions using `ctx.meta` interface with automatic validation and size enforcement.
  * Metadata supports system-level tracking including execution IDs and action depth information.

* **Tests**
  * Comprehensive test coverage for metadata propagation, validation, and engine integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->