### PR TITLE
feat(graphql): auto-generate <entity>_onchange mutations (Spec 64 §4.2, refs #148)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/onchange-graphql.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/onchange-graphql.test.ts
@@ -1,0 +1,357 @@
+/**
+ * GraphQL `<entity>_onchange` mutation integration tests (Spec 64 §4.2).
+ *
+ * Covers the full GraphQL flow:
+ *   - Auto-generation only fires for entities with an onchange map
+ *   - CommandLayer runs (auth/permission/tenant) before the evaluator
+ *   - Permission denial collapses to canonical AUTHZ_DENIED (no enumeration)
+ *   - Malformed values arg → INVALID_REQUEST.MALFORMED_VALUES
+ *   - Successful evaluation returns { updates: <json>, warnings: [...] }
+ *   - OnchangeEvaluatorError propagates with a stable extension code
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import type { EntityDefinition } from "@linchkit/core";
+import {
+  createActionExecutor,
+  createCommandLayer,
+  createEntityRegistry,
+  createOnchangeEvaluator,
+  InMemoryStore,
+  PipelineError,
+} from "@linchkit/core/server";
+import { buildGraphQLSchema } from "../src/graphql/build-schema";
+import { createServer } from "../src/server";
+
+// ── Fixtures ──────────────────────────────────────────────
+
+const lineEntity: EntityDefinition = {
+  name: "purchase_line_gql",
+  fields: {
+    product_id: { type: "string", label: "Product" },
+    unit_price: { type: "number", label: "Unit Price" },
+    description: { type: "string", label: "Description" },
+    quantity: { type: "number", label: "Quantity" },
+    subtotal: { type: "number", label: "Subtotal" },
+  },
+  onchange: {
+    product_id: {
+      updates: ["unit_price", "description"],
+      compute: async (ctx) => ({
+        unit_price: await ctx.lookup("product_gql", ctx.value as string, "price"),
+        description: await ctx.lookup("product_gql", ctx.value as string, "description"),
+      }),
+    },
+    "quantity,unit_price": {
+      updates: ["subtotal"],
+      compute: (ctx) => ({
+        subtotal: ((ctx.values.quantity as number) ?? 0) * ((ctx.values.unit_price as number) ?? 0),
+      }),
+    },
+  },
+};
+
+// Entity with NO onchange map — its `<name>_onchange` field must NOT appear in the schema.
+const plainEntity: EntityDefinition = {
+  name: "plain_gql",
+  fields: {
+    title: { type: "string" },
+  },
+};
+
+// Onchange evaluator uses this provider for lookups.
+const store = new InMemoryStore();
+await store.create("product_gql", { id: "pg1", price: 49.5, description: "Sprocket" });
+
+// ── Server harness ────────────────────────────────────────
+
+function buildServer(options: {
+  permissionDeny?: boolean;
+  permissionDenyMessage?: string;
+  port: number;
+}) {
+  const entityRegistry = createEntityRegistry();
+  entityRegistry.register(lineEntity);
+  entityRegistry.register(plainEntity);
+
+  const executor = createActionExecutor({ dataProvider: store });
+  const commandLayer = createCommandLayer({ executor });
+
+  if (options.permissionDeny) {
+    const message = options.permissionDenyMessage ?? "Actor lacks read permission on entity";
+    commandLayer.use({
+      name: "deny_all",
+      slot: "permission",
+      handler: async () => {
+        throw new PipelineError(message, "authz.action.denied");
+      },
+    });
+  } else {
+    // Non-action dispatch (`skipActionSlots`) requires a permission middleware
+    // (fail-closed guard). Register a no-op allow-all stub for the happy path.
+    commandLayer.use({
+      name: "allow_all",
+      slot: "permission",
+      handler: async (_ctx, next) => {
+        await next();
+      },
+    });
+  }
+
+  const evaluator = createOnchangeEvaluator({ entityRegistry, dataProvider: store });
+
+  const graphqlSchema = buildGraphQLSchema([lineEntity, plainEntity], {
+    executor,
+    commandLayer,
+    onchangeEvaluator: evaluator,
+  });
+
+  const app = createServer(graphqlSchema, { executor, commandLayer, entityRegistry });
+  app.listen(options.port);
+  return app;
+}
+
+// Server with NO evaluator wired — onchange mutation should be omitted entirely.
+function buildServerWithoutEvaluator(port: number) {
+  const entityRegistry = createEntityRegistry();
+  entityRegistry.register(lineEntity);
+
+  const executor = createActionExecutor({ dataProvider: store });
+  const commandLayer = createCommandLayer({ executor });
+  commandLayer.use({
+    name: "allow_all",
+    slot: "permission",
+    handler: async (_ctx, next) => {
+      await next();
+    },
+  });
+
+  const graphqlSchema = buildGraphQLSchema([lineEntity], { executor, commandLayer });
+  const app = createServer(graphqlSchema, { executor, commandLayer, entityRegistry });
+  app.listen(port);
+  return app;
+}
+
+const happyPort = 4310;
+const denyPort = 4311;
+const leakyDenyPort = 4312;
+const noEvaluatorPort = 4313;
+let happyApp: ReturnType<typeof buildServer>;
+let denyApp: ReturnType<typeof buildServer>;
+let leakyDenyApp: ReturnType<typeof buildServer>;
+let noEvaluatorApp: ReturnType<typeof buildServer>;
+
+beforeAll(() => {
+  happyApp = buildServer({ port: happyPort });
+  denyApp = buildServer({ port: denyPort, permissionDeny: true });
+  leakyDenyApp = buildServer({
+    port: leakyDenyPort,
+    permissionDeny: true,
+    permissionDenyMessage: "forbidden: entity admin_secret",
+  });
+  noEvaluatorApp = buildServerWithoutEvaluator(noEvaluatorPort);
+});
+
+afterAll(() => {
+  happyApp.stop();
+  denyApp.stop();
+  leakyDenyApp.stop();
+  noEvaluatorApp.stop();
+});
+
+// ── Helpers ──────────────────────────────────────────────
+
+interface GraphQLResponse {
+  data?: Record<string, unknown> | null;
+  errors?: Array<{ message: string; extensions?: Record<string, unknown> }>;
+}
+
+async function gql(port: number, query: string, variables?: Record<string, unknown>) {
+  const res = await fetch(`http://localhost:${port}/graphql`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ query, variables }),
+  });
+  return (await res.json()) as GraphQLResponse;
+}
+
+const ONCHANGE_MUTATION = /* GraphQL */ `
+  mutation Onchange($field: String!, $values: String!) {
+    purchase_line_gql_onchange(changedField: $field, values: $values) {
+      updates
+      warnings
+    }
+  }
+`;
+
+// ── Tests ─────────────────────────────────────────────────
+
+describe("GraphQL `<entity>_onchange` auto-generation", () => {
+  test("schema exposes purchase_line_gql_onchange but NOT plain_gql_onchange", async () => {
+    const introspection = await gql(
+      happyPort,
+      /* GraphQL */ `
+        {
+          __type(name: "Mutation") {
+            fields {
+              name
+            }
+          }
+        }
+      `,
+    );
+    const fields = (
+      introspection.data?.__type as { fields: Array<{ name: string }> } | null
+    )?.fields.map((f) => f.name);
+    expect(fields).toContain("purchase_line_gql_onchange");
+    // Entity without onchange map must not get a mutation.
+    expect(fields).not.toContain("plain_gql_onchange");
+  });
+
+  test("mutation is omitted entirely when no evaluator is wired", async () => {
+    const introspection = await gql(
+      noEvaluatorPort,
+      /* GraphQL */ `
+        {
+          __type(name: "Mutation") {
+            fields {
+              name
+            }
+          }
+        }
+      `,
+    );
+    const fields = (
+      introspection.data?.__type as { fields: Array<{ name: string }> } | null
+    )?.fields.map((f) => f.name);
+    expect(fields).not.toContain("purchase_line_gql_onchange");
+  });
+
+  test("OnchangeResponse type is exported with updates + warnings shape", async () => {
+    const introspection = await gql(
+      happyPort,
+      /* GraphQL */ `
+        {
+          __type(name: "OnchangeResponse") {
+            fields {
+              name
+              type {
+                kind
+                ofType {
+                  name
+                }
+              }
+            }
+          }
+        }
+      `,
+    );
+    const t = introspection.data?.__type as {
+      fields: Array<{ name: string; type: { kind: string; ofType?: { name?: string } } }>;
+    } | null;
+    const fieldNames = t?.fields.map((f) => f.name).sort();
+    expect(fieldNames).toEqual(["updates", "warnings"]);
+  });
+});
+
+describe("GraphQL `<entity>_onchange` happy path", () => {
+  test("returns updates JSON + warnings array with chained subtotal cascade", async () => {
+    const result = await gql(happyPort, ONCHANGE_MUTATION, {
+      field: "product_id",
+      values: JSON.stringify({ product_id: "pg1", quantity: 3 }),
+    });
+    expect(result.errors).toBeUndefined();
+    const payload = result.data?.purchase_line_gql_onchange as {
+      updates: string;
+      warnings: string[];
+    };
+    expect(typeof payload.updates).toBe("string");
+    const updates = JSON.parse(payload.updates) as Record<string, unknown>;
+    expect(updates.unit_price).toBe(49.5);
+    expect(updates.description).toBe("Sprocket");
+    expect(updates.subtotal).toBeCloseTo(148.5, 5);
+    expect(Array.isArray(payload.warnings)).toBe(true);
+  });
+
+  test("comma-separated trigger updates only the cascaded field", async () => {
+    const result = await gql(happyPort, ONCHANGE_MUTATION, {
+      field: "quantity",
+      values: JSON.stringify({ quantity: 4, unit_price: 5 }),
+    });
+    expect(result.errors).toBeUndefined();
+    const payload = result.data?.purchase_line_gql_onchange as {
+      updates: string;
+      warnings: string[];
+    };
+    expect(JSON.parse(payload.updates)).toEqual({ subtotal: 20 });
+  });
+});
+
+describe("GraphQL `<entity>_onchange` validation", () => {
+  test("malformed JSON in values arg returns INVALID_REQUEST.MALFORMED_VALUES", async () => {
+    const result = await gql(happyPort, ONCHANGE_MUTATION, {
+      field: "product_id",
+      values: "not-json",
+    });
+    expect(result.errors?.[0]?.extensions?.code).toBe("INVALID_REQUEST.MALFORMED_VALUES");
+  });
+
+  test("non-object JSON in values arg (array) returns MALFORMED_VALUES", async () => {
+    const result = await gql(happyPort, ONCHANGE_MUTATION, {
+      field: "product_id",
+      values: JSON.stringify([1, 2, 3]),
+    });
+    expect(result.errors?.[0]?.extensions?.code).toBe("INVALID_REQUEST.MALFORMED_VALUES");
+  });
+
+  test("oversized values arg returns VALUES_TOO_LARGE", async () => {
+    // 10_001 chars of whitespace is still valid JSON (`"x...x"`) but exceeds the cap.
+    const huge = `"${"x".repeat(10_001)}"`;
+    const result = await gql(happyPort, ONCHANGE_MUTATION, {
+      field: "product_id",
+      values: huge,
+    });
+    expect(result.errors?.[0]?.extensions?.code).toBe("INVALID_REQUEST.VALUES_TOO_LARGE");
+  });
+
+  test("changedField with no registered hook surfaces ONCHANGE.NO_HOOK_FOR_FIELD", async () => {
+    // `description` is a known field but has no hook registered.
+    const result = await gql(happyPort, ONCHANGE_MUTATION, {
+      field: "description",
+      values: JSON.stringify({ description: "x" }),
+    });
+    expect(result.errors?.[0]?.extensions?.code).toBe("ONCHANGE.NO_HOOK_FOR_FIELD");
+  });
+
+  test("changedField unknown to the entity surfaces ONCHANGE.FIELD_UNKNOWN", async () => {
+    const result = await gql(happyPort, ONCHANGE_MUTATION, {
+      field: "does_not_exist",
+      values: JSON.stringify({}),
+    });
+    expect(result.errors?.[0]?.extensions?.code).toBe("ONCHANGE.FIELD_UNKNOWN");
+  });
+});
+
+describe("GraphQL `<entity>_onchange` permission denial canonicalization", () => {
+  test("denied permission collapses to AUTHZ_DENIED with generic message", async () => {
+    const result = await gql(denyPort, ONCHANGE_MUTATION, {
+      field: "product_id",
+      values: JSON.stringify({ product_id: "pg1" }),
+    });
+    expect(result.errors?.[0]?.extensions?.code).toBe("AUTHZ_DENIED");
+    expect(result.errors?.[0]?.message).toBe("Access denied");
+  });
+
+  test("middleware-supplied entity-specific denial text does NOT leak through GraphQL", async () => {
+    // The leaky middleware sends "forbidden: entity admin_secret". The
+    // resolver must canonicalize the response so attackers cannot enumerate
+    // entities by reading varying error strings.
+    const result = await gql(leakyDenyPort, ONCHANGE_MUTATION, {
+      field: "product_id",
+      values: JSON.stringify({ product_id: "pg1" }),
+    });
+    expect(result.errors?.[0]?.message).toBe("Access denied");
+    expect(result.errors?.[0]?.message).not.toContain("admin_secret");
+    expect(JSON.stringify(result.errors)).not.toContain("admin_secret");
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/__tests__/onchange-graphql.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/onchange-graphql.test.ts
@@ -414,6 +414,72 @@ describe("GraphQL `<entity>_onchange` non-auth pipeline failures", () => {
   });
 });
 
+// ── Codex Round-2 P2: tenant scope cleared by middleware is honored ──
+
+describe("GraphQL `<entity>_onchange` tenant scope handling", () => {
+  test("when tenant middleware clears tenantId, evaluator is called with undefined (no fallback)", async () => {
+    const entityRegistry = createEntityRegistry();
+    entityRegistry.register(lineEntity);
+    const executor = createActionExecutor({ dataProvider: store });
+    const commandLayer = createCommandLayer({ executor });
+    commandLayer.use({
+      name: "allow_all",
+      slot: "permission",
+      handler: async (_ctx, next) => {
+        await next();
+      },
+    });
+    // Tenant middleware that intentionally clears the request tenant —
+    // simulates a system actor bypass or admin escalation. The resolver
+    // MUST honor this and not silently re-inject the request tenant.
+    commandLayer.use({
+      name: "clear_tenant",
+      slot: "tenant",
+      handler: async (c, next) => {
+        c.tenantId = undefined;
+        await next();
+      },
+    });
+    // Spy evaluator: capture the tenantId argument passed to evaluate().
+    let capturedTenantId: string | undefined = "SENTINEL_NOT_CALLED";
+    const spyEvaluator = {
+      evaluate: async (args: { tenantId?: string }) => {
+        capturedTenantId = args.tenantId;
+        return { updates: {}, warnings: [] };
+      },
+    };
+    const schema = buildGraphQLSchema([lineEntity], {
+      executor,
+      commandLayer,
+      onchangeEvaluator: spyEvaluator,
+    });
+    const port = 4316;
+    const app = createServer(schema, {
+      executor,
+      commandLayer,
+      entityRegistry,
+      // Inject a non-null request tenantId so we'd notice fallback if it
+      // happened — the resolver receives ctx.tenantId="rt-incoming" yet
+      // must pass undefined through because middleware cleared it.
+      resolveRequestTenantId: () => "rt-incoming",
+    });
+    app.listen(port);
+    try {
+      const result = await gql(port, ONCHANGE_MUTATION, {
+        field: "product_id",
+        values: JSON.stringify({ product_id: "pg1" }),
+      });
+      expect(result.errors).toBeUndefined();
+      // Evaluator must have been called with undefined tenantId — not
+      // "rt-incoming". This proves the resolver respects the middleware's
+      // decision to clear scope.
+      expect(capturedTenantId).toBeUndefined();
+    } finally {
+      app.stop();
+    }
+  });
+});
+
 // ── Codex Round-1 P3: unknown evaluator errors do not leak details ──
 
 describe("GraphQL `<entity>_onchange` unexpected evaluator failures", () => {

--- a/addons/adapter-server/cap-adapter-server/__tests__/onchange-graphql.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/onchange-graphql.test.ts
@@ -354,4 +354,111 @@ describe("GraphQL `<entity>_onchange` permission denial canonicalization", () =>
     expect(result.errors?.[0]?.message).not.toContain("admin_secret");
     expect(JSON.stringify(result.errors)).not.toContain("admin_secret");
   });
+
+  test("auth runs BEFORE values validation — denying side sees AUTHZ_DENIED, not MALFORMED_VALUES", async () => {
+    // Codex Round-1 P3 — uniform-denial property. An unauthorized caller
+    // sending malformed `values` must get the same canonical AUTHZ_DENIED
+    // response as a request with valid input shape; otherwise the caller
+    // could distinguish "endpoint exists, request rejected at validation"
+    // from "endpoint denied entirely" and enumerate which entities have
+    // onchange hooks.
+    const result = await gql(denyPort, ONCHANGE_MUTATION, {
+      field: "product_id",
+      values: "definitely not json",
+    });
+    expect(result.errors?.[0]?.extensions?.code).toBe("AUTHZ_DENIED");
+    expect(result.errors?.[0]?.extensions?.code).not.toBe("INVALID_REQUEST.MALFORMED_VALUES");
+  });
+});
+
+// ── Codex Round-1 P2: non-auth pipeline failures retain their semantics ──
+
+describe("GraphQL `<entity>_onchange` non-auth pipeline failures", () => {
+  test("rate_limit pipeline failure surfaces the original code, NOT canonical AUTHZ_DENIED", async () => {
+    const entityRegistry = createEntityRegistry();
+    entityRegistry.register(lineEntity);
+    const executor = createActionExecutor({ dataProvider: store });
+    const commandLayer = createCommandLayer({ executor });
+    commandLayer.use({
+      name: "rate_limit_throttle",
+      slot: "permission",
+      handler: async () => {
+        throw new PipelineError("Too many requests, retry later", "rate_limit.exceeded");
+      },
+    });
+    const evaluator = createOnchangeEvaluator({ entityRegistry, dataProvider: store });
+    const schema = buildGraphQLSchema([lineEntity], {
+      executor,
+      commandLayer,
+      onchangeEvaluator: evaluator,
+    });
+    const port = 4314;
+    const app = createServer(schema, { executor, commandLayer, entityRegistry });
+    app.listen(port);
+    try {
+      const result = await gql(port, ONCHANGE_MUTATION, {
+        field: "product_id",
+        values: JSON.stringify({ product_id: "pg1" }),
+      });
+      // Must NOT collapse to AUTHZ_DENIED — clients need to recognize
+      // throttling so they can backoff/retry. The original error code
+      // is preserved verbatim in extensions.
+      expect(result.errors?.[0]?.extensions?.code).toBe("rate_limit.exceeded");
+      expect(result.errors?.[0]?.extensions?.code).not.toBe("AUTHZ_DENIED");
+      // The structured message reaches the client (auth gates already passed,
+      // so non-auth failure detail is safe to surface).
+      expect(result.errors?.[0]?.message).toBe("Too many requests, retry later");
+    } finally {
+      app.stop();
+    }
+  });
+});
+
+// ── Codex Round-1 P3: unknown evaluator errors do not leak details ──
+
+describe("GraphQL `<entity>_onchange` unexpected evaluator failures", () => {
+  test("non-OnchangeEvaluatorError from evaluator returns a fixed generic message", async () => {
+    // The OnchangeEvaluator normally catches hook failures internally and
+    // converts them to warnings — direct hook throws don't reach the
+    // resolver's catch block. To exercise the unknown-error path that
+    // Codex Round-1 P3 hardens, we wrap the evaluator with a stub that
+    // throws a non-OnchangeEvaluatorError directly. This proves the
+    // resolver swallows the message and never echoes it to the client.
+    const entityRegistry = createEntityRegistry();
+    entityRegistry.register(lineEntity);
+    const executor = createActionExecutor({ dataProvider: store });
+    const commandLayer = createCommandLayer({ executor });
+    commandLayer.use({
+      name: "allow_all",
+      slot: "permission",
+      handler: async (_ctx, next) => {
+        await next();
+      },
+    });
+    // Stub evaluator that always throws a generic Error with secret detail.
+    const leakyEvaluator = {
+      evaluate: async () => {
+        throw new Error("SECRET_INTERNAL_DETAIL: connection to db-replica-3 timed out");
+      },
+    };
+    const schema = buildGraphQLSchema([lineEntity], {
+      executor,
+      commandLayer,
+      onchangeEvaluator: leakyEvaluator,
+    });
+    const port = 4315;
+    const app = createServer(schema, { executor, commandLayer, entityRegistry });
+    app.listen(port);
+    try {
+      const result = await gql(port, ONCHANGE_MUTATION, {
+        field: "product_id",
+        values: JSON.stringify({ product_id: "pg1" }),
+      });
+      expect(result.errors?.[0]?.extensions?.code).toBe("ONCHANGE.EVALUATION_FAILED");
+      expect(result.errors?.[0]?.message).toBe("Onchange evaluation failed");
+      expect(JSON.stringify(result)).not.toContain("SECRET_INTERNAL_DETAIL");
+    } finally {
+      app.stop();
+    }
+  });
 });

--- a/addons/adapter-server/cap-adapter-server/__tests__/onchange-graphql.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/onchange-graphql.test.ts
@@ -414,6 +414,109 @@ describe("GraphQL `<entity>_onchange` non-auth pipeline failures", () => {
   });
 });
 
+// ── Codex Round-4 P2: schema-build-time guards ─────────────
+
+describe("GraphQL `<entity>_onchange` schema build-time guards", () => {
+  test("entity name with `-` is sanitized — schema construction succeeds and field is queryable", async () => {
+    // Without sanitization, an entity name like `sales-order` would crash
+    // during schema construction because `-` is not a legal GraphQL field
+    // name character.
+    const dashEntity: EntityDefinition = {
+      name: "sales-order",
+      fields: { trigger: { type: "string" }, result: { type: "string" } },
+      onchange: {
+        trigger: {
+          updates: ["result"],
+          compute: () => ({ result: "ok" }),
+        },
+      },
+    };
+    const entityRegistry = createEntityRegistry();
+    entityRegistry.register(dashEntity);
+    const executor = createActionExecutor({ dataProvider: store });
+    const commandLayer = createCommandLayer({ executor });
+    commandLayer.use({
+      name: "allow_all",
+      slot: "permission",
+      handler: async (_ctx, next) => {
+        await next();
+      },
+    });
+    const evaluator = createOnchangeEvaluator({ entityRegistry, dataProvider: store });
+    // This call MUST NOT throw. Pre-fix it would: GraphQL rejects
+    // `sales-order_onchange` as an invalid field name.
+    const schema = buildGraphQLSchema([dashEntity], {
+      executor,
+      commandLayer,
+      onchangeEvaluator: evaluator,
+    });
+    const port = 4319;
+    const app = createServer(schema, { executor, commandLayer, entityRegistry });
+    app.listen(port);
+    try {
+      const introspection = await gql(
+        port,
+        /* GraphQL */ `
+          {
+            __type(name: "Mutation") {
+              fields {
+                name
+              }
+            }
+          }
+        `,
+      );
+      const fields = (
+        introspection.data?.__type as { fields: Array<{ name: string }> } | null
+      )?.fields.map((f) => f.name);
+      // Underscore is the canonical replacement for `-` per the sanitizer.
+      expect(fields).toContain("sales_order_onchange");
+    } finally {
+      app.stop();
+    }
+  });
+
+  test("schema omits onchange mutations when CommandLayer has no permission middleware", async () => {
+    // skipActionSlots fails at execute time without a permission middleware.
+    // Advertising the field in introspection would mean every call fails
+    // with PERMISSION.MIDDLEWARE_MISSING — better to omit it entirely.
+    const entityRegistry = createEntityRegistry();
+    entityRegistry.register(lineEntity);
+    const executor = createActionExecutor({ dataProvider: store });
+    const commandLayer = createCommandLayer({ executor });
+    // Deliberately do NOT register a permission middleware.
+    const evaluator = createOnchangeEvaluator({ entityRegistry, dataProvider: store });
+    const schema = buildGraphQLSchema([lineEntity], {
+      executor,
+      commandLayer,
+      onchangeEvaluator: evaluator,
+    });
+    const port = 4320;
+    const app = createServer(schema, { executor, commandLayer, entityRegistry });
+    app.listen(port);
+    try {
+      const introspection = await gql(
+        port,
+        /* GraphQL */ `
+          {
+            __type(name: "Mutation") {
+              fields {
+                name
+              }
+            }
+          }
+        `,
+      );
+      const fields = (
+        introspection.data?.__type as { fields: Array<{ name: string }> } | null
+      )?.fields.map((f) => f.name);
+      expect(fields).not.toContain("purchase_line_gql_onchange");
+    } finally {
+      app.stop();
+    }
+  });
+});
+
 // ── Codex Round-3 P2: post-auth actor reaches the evaluator ──
 
 describe("GraphQL `<entity>_onchange` post-auth actor propagation", () => {

--- a/addons/adapter-server/cap-adapter-server/__tests__/onchange-graphql.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/onchange-graphql.test.ts
@@ -414,6 +414,121 @@ describe("GraphQL `<entity>_onchange` non-auth pipeline failures", () => {
   });
 });
 
+// ── Codex Round-3 P2: post-auth actor reaches the evaluator ──
+
+describe("GraphQL `<entity>_onchange` post-auth actor propagation", () => {
+  test("auth middleware that enriches actor.groups is honored by evaluator", async () => {
+    const entityRegistry = createEntityRegistry();
+    entityRegistry.register(lineEntity);
+    const executor = createActionExecutor({ dataProvider: store });
+    const commandLayer = createCommandLayer({ executor });
+    // Auth middleware that hydrates the actor's roles (e.g. fetches DB
+    // groups). The evaluator must observe this enrichment, not the bare
+    // actor that arrived in the GraphQL context.
+    commandLayer.use({
+      name: "hydrate_groups",
+      slot: "auth",
+      handler: async (c, next) => {
+        c.actor = {
+          ...c.actor,
+          groups: [...(c.actor.groups ?? []), "hydrated-admin"],
+        };
+        await next();
+      },
+    });
+    commandLayer.use({
+      name: "allow_all",
+      slot: "permission",
+      handler: async (_ctx, next) => {
+        await next();
+      },
+    });
+    let capturedActor: { id?: string; groups?: string[] } | undefined;
+    const spyEvaluator = {
+      evaluate: async (args: { actor: { id?: string; groups?: string[] } }) => {
+        capturedActor = args.actor;
+        return { updates: {}, warnings: [] };
+      },
+    };
+    const schema = buildGraphQLSchema([lineEntity], {
+      executor,
+      commandLayer,
+      onchangeEvaluator: spyEvaluator,
+    });
+    const port = 4317;
+    const app = createServer(schema, { executor, commandLayer, entityRegistry });
+    app.listen(port);
+    try {
+      const result = await gql(port, ONCHANGE_MUTATION, {
+        field: "product_id",
+        values: JSON.stringify({ product_id: "pg1" }),
+      });
+      expect(result.errors).toBeUndefined();
+      expect(capturedActor?.groups).toContain("hydrated-admin");
+    } finally {
+      app.stop();
+    }
+  });
+});
+
+// ── Codex Round-3 P3: internalSchemas filter applies to onchange too ──
+
+describe("GraphQL `<entity>_onchange` internalSchemas filter", () => {
+  test("entity in internalSchemas does NOT get an auto-generated onchange mutation", async () => {
+    const internalEntity: EntityDefinition = {
+      name: "system_internal_gql",
+      fields: { trigger: { type: "string" }, result: { type: "string" } },
+      onchange: {
+        trigger: {
+          updates: ["result"],
+          compute: () => ({ result: "computed" }),
+        },
+      },
+    };
+    const entityRegistry = createEntityRegistry();
+    entityRegistry.register(internalEntity);
+    const executor = createActionExecutor({ dataProvider: store });
+    const commandLayer = createCommandLayer({ executor });
+    commandLayer.use({
+      name: "allow_all",
+      slot: "permission",
+      handler: async (_ctx, next) => {
+        await next();
+      },
+    });
+    const evaluator = createOnchangeEvaluator({ entityRegistry, dataProvider: store });
+    const schema = buildGraphQLSchema([internalEntity], {
+      executor,
+      commandLayer,
+      onchangeEvaluator: evaluator,
+      internalSchemas: new Set(["system_internal_gql"]),
+    });
+    const port = 4318;
+    const app = createServer(schema, { executor, commandLayer, entityRegistry });
+    app.listen(port);
+    try {
+      const introspection = await gql(
+        port,
+        /* GraphQL */ `
+          {
+            __type(name: "Mutation") {
+              fields {
+                name
+              }
+            }
+          }
+        `,
+      );
+      const fields = (
+        introspection.data?.__type as { fields: Array<{ name: string }> } | null
+      )?.fields.map((f) => f.name);
+      expect(fields).not.toContain("system_internal_gql_onchange");
+    } finally {
+      app.stop();
+    }
+  });
+});
+
 // ── Codex Round-2 P2: tenant scope cleared by middleware is honored ──
 
 describe("GraphQL `<entity>_onchange` tenant scope handling", () => {

--- a/addons/adapter-server/cap-adapter-server/src/capability.ts
+++ b/addons/adapter-server/cap-adapter-server/src/capability.ts
@@ -79,6 +79,28 @@ export const capAdapterServer = defineCapability({
           // Collect permission groups for data masking in GraphQL resolvers
           const permGroups = ctx.permissionRegistry?.getAll() ?? [];
 
+          // Construct the onchange evaluator (Spec 64) BEFORE building the
+          // GraphQL schema so per-entity `<entity>_onchange` mutations can be
+          // auto-generated. Use the same data provider chain that the rest of
+          // the server uses (system-wrapped when available) so lookups from
+          // onchange hooks honor internal schema handling and tenant
+          // isolation. No permission callback is wired here either — emit a
+          // single structured warning so operators understand entity-level
+          // read gating is not active until a permission capability wires a
+          // `checkReadPermission`.
+          const onchangeDataProvider = systemDataProvider ?? ctx.dataProvider;
+          const onchangeEvaluator = onchangeDataProvider
+            ? createOnchangeEvaluator({
+                entityRegistry: ctx.entityRegistry,
+                dataProvider: onchangeDataProvider,
+              })
+            : undefined;
+          if (onchangeEvaluator) {
+            consoleLogger.warn(
+              "[onchange] no checkReadPermission configured — lookup/query helpers return data without permission enforcement. Wire cap-permission (or an equivalent) to gate entity reads inside onchange hooks.",
+            );
+          }
+
           // Build GraphQL schema — uses composite data provider for all schemas
           const graphqlSchema = buildGraphQLSchema(allSchemas, {
             executor: ctx.executor,
@@ -91,6 +113,7 @@ export const capAdapterServer = defineCapability({
             stateDefinitions: ctx.states ?? [],
             cacheManager: ctx.cacheManager,
             internalSchemas: INTERNAL_SCHEMA_NAMES,
+            onchangeEvaluator,
           });
 
           // Read port/host from system:server config (falls back to defaults via Zod)
@@ -106,26 +129,6 @@ export const capAdapterServer = defineCapability({
 
           // Collect rule definitions from all capabilities for /api/rules endpoint
           const allRules = (ctx.capabilities ?? []).flatMap((c) => c.rules ?? []);
-
-          // Construct the onchange evaluator (Spec 64). Use the same data
-          // provider chain that the rest of the server uses (system-wrapped
-          // when available) so lookups from onchange hooks honor internal
-          // schema handling and tenant isolation. No permission callback is
-          // wired here either — emit a single structured warning so operators
-          // understand entity-level read gating is not active until a
-          // permission capability wires a `checkReadPermission`.
-          const onchangeDataProvider = systemDataProvider ?? ctx.dataProvider;
-          const onchangeEvaluator = onchangeDataProvider
-            ? createOnchangeEvaluator({
-                entityRegistry: ctx.entityRegistry,
-                dataProvider: onchangeDataProvider,
-              })
-            : undefined;
-          if (onchangeEvaluator) {
-            consoleLogger.warn(
-              "[onchange] no checkReadPermission configured — lookup/query helpers return data without permission enforcement. Wire cap-permission (or an equivalent) to gate entity reads inside onchange hooks.",
-            );
-          }
 
           // Use the shared runtime from CLI — no duplicate executor/commandLayer
           const app = createServer(graphqlSchema, {

--- a/addons/adapter-server/cap-adapter-server/src/dev.ts
+++ b/addons/adapter-server/cap-adapter-server/src/dev.ts
@@ -217,26 +217,6 @@ if (runtime.dataProvider instanceof InMemoryStore) {
 
 const customActions = capContributions.actions;
 
-const graphqlSchema = buildGraphQLSchema(allEntities, {
-  executor: runtime.executor,
-  commandLayer: runtime.commandLayer,
-  dataProvider: runtime.dataProvider,
-  actions: customActions,
-  relations: capContributions.relations,
-  stateDefinitions: capContributions.states,
-  extraQueryFields: capContributions.extraQueryFields as Record<
-    string,
-    import("graphql").GraphQLFieldConfig<unknown, unknown>
-  >,
-  extraMutationFields: capContributions.extraMutationFields as Record<
-    string,
-    import("graphql").GraphQLFieldConfig<unknown, unknown>
-  >,
-});
-
-const port = config.server?.port ?? 3001;
-const host = config.server?.host ?? "0.0.0.0";
-
 // Construct the onchange evaluator (Spec 64). No permission capability is wired
 // into `dev.ts`, so reads from within onchange hooks are ALL ALLOWED by default.
 // Log a structured warning once at startup so operators know the evaluator has
@@ -249,6 +229,27 @@ const onchangeEvaluator = createOnchangeEvaluator({
 consoleLogger.warn(
   "[onchange] no checkReadPermission configured — lookup/query helpers return data without permission enforcement. Wire cap-permission (or an equivalent) to gate entity reads inside onchange hooks.",
 );
+
+const graphqlSchema = buildGraphQLSchema(allEntities, {
+  executor: runtime.executor,
+  commandLayer: runtime.commandLayer,
+  dataProvider: runtime.dataProvider,
+  actions: customActions,
+  relations: capContributions.relations,
+  stateDefinitions: capContributions.states,
+  onchangeEvaluator,
+  extraQueryFields: capContributions.extraQueryFields as Record<
+    string,
+    import("graphql").GraphQLFieldConfig<unknown, unknown>
+  >,
+  extraMutationFields: capContributions.extraMutationFields as Record<
+    string,
+    import("graphql").GraphQLFieldConfig<unknown, unknown>
+  >,
+});
+
+const port = config.server?.port ?? 3001;
+const host = config.server?.host ?? "0.0.0.0";
 
 const server = createServer(graphqlSchema, {
   port,

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-onchange-mutations.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-onchange-mutations.ts
@@ -20,7 +20,7 @@
  * obtain the object.
  */
 
-import type { CommandLayer, EntityDefinition } from "@linchkit/core";
+import type { Actor, CommandLayer, EntityDefinition } from "@linchkit/core";
 import type { OnchangeEvaluator } from "@linchkit/core/server";
 import { consoleLogger, OnchangeEvaluatorError } from "@linchkit/core/server";
 import {
@@ -56,6 +56,14 @@ export interface BuildOnchangeMutationsOptions {
   commandLayer?: CommandLayer;
   /** OnchangeEvaluator for the actual computation. */
   onchangeEvaluator?: OnchangeEvaluator;
+  /**
+   * Schema names that are internal (read-only) — onchange mutations are
+   * skipped for these, mirroring the CRUD generator's behavior. Without
+   * this filter, an internal schema that declares an `onchange` map would
+   * leak a public `<entity>_onchange` mutation even though the rest of
+   * its mutation surface is suppressed.
+   */
+  internalSchemas?: Set<string>;
 }
 
 /**
@@ -68,13 +76,17 @@ export function buildOnchangeMutationFields(
   entities: EntityDefinition[],
   options: BuildOnchangeMutationsOptions,
 ): Record<string, GraphQLFieldConfig<unknown, GraphQLContext>> {
-  const { commandLayer, onchangeEvaluator } = options;
+  const { commandLayer, onchangeEvaluator, internalSchemas } = options;
   if (!commandLayer || !onchangeEvaluator) return {};
 
   const fields: Record<string, GraphQLFieldConfig<unknown, GraphQLContext>> = {};
 
   for (const entity of entities) {
     if (!entity.onchange || Object.keys(entity.onchange).length === 0) continue;
+    // Codex Round-3 P3: respect the same read-only filter the CRUD
+    // generator uses, otherwise an internal/system schema with an
+    // onchange map would leak a public mutation.
+    if (internalSchemas?.has(entity.name)) continue;
 
     const entityName = entity.name;
     const fieldName = `${entityName}_onchange`;
@@ -181,23 +193,26 @@ export function buildOnchangeMutationFields(
         const values = parsed as Record<string, unknown>;
 
         // ── Run evaluator ───────────────────────────────────────
-        // Codex Round-2 P2: trust the middleware-resolved tenant verbatim.
-        // The synthetic skipActionSlots result populates `tenantId` from
-        // the final ctx after the tenant slot ran — this may be undefined
-        // by design (e.g. a system actor bypassing row-level scoping).
-        // Falling back to the original request tenant would re-introduce
-        // a scope the middleware just cleared, diverging from the REST
-        // path and potentially leaking cross-tenant data.
+        // Codex Round-2 P2 (tenant) + Round-3 P2 (actor): trust the
+        // middleware-resolved values verbatim. The synthetic
+        // skipActionSlots result carries the post-pipeline `actor` /
+        // `tenantId` / `locale` from the final ctx, so onchange runs
+        // under the identity the auth slot produced (role hydration,
+        // impersonation) and under whatever scope the tenant slot
+        // resolved (or cleared). Falling back to the request-context
+        // values would silently undo middleware decisions and could
+        // either leak cross-tenant data or run lookups under broader
+        // permissions than the pipeline intended.
         const resolvedContext =
           commandResult.data && typeof commandResult.data === "object"
-            ? (commandResult.data as { tenantId?: string; locale?: string })
+            ? (commandResult.data as { actor?: Actor; tenantId?: string; locale?: string })
             : undefined;
         try {
           const result = await onchangeEvaluator.evaluate({
             entityName,
             changedField: args.changedField,
             values,
-            actor: ctx.actor,
+            actor: resolvedContext?.actor ?? ctx.actor,
             tenantId: resolvedContext?.tenantId,
           });
           return {

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-onchange-mutations.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-onchange-mutations.ts
@@ -32,7 +32,7 @@
  *   trade-off for public GraphQL endpoints, not specific to onchange.
  */
 
-import type { Actor, CommandLayer, EntityDefinition } from "@linchkit/core";
+import type { CommandLayer, EntityDefinition } from "@linchkit/core";
 import type { OnchangeEvaluator } from "@linchkit/core/server";
 import { consoleLogger, OnchangeEvaluatorError } from "@linchkit/core/server";
 import {
@@ -43,7 +43,7 @@ import {
   GraphQLObjectType,
   GraphQLString,
 } from "graphql";
-import { resolveStatusCode } from "../routes/shared";
+import { extractSkipActionSlotsContext, resolveStatusCode } from "../routes/shared";
 import { type GraphQLContext, sanitizeGraphQLFieldName } from "./build-schema";
 
 const MAX_VALUES_LENGTH = 10_000;
@@ -231,10 +231,7 @@ export function buildOnchangeMutationFields(
         // values would silently undo middleware decisions and could
         // either leak cross-tenant data or run lookups under broader
         // permissions than the pipeline intended.
-        const resolvedContext =
-          commandResult.data && typeof commandResult.data === "object"
-            ? (commandResult.data as { actor?: Actor; tenantId?: string; locale?: string })
-            : undefined;
+        const resolvedContext = extractSkipActionSlotsContext(commandResult.data);
         try {
           const result = await onchangeEvaluator.evaluate({
             entityName,

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-onchange-mutations.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-onchange-mutations.ts
@@ -31,6 +31,7 @@ import {
   GraphQLObjectType,
   GraphQLString,
 } from "graphql";
+import { resolveStatusCode } from "../routes/shared";
 import type { GraphQLContext } from "./build-schema";
 
 const MAX_VALUES_LENGTH = 10_000;
@@ -93,7 +94,71 @@ export function buildOnchangeMutationFields(
         args: { changedField: string; values: string },
         ctx: GraphQLContext,
       ) => {
-        // ── Parse & validate `values` JSON ────────────────────
+        // ── Run CommandLayer (auth/permission/tenant) FIRST ────────
+        // Codex Round-1 P3: keep the uniform-denial property — input
+        // validation runs AFTER auth so an unauthenticated probe cannot
+        // distinguish "endpoint exists, request shape rejected" from
+        // "endpoint denied". An attacker forging an oversized or malformed
+        // `values` arg must hit the same canonical AUTHZ_DENIED as a
+        // request that's well-formed but unauthorized.
+        const commandResult = await commandLayer.execute({
+          command: `${entityName}.onchange`,
+          input: { entity: entityName, changedField: args.changedField },
+          actor: ctx.actor,
+          // Existing GraphQL mutations route as "http" — keep that convention
+          // so per-channel exposure / metrics behave identically across REST
+          // and GraphQL onchange calls.
+          channel: "http",
+          tenantId: ctx.tenantId,
+          locale: ctx.locale,
+          meta: {
+            onchange: {
+              entity: entityName,
+              changedField: args.changedField,
+            },
+          },
+          skipActionSlots: true,
+        });
+
+        if (!commandResult.success) {
+          // Codex Round-1 P2: only canonicalize 401/403 to AUTHZ_DENIED.
+          // Other pipeline failures (rate_limit.exceeded → 429, fail-closed
+          // PERMISSION.MIDDLEWARE_MISSING → 500, etc.) carry meaningful
+          // semantics that GraphQL clients need to distinguish — collapsing
+          // every failure into 403 would mask retryable/operator-actionable
+          // states behind RBAC denials.
+          const errData = commandResult.data as Record<string, unknown> | undefined;
+          const middlewareCode = (errData?.code as string) ?? "ONCHANGE.BLOCKED";
+          const middlewareMessage = (errData?.error as string) ?? "Onchange request blocked";
+          const status = resolveStatusCode(commandResult);
+
+          if (status === 401 || status === 403) {
+            consoleLogger.warn("onchange-graphql: authorization denied", {
+              entity: entityName,
+              changedField: args.changedField,
+              actor: ctx.actor.id,
+              middlewareCode,
+              middlewareMessage,
+            });
+            throw new GraphQLError("Access denied", {
+              extensions: { code: "AUTHZ_DENIED", http: { status: 403 } },
+            });
+          }
+
+          // Non-auth pipeline failure: surface the structured code/message so
+          // clients can branch on it (e.g. throttling → backoff). Operator
+          // detail is preserved here — auth gates already passed if we got a
+          // non-401/403 status, so leaking the code is safe.
+          throw new GraphQLError(middlewareMessage, {
+            extensions: { code: middlewareCode, http: { status } },
+          });
+        }
+
+        // ── Post-auth: validate `values` JSON ───────────────────
+        // Codex Round-1 P3: validation lives AFTER auth so that the
+        // "endpoint exists" signal can only be observed by authorized
+        // callers. Stable extension codes let clients distinguish bad
+        // input shape from an unrecognized field or evaluator failure.
         if (args.values.length > MAX_VALUES_LENGTH) {
           throw new GraphQLError(
             `Argument "values" exceeds maximum allowed length of ${MAX_VALUES_LENGTH} characters`,
@@ -115,46 +180,7 @@ export function buildOnchangeMutationFields(
         }
         const values = parsed as Record<string, unknown>;
 
-        // ── Run CommandLayer (auth/permission/tenant) BEFORE revealing entity shape ──
-        const commandResult = await commandLayer.execute({
-          command: `${entityName}.onchange`,
-          input: { entity: entityName, changedField: args.changedField },
-          actor: ctx.actor,
-          // Existing GraphQL mutations route as "http" — keep that convention
-          // so per-channel exposure / metrics behave identically across REST
-          // and GraphQL onchange calls.
-          channel: "http",
-          tenantId: ctx.tenantId,
-          locale: ctx.locale,
-          meta: {
-            onchange: {
-              entity: entityName,
-              changedField: args.changedField,
-            },
-          },
-          skipActionSlots: true,
-        });
-
-        if (!commandResult.success) {
-          // Canonicalize all auth failures (mirror REST AUTHZ_DENIED). Log the
-          // raw middleware detail for operator debugging — never echo it to
-          // the client where it would leak entity existence / hook presence.
-          const errData = commandResult.data as Record<string, unknown> | undefined;
-          const middlewareCode = (errData?.code as string) ?? "ONCHANGE.BLOCKED";
-          const middlewareMessage = (errData?.error as string) ?? "Onchange request blocked";
-          consoleLogger.warn("onchange-graphql: authorization denied", {
-            entity: entityName,
-            changedField: args.changedField,
-            actor: ctx.actor.id,
-            middlewareCode,
-            middlewareMessage,
-          });
-          throw new GraphQLError("Access denied", {
-            extensions: { code: "AUTHZ_DENIED", http: { status: 403 } },
-          });
-        }
-
-        // ── Post-auth: safe to surface evaluator-level errors ────────
+        // ── Run evaluator ───────────────────────────────────────
         const resolvedContext =
           commandResult.data && typeof commandResult.data === "object"
             ? (commandResult.data as { tenantId?: string; locale?: string })
@@ -179,10 +205,17 @@ export function buildOnchangeMutationFields(
               extensions: { code: `ONCHANGE.${err.code}` },
             });
           }
-          // Unknown failure — surface as generic GraphQL error without
-          // leaking implementation details.
-          const message = err instanceof Error ? err.message : "Onchange evaluation failed";
-          throw new GraphQLError(message, {
+          // Codex Round-1 P3: unknown failure — log full detail server-side
+          // and return a fixed message so SQL driver / upstream HTTP error
+          // strings can't leak through the client-visible GraphQL error.
+          consoleLogger.warn("onchange-graphql: unexpected evaluator failure", {
+            entity: entityName,
+            changedField: args.changedField,
+            actor: ctx.actor.id,
+            error: err instanceof Error ? err.message : String(err),
+            stack: err instanceof Error ? err.stack : undefined,
+          });
+          throw new GraphQLError("Onchange evaluation failed", {
             extensions: { code: "ONCHANGE.EVALUATION_FAILED" },
           });
         }

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-onchange-mutations.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-onchange-mutations.ts
@@ -18,6 +18,18 @@
  * `executeAction` precedent, both the input `values` argument and the
  * `updates` output field are JSON-encoded strings. Clients `JSON.parse` to
  * obtain the object.
+ *
+ * Known limitation — schema introspection enumeration:
+ *   GraphQL introspection (`{ __type(name: "Mutation") { fields { name } } }`)
+ *   is enabled by default and will list every `<entity>_onchange` field
+ *   alongside CRUD mutations. The resolver-level AUTHZ_DENIED canonicalization
+ *   prevents enumeration through call responses, but introspection itself
+ *   remains a separate concern that applies to the entire GraphQL surface.
+ *   Operators who treat onchange-enabled entities as confidential should
+ *   disable introspection in production (graphql-yoga `landingPage: false`
+ *   + a schema policy plugin gating __schema/__type) or wire a
+ *   field-level introspection authorizer. This is an industry-standard
+ *   trade-off for public GraphQL endpoints, not specific to onchange.
  */
 
 import type { Actor, CommandLayer, EntityDefinition } from "@linchkit/core";
@@ -32,7 +44,7 @@ import {
   GraphQLString,
 } from "graphql";
 import { resolveStatusCode } from "../routes/shared";
-import type { GraphQLContext } from "./build-schema";
+import { type GraphQLContext, sanitizeGraphQLFieldName } from "./build-schema";
 
 const MAX_VALUES_LENGTH = 10_000;
 
@@ -79,6 +91,18 @@ export function buildOnchangeMutationFields(
   const { commandLayer, onchangeEvaluator, internalSchemas } = options;
   if (!commandLayer || !onchangeEvaluator) return {};
 
+  // Codex Round-4 P2: skipActionSlots fails fast at execute time when no
+  // permission middleware is registered (fail-closed guard in command-layer).
+  // If this server hasn't wired one yet, advertising `<entity>_onchange`
+  // mutations through the schema would mean introspection lists fields that
+  // can never succeed — every call would return PERMISSION.MIDDLEWARE_MISSING.
+  // Suppressing the field at schema build time keeps the public surface
+  // honest and avoids advertising an inert API.
+  const hasPermissionMiddleware = commandLayer
+    .getMiddlewares()
+    .some((m) => m.slot === "permission");
+  if (!hasPermissionMiddleware) return {};
+
   const fields: Record<string, GraphQLFieldConfig<unknown, GraphQLContext>> = {};
 
   for (const entity of entities) {
@@ -89,7 +113,11 @@ export function buildOnchangeMutationFields(
     if (internalSchemas?.has(entity.name)) continue;
 
     const entityName = entity.name;
-    const fieldName = `${entityName}_onchange`;
+    // Codex Round-4 P2: sanitize the entity name so non-GraphQL chars
+    // (e.g. `-` in `sales-order`) don't blow up schema construction.
+    // The resulting field is `<safe>_onchange` — snake_case is preserved
+    // for spec consistency and stays valid for any user-defined entity.
+    const fieldName = `${sanitizeGraphQLFieldName(entityName)}_onchange`;
 
     fields[fieldName] = {
       type: new GraphQLNonNull(OnchangeResponseType),

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-onchange-mutations.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-onchange-mutations.ts
@@ -1,0 +1,194 @@
+/**
+ * Auto-generated `<entity>_onchange` GraphQL mutations (Spec 64 §4.2).
+ *
+ * For each registered EntityDefinition that declares an `onchange` map, emit
+ * one mutation field with the name `<entityName>_onchange`. The resolver
+ * mirrors the REST endpoint's authorization + evaluation flow:
+ *
+ *   1. Dispatch through CommandLayer with `skipActionSlots: true` so the
+ *      pre / auth / exposure / permission / tenant slots run, but
+ *      pre-action / post-action do not (onchange is read-only — Spec 64 §4.3).
+ *   2. On any pipeline failure, return a canonical AUTHZ_DENIED GraphQL
+ *      error so the response cannot be used as a side-channel to enumerate
+ *      which entities exist or have onchange hooks (Non-blocker 4 from PR #198).
+ *   3. Run the OnchangeEvaluator with the resolved tenantId / actor and
+ *      return `{ updates: <json>, warnings: [...] }`.
+ *
+ * GraphQL has no native JSON scalar in this codebase; following the existing
+ * `executeAction` precedent, both the input `values` argument and the
+ * `updates` output field are JSON-encoded strings. Clients `JSON.parse` to
+ * obtain the object.
+ */
+
+import type { CommandLayer, EntityDefinition } from "@linchkit/core";
+import type { OnchangeEvaluator } from "@linchkit/core/server";
+import { consoleLogger, OnchangeEvaluatorError } from "@linchkit/core/server";
+import {
+  GraphQLError,
+  type GraphQLFieldConfig,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql";
+import type { GraphQLContext } from "./build-schema";
+
+const MAX_VALUES_LENGTH = 10_000;
+
+/** Stable response type used by every auto-generated `<entity>_onchange` mutation. */
+const OnchangeResponseType = new GraphQLObjectType({
+  name: "OnchangeResponse",
+  fields: {
+    updates: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "JSON-encoded map of suggested field updates",
+    },
+    warnings: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLString))),
+      description: "Non-blocking warnings to surface to the user",
+    },
+  },
+});
+
+export interface BuildOnchangeMutationsOptions {
+  /** CommandLayer that will run pre/auth/exposure/permission/tenant slots. */
+  commandLayer?: CommandLayer;
+  /** OnchangeEvaluator for the actual computation. */
+  onchangeEvaluator?: OnchangeEvaluator;
+}
+
+/**
+ * Build the per-entity onchange mutation fields. Emits no fields when either
+ * a CommandLayer or evaluator is missing (matches the REST `503` semantics —
+ * the GraphQL surface simply omits the mutation rather than serving a broken
+ * one). Entities without an `onchange` map are skipped.
+ */
+export function buildOnchangeMutationFields(
+  entities: EntityDefinition[],
+  options: BuildOnchangeMutationsOptions,
+): Record<string, GraphQLFieldConfig<unknown, GraphQLContext>> {
+  const { commandLayer, onchangeEvaluator } = options;
+  if (!commandLayer || !onchangeEvaluator) return {};
+
+  const fields: Record<string, GraphQLFieldConfig<unknown, GraphQLContext>> = {};
+
+  for (const entity of entities) {
+    if (!entity.onchange || Object.keys(entity.onchange).length === 0) continue;
+
+    const entityName = entity.name;
+    const fieldName = `${entityName}_onchange`;
+
+    fields[fieldName] = {
+      type: new GraphQLNonNull(OnchangeResponseType),
+      description: `Compute suggested form-field updates for ${entityName} (Spec 64).`,
+      args: {
+        changedField: { type: new GraphQLNonNull(GraphQLString) },
+        values: {
+          type: new GraphQLNonNull(GraphQLString),
+          description: "JSON-encoded map of current form values",
+        },
+      },
+      resolve: async (
+        _root: unknown,
+        args: { changedField: string; values: string },
+        ctx: GraphQLContext,
+      ) => {
+        // ── Parse & validate `values` JSON ────────────────────
+        if (args.values.length > MAX_VALUES_LENGTH) {
+          throw new GraphQLError(
+            `Argument "values" exceeds maximum allowed length of ${MAX_VALUES_LENGTH} characters`,
+            { extensions: { code: "INVALID_REQUEST.VALUES_TOO_LARGE" } },
+          );
+        }
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(args.values);
+        } catch {
+          throw new GraphQLError('Argument "values" contains invalid JSON', {
+            extensions: { code: "INVALID_REQUEST.MALFORMED_VALUES" },
+          });
+        }
+        if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+          throw new GraphQLError('Argument "values" must be a JSON object', {
+            extensions: { code: "INVALID_REQUEST.MALFORMED_VALUES" },
+          });
+        }
+        const values = parsed as Record<string, unknown>;
+
+        // ── Run CommandLayer (auth/permission/tenant) BEFORE revealing entity shape ──
+        const commandResult = await commandLayer.execute({
+          command: `${entityName}.onchange`,
+          input: { entity: entityName, changedField: args.changedField },
+          actor: ctx.actor,
+          // Existing GraphQL mutations route as "http" — keep that convention
+          // so per-channel exposure / metrics behave identically across REST
+          // and GraphQL onchange calls.
+          channel: "http",
+          tenantId: ctx.tenantId,
+          locale: ctx.locale,
+          meta: {
+            onchange: {
+              entity: entityName,
+              changedField: args.changedField,
+            },
+          },
+          skipActionSlots: true,
+        });
+
+        if (!commandResult.success) {
+          // Canonicalize all auth failures (mirror REST AUTHZ_DENIED). Log the
+          // raw middleware detail for operator debugging — never echo it to
+          // the client where it would leak entity existence / hook presence.
+          const errData = commandResult.data as Record<string, unknown> | undefined;
+          const middlewareCode = (errData?.code as string) ?? "ONCHANGE.BLOCKED";
+          const middlewareMessage = (errData?.error as string) ?? "Onchange request blocked";
+          consoleLogger.warn("onchange-graphql: authorization denied", {
+            entity: entityName,
+            changedField: args.changedField,
+            actor: ctx.actor.id,
+            middlewareCode,
+            middlewareMessage,
+          });
+          throw new GraphQLError("Access denied", {
+            extensions: { code: "AUTHZ_DENIED", http: { status: 403 } },
+          });
+        }
+
+        // ── Post-auth: safe to surface evaluator-level errors ────────
+        const resolvedContext =
+          commandResult.data && typeof commandResult.data === "object"
+            ? (commandResult.data as { tenantId?: string; locale?: string })
+            : undefined;
+        try {
+          const result = await onchangeEvaluator.evaluate({
+            entityName,
+            changedField: args.changedField,
+            values,
+            actor: ctx.actor,
+            tenantId: resolvedContext?.tenantId ?? ctx.tenantId,
+          });
+          return {
+            updates: JSON.stringify(result.updates),
+            warnings: result.warnings,
+          };
+        } catch (err) {
+          if (err instanceof OnchangeEvaluatorError) {
+            // Map evaluator codes to GraphQL extensions. The error message is
+            // safe to expose post-auth (mirrors REST behavior).
+            throw new GraphQLError(err.message, {
+              extensions: { code: `ONCHANGE.${err.code}` },
+            });
+          }
+          // Unknown failure — surface as generic GraphQL error without
+          // leaking implementation details.
+          const message = err instanceof Error ? err.message : "Onchange evaluation failed";
+          throw new GraphQLError(message, {
+            extensions: { code: "ONCHANGE.EVALUATION_FAILED" },
+          });
+        }
+      },
+    };
+  }
+
+  return fields;
+}

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-onchange-mutations.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-onchange-mutations.ts
@@ -181,6 +181,13 @@ export function buildOnchangeMutationFields(
         const values = parsed as Record<string, unknown>;
 
         // ── Run evaluator ───────────────────────────────────────
+        // Codex Round-2 P2: trust the middleware-resolved tenant verbatim.
+        // The synthetic skipActionSlots result populates `tenantId` from
+        // the final ctx after the tenant slot ran — this may be undefined
+        // by design (e.g. a system actor bypassing row-level scoping).
+        // Falling back to the original request tenant would re-introduce
+        // a scope the middleware just cleared, diverging from the REST
+        // path and potentially leaking cross-tenant data.
         const resolvedContext =
           commandResult.data && typeof commandResult.data === "object"
             ? (commandResult.data as { tenantId?: string; locale?: string })
@@ -191,7 +198,7 @@ export function buildOnchangeMutationFields(
             changedField: args.changedField,
             values,
             actor: ctx.actor,
-            tenantId: resolvedContext?.tenantId ?? ctx.tenantId,
+            tenantId: resolvedContext?.tenantId,
           });
           return {
             updates: JSON.stringify(result.updates),

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
@@ -23,7 +23,7 @@ import type {
   StateDefinition,
 } from "@linchkit/core";
 import { normalizeTranslatableRow, resolveTranslatableRow } from "@linchkit/core";
-import type { CacheManager, OverlayRegistry } from "@linchkit/core/server";
+import type { CacheManager, OnchangeEvaluator, OverlayRegistry } from "@linchkit/core/server";
 import { createStateMachine, getAvailableTransitions, maskRecord } from "@linchkit/core/server";
 
 export { type GenerateCrudActionsOptions, generateCrudActions } from "./build-crud-actions";
@@ -40,6 +40,7 @@ import {
   GraphQLSchema,
   GraphQLString,
 } from "graphql";
+import { buildOnchangeMutationFields } from "./build-onchange-mutations";
 import { buildSubscriptionFields, createEventBusPubSub } from "./build-subscriptions";
 import {
   generateActionInputType,
@@ -184,6 +185,13 @@ export interface BuildGraphQLSchemaOptions {
   extraMutationFields?: Record<string, GraphQLFieldConfig<unknown, unknown>>;
   /** Overlay registry for dynamic runtime fields (Phase 3 — overlay fields in GraphQL) */
   overlayRegistry?: OverlayRegistry;
+  /**
+   * Onchange evaluator (Spec 64) — when provided alongside `commandLayer`,
+   * each entity that declares an `onchange` map gets an auto-generated
+   * `<entity>_onchange` mutation. Without both, the GraphQL surface omits
+   * the mutation entirely (mirrors REST 503 behavior of skipping the route).
+   */
+  onchangeEvaluator?: OnchangeEvaluator;
 }
 
 /**
@@ -958,6 +966,15 @@ export function buildGraphQLSchema(
           executionId: null,
         }),
   };
+
+  // Auto-generate `<entity>_onchange` mutations for entities with an
+  // onchange map (Spec 64 §4.2). Skipped when CommandLayer or evaluator
+  // is missing — keeps test setups that don't wire either from breaking.
+  const onchangeFields = buildOnchangeMutationFields(autoEntities, {
+    commandLayer,
+    onchangeEvaluator: options?.onchangeEvaluator,
+  });
+  Object.assign(mutationFields, onchangeFields);
 
   // Merge capability-contributed GraphQL fields (Spec 57 graphqlExtensions)
   if (options?.extraQueryFields) {

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
@@ -970,9 +970,12 @@ export function buildGraphQLSchema(
   // Auto-generate `<entity>_onchange` mutations for entities with an
   // onchange map (Spec 64 §4.2). Skipped when CommandLayer or evaluator
   // is missing — keeps test setups that don't wire either from breaking.
+  // `internalSchemas` is passed through so internal/system schemas with an
+  // onchange map don't leak a public mutation (Codex Round-3 P3).
   const onchangeFields = buildOnchangeMutationFields(autoEntities, {
     commandLayer,
     onchangeEvaluator: options?.onchangeEvaluator,
+    internalSchemas,
   });
   Object.assign(mutationFields, onchangeFields);
 

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
@@ -51,6 +51,18 @@ import {
 const GRAPHQL_NAME_RE = /^[_A-Za-z][_0-9A-Za-z]*$/;
 
 /**
+ * Sanitize an arbitrary identifier to a valid GraphQL field-name component
+ * by replacing any disallowed character with `_` and prefixing the result
+ * with `_` if it does not start with a letter or underscore. Preserves
+ * snake_case for entity names — used by call sites that build composite
+ * names like `<entity>_onchange` and want the entity portion intact.
+ */
+export function sanitizeGraphQLFieldName(name: string): string {
+  const replaced = name.replace(/[^_0-9A-Za-z]/g, "_");
+  return GRAPHQL_NAME_RE.test(replaced) ? replaced : `_${replaced}`;
+}
+
+/**
  * Convert a schema name to PascalCase with GraphQL name sanitization.
  * e.g. "purchase_request" -> "PurchaseRequest"
  */

--- a/addons/adapter-server/cap-adapter-server/src/routes/onchange-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/onchange-api.ts
@@ -188,19 +188,26 @@ export function mountOnchangeRoutes(
     // lookups via the DataProvider.
     //
     // The synthetic success result from `skipActionSlots` carries the resolved
-    // `tenantId` / `locale` read from the command context after the tenant +
-    // auth middlewares ran, so downstream handlers pick up whatever the
-    // pipeline decided rather than whatever the caller initially sent.
+    // `actor` / `tenantId` / `locale` read from the command context after the
+    // auth + tenant middlewares ran. Spec 64 §9.1 mandates that onchange runs
+    // with the caller's resolved permissions — auth middleware that enriches
+    // the actor (role hydration, impersonation) MUST be honored here, so we
+    // prefer the post-pipeline actor over the actor we resolved from the
+    // request before dispatch.
     const resolvedContext =
       commandResult.data && typeof commandResult.data === "object"
-        ? (commandResult.data as { tenantId?: string; locale?: string })
+        ? (commandResult.data as {
+            actor?: typeof actor;
+            tenantId?: string;
+            locale?: string;
+          })
         : undefined;
     try {
       const result = await onchangeEvaluator.evaluate({
         entityName,
         changedField,
         values,
-        actor,
+        actor: resolvedContext?.actor ?? actor,
         tenantId: resolvedContext?.tenantId,
       });
       return {

--- a/addons/adapter-server/cap-adapter-server/src/routes/onchange-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/onchange-api.ts
@@ -23,6 +23,7 @@ import type { Elysia } from "elysia";
 import type { ServerOptions } from "../server";
 import {
   badRequest,
+  extractSkipActionSlotsContext,
   notFound,
   resolveActor,
   resolveStatusCode,
@@ -194,14 +195,7 @@ export function mountOnchangeRoutes(
     // the actor (role hydration, impersonation) MUST be honored here, so we
     // prefer the post-pipeline actor over the actor we resolved from the
     // request before dispatch.
-    const resolvedContext =
-      commandResult.data && typeof commandResult.data === "object"
-        ? (commandResult.data as {
-            actor?: typeof actor;
-            tenantId?: string;
-            locale?: string;
-          })
-        : undefined;
+    const resolvedContext = extractSkipActionSlotsContext(commandResult.data);
     try {
       const result = await onchangeEvaluator.evaluate({
         entityName,

--- a/addons/adapter-server/cap-adapter-server/src/routes/shared.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/shared.ts
@@ -27,6 +27,38 @@ export const NO_AUTH_ACTOR: Actor = {
 };
 
 /**
+ * Shape of the synthetic data carried by a successful `skipActionSlots`
+ * CommandLayer result (non-action dispatch — Spec 64 onchange, etc.).
+ * The CommandLayer populates `actor`, `tenantId`, and `locale` from the
+ * final ctx after middleware has run, so callers see the post-pipeline
+ * identity / scope rather than whatever the request initially carried.
+ */
+export interface SkipActionSlotsResolvedContext {
+  actor?: Actor;
+  tenantId?: string;
+  locale?: string;
+}
+
+/**
+ * Defensively extract the post-middleware actor / tenantId / locale from a
+ * successful `skipActionSlots` result. Returns `undefined` if the data shape
+ * is unexpected — callers should fall back to their request-context values.
+ *
+ * Used by both the REST onchange route and the GraphQL `<entity>_onchange`
+ * resolver so that an auth middleware that enriches the actor (role
+ * hydration, impersonation) and/or a tenant middleware that clears scope
+ * are honored consistently across channels (Spec 64 §9.1).
+ */
+export function extractSkipActionSlotsContext(
+  data: unknown,
+): SkipActionSlotsResolvedContext | undefined {
+  if (data && typeof data === "object") {
+    return data as SkipActionSlotsResolvedContext;
+  }
+  return undefined;
+}
+
+/**
  * Map structured error codes to HTTP status codes.
  * Preferred over message-text matching when a code is available.
  */

--- a/packages/core/src/engine/command-layer.ts
+++ b/packages/core/src/engine/command-layer.ts
@@ -487,14 +487,19 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
       // Non-action dispatch: set a synthetic success result so downstream code
       // knows the pipeline completed without error. The caller is responsible
       // for producing the actual response payload (e.g. onchange updates).
-      // Include the resolved tenantId / locale (read from the final ctx after
-      // middleware runs) so downstream handlers like the onchange REST route
-      // can propagate them without having to re-derive from the request.
+      // Include the resolved actor / tenantId / locale (read from the final
+      // ctx after middleware runs) so downstream handlers like the onchange
+      // REST/GraphQL routes can propagate them without having to re-derive
+      // from the request — auth middleware that enriches/replaces the actor
+      // (role hydration, impersonation) MUST be honored here, otherwise
+      // OnchangeContext.actor would diverge from the pipeline-resolved
+      // identity. (Spec 64 §9.1 — onchange runs with caller's permissions.)
       pipeline.push(async (c: CommandContext, _next: () => Promise<void>) => {
         c.result = {
           success: true,
           data: {
             skipped: true,
+            actor: c.actor,
             tenantId: c.tenantId,
             locale: c.locale,
           },


### PR DESCRIPTION
## Summary

Closes the M5 GraphQL gap left by PR #191/#198 — every entity that declares an `onchange` map now gets a `<name>_onchange` GraphQL mutation auto-generated alongside CRUD. The resolver mirrors the REST flow: CommandLayer with `skipActionSlots` runs auth/permission/tenant first, then OnchangeEvaluator returns `{ updates, warnings }`.

This is the last item in Spec 64 §13 M5; M6 (frontend AutoForm integration) remains a separate scope.

## Module

- **New module**: `addons/adapter-server/cap-adapter-server/src/graphql/build-onchange-mutations.ts` — keeps build-schema.ts size in check; one auto-generated mutation per entity with onchange, JSON-encoded \`updates\` + \`warnings: [String!]!\` response.
- **Schema integration**: \`BuildGraphQLSchemaOptions\` gains \`onchangeEvaluator?\`. When absent (or when CommandLayer is missing or has no permission middleware), the mutation is silently omitted — matches the REST 503 omission semantics.
- **Wiring**: \`dev.ts\` and \`capability.ts\` thread the evaluator into \`buildGraphQLSchema()\` so both the CLI dev server and the Spec 57 capability autoload path get the mutation.
- **Core change**: \`command-layer.ts\` — synthetic \`skipActionSlots\` result now includes \`actor: c.actor\` alongside \`tenantId\`/\`locale\` so the post-pipeline identity is observable to the caller (Spec 64 §9.1 — onchange runs with the caller's resolved permissions).
- **REST parity**: \`routes/onchange-api.ts\` — uses the new \`resolvedContext.actor\` so the REST path also benefits from auth-middleware actor enrichment (silently fixed alongside).

## Codex review — all 4 rounds resolved

| Round | Finding | Severity | Resolution |
|---|---|---|---|
| 1 | Non-auth pipeline failures rewritten to AUTHZ_DENIED (rate_limit/fail-closed misclassified) | P2 | Only 401/403 collapse to AUTHZ_DENIED; other codes preserved |
| 1 | Validation runs before auth — leaks endpoint existence | P3 | Reordered: CommandLayer first, then values validation |
| 1 | Unexpected evaluator errors echo \`err.message\` to client | P3 | Fixed message + log raw detail server-side |
| 2 | \`?? ctx.tenantId\` overrides middleware that intentionally clears tenant | P2 | Trust resolvedContext.tenantId verbatim |
| 3 | Pre-pipeline actor used (auth middleware enrichment ignored) | P2 | command-layer carries post-auth actor; both REST and GraphQL use it |
| 3 | \`internalSchemas\` filter ignored — internal schemas leak public mutation | P3 | Filter threaded through buildOnchangeMutationFields |
| 4 | Field name like \`sales-order_onchange\` crashes schema build | P2 | New \`sanitizeGraphQLFieldName()\` helper |
| 4 | Mutation advertised when no permission middleware (always fails at runtime) | P2 | Suppress at build time when \`getMiddlewares()\` lacks permission slot |
| 4 | Schema introspection enumerates onchange-enabled entities | P2 | Documented as system-wide limitation (orthogonal to onchange) |

## Gemini review

Round 5 — clean except 1 P3 nice-to-have (share \`MAX_VALUES_LENGTH\` constant with REST). Deferred: REST onchange has no body-size limit currently, so introducing one is a behavior change beyond this PR's scope.

## Test plan

- [x] \`bun run check\` — clean
- [x] \`bun run typecheck\` — clean
- [x] \`bun test\` — 4477 pass / 0 fail / 3 skip across 271 files
- [x] 20 new GraphQL onchange integration tests covering: auto-generation visibility, happy path with chained cascade, JSON validation (malformed/oversized/array), evaluator error code mapping, AUTHZ_DENIED canonicalization, validation-after-auth ordering, non-auth failure preservation, post-auth actor propagation, tenant scope clearing, internal schema filter, name sanitization with \`-\`, permission-middleware suppression, leaky-evaluator stub
- [x] 4 rounds of Codex cross-model review (round 5 hit usage limit; substituted with Gemini)
- [x] 1 round of Gemini cross-model review

Refs #148 (Phase 1 M5 GraphQL — closes the last item in Spec 64 §13 M5; M6 frontend AutoForm integration remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GraphQL mutations to trigger onchange evaluators for entities with onchange configuration, returning structured updates and warnings.

* **Bug Fixes**
  * Improved authorization and error handling for onchange operations with consistent error codes and validation failure detection.

* **Tests**
  * Added comprehensive integration test suite validating schema behavior, successful evaluation, permission enforcement, error canonicalization, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->