### PR TITLE
feat(core): batch_actions execution + REST endpoint (Spec 04 §8, closes #129)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/batch-actions-api.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/batch-actions-api.test.ts
@@ -1,0 +1,271 @@
+/**
+ * REST `POST /api/actions/batch` integration tests (Spec 16 §3.1).
+ *
+ * Covers route registration order (the parametric `:name` route MUST NOT
+ * capture `batch`), body validation, and the structured BatchActionsResult
+ * envelope produced by `CommandLayer.executeBatch`.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import type {
+  ActionDefinition,
+  DataProvider,
+  EntityDefinition,
+  PendingEvent,
+  TransactionManager,
+} from "@linchkit/core";
+import { createActionExecutor, createCommandLayer, PipelineError } from "@linchkit/core/server";
+import { buildGraphQLSchema } from "../src/graphql/build-schema";
+import { createServer } from "../src/server";
+
+// ── Fixtures ──────────────────────────────────────────────
+
+const itemSchema: EntityDefinition = {
+  name: "item",
+  label: "Item",
+  fields: {
+    title: { type: "string", required: true, label: "Title" },
+  },
+};
+
+const createItem: ActionDefinition = {
+  name: "create_item",
+  entity: "item",
+  label: "Create Item",
+  policy: { mode: "sync", transaction: true },
+  exposure: "all",
+  handler: async (ctx) => ctx.create("item", { title: ctx.input.title }),
+};
+
+const failItem: ActionDefinition = {
+  name: "fail_item",
+  entity: "item",
+  label: "Fail Item",
+  policy: { mode: "sync", transaction: true },
+  exposure: "all",
+  handler: async () => {
+    throw new Error("intentional failure");
+  },
+};
+
+const adminOnly: ActionDefinition = {
+  name: "delete_item",
+  entity: "item",
+  label: "Delete Item",
+  policy: { mode: "sync", transaction: true },
+  exposure: "all",
+  handler: async () => ({ ok: true }),
+};
+
+// Snapshot-aware in-memory provider so we can verify rollback behavior under
+// `all_or_nothing`. InMemoryStore alone has no rollback semantics, so we
+// pair a custom DataProvider with a fake TransactionManager.
+function createSnapshotProvider() {
+  const records = new Map<string, Record<string, unknown>>();
+  let counter = 0;
+  const provider: DataProvider = {
+    async get(_schema, id) {
+      const found = records.get(id);
+      if (!found) throw new Error(`not found: ${id}`);
+      return found;
+    },
+    async query() {
+      return [];
+    },
+    async create(_schema, data) {
+      counter++;
+      const id = `rec_${counter}`;
+      const rec = { id, ...data };
+      records.set(id, rec);
+      return rec;
+    },
+    async update(_schema, id, data) {
+      const existing = records.get(id) ?? { id };
+      const updated = { ...existing, ...data };
+      records.set(id, updated);
+      return updated;
+    },
+    async delete(_schema, id) {
+      records.delete(id);
+    },
+    async count() {
+      return records.size;
+    },
+  };
+  return Object.assign(provider, {
+    records,
+    snapshot: () => new Map(records),
+  });
+}
+
+function createFakeTxManager(
+  provider: ReturnType<typeof createSnapshotProvider>,
+): TransactionManager {
+  return {
+    async runInTransaction<T>(
+      fn: (tx: DataProvider) => Promise<T>,
+      _pending: PendingEvent[],
+    ): Promise<T> {
+      const before = provider.snapshot();
+      try {
+        return await fn(provider);
+      } catch (err) {
+        provider.records.clear();
+        for (const [k, v] of before) provider.records.set(k, v);
+        throw err;
+      }
+    },
+  };
+}
+
+// ── Server setup ──────────────────────────────────────────
+
+const provider = createSnapshotProvider();
+const txManager = createFakeTxManager(provider);
+
+const executor = createActionExecutor({
+  dataProvider: provider,
+  transactionManager: txManager,
+});
+executor.registry.register(createItem);
+executor.registry.register(failItem);
+executor.registry.register(adminOnly);
+
+const commandLayer = createCommandLayer({ executor });
+commandLayer.use({
+  name: "test_permission",
+  slot: "permission",
+  handler: async (ctx, next) => {
+    if (ctx.command === "delete_item" && !ctx.actor.groups.includes("admin")) {
+      throw new PipelineError(
+        "Actor does not belong to required group: admin",
+        "PERMISSION.DENIED",
+      );
+    }
+    await next();
+  },
+});
+
+const graphqlSchema = buildGraphQLSchema([itemSchema]);
+const app = createServer(graphqlSchema, {
+  executor,
+  commandLayer,
+  transactionManager: txManager,
+});
+const port = 4030;
+
+const baseUrl = () => `http://localhost:${port}`;
+
+async function postJSON(path: string, body: unknown, init?: RequestInit) {
+  const res = await fetch(`${baseUrl()}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    ...init,
+  });
+  const text = await res.text();
+  let json: Record<string, unknown> | undefined;
+  try {
+    json = text ? (JSON.parse(text) as Record<string, unknown>) : undefined;
+  } catch {
+    json = undefined;
+  }
+  return { status: res.status, body: json, raw: text };
+}
+
+beforeAll(() => {
+  app.listen(port);
+});
+
+afterAll(() => {
+  app.stop();
+});
+
+describe("POST /api/actions/batch", () => {
+  test("(a) valid partial batch returns 200 with structured BatchActionsResult", async () => {
+    provider.records.clear();
+    const { status, body } = await postJSON("/api/actions/batch", {
+      strategy: "partial",
+      actions: [
+        { name: "create_item", input: { title: "X" } },
+        { name: "create_item", input: { title: "Y" } },
+      ],
+    });
+    expect(status).toBe(200);
+    expect(body?.success).toBe(true);
+    expect(body?.strategy).toBe("partial");
+    expect(Array.isArray(body?.succeeded)).toBe(true);
+    expect((body?.succeeded as unknown[]).length).toBe(2);
+    expect((body?.failed as unknown[]).length).toBe(0);
+    expect((body?.summary as Record<string, number>).total).toBe(2);
+  });
+
+  test("(b) missing actions field → 400", async () => {
+    const { status, body } = await postJSON("/api/actions/batch", { strategy: "partial" });
+    expect(status).toBe(400);
+    expect(body?.success).toBe(false);
+  });
+
+  test("(c) actions not an array → 400", async () => {
+    const { status, body } = await postJSON("/api/actions/batch", {
+      actions: "not an array",
+    });
+    expect(status).toBe(400);
+    expect(body?.success).toBe(false);
+  });
+
+  test("(d) unknown strategy → 400", async () => {
+    const { status, body } = await postJSON("/api/actions/batch", {
+      strategy: "fast",
+      actions: [{ name: "create_item", input: { title: "x" } }],
+    });
+    expect(status).toBe(400);
+    expect(body?.success).toBe(false);
+  });
+
+  test("(e) empty actions array → 200 with structured BATCH_EMPTY failure", async () => {
+    // Empty body validation now happens in the engine layer (returns
+    // structured failure); request shape is valid, so HTTP is still 200.
+    const { status, body } = await postJSON("/api/actions/batch", {
+      strategy: "partial",
+      actions: [],
+    });
+    expect(status).toBe(200);
+    expect(body?.success).toBe(false);
+    const failed = body?.failed as Array<{ error: { code: string } }>;
+    expect(failed[0]?.error.code).toBe("BATCH_EMPTY");
+  });
+
+  test("(f) all_or_nothing rollback returns 200 with rolledBack populated", async () => {
+    provider.records.clear();
+    const { status, body } = await postJSON("/api/actions/batch", {
+      strategy: "all_or_nothing",
+      actions: [
+        { name: "create_item", input: { title: "A" } },
+        { name: "fail_item", input: {} },
+      ],
+    });
+    expect(status).toBe(200);
+    expect(body?.success).toBe(false);
+    expect(body?.strategy).toBe("all_or_nothing");
+    const rolledBack = body?.rolledBack as unknown[];
+    expect(rolledBack.length).toBe(1);
+    expect(provider.records.size).toBe(0);
+  });
+
+  test("(g) /api/actions/batch is NOT captured by /api/actions/:name", async () => {
+    // Sanity check: posting to `/api/actions/batch` reaches the batch handler
+    // (validates the body shape and rejects an empty `actions` array via
+    // structured failure) — NOT the single-action handler, which would have
+    // returned a 404 with "Action 'batch' not found".
+    const { status, body } = await postJSON("/api/actions/batch", {
+      strategy: "partial",
+      actions: [],
+    });
+    expect(status).toBe(200);
+    // Single-action handler returns `{ success, error: { code: "ACTION.EXECUTION.FAILED" } }`,
+    // batch handler returns BatchActionsResult shape with `failed` array.
+    expect(Array.isArray(body?.failed)).toBe(true);
+    expect("strategy" in (body ?? {})).toBe(true);
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/__tests__/batch-actions-api.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/batch-actions-api.test.ts
@@ -214,6 +214,17 @@ describe("POST /api/actions/batch", () => {
     expect(body?.success).toBe(false);
   });
 
+  test("(c2) array-valued input → 400 (object spread would silently rewrite arrays)", async () => {
+    const { status, body } = await postJSON("/api/actions/batch", {
+      strategy: "partial",
+      actions: [{ name: "create_item", input: [] }],
+    });
+    expect(status).toBe(400);
+    expect(body?.success).toBe(false);
+    const message = (body?.error as { message?: string } | undefined)?.message ?? "";
+    expect(message).toContain("actions[0].input must be an object when present.");
+  });
+
   test("(d) unknown strategy → 400", async () => {
     const { status, body } = await postJSON("/api/actions/batch", {
       strategy: "fast",
@@ -251,6 +262,39 @@ describe("POST /api/actions/batch", () => {
     const rolledBack = body?.rolledBack as unknown[];
     expect(rolledBack.length).toBe(1);
     expect(provider.records.size).toBe(0);
+  });
+
+  test("(h) production mode sanitizes per-item error messages", async () => {
+    // The `fail_item` handler throws a recognizable internal message; in
+    // production mode we expect the per-item `error.message` to be replaced
+    // with the generic placeholder while `code` is preserved.
+    provider.records.clear();
+    const prevEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      const { status, body } = await postJSON("/api/actions/batch", {
+        strategy: "partial",
+        actions: [
+          { name: "create_item", input: { title: "ok" } },
+          { name: "fail_item", input: {} },
+        ],
+      });
+      expect(status).toBe(200);
+      expect(body?.success).toBe(false);
+      const failed = body?.failed as Array<{ error: { code: string; message: string } }>;
+      expect(failed.length).toBe(1);
+      expect(failed[0]?.error.message).toBe("Action execution failed");
+      // The internal message MUST NOT leak.
+      expect(failed[0]?.error.message).not.toContain("intentional failure");
+      // Codes are still informative.
+      expect(typeof failed[0]?.error.code).toBe("string");
+    } finally {
+      if (prevEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = prevEnv;
+      }
+    }
   });
 
   test("(g) /api/actions/batch is NOT captured by /api/actions/:name", async () => {

--- a/addons/adapter-server/cap-adapter-server/__tests__/batch-actions-api.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/batch-actions-api.test.ts
@@ -152,7 +152,7 @@ const app = createServer(graphqlSchema, {
   commandLayer,
   transactionManager: txManager,
 });
-const port = 4030;
+const port = 4031;
 
 const baseUrl = () => `http://localhost:${port}`;
 

--- a/addons/adapter-server/cap-adapter-server/src/routes/action-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/action-api.ts
@@ -1,20 +1,122 @@
 /**
  * REST action endpoint.
  *
- * - POST /api/actions/:name — execute an action via ActionExecutor or CommandLayer
+ * - POST /api/actions/batch — execute multiple actions via CommandLayer.executeBatch (Spec 16 §3.1)
+ * - POST /api/actions/:name — execute a single action via ActionExecutor or CommandLayer
+ *
+ * Route ordering matters: `/api/actions/batch` MUST be registered before
+ * `/api/actions/:name` so the parametric route does not capture "batch".
  */
 
-import type { ActionResult } from "@linchkit/core";
+import type {
+  ActionResult,
+  BatchActionsInput,
+  BatchActionsResult,
+  BatchTransactionStrategy,
+} from "@linchkit/core";
 import type { Elysia } from "elysia";
 import type { ServerOptions } from "../server";
-import { resolveActor, resolveRequestLocale, resolveStatusCode } from "./shared";
+import {
+  badRequest,
+  resolveActor,
+  resolveRequestLocale,
+  resolveStatusCode,
+  serverError,
+} from "./shared";
+
+/** Validate the JSON body shape for `POST /api/actions/batch`. */
+function parseBatchBody(
+  body: unknown,
+): { ok: true; input: BatchActionsInput } | { ok: false; reason: string } {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return { ok: false, reason: "Request body must be a JSON object." };
+  }
+  const obj = body as Record<string, unknown>;
+  if (!Array.isArray(obj.actions)) {
+    return { ok: false, reason: "`actions` must be an array." };
+  }
+  for (let i = 0; i < obj.actions.length; i++) {
+    const item = obj.actions[i];
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      return { ok: false, reason: `actions[${i}] must be an object.` };
+    }
+    const it = item as Record<string, unknown>;
+    if (typeof it.name !== "string" || it.name.length === 0) {
+      return { ok: false, reason: `actions[${i}].name must be a non-empty string.` };
+    }
+    if (it.input !== undefined && (typeof it.input !== "object" || it.input === null)) {
+      return { ok: false, reason: `actions[${i}].input must be an object when present.` };
+    }
+  }
+  if (obj.strategy !== undefined) {
+    if (obj.strategy !== "all_or_nothing" && obj.strategy !== "partial") {
+      return {
+        ok: false,
+        reason: "`strategy` must be 'all_or_nothing' or 'partial'.",
+      };
+    }
+  }
+  const actions = obj.actions.map((raw) => {
+    const it = raw as Record<string, unknown>;
+    return {
+      name: it.name as string,
+      input: (it.input as Record<string, unknown>) ?? {},
+    };
+  });
+  const input: BatchActionsInput = { actions };
+  if (obj.strategy !== undefined) {
+    input.strategy = obj.strategy as BatchTransactionStrategy;
+  }
+  return { ok: true, input };
+}
 
 export function mountActionRoutes(app: Elysia, options: ServerOptions): void {
   const executor = options.executor;
   const commandLayer = options.commandLayer;
+  const transactionManager = options.transactionManager;
   const resolveRequestActor = options.resolveRequestActor;
 
   app
+    // Batch endpoint — must be registered BEFORE the `/:name` route so the
+    // parametric matcher does not capture "batch". HTTP 200 is used for all
+    // structured results in v1, including partial failures (consider 207
+    // Multi-Status in a follow-up if downstream tooling benefits from it).
+    .post("/api/actions/batch", async ({ body, set, request }) => {
+      if (!commandLayer) {
+        return serverError(
+          set,
+          "Batch action endpoint requires a CommandLayer to enforce permissions.",
+        );
+      }
+
+      const parsed = parseBatchBody(body);
+      if (!parsed.ok) {
+        return badRequest(set, parsed.reason);
+      }
+
+      const locale = resolveRequestLocale(request);
+      const actor = await resolveActor(request, resolveRequestActor);
+      const incomingTraceId = request.headers.get("x-trace-id") ?? undefined;
+      const headers: Record<string, string> = {};
+      for (const [key, value] of request.headers.entries()) {
+        headers[key] = value;
+      }
+
+      const result: BatchActionsResult = await commandLayer.executeBatch({
+        input: parsed.input,
+        actor,
+        channel: "http",
+        locale,
+        headers,
+        traceId: incomingTraceId,
+        transactionManager,
+      });
+
+      // v1 returns 200 for any structurally valid request — clients inspect
+      // `success` and the per-item arrays. (Consider HTTP 207 Multi-Status
+      // for `partial` mode with mixed outcomes in a follow-up.)
+      return result;
+    })
     // REST action endpoint — executes via ActionExecutor
     // Body is unwrapped action input (Stripe-style, see spec 16 §2.4)
     .post("/api/actions/:name", async ({ params, body, set, request }) => {

--- a/addons/adapter-server/cap-adapter-server/src/routes/action-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/action-api.ts
@@ -24,6 +24,29 @@ import {
   serverError,
 } from "./shared";
 
+/**
+ * In production mode, replace per-item `error.message` strings with a
+ * generic placeholder to avoid leaking internal details (driver errors,
+ * stack-trace fragments, etc.) over HTTP. Codes and field locators are
+ * preserved so clients can still differentiate validation vs. permission
+ * failures. `rolledBack` items are successes (no error message), so they
+ * are passed through untouched.
+ *
+ * Mirrors the single-action sanitization at the bottom of `mountActionRoutes`
+ * to keep dev-mode parity (full message visible) and prod-mode safety.
+ */
+function sanitizeBatchResult(result: BatchActionsResult): BatchActionsResult {
+  const isDevMode = process.env.NODE_ENV !== "production";
+  if (isDevMode) return result;
+  return {
+    ...result,
+    failed: result.failed.map((f) => ({
+      ...f,
+      error: { ...f.error, message: "Action execution failed" },
+    })),
+  };
+}
+
 /** Validate the JSON body shape for `POST /api/actions/batch`. */
 function parseBatchBody(
   body: unknown,
@@ -44,7 +67,12 @@ function parseBatchBody(
     if (typeof it.name !== "string" || it.name.length === 0) {
       return { ok: false, reason: `actions[${i}].name must be a non-empty string.` };
     }
-    if (it.input !== undefined && (typeof it.input !== "object" || it.input === null)) {
+    if (
+      it.input !== undefined &&
+      (typeof it.input !== "object" || it.input === null || Array.isArray(it.input))
+    ) {
+      // Reject arrays explicitly: `typeof [] === "object"` would otherwise
+      // pass through and get spread-cloned into `{0: ..., 1: ...}` downstream.
       return { ok: false, reason: `actions[${i}].input must be an object when present.` };
     }
   }
@@ -114,8 +142,10 @@ export function mountActionRoutes(app: Elysia, options: ServerOptions): void {
 
       // v1 returns 200 for any structurally valid request — clients inspect
       // `success` and the per-item arrays. (Consider HTTP 207 Multi-Status
-      // for `partial` mode with mixed outcomes in a follow-up.)
-      return result;
+      // for `partial` mode with mixed outcomes in a follow-up.) In production
+      // we strip per-item error messages to prevent internal-detail leakage,
+      // matching the single-action route below.
+      return sanitizeBatchResult(result);
     })
     // REST action endpoint — executes via ActionExecutor
     // Body is unwrapped action input (Stripe-style, see spec 16 §2.4)

--- a/addons/adapter-server/cap-adapter-server/src/runtime-context.ts
+++ b/addons/adapter-server/cap-adapter-server/src/runtime-context.ts
@@ -20,6 +20,7 @@ import type {
   InterfaceDefinition,
   MiddlewareRegistration,
   StateDefinition,
+  TransactionManager,
   ViewDefinition,
 } from "@linchkit/core";
 import {
@@ -64,6 +65,13 @@ export interface RuntimeContextOptions {
   eventBus?: EventBus;
   /** Names of registered capabilities — enables ctx.hasCapability() for weak dependency checks */
   capabilityNames?: ReadonlySet<string>;
+  /**
+   * Transaction manager — wired into both the action executor and the
+   * CommandLayer so `executeBatch` with the default `all_or_nothing`
+   * strategy works without per-call plumbing. When omitted, batch callers
+   * must pass `strategy: "partial"` (or supply a per-call manager).
+   */
+  transactionManager?: TransactionManager;
 }
 
 /**
@@ -114,6 +122,7 @@ export function createRuntimeContext(options?: RuntimeContextOptions): RuntimeCo
     aiService: ai,
     capabilityNames: options?.capabilityNames,
     entityRegistry,
+    transactionManager: options?.transactionManager,
   });
 
   // Register actions
@@ -123,8 +132,14 @@ export function createRuntimeContext(options?: RuntimeContextOptions): RuntimeCo
     }
   }
 
-  // Build command layer
-  const commandLayer = createCommandLayer({ executor });
+  // Build command layer. The TM is plumbed through so `executeBatch` can run
+  // `all_or_nothing` without per-call wiring; without one, batch callers must
+  // use `strategy: "partial"` (the engine returns BATCH_TX_MANAGER_REQUIRED
+  // otherwise).
+  const commandLayer = createCommandLayer({
+    executor,
+    transactionManager: options?.transactionManager,
+  });
   if (options?.middlewares) {
     for (const mw of options.middlewares) {
       commandLayer.use(mw);

--- a/addons/adapter-server/cap-adapter-server/src/server.ts
+++ b/addons/adapter-server/cap-adapter-server/src/server.ts
@@ -29,6 +29,7 @@ import type {
   RuntimeConfigRegistry,
   StateDefinition,
   SubscriptionConfig,
+  TransactionManager,
   ViewDefinition,
 } from "@linchkit/core";
 import type {
@@ -68,6 +69,12 @@ export interface ServerOptions {
   executor?: ActionExecutor;
   /** Command layer — if provided, REST actions go through the pipeline */
   commandLayer?: CommandLayer;
+  /**
+   * Transaction manager — required by `POST /api/actions/batch` for the
+   * `all_or_nothing` strategy. Without it, batch requests using
+   * `all_or_nothing` are rejected with a structured failure.
+   */
+  transactionManager?: TransactionManager;
   /** Execution logger for log query endpoints */
   executionLogger?: ExecutionLogger;
   /** Schema registry for metadata endpoints */

--- a/docs/specs/16_command_layer_and_api.md
+++ b/docs/specs/16_command_layer_and_api.md
@@ -27,7 +27,7 @@ UI ───────┘         │
 interface CommandRegistry {
   // --- Action 执行 ---
   execute_action: (name: string, input: object) => ActionResult
-  batch_actions: (actions: Array<{ name: string, input: object }>) => ActionResult[]
+  batch_actions: (input: BatchActionsInput) => Promise<BatchActionsResult>
 
   // --- 数据查询 ---
   query: (graphql: string, variables?: object) => QueryResult

--- a/packages/cli/src/commands/dev-wiring.ts
+++ b/packages/cli/src/commands/dev-wiring.ts
@@ -183,6 +183,7 @@ export async function wireDevEngines(input: WireDevEnginesInput): Promise<WireDe
   const commandLayer = createCommandLayer({
     executor,
     verifyApproval: createApprovalVerifier(approvalStore),
+    transactionManager,
   });
 
   // Register all collected middlewares on the command layer

--- a/packages/core/__tests__/batch-action-engine.test.ts
+++ b/packages/core/__tests__/batch-action-engine.test.ts
@@ -319,7 +319,7 @@ describe("executeBatch — input validation", () => {
 });
 
 describe("executeBatch — meta propagation", () => {
-  it("stamps _batch.parentExecutionId and _batch.index into each child meta", async () => {
+  it("stamps batch.parentExecutionId and batch.index into each child meta", async () => {
     const provider = createSnapshotProvider();
     const seenMetas: Array<{ parent?: unknown; index?: unknown }> = [];
 

--- a/packages/core/__tests__/batch-action-engine.test.ts
+++ b/packages/core/__tests__/batch-action-engine.test.ts
@@ -1,0 +1,392 @@
+/**
+ * Tests for `executeBatch` (Spec 04 §8, Spec 16 §2.1).
+ *
+ * Covers strategy selection, transaction propagation via the existing
+ * `_txDataProvider` seam in ActionExecutor, input validation, and meta
+ * propagation of the parent execution ID.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  createActionExecutor,
+  type DataProvider,
+  type PendingEvent,
+  type TransactionManager,
+} from "../src/engine/action-engine";
+import {
+  BatchValidationError,
+  executeBatch,
+  MAX_BATCH_SIZE,
+} from "../src/engine/batch-action-engine";
+import type { ActionDefinition, Actor } from "../src/types/action";
+
+// ── Test fixtures ───────────────────────────────────────────
+
+const actor: Actor = {
+  type: "human",
+  id: "user-1",
+  groups: ["admin"],
+};
+
+interface SnapshotProvider extends DataProvider {
+  records: Map<string, Record<string, unknown>>;
+  snapshot(): Map<string, Record<string, unknown>>;
+}
+
+/**
+ * Tiny in-memory data provider that lets tests verify whether writes were
+ * actually persisted (or rolled back). The store has no transaction
+ * semantics on its own — the fake TransactionManager below pairs with it
+ * to simulate commit/rollback.
+ */
+function createSnapshotProvider(): SnapshotProvider {
+  const records = new Map<string, Record<string, unknown>>();
+  let counter = 0;
+  const provider: DataProvider = {
+    async get(_schema: string, id: string) {
+      const found = records.get(id);
+      if (!found) throw new Error(`not found: ${id}`);
+      return found;
+    },
+    async query() {
+      return [];
+    },
+    async create(_schema: string, data: Record<string, unknown>) {
+      counter++;
+      const id = `rec_${counter}`;
+      const rec = { id, ...data };
+      records.set(id, rec);
+      return rec;
+    },
+    async update(_schema: string, id: string, data: Record<string, unknown>) {
+      const existing = records.get(id) ?? { id };
+      const updated = { ...existing, ...data };
+      records.set(id, updated);
+      return updated;
+    },
+    async delete(_schema: string, id: string) {
+      records.delete(id);
+    },
+    async count() {
+      return records.size;
+    },
+  };
+  return Object.assign(provider, {
+    records,
+    snapshot: () => new Map(records),
+  });
+}
+
+/**
+ * Fake TransactionManager. It snapshots the provided `SnapshotProvider`
+ * before running `fn`; if `fn` throws, it restores the snapshot. This
+ * mimics the rollback semantics we need for `all_or_nothing` tests
+ * without bringing in a real DB.
+ */
+function createFakeTxManager(provider: SnapshotProvider): TransactionManager {
+  return {
+    async runInTransaction<T>(
+      fn: (tx: DataProvider) => Promise<T>,
+      _pending: PendingEvent[],
+    ): Promise<T> {
+      const before = provider.snapshot();
+      try {
+        return await fn(provider);
+      } catch (err) {
+        provider.records.clear();
+        for (const [k, v] of before) provider.records.set(k, v);
+        throw err;
+      }
+    },
+  };
+}
+
+const createItem: ActionDefinition = {
+  name: "create_item",
+  entity: "item",
+  label: "Create Item",
+  policy: { mode: "sync", transaction: true },
+  handler: async (ctx) => ctx.create("item", { title: ctx.input.title }),
+};
+
+const updateItem: ActionDefinition = {
+  name: "update_item",
+  entity: "item",
+  label: "Update Item",
+  policy: { mode: "sync", transaction: true },
+  handler: async (ctx) => {
+    const id = ctx.input.id as string;
+    return ctx.update("item", id, { title: ctx.input.title });
+  },
+};
+
+const failingItem: ActionDefinition = {
+  name: "fail_item",
+  entity: "item",
+  label: "Fail Item",
+  policy: { mode: "sync", transaction: true },
+  handler: async () => {
+    throw new Error("intentional failure");
+  },
+};
+
+function buildExecutor() {
+  const provider = createSnapshotProvider();
+  const txManager = createFakeTxManager(provider);
+  const executor = createActionExecutor({
+    dataProvider: provider,
+    transactionManager: txManager,
+  });
+  executor.registry.register(createItem);
+  executor.registry.register(updateItem);
+  executor.registry.register(failingItem);
+  return { executor, provider, txManager };
+}
+
+// ── Tests ───────────────────────────────────────────────────
+
+describe("executeBatch — partial strategy", () => {
+  it("returns success=true when all items succeed", async () => {
+    const { executor, provider } = buildExecutor();
+
+    const result = await executeBatch(
+      {
+        strategy: "partial",
+        actions: [
+          { name: "create_item", input: { title: "A" } },
+          { name: "create_item", input: { title: "B" } },
+          { name: "create_item", input: { title: "C" } },
+        ],
+      },
+      { executor, actor },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.strategy).toBe("partial");
+    expect(result.succeeded.length).toBe(3);
+    expect(result.failed.length).toBe(0);
+    expect(result.summary).toEqual({ total: 3, succeeded: 3, failed: 0 });
+    expect(provider.records.size).toBe(3);
+    // Each item gets its own executionId
+    const ids = new Set(result.succeeded.map((s) => s.executionId));
+    expect(ids.size).toBe(3);
+  });
+
+  it("continues on failure and reports per-item details", async () => {
+    const { executor, provider } = buildExecutor();
+
+    const result = await executeBatch(
+      {
+        strategy: "partial",
+        actions: [
+          { name: "create_item", input: { title: "A" } },
+          { name: "fail_item", input: {} },
+          { name: "create_item", input: { title: "C" } },
+        ],
+      },
+      { executor, actor },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.succeeded.length).toBe(2);
+    expect(result.failed.length).toBe(1);
+    expect(result.failed[0]?.index).toBe(1);
+    expect(result.failed[0]?.error.message).toContain("intentional failure");
+    // Items 0 and 2 should have persisted (each ran in its own tx).
+    expect(provider.records.size).toBe(2);
+    expect(result.summary).toEqual({ total: 3, succeeded: 2, failed: 1 });
+  });
+});
+
+describe("executeBatch — all_or_nothing strategy", () => {
+  it("commits all items inside one shared transaction", async () => {
+    const { executor, provider, txManager } = buildExecutor();
+
+    const result = await executeBatch(
+      {
+        strategy: "all_or_nothing",
+        actions: [
+          { name: "create_item", input: { title: "A" } },
+          { name: "create_item", input: { title: "B" } },
+          { name: "create_item", input: { title: "C" } },
+        ],
+      },
+      { executor, actor, transactionManager: txManager },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.succeeded.length).toBe(3);
+    expect(result.failed.length).toBe(0);
+    expect(provider.records.size).toBe(3);
+  });
+
+  it("rolls back earlier successful items when a later item fails", async () => {
+    const { executor, provider, txManager } = buildExecutor();
+
+    const result = await executeBatch(
+      {
+        strategy: "all_or_nothing",
+        actions: [
+          { name: "create_item", input: { title: "A" } },
+          { name: "create_item", input: { title: "B" } },
+          { name: "fail_item", input: {} },
+          { name: "create_item", input: { title: "D" } },
+        ],
+      },
+      { executor, actor, transactionManager: txManager },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.strategy).toBe("all_or_nothing");
+    expect(result.succeeded.length).toBe(0);
+    expect(result.failed.length).toBe(1);
+    expect(result.failed[0]?.index).toBe(2);
+    // The two items that ran successfully before the abort surface via rolledBack.
+    expect(result.rolledBack?.length).toBe(2);
+    expect(result.rolledBack?.[0]?.index).toBe(0);
+    expect(result.rolledBack?.[1]?.index).toBe(1);
+    // No records persisted — fake tx manager restores the pre-batch snapshot.
+    expect(provider.records.size).toBe(0);
+  });
+
+  it("default strategy is all_or_nothing", async () => {
+    const { executor, txManager, provider } = buildExecutor();
+
+    const result = await executeBatch(
+      {
+        actions: [{ name: "create_item", input: { title: "A" } }],
+      },
+      { executor, actor, transactionManager: txManager },
+    );
+
+    expect(result.strategy).toBe("all_or_nothing");
+    expect(result.success).toBe(true);
+    expect(provider.records.size).toBe(1);
+  });
+
+  it("throws when no transactionManager is provided", async () => {
+    const { executor } = buildExecutor();
+
+    expect(
+      executeBatch(
+        {
+          strategy: "all_or_nothing",
+          actions: [{ name: "create_item", input: { title: "A" } }],
+        },
+        { executor, actor },
+      ),
+    ).rejects.toThrow(/all_or_nothing strategy requires a TransactionManager/);
+  });
+});
+
+describe("executeBatch — input validation", () => {
+  it("throws BATCH_EMPTY when actions is empty", async () => {
+    const { executor, txManager } = buildExecutor();
+
+    let caught: unknown;
+    try {
+      await executeBatch(
+        { strategy: "partial", actions: [] },
+        { executor, actor, transactionManager: txManager },
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(BatchValidationError);
+    expect((caught as BatchValidationError).code).toBe("BATCH_EMPTY");
+  });
+
+  it("throws BATCH_TOO_LARGE when actions exceed MAX_BATCH_SIZE", async () => {
+    const { executor, txManager } = buildExecutor();
+
+    const oversized = Array.from({ length: MAX_BATCH_SIZE + 1 }, () => ({
+      name: "create_item",
+      input: { title: "x" },
+    }));
+
+    let caught: unknown;
+    try {
+      await executeBatch(
+        { strategy: "partial", actions: oversized },
+        { executor, actor, transactionManager: txManager },
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(BatchValidationError);
+    expect((caught as BatchValidationError).code).toBe("BATCH_TOO_LARGE");
+  });
+});
+
+describe("executeBatch — meta propagation", () => {
+  it("stamps _batch.parentExecutionId and _batch.index into each child meta", async () => {
+    const provider = createSnapshotProvider();
+    const seenMetas: Array<{ parent?: unknown; index?: unknown }> = [];
+
+    const recordingAction: ActionDefinition = {
+      name: "record_meta",
+      entity: "item",
+      label: "Record Meta",
+      policy: { mode: "sync", transaction: false },
+      handler: async (ctx) => {
+        seenMetas.push({
+          parent: ctx.meta.get("batch.parentExecutionId"),
+          index: ctx.meta.get("batch.index"),
+        });
+        return { ok: true };
+      },
+    };
+
+    const executor = createActionExecutor({ dataProvider: provider });
+    executor.registry.register(recordingAction);
+
+    const result = await executeBatch(
+      {
+        strategy: "partial",
+        actions: [
+          { name: "record_meta", input: {} },
+          { name: "record_meta", input: {} },
+          { name: "record_meta", input: {} },
+        ],
+      },
+      { executor, actor },
+    );
+
+    expect(result.success).toBe(true);
+    expect(seenMetas.length).toBe(3);
+    // Same parent across all items
+    const parents = new Set(seenMetas.map((m) => m.parent));
+    expect(parents.size).toBe(1);
+    const parent = [...parents][0];
+    expect(parent).toBe(result.parentExecutionId);
+    // Each item sees its index
+    expect(seenMetas.map((m) => m.index)).toEqual([0, 1, 2]);
+  });
+});
+
+describe("executeBatch — mixed action types", () => {
+  it("supports different actions in one batch (partial)", async () => {
+    const { executor, provider } = buildExecutor();
+    // Pre-create a record so update_item has something to update.
+    await executor.execute("create_item", { title: "Seed" }, actor);
+
+    const id = [...provider.records.keys()][0];
+    if (!id) throw new Error("seed record missing");
+
+    const result = await executeBatch(
+      {
+        strategy: "partial",
+        actions: [
+          { name: "create_item", input: { title: "New" } },
+          { name: "update_item", input: { id, title: "Renamed" } },
+        ],
+      },
+      { executor, actor },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.succeeded.length).toBe(2);
+    const renamed = provider.records.get(id);
+    expect(renamed?.title).toBe("Renamed");
+  });
+});

--- a/packages/core/__tests__/command-layer-batch.test.ts
+++ b/packages/core/__tests__/command-layer-batch.test.ts
@@ -287,4 +287,34 @@ describe("CommandLayer.executeBatch — input validation", () => {
     expect(result.success).toBe(false);
     expect(result.failed[0]?.error.code).toBe("BATCH_TX_MANAGER_REQUIRED");
   });
+
+  it("uses factory-level transactionManager when per-call options omit it", async () => {
+    // Verify production wiring: createCommandLayer({ transactionManager })
+    // makes `all_or_nothing` work without callers having to plumb the TM
+    // through every executeBatch invocation.
+    const provider = createSnapshotProvider();
+    const txManager = createFakeTxManager(provider);
+    const executor = createActionExecutor({
+      dataProvider: provider,
+      transactionManager: txManager,
+    });
+    executor.registry.register(createItem);
+
+    const layer = createCommandLayer({ executor, transactionManager: txManager });
+    const result = await layer.executeBatch({
+      input: {
+        strategy: "all_or_nothing",
+        actions: [
+          { name: "create_item", input: { title: "a" } },
+          { name: "create_item", input: { title: "b" } },
+        ],
+      },
+      actor: adminActor,
+      // intentionally omit transactionManager — factory default should apply.
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.succeeded.length).toBe(2);
+    expect(provider.records.size).toBe(2);
+  });
 });

--- a/packages/core/__tests__/command-layer-batch.test.ts
+++ b/packages/core/__tests__/command-layer-batch.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Tests for `CommandLayer.executeBatch` (Spec 04 §8, Spec 16 §2.1).
+ *
+ * Covers permission-slot integration (per-item denial), tenant scoping
+ * applied per item, actor propagation, and the same `all_or_nothing`
+ * vs `partial` semantics validated at the executor level — but here
+ * exercised through the full pipeline.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  createActionExecutor,
+  type DataProvider,
+  type PendingEvent,
+  type TransactionManager,
+} from "../src/engine/action-engine";
+import { createCommandLayer, PipelineError } from "../src/engine/command-layer";
+import type { ActionDefinition, Actor } from "../src/types/action";
+
+const adminActor: Actor = { type: "human", id: "u1", groups: ["admin"] };
+const restrictedActor: Actor = { type: "human", id: "u2", groups: ["user"] };
+
+interface SnapshotProvider extends DataProvider {
+  records: Map<string, Record<string, unknown>>;
+  snapshot(): Map<string, Record<string, unknown>>;
+}
+
+function createSnapshotProvider(): SnapshotProvider {
+  const records = new Map<string, Record<string, unknown>>();
+  let counter = 0;
+  const provider: DataProvider = {
+    async get(_schema, id) {
+      const found = records.get(id);
+      if (!found) throw new Error(`not found: ${id}`);
+      return found;
+    },
+    async query() {
+      return [];
+    },
+    async create(_schema, data) {
+      counter++;
+      const id = `rec_${counter}`;
+      const rec = { id, ...data };
+      records.set(id, rec);
+      return rec;
+    },
+    async update(_schema, id, data) {
+      const existing = records.get(id) ?? { id };
+      const updated = { ...existing, ...data };
+      records.set(id, updated);
+      return updated;
+    },
+    async delete(_schema, id) {
+      records.delete(id);
+    },
+    async count() {
+      return records.size;
+    },
+  };
+  return Object.assign(provider, {
+    records,
+    snapshot: () => new Map(records),
+  });
+}
+
+function createFakeTxManager(provider: SnapshotProvider): TransactionManager {
+  return {
+    async runInTransaction<T>(
+      fn: (tx: DataProvider) => Promise<T>,
+      _pending: PendingEvent[],
+    ): Promise<T> {
+      const before = provider.snapshot();
+      try {
+        return await fn(provider);
+      } catch (err) {
+        provider.records.clear();
+        for (const [k, v] of before) provider.records.set(k, v);
+        throw err;
+      }
+    },
+  };
+}
+
+const createItem: ActionDefinition = {
+  name: "create_item",
+  entity: "item",
+  label: "Create Item",
+  policy: { mode: "sync", transaction: true },
+  exposure: "all",
+  handler: async (ctx) => {
+    return ctx.create("item", { title: ctx.input.title });
+  },
+};
+
+const restrictedAction: ActionDefinition = {
+  name: "delete_item",
+  entity: "item",
+  label: "Delete Item",
+  policy: { mode: "sync", transaction: true },
+  exposure: "all",
+  handler: async (ctx) => {
+    return ctx.create("item", { tag: "restricted", input: ctx.input });
+  },
+};
+
+function buildSetup() {
+  const provider = createSnapshotProvider();
+  const txManager = createFakeTxManager(provider);
+  const executor = createActionExecutor({
+    dataProvider: provider,
+    transactionManager: txManager,
+  });
+  executor.registry.register(createItem);
+  executor.registry.register(restrictedAction);
+
+  const layer = createCommandLayer({ executor });
+  // Permission middleware: only admins can run delete_item.
+  layer.use({
+    name: "test_permission",
+    slot: "permission",
+    handler: async (ctx, next) => {
+      if (ctx.command === "delete_item" && !ctx.actor.groups.includes("admin")) {
+        throw new PipelineError(
+          "Actor does not belong to required group: admin",
+          "PERMISSION.DENIED",
+        );
+      }
+      await next();
+    },
+  });
+  return { provider, txManager, executor, layer };
+}
+
+describe("CommandLayer.executeBatch — permission slot per item", () => {
+  it("partial: per-item permission failure is recorded, others succeed", async () => {
+    const { layer, provider } = buildSetup();
+
+    const result = await layer.executeBatch({
+      input: {
+        strategy: "partial",
+        actions: [
+          { name: "create_item", input: { title: "ok-1" } },
+          { name: "delete_item", input: { id: "x" } },
+          { name: "create_item", input: { title: "ok-2" } },
+        ],
+      },
+      actor: restrictedActor,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.succeeded.length).toBe(2);
+    expect(result.failed.length).toBe(1);
+    expect(result.failed[0]?.index).toBe(1);
+    expect(result.failed[0]?.error.code).toBe("PERMISSION.DENIED");
+    // Two persisted items.
+    expect(provider.records.size).toBe(2);
+  });
+
+  it("all_or_nothing: permission failure rolls back the whole batch", async () => {
+    const { layer, provider, txManager } = buildSetup();
+
+    const result = await layer.executeBatch({
+      input: {
+        strategy: "all_or_nothing",
+        actions: [
+          { name: "create_item", input: { title: "ok-1" } },
+          { name: "create_item", input: { title: "ok-2" } },
+          { name: "delete_item", input: { id: "x" } },
+        ],
+      },
+      actor: restrictedActor,
+      transactionManager: txManager,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.succeeded.length).toBe(0);
+    expect(result.failed.length).toBe(1);
+    expect(result.failed[0]?.index).toBe(2);
+    expect(result.failed[0]?.error.code).toBe("PERMISSION.DENIED");
+    expect(result.rolledBack?.length).toBe(2);
+    // Snapshot rollback wipes the previously created records.
+    expect(provider.records.size).toBe(0);
+  });
+});
+
+describe("CommandLayer.executeBatch — actor and tenant propagation", () => {
+  it("propagates the supplied actor to every item", async () => {
+    const provider = createSnapshotProvider();
+    const txManager = createFakeTxManager(provider);
+    const executor = createActionExecutor({
+      dataProvider: provider,
+      transactionManager: txManager,
+    });
+
+    const seenActors: Actor[] = [];
+    const recordingAction: ActionDefinition = {
+      name: "record_actor",
+      entity: "item",
+      label: "Record Actor",
+      policy: { mode: "sync", transaction: false },
+      handler: async (ctx) => {
+        seenActors.push(ctx.actor);
+        return { ok: true };
+      },
+    };
+    executor.registry.register(recordingAction);
+
+    const layer = createCommandLayer({ executor });
+    const result = await layer.executeBatch({
+      input: {
+        strategy: "partial",
+        actions: [
+          { name: "record_actor", input: {} },
+          { name: "record_actor", input: {} },
+        ],
+      },
+      actor: adminActor,
+    });
+
+    expect(result.success).toBe(true);
+    expect(seenActors.length).toBe(2);
+    for (const a of seenActors) {
+      expect(a.id).toBe(adminActor.id);
+      expect(a.groups).toEqual(adminActor.groups);
+    }
+  });
+
+  it("applies tenantId to every item via tenant-scoped writes", async () => {
+    const provider = createSnapshotProvider();
+    const executor = createActionExecutor({ dataProvider: provider });
+    executor.registry.register(createItem);
+
+    const layer = createCommandLayer({ executor });
+    // Tenant middleware sets ctx.tenantId from a header (test sim — directly forwarded).
+    layer.use({
+      name: "test_tenant",
+      slot: "tenant",
+      handler: async (ctx, next) => {
+        if (!ctx.tenantId && ctx.headers?.["x-tenant"]) {
+          ctx.tenantId = ctx.headers["x-tenant"];
+        }
+        await next();
+      },
+    });
+
+    const result = await layer.executeBatch({
+      input: {
+        strategy: "partial",
+        actions: [
+          { name: "create_item", input: { title: "A" } },
+          { name: "create_item", input: { title: "B" } },
+        ],
+      },
+      actor: adminActor,
+      headers: { "x-tenant": "tenant-1" },
+    });
+
+    expect(result.success).toBe(true);
+    // Tenant isolation injects tenant_id on create.
+    for (const rec of provider.records.values()) {
+      expect(rec.tenant_id).toBe("tenant-1");
+    }
+  });
+});
+
+describe("CommandLayer.executeBatch — input validation", () => {
+  it("rejects empty actions array with structured failure", async () => {
+    const { layer } = buildSetup();
+    const result = await layer.executeBatch({
+      input: { actions: [] },
+      actor: adminActor,
+    });
+    expect(result.success).toBe(false);
+    expect(result.failed[0]?.error.code).toBe("BATCH_EMPTY");
+  });
+
+  it("rejects all_or_nothing without transactionManager with structured failure", async () => {
+    const { layer } = buildSetup();
+    const result = await layer.executeBatch({
+      input: {
+        strategy: "all_or_nothing",
+        actions: [{ name: "create_item", input: { title: "a" } }],
+      },
+      actor: adminActor,
+      // intentionally omit transactionManager
+    });
+    expect(result.success).toBe(false);
+    expect(result.failed[0]?.error.code).toBe("BATCH_TX_MANAGER_REQUIRED");
+  });
+});

--- a/packages/core/__tests__/command-layer-batch.test.ts
+++ b/packages/core/__tests__/command-layer-batch.test.ts
@@ -263,6 +263,79 @@ describe("CommandLayer.executeBatch — actor and tenant propagation", () => {
   });
 });
 
+describe("CommandLayer.executeBatch — observability", () => {
+  it("shares one traceId across all items in the batch", async () => {
+    const provider = createSnapshotProvider();
+    const txManager = createFakeTxManager(provider);
+    const executor = createActionExecutor({
+      dataProvider: provider,
+      transactionManager: txManager,
+    });
+    executor.registry.register(createItem);
+
+    const seenTraceIds: Array<string | undefined> = [];
+    const layer = createCommandLayer({ executor });
+    layer.use({
+      name: "capture_trace",
+      slot: "permission",
+      handler: async (ctx, next) => {
+        seenTraceIds.push(ctx.traceId);
+        await next();
+      },
+    });
+
+    const result = await layer.executeBatch({
+      input: {
+        strategy: "partial",
+        actions: [
+          { name: "create_item", input: { title: "A" } },
+          { name: "create_item", input: { title: "B" } },
+          { name: "create_item", input: { title: "C" } },
+        ],
+      },
+      actor: adminActor,
+    });
+
+    expect(result.success).toBe(true);
+    expect(seenTraceIds.length).toBe(3);
+    const [first, ...rest] = seenTraceIds;
+    expect(first).toBeDefined();
+    for (const id of rest) expect(id).toBe(first);
+  });
+
+  it("uses the caller-supplied traceId when provided", async () => {
+    const provider = createSnapshotProvider();
+    const executor = createActionExecutor({ dataProvider: provider });
+    executor.registry.register(createItem);
+
+    const seenTraceIds: Array<string | undefined> = [];
+    const layer = createCommandLayer({ executor });
+    layer.use({
+      name: "capture_trace",
+      slot: "permission",
+      handler: async (ctx, next) => {
+        seenTraceIds.push(ctx.traceId);
+        await next();
+      },
+    });
+
+    const externalTrace = "ext-trace-xyz";
+    await layer.executeBatch({
+      input: {
+        strategy: "partial",
+        actions: [
+          { name: "create_item", input: { title: "A" } },
+          { name: "create_item", input: { title: "B" } },
+        ],
+      },
+      actor: adminActor,
+      traceId: externalTrace,
+    });
+
+    for (const id of seenTraceIds) expect(id).toBe(externalTrace);
+  });
+});
+
 describe("CommandLayer.executeBatch — input validation", () => {
   it("rejects empty actions array with structured failure", async () => {
     const { layer } = buildSetup();

--- a/packages/core/src/engine/batch-action-engine.ts
+++ b/packages/core/src/engine/batch-action-engine.ts
@@ -1,0 +1,403 @@
+/**
+ * Batch Action Engine — implements `batch_actions` (Spec 04 §8, Spec 16 §2.1).
+ *
+ * Direct executor-level batch entry point. The Command Layer's
+ * `executeBatch` method delegates here for `all_or_nothing` shared-tx
+ * orchestration, but `executeBatch` can also be called from internal
+ * code that has an `ActionExecutor` directly (e.g. tests, scripts).
+ *
+ * v1 scope:
+ *  - `all_or_nothing` (default) — one outer DB transaction wraps every
+ *    item; any failure rolls back every prior write. Reuses the existing
+ *    `_txDataProvider` / `_parentPendingEvents` plumbing in
+ *    `ActionExecutor.execute()` so child executions participate in the
+ *    parent transaction without any executor-level changes.
+ *  - `partial` — sequential, independent execution. Each item runs in its
+ *    own transaction (managed by the executor's normal flow); failures
+ *    are recorded and execution continues.
+ *
+ * Deferred (Spec 04 §8.2 — follow-up issues):
+ *  - Rule-evaluation merging (collect once, evaluate per record).
+ *  - Batch event merging into `record.batch_*` events.
+ *  - Parallel `partial`-mode execution (sequential is fine for v1: order
+ *    matters in many UIs and serial keeps DB connection usage bounded).
+ */
+
+import type { Actor } from "../types/action";
+import type { BatchActionsInput, BatchActionsResult, BatchSucceededItem } from "../types/batch";
+import type { ExecutionMeta } from "../types/execution-meta";
+import { createExecutionMeta, extendExecutionMeta } from "../types/execution-meta";
+import type {
+  ActionExecutor,
+  DataProvider,
+  ExecuteOptions,
+  ExecutionChannel,
+  PendingEvent,
+  TransactionManager,
+} from "./action-engine";
+import { generateExecutionId } from "./action-helpers";
+
+/**
+ * Maximum number of items allowed in a single batch.
+ *
+ * Conservative starting value. Rationale:
+ *  - Each item runs the full pipeline (auth/permission/tenant + executor),
+ *    so very large batches multiply per-call overhead.
+ *  - `all_or_nothing` holds one DB transaction open for the entire batch;
+ *    long transactions block other writers and risk timeouts on Postgres.
+ *  - 500 covers the typical bulk-edit UI use case (a list page selection)
+ *    while leaving headroom to raise the limit later without breaking
+ *    callers built against a smaller value.
+ */
+export const MAX_BATCH_SIZE = 500;
+
+/**
+ * Reserved meta key for the batch parent execution ID.
+ *
+ * Note: NOT underscore-prefixed. The action engine treats the root meta as
+ * external input and strips `_`-prefixed keys (Spec 65 §4.4 — system-key
+ * namespace protection). Using `batch.*` here keeps the key visible to
+ * handlers and execution logs without smuggling it through the system-key
+ * channel.
+ */
+const BATCH_PARENT_META_KEY = "batch.parentExecutionId";
+
+/** Reserved meta key for the item's index within the batch. */
+const BATCH_INDEX_META_KEY = "batch.index";
+
+/** Options for {@link executeBatch}. */
+export interface ExecuteBatchOptions {
+  /** Executor used to dispatch each item. */
+  executor: ActionExecutor;
+  /**
+   * Transaction manager used by `all_or_nothing` to wrap every item in one
+   * transaction. Required for `all_or_nothing` — the function throws if
+   * absent rather than silently degrading to per-item transactions.
+   * Optional for `partial`.
+   */
+  transactionManager?: TransactionManager;
+  /** Caller actor — propagated to every child execution. */
+  actor: Actor;
+  /** Channel — propagated to every child execution (default: `internal`). */
+  channel?: ExecutionChannel;
+  /** Tenant ID — propagated to every child execution. */
+  tenantId?: string;
+  /** Locale — propagated to every child execution. */
+  locale?: string;
+  /**
+   * Caller-supplied meta. Merged into each child execution under the same
+   * key namespace. The framework adds `_batch.parentExecutionId` and
+   * `_batch.index` automatically.
+   */
+  meta?: ExecutionMeta | Record<string, unknown>;
+}
+
+/**
+ * Internal sentinel thrown by `all_or_nothing` to roll back the outer
+ * transaction. Carries the failed item plus everything that succeeded
+ * before so the caller can report `rolledBack` in the final result.
+ */
+class BatchAbortError extends Error {
+  constructor(
+    public readonly failedIndex: number,
+    public readonly failedExecutionId: string | undefined,
+    public readonly failedErrorCode: string,
+    public readonly failedErrorMessage: string,
+    public readonly accumulatedSucceeded: BatchSucceededItem[],
+  ) {
+    super(`Batch aborted at index ${failedIndex}: ${failedErrorMessage}`);
+    this.name = "BatchAbortError";
+  }
+}
+
+/**
+ * Build a child meta carrying the batch-tracking keys. We always start
+ * from an {@link ExecutionMeta} (creating one when the caller supplied
+ * a plain record) so `extendExecutionMeta` can stamp the system keys
+ * without going through the untrusted-input factory each time.
+ */
+function buildItemMeta(
+  parentMeta: ExecutionMeta | Record<string, unknown> | undefined,
+  parentExecutionId: string,
+  index: number,
+): ExecutionMeta {
+  // Add the batch tracking keys via the regular `extra` channel — the action
+  // engine treats root meta as external input and only `extra` (non-underscore)
+  // keys survive `createExecutionMeta`'s system-key namespace strip. Caller
+  // meta still wins on collision (parent-wins semantics inside `extend`),
+  // so a caller cannot accidentally clobber these tracking keys by passing
+  // colliding values; we set them on a fresh ExecutionMeta below before
+  // merging caller meta on top would invert that — instead we put them into
+  // `extra` here, which `extend` skips when the parent already carries the
+  // key, ensuring framework-owned values stay authoritative.
+  //
+  // To get framework-wins semantics on collision, we layer the parent meta
+  // OVER the batch keys: build a meta carrying batch keys first, then call
+  // `extend` with caller meta as `extra`. `extend`'s parent-wins rule then
+  // means the batch keys (the new "parent") survive any caller-supplied
+  // collision.
+  const batchSeed = createExecutionMeta({
+    raw: {
+      [BATCH_PARENT_META_KEY]: parentExecutionId,
+      [BATCH_INDEX_META_KEY]: index,
+    },
+  });
+
+  // Layer caller meta on top — `extend` keeps the seed's value when keys
+  // collide, so a caller passing `batch.index: 999` cannot override the
+  // framework's value.
+  const callerMeta = isExecutionMetaLike(parentMeta)
+    ? parentMeta.toJSON()
+    : ((parentMeta as Record<string, unknown> | undefined) ?? {});
+
+  return extendExecutionMeta(batchSeed, callerMeta);
+}
+
+/** Duck-type check matching the action-engine helper (kept private here). */
+function isExecutionMetaLike(value: unknown): value is ExecutionMeta {
+  if (value === null || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.get === "function" &&
+    typeof candidate.has === "function" &&
+    typeof candidate.require === "function" &&
+    typeof candidate.toJSON === "function"
+  );
+}
+
+/** Map an action result's data payload to a structured error. */
+function extractErrorFromResult(result: { data?: unknown }): {
+  code: string;
+  message: string;
+  field?: string;
+} {
+  const data = result.data as Record<string, unknown> | undefined;
+  const message = (data?.error as string) ?? "Action execution failed";
+  const code = (data?.code as string) ?? "ACTION.EXECUTION.FAILED";
+  const ctx = data?.context as Record<string, unknown> | undefined;
+  const field = ctx?.field as string | undefined;
+  return field ? { code, message, field } : { code, message };
+}
+
+/**
+ * Build the structured result for a successful child execution.
+ */
+function toSucceededItem(
+  index: number,
+  executionId: string,
+  result: { data?: unknown; record?: Record<string, unknown>; warnings?: string[] },
+): BatchSucceededItem {
+  const item: BatchSucceededItem = { index, executionId };
+  if (result.data !== undefined) item.data = result.data;
+  if (result.record !== undefined) item.record = result.record;
+  if (result.warnings !== undefined && result.warnings.length > 0) {
+    item.warnings = [...result.warnings];
+  }
+  return item;
+}
+
+/**
+ * Execute a batch of actions via an {@link ActionExecutor}.
+ *
+ * The function returns a {@link BatchActionsResult} regardless of strategy.
+ * Callers should NOT throw on a non-success result — failures are surfaced
+ * through `failed` (and `rolledBack` for `all_or_nothing`).
+ *
+ * @throws Error when `all_or_nothing` is requested without a transaction manager.
+ * @throws Error when the input violates the validation rules (empty / oversized)
+ *   — emitted as a thrown error rather than a result so callers can rely on
+ *   batch result shape only when the request was structurally valid. The
+ *   {@link CommandLayer} wrapper translates these into structured failed
+ *   responses for transport-layer callers.
+ *
+ *   Note: this function reports input validation errors via thrown exceptions
+ *   AND structured results — the returned shape never silently swallows them.
+ *   See the `BATCH_EMPTY` / `BATCH_TOO_LARGE` codes in {@link BatchValidationError}.
+ */
+export async function executeBatch(
+  input: BatchActionsInput,
+  options: ExecuteBatchOptions,
+): Promise<BatchActionsResult> {
+  const strategy = input.strategy ?? "all_or_nothing";
+  const items = input.actions;
+  const parentExecutionId = generateExecutionId();
+
+  // ── Input validation ─────────────────────────────────────
+  if (!Array.isArray(items) || items.length === 0) {
+    throw new BatchValidationError("BATCH_EMPTY", "Batch must contain at least one action.");
+  }
+  if (items.length > MAX_BATCH_SIZE) {
+    throw new BatchValidationError(
+      "BATCH_TOO_LARGE",
+      `Batch size ${items.length} exceeds the maximum of ${MAX_BATCH_SIZE}.`,
+    );
+  }
+
+  if (strategy === "all_or_nothing" && !options.transactionManager) {
+    throw new Error(
+      "all_or_nothing strategy requires a TransactionManager. Pass one via options.transactionManager or use strategy: 'partial'.",
+    );
+  }
+
+  // ── Common per-item executor options ─────────────────────
+  const baseExecOptions: Pick<
+    ExecuteOptions,
+    "channel" | "tenantId" | "locale" | "skipExposureCheck"
+  > = {
+    channel: options.channel ?? "internal",
+    tenantId: options.tenantId,
+    locale: options.locale,
+  };
+
+  // ── Strategy: partial ────────────────────────────────────
+  if (strategy === "partial") {
+    return runPartial(items, parentExecutionId, options, baseExecOptions);
+  }
+
+  // ── Strategy: all_or_nothing ─────────────────────────────
+  // We KNOW transactionManager is set (validated above). Capture in a const
+  // so the closure does not have to re-narrow.
+  const txManager = options.transactionManager as TransactionManager;
+  return runAllOrNothing(items, parentExecutionId, options, baseExecOptions, txManager);
+}
+
+/** Execute items independently. Per-item failures don't stop the batch. */
+async function runPartial(
+  items: BatchActionsInput["actions"],
+  parentExecutionId: string,
+  options: ExecuteBatchOptions,
+  baseExecOptions: Pick<ExecuteOptions, "channel" | "tenantId" | "locale" | "skipExposureCheck">,
+): Promise<BatchActionsResult> {
+  const succeeded: BatchSucceededItem[] = [];
+  const failed: BatchActionsResult["failed"] = [];
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    if (!item) continue; // defensive — type guarantees but keeps TS happy
+    const meta = buildItemMeta(options.meta, parentExecutionId, i);
+    const result = await options.executor.execute(item.name, item.input, options.actor, {
+      ...baseExecOptions,
+      meta,
+    });
+    if (result.success) {
+      succeeded.push(toSucceededItem(i, result.executionId, result));
+    } else {
+      const err = extractErrorFromResult(result);
+      failed.push({ index: i, executionId: result.executionId, error: err });
+    }
+  }
+
+  return {
+    success: failed.length === 0,
+    parentExecutionId,
+    strategy: "partial",
+    succeeded,
+    failed,
+    summary: { total: items.length, succeeded: succeeded.length, failed: failed.length },
+  };
+}
+
+/**
+ * Execute all items inside one shared DB transaction. Any failure throws
+ * a `BatchAbortError` to roll back; we then assemble a result reporting
+ * the rolled-back items via `rolledBack`.
+ */
+async function runAllOrNothing(
+  items: BatchActionsInput["actions"],
+  parentExecutionId: string,
+  options: ExecuteBatchOptions,
+  baseExecOptions: Pick<ExecuteOptions, "channel" | "tenantId" | "locale" | "skipExposureCheck">,
+  txManager: TransactionManager,
+): Promise<BatchActionsResult> {
+  const succeededInside: BatchSucceededItem[] = [];
+  const sharedPendingEvents: PendingEvent[] = [];
+
+  try {
+    await txManager.runInTransaction(async (txProvider: DataProvider) => {
+      for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        if (!item) continue;
+        const meta = buildItemMeta(options.meta, parentExecutionId, i);
+        const result = await options.executor.execute(item.name, item.input, options.actor, {
+          ...baseExecOptions,
+          meta,
+          // Reuse the parent transaction for every item — the executor's
+          // existing `_txDataProvider` short-circuit honors this seam.
+          _txDataProvider: txProvider,
+          _parentPendingEvents: sharedPendingEvents,
+        });
+        if (!result.success) {
+          const err = extractErrorFromResult(result);
+          throw new BatchAbortError(i, result.executionId, err.code, err.message, succeededInside);
+        }
+        succeededInside.push(toSucceededItem(i, result.executionId, result));
+      }
+    }, sharedPendingEvents);
+  } catch (err) {
+    if (err instanceof BatchAbortError) {
+      return {
+        success: false,
+        parentExecutionId,
+        strategy: "all_or_nothing",
+        succeeded: [],
+        failed: [
+          {
+            index: err.failedIndex,
+            executionId: err.failedExecutionId,
+            error: { code: err.failedErrorCode, message: err.failedErrorMessage },
+          },
+        ],
+        rolledBack: err.accumulatedSucceeded,
+        summary: { total: items.length, succeeded: 0, failed: 1 },
+      };
+    }
+    // Unexpected throw (e.g., DB error inside runInTransaction). Surface as a
+    // single failure at the next pending index so the caller still sees a
+    // structured result. We don't know exactly which item triggered the
+    // throw; report at `succeededInside.length` (the next item that would
+    // have run) and include accumulatedSucceeded for diagnostics.
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      success: false,
+      parentExecutionId,
+      strategy: "all_or_nothing",
+      succeeded: [],
+      failed: [
+        {
+          index: succeededInside.length,
+          error: { code: "BATCH_TRANSACTION_FAILED", message },
+        },
+      ],
+      rolledBack: succeededInside,
+      summary: { total: items.length, succeeded: 0, failed: 1 },
+    };
+  }
+
+  return {
+    success: true,
+    parentExecutionId,
+    strategy: "all_or_nothing",
+    succeeded: succeededInside,
+    failed: [],
+    summary: {
+      total: items.length,
+      succeeded: succeededInside.length,
+      failed: 0,
+    },
+  };
+}
+
+/**
+ * Thrown when the batch input shape is invalid (empty array, oversized).
+ * Callers (e.g. CommandLayer.executeBatch, REST handler) translate this
+ * into a structured failed response.
+ */
+export class BatchValidationError extends Error {
+  constructor(
+    public readonly code: "BATCH_EMPTY" | "BATCH_TOO_LARGE",
+    message: string,
+  ) {
+    super(message);
+    this.name = "BatchValidationError";
+  }
+}

--- a/packages/core/src/engine/batch-action-engine.ts
+++ b/packages/core/src/engine/batch-action-engine.ts
@@ -86,8 +86,8 @@ export interface ExecuteBatchOptions {
   locale?: string;
   /**
    * Caller-supplied meta. Merged into each child execution under the same
-   * key namespace. The framework adds `_batch.parentExecutionId` and
-   * `_batch.index` automatically.
+   * key namespace. The framework adds `batch.parentExecutionId` and
+   * `batch.index` automatically.
    */
   meta?: ExecutionMeta | Record<string, unknown>;
 }

--- a/packages/core/src/engine/command-layer.ts
+++ b/packages/core/src/engine/command-layer.ts
@@ -140,6 +140,14 @@ export interface CommandLayerOptions {
   verifyApproval?: (approvalId: string) => Promise<boolean>;
   /** Metrics collector — optional, defaults to noopMetricsCollector (zero overhead) */
   metrics?: MetricsCollector;
+  /**
+   * Default transaction manager used by `executeBatch` when the strategy is
+   * `all_or_nothing` and the per-call options omit `transactionManager`. Wire
+   * this from the same instance you pass to `createActionExecutor` so REST /
+   * MCP / CLI callers all get transactional batch semantics for free. A
+   * per-call `options.transactionManager` still wins when supplied.
+   */
+  transactionManager?: TransactionManager;
 }
 
 export interface CommandLayer {
@@ -252,10 +260,10 @@ export interface CommandBatchExecuteOptions {
   /** Caller meta — merged with batch tracking keys per item. */
   meta?: Record<string, unknown>;
   /**
-   * Transaction manager used by `all_or_nothing`. Required when the input
-   * (or default) strategy is `all_or_nothing` and the executor itself does
-   * not provide one (the executor's tx manager is reachable through
-   * private state, so we accept it explicitly here for API clarity).
+   * Transaction manager used by `all_or_nothing`. When omitted, falls back
+   * to the `transactionManager` configured on `createCommandLayer`. If
+   * neither is provided and the strategy is `all_or_nothing`, the call
+   * returns a structured `BATCH_TX_MANAGER_REQUIRED` failure.
    */
   transactionManager?: TransactionManager;
   /** External trace ID — when provided, the pipeline reuses it. */
@@ -278,6 +286,7 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
     logger = consoleLogger,
     verifyApproval,
     metrics = noopMetricsCollector,
+    transactionManager: defaultTransactionManager,
   } = options;
   const middlewares: MiddlewareRegistration[] = [];
 
@@ -736,12 +745,13 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
       );
     }
 
-    if (strategy === "all_or_nothing" && !options.transactionManager) {
+    const effectiveTxManager = options.transactionManager ?? defaultTransactionManager;
+    if (strategy === "all_or_nothing" && !effectiveTxManager) {
       return buildBatchValidationFailure(
         parentExecutionId,
         strategy,
         "BATCH_TX_MANAGER_REQUIRED",
-        "all_or_nothing strategy requires a TransactionManager.",
+        "all_or_nothing strategy requires a TransactionManager. Pass one via createCommandLayer's options.transactionManager or per-call options.transactionManager, or use strategy: 'partial'.",
       );
     }
 
@@ -815,7 +825,7 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
     }
 
     // ── Strategy: all_or_nothing ──────────────────────────
-    const txManager = options.transactionManager as TransactionManager;
+    const txManager = effectiveTxManager as TransactionManager;
     const sharedPendingEvents: PendingEvent[] = [];
     const succeededInside: BatchSucceededItem[] = [];
 

--- a/packages/core/src/engine/command-layer.ts
+++ b/packages/core/src/engine/command-layer.ts
@@ -726,6 +726,9 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
     const strategy = options.input.strategy ?? "all_or_nothing";
     const items = options.input.actions;
     const parentExecutionId = generateExecutionId();
+    // Generate one shared trace ID per batch when the caller doesn't supply
+    // one, so all child executions correlate in observability tools.
+    const batchTraceId = options.traceId ?? generateExecutionId();
 
     // Input validation — same rules as executeBatch in batch-action-engine.
     if (!Array.isArray(items) || items.length === 0) {
@@ -782,7 +785,7 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
         locale: options.locale,
         meta: itemMeta,
       };
-      if (options.traceId) opts.traceId = options.traceId;
+      opts.traceId = batchTraceId;
       if (tx) {
         opts._txDataProvider = tx.provider;
         opts._parentPendingEvents = tx.events;

--- a/packages/core/src/engine/command-layer.ts
+++ b/packages/core/src/engine/command-layer.ts
@@ -31,8 +31,18 @@ import type { MetricsCollector } from "../observability/metrics";
 import { noopMetricsCollector } from "../observability/metrics";
 import { getCurrentTrace, withTrace, withTraceId } from "../observability/trace-context";
 import type { ActionDefinition, ActionResult, Actor } from "../types/action";
+import type { BatchActionsInput, BatchActionsResult, BatchSucceededItem } from "../types/batch";
 import type { Logger } from "../types/logger";
-import type { ActionExecutor, ExecuteOptions, ExecutionChannel } from "./action-engine";
+import type {
+  ActionExecutor,
+  DataProvider,
+  ExecuteOptions,
+  ExecutionChannel,
+  PendingEvent,
+  TransactionManager,
+} from "./action-engine";
+import { generateExecutionId } from "./action-helpers";
+import { MAX_BATCH_SIZE } from "./batch-action-engine";
 
 // ── Slot names (execution order) ────────────────────────────
 
@@ -137,6 +147,13 @@ export interface CommandLayer {
   use(registration: MiddlewareRegistration): void;
   /** Execute the full pipeline for a command */
   execute(options: CommandExecuteOptions): Promise<ActionResult>;
+  /**
+   * Execute a batch of actions through the full pipeline (Spec 04 §8,
+   * Spec 16 §2.1). Each item runs the same pipeline as `execute()`; for
+   * `all_or_nothing` strategy a single shared DB transaction wraps all
+   * items so any failure rolls back every prior write.
+   */
+  executeBatch(options: CommandBatchExecuteOptions): Promise<BatchActionsResult>;
   /** Get all registered middlewares (for introspection) */
   getMiddlewares(): MiddlewareRegistration[];
 }
@@ -200,6 +217,49 @@ export interface CommandExecuteOptions {
    * ```
    */
   skipActionSlots?: boolean;
+  /**
+   * Internal: shared transactional data provider injected by
+   * `CommandLayer.executeBatch` when running the `all_or_nothing` strategy.
+   * Forwarded to the executor so every batch item participates in the
+   * outer transaction. Public callers MUST NOT set this — it is reserved
+   * for the batch pipeline.
+   */
+  _txDataProvider?: DataProvider;
+  /**
+   * Internal: shared pending-events array for the batch transaction.
+   * Forwarded to the executor so child events accumulate in the parent's
+   * outbox. See `_txDataProvider`.
+   */
+  _parentPendingEvents?: PendingEvent[];
+}
+
+// ── Batch execute options ───────────────────────────────────
+
+/** Options for {@link CommandLayer.executeBatch}. */
+export interface CommandBatchExecuteOptions {
+  /** Batch payload (`actions`, optional `strategy`). */
+  input: BatchActionsInput;
+  /** Channel — propagated to every item (default: `internal`). */
+  channel?: ExecutionChannel;
+  /** Caller actor — propagated to every item. */
+  actor?: Actor;
+  /** HTTP headers — propagated to every item (when channel is http). */
+  headers?: Record<string, string>;
+  /** Tenant ID — propagated to every item. */
+  tenantId?: string;
+  /** Locale — propagated to every item. */
+  locale?: string;
+  /** Caller meta — merged with batch tracking keys per item. */
+  meta?: Record<string, unknown>;
+  /**
+   * Transaction manager used by `all_or_nothing`. Required when the input
+   * (or default) strategy is `all_or_nothing` and the executor itself does
+   * not provide one (the executor's tx manager is reachable through
+   * private state, so we accept it explicitly here for API clarity).
+   */
+  transactionManager?: TransactionManager;
+  /** External trace ID — when provided, the pipeline reuses it. */
+  traceId?: string;
 }
 
 /**
@@ -440,6 +500,16 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
     if (execOptions.includeDeleted) {
       executorOptions.includeDeleted = execOptions.includeDeleted;
     }
+    // Internal batch plumbing: forward shared transaction context when set
+    // by `executeBatch`. Public callers do not set these (see
+    // CommandExecuteOptions docs); the pipeline still runs every slot for
+    // each item, so security guarantees match a single-action call.
+    if (execOptions._txDataProvider) {
+      executorOptions._txDataProvider = execOptions._txDataProvider;
+    }
+    if (execOptions._parentPendingEvents) {
+      executorOptions._parentPendingEvents = execOptions._parentPendingEvents;
+    }
 
     // Action execution as the innermost handler in the compose chain (#2).
     // If any middleware does not call next(), the action will NOT run.
@@ -621,7 +691,259 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
     return ctx.result;
   }
 
-  return { use, execute, getMiddlewares };
+  /**
+   * Execute a batch of actions. v1 implementation chooses the simpler
+   * "execute()-per-item" fallback over a per-slot refactor:
+   *
+   *   - Each item runs the full pipeline (auth/exposure/permission/tenant/
+   *     pre-action/post-action) by reusing `executeInner` directly. This
+   *     means auth and tenant slots run once per item rather than once per
+   *     batch — acceptable trade-off for batch sizes ≤ MAX_BATCH_SIZE
+   *     (500), since the auth slot caches actor lookups and tenant slot
+   *     work is cheap.
+   *   - For `all_or_nothing`, we open one outer transaction and inject
+   *     `_txDataProvider` + `_parentPendingEvents` into each item's
+   *     pipeline. The executor's existing shared-tx seam (action-engine.ts
+   *     `parentTxProvider` branch) honors this and skips opening a nested
+   *     transaction.
+   *
+   * Trade-off justification: a slot-level refactor would split the pipeline
+   * into "once per batch" (auth/tenant) + "once per item" (exposure/
+   * permission/pre-action/post-action). That's a bigger refactor of
+   * existing code with no observable behavior difference at batch size
+   * ≤ 500. Defer until real benchmarks show auth/tenant overhead matters.
+   */
+  async function executeBatch(options: CommandBatchExecuteOptions): Promise<BatchActionsResult> {
+    const strategy = options.input.strategy ?? "all_or_nothing";
+    const items = options.input.actions;
+    const parentExecutionId = generateExecutionId();
+
+    // Input validation — same rules as executeBatch in batch-action-engine.
+    if (!Array.isArray(items) || items.length === 0) {
+      return buildBatchValidationFailure(
+        parentExecutionId,
+        strategy,
+        "BATCH_EMPTY",
+        "Batch must contain at least one action.",
+      );
+    }
+    if (items.length > MAX_BATCH_SIZE) {
+      return buildBatchValidationFailure(
+        parentExecutionId,
+        strategy,
+        "BATCH_TOO_LARGE",
+        `Batch size ${items.length} exceeds the maximum of ${MAX_BATCH_SIZE}.`,
+      );
+    }
+
+    if (strategy === "all_or_nothing" && !options.transactionManager) {
+      return buildBatchValidationFailure(
+        parentExecutionId,
+        strategy,
+        "BATCH_TX_MANAGER_REQUIRED",
+        "all_or_nothing strategy requires a TransactionManager.",
+      );
+    }
+
+    const baseChannel = options.channel ?? "internal";
+
+    // Build per-item options once — we vary only the per-item meta + tx fields.
+    const buildItemOptions = (
+      index: number,
+      item: { name: string; input: Record<string, unknown> },
+      tx?: { provider: DataProvider; events: PendingEvent[] },
+    ): CommandExecuteOptions => {
+      // Use non-underscore keys so the action engine's system-key strip
+      // (Spec 65 §4.4) doesn't drop batch tracking keys at root depth.
+      // Place batch keys AFTER caller meta so they overwrite — these are
+      // framework-owned and a caller must not be able to clobber them.
+      const itemMeta: Record<string, unknown> = {
+        ...(options.meta ?? {}),
+        "batch.parentExecutionId": parentExecutionId,
+        "batch.index": index,
+      };
+      const opts: CommandExecuteOptions = {
+        command: item.name,
+        input: item.input,
+        channel: baseChannel,
+        actor: options.actor,
+        headers: options.headers,
+        tenantId: options.tenantId,
+        locale: options.locale,
+        meta: itemMeta,
+      };
+      if (options.traceId) opts.traceId = options.traceId;
+      if (tx) {
+        opts._txDataProvider = tx.provider;
+        opts._parentPendingEvents = tx.events;
+      }
+      return opts;
+    };
+
+    // ── Strategy: partial ─────────────────────────────────
+    if (strategy === "partial") {
+      const succeeded: BatchSucceededItem[] = [];
+      const failed: BatchActionsResult["failed"] = [];
+
+      for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        if (!item) continue;
+        const result = await execute(buildItemOptions(i, item));
+        if (result.success) {
+          succeeded.push(toSucceededItem(i, result));
+        } else {
+          failed.push({
+            index: i,
+            executionId: result.executionId,
+            error: extractErrorFromActionResult(result),
+          });
+        }
+      }
+
+      return {
+        success: failed.length === 0,
+        parentExecutionId,
+        strategy: "partial",
+        succeeded,
+        failed,
+        summary: {
+          total: items.length,
+          succeeded: succeeded.length,
+          failed: failed.length,
+        },
+      };
+    }
+
+    // ── Strategy: all_or_nothing ──────────────────────────
+    const txManager = options.transactionManager as TransactionManager;
+    const sharedPendingEvents: PendingEvent[] = [];
+    const succeededInside: BatchSucceededItem[] = [];
+
+    /** Sentinel error used to abort the outer transaction. */
+    class BatchAbort extends Error {
+      constructor(
+        public readonly index: number,
+        public readonly executionId: string | undefined,
+        public readonly errCode: string,
+        public readonly errMessage: string,
+      ) {
+        super(errMessage);
+      }
+    }
+
+    try {
+      await txManager.runInTransaction(async (txProvider: DataProvider) => {
+        for (let i = 0; i < items.length; i++) {
+          const item = items[i];
+          if (!item) continue;
+          const result = await execute(
+            buildItemOptions(i, item, {
+              provider: txProvider,
+              events: sharedPendingEvents,
+            }),
+          );
+          if (!result.success) {
+            const err = extractErrorFromActionResult(result);
+            throw new BatchAbort(i, result.executionId, err.code, err.message);
+          }
+          succeededInside.push(toSucceededItem(i, result));
+        }
+      }, sharedPendingEvents);
+    } catch (err) {
+      if (err instanceof BatchAbort) {
+        return {
+          success: false,
+          parentExecutionId,
+          strategy: "all_or_nothing",
+          succeeded: [],
+          failed: [
+            {
+              index: err.index,
+              executionId: err.executionId,
+              error: { code: err.errCode, message: err.errMessage },
+            },
+          ],
+          rolledBack: succeededInside,
+          summary: { total: items.length, succeeded: 0, failed: 1 },
+        };
+      }
+      // Unexpected DB / runtime error — surface as a structured failure.
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        success: false,
+        parentExecutionId,
+        strategy: "all_or_nothing",
+        succeeded: [],
+        failed: [
+          {
+            index: succeededInside.length,
+            error: { code: "BATCH_TRANSACTION_FAILED", message },
+          },
+        ],
+        rolledBack: succeededInside,
+        summary: { total: items.length, succeeded: 0, failed: 1 },
+      };
+    }
+
+    return {
+      success: true,
+      parentExecutionId,
+      strategy: "all_or_nothing",
+      succeeded: succeededInside,
+      failed: [],
+      summary: {
+        total: items.length,
+        succeeded: succeededInside.length,
+        failed: 0,
+      },
+    };
+  }
+
+  return { use, execute, executeBatch, getMiddlewares };
+}
+
+// ── Batch helpers ───────────────────────────────────────────
+
+/** Map an `ActionResult.data` payload into a structured batch error. */
+function extractErrorFromActionResult(result: ActionResult): {
+  code: string;
+  message: string;
+  field?: string;
+} {
+  const data = result.data as Record<string, unknown> | undefined;
+  const message = (data?.error as string) ?? "Action execution failed";
+  const code = (data?.code as string) ?? "ACTION.EXECUTION.FAILED";
+  const ctx = data?.context as Record<string, unknown> | undefined;
+  const field = ctx?.field as string | undefined;
+  return field ? { code, message, field } : { code, message };
+}
+
+/** Build a {@link BatchSucceededItem} from a successful {@link ActionResult}. */
+function toSucceededItem(index: number, result: ActionResult): BatchSucceededItem {
+  const item: BatchSucceededItem = { index, executionId: result.executionId };
+  if (result.data !== undefined) item.data = result.data;
+  if (result.record !== undefined) item.record = result.record;
+  if (result.warnings !== undefined && result.warnings.length > 0) {
+    item.warnings = [...result.warnings];
+  }
+  return item;
+}
+
+/** Construct a structured failure result for batch input validation. */
+function buildBatchValidationFailure(
+  parentExecutionId: string,
+  strategy: "all_or_nothing" | "partial",
+  code: string,
+  message: string,
+): BatchActionsResult {
+  return {
+    success: false,
+    parentExecutionId,
+    strategy,
+    succeeded: [],
+    failed: [{ index: 0, error: { code, message } }],
+    summary: { total: 0, succeeded: 0, failed: 1 },
+  };
 }
 
 // ── Pipeline errors ─────────────────────────────────────────

--- a/packages/core/src/engine/index.ts
+++ b/packages/core/src/engine/index.ts
@@ -29,8 +29,16 @@ export {
   createApprovalVerifier,
   InMemoryApprovalStore,
 } from "./approval-engine";
+// Batch action engine (Spec 04 §8, Spec 16 §2.1)
+export {
+  BatchValidationError,
+  type ExecuteBatchOptions,
+  executeBatch,
+  MAX_BATCH_SIZE,
+} from "./batch-action-engine";
 // Command layer
 export {
+  type CommandBatchExecuteOptions,
   type CommandContext,
   type CommandExecuteOptions,
   type CommandLayer,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -147,6 +147,7 @@ export type {
   CreateApprovalOptions,
 } from "./engine/approval-engine";
 export type {
+  CommandBatchExecuteOptions,
   CommandContext,
   CommandExecuteOptions,
   CommandLayer,

--- a/packages/core/src/server-entry.ts
+++ b/packages/core/src/server-entry.ts
@@ -34,7 +34,6 @@ export {
   type PendingEvent,
   type TransactionManager,
 } from "./engine/action-engine";
-
 export {
   type ApprovalEngine,
   type ApprovalEngineOptions,
@@ -43,8 +42,16 @@ export {
   createApprovalVerifier,
   InMemoryApprovalStore,
 } from "./engine/approval-engine";
+// Batch action engine (Spec 04 §8, Spec 16 §2.1)
+export {
+  BatchValidationError,
+  type ExecuteBatchOptions,
+  executeBatch,
+  MAX_BATCH_SIZE,
+} from "./engine/batch-action-engine";
 
 export {
+  type CommandBatchExecuteOptions,
   type CommandContext,
   type CommandExecuteOptions,
   type CommandLayer,

--- a/packages/core/src/types/batch.ts
+++ b/packages/core/src/types/batch.ts
@@ -1,0 +1,94 @@
+/**
+ * Batch action type definitions (Spec 04 §8, Spec 16 §2.1).
+ *
+ * Batch operations execute multiple actions through the Command Layer in
+ * one call. A parent execution groups all child executions; each child
+ * runs the same single-action pipeline (auth/exposure/permission/tenant/
+ * pre-action/post-action) so security guarantees match a per-action call.
+ *
+ * Two transactional strategies (Spec 04 §8.2):
+ * - `all_or_nothing` (default): all items run inside one shared DB
+ *   transaction. Any failure rolls back every prior write.
+ * - `partial`: each item runs in its own transaction; the response reports
+ *   per-item success/failure.
+ */
+
+/** Strategy controlling cross-item transactionality (Spec 04 §8.2). */
+export type BatchTransactionStrategy = "all_or_nothing" | "partial";
+
+/** A single action invocation within a batch payload. */
+export interface BatchActionItem {
+  /** Action name (verb_noun). Different items may invoke different actions. */
+  name: string;
+  /** Action input. Same shape as a single-action call. */
+  input: Record<string, unknown>;
+}
+
+/** Top-level batch input. */
+export interface BatchActionsInput {
+  /** Action items to execute, in order. */
+  actions: BatchActionItem[];
+  /**
+   * Transaction strategy. Defaults to `'all_or_nothing'` per Spec 04 §8.2 —
+   * the conservative choice for write batches.
+   */
+  strategy?: BatchTransactionStrategy;
+}
+
+/** Result for a single succeeded action item. */
+export interface BatchSucceededItem {
+  /** Position in the input `actions` array. */
+  index: number;
+  /** Child execution ID. */
+  executionId: string;
+  /** Action `data` payload (handler return value). */
+  data?: unknown;
+  /** Action `record` payload when present. */
+  record?: Record<string, unknown>;
+  /** Warnings surfaced by post-action hooks, etc. */
+  warnings?: string[];
+}
+
+/** Result for a single failed action item. */
+export interface BatchFailedItem {
+  /** Position in the input `actions` array. */
+  index: number;
+  /** Child execution ID, if the executor produced one before failing. */
+  executionId?: string;
+  /** Structured error. */
+  error: { code: string; message: string; field?: string };
+}
+
+/** Top-level batch result returned by `executeBatch` / `CommandLayer.executeBatch`. */
+export interface BatchActionsResult {
+  /**
+   * Overall success. `true` iff every item succeeded (any strategy).
+   * For `all_or_nothing` rollback this is always `false`.
+   */
+  success: boolean;
+  /** Parent execution ID grouping all child executions. */
+  parentExecutionId: string;
+  /** Strategy actually used (echoed back for clients that omit it). */
+  strategy: BatchTransactionStrategy;
+  /**
+   * Items that succeeded.
+   *
+   * For `all_or_nothing` rollback this is always empty — successful items
+   * are surfaced via `rolledBack` instead.
+   */
+  succeeded: BatchSucceededItem[];
+  /**
+   * Items that failed. For `all_or_nothing` rollback this contains exactly
+   * the item that triggered the abort (later items never ran).
+   */
+  failed: BatchFailedItem[];
+  /**
+   * Items that ran successfully but were rolled back because a later item
+   * failed. Only populated under `all_or_nothing` rollback. Useful for
+   * observability: clients can show "we tried these items but had to undo
+   * them when item N failed".
+   */
+  rolledBack?: BatchSucceededItem[];
+  /** Aggregate counts. */
+  summary: { total: number; succeeded: number; failed: number };
+}

--- a/packages/core/src/types/command.ts
+++ b/packages/core/src/types/command.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ActionDefinition, ActionResult } from "./action";
+import type { BatchActionsInput, BatchActionsResult } from "./batch";
 import type { CapabilityDefinition } from "./capability";
 import type { EntityDefinition } from "./entity";
 import type { RuleDefinition } from "./rule";
@@ -34,9 +35,12 @@ export interface CommandResponse<T = unknown> {
 export interface CommandRegistry {
   // Action execution
   execute_action: (name: string, input: Record<string, unknown>) => Promise<ActionResult>;
-  batch_actions: (
-    actions: Array<{ name: string; input: Record<string, unknown> }>,
-  ) => Promise<ActionResult[]>;
+  /**
+   * Execute multiple actions in a single call (Spec 04 §8, Spec 16 §2.1).
+   * Each item runs through the full Command Layer pipeline; the strategy
+   * controls cross-item transactionality.
+   */
+  batch_actions: (input: BatchActionsInput) => Promise<BatchActionsResult>;
 
   // Data query
   query: (graphql: string, variables?: Record<string, unknown>) => Promise<unknown>;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -5,6 +5,7 @@
 export type * from "./action";
 export type * from "./ai";
 export type * from "./approval";
+export type * from "./batch";
 export type * from "./capability";
 export type {
   CapabilityMetadata,


### PR DESCRIPTION
## Summary

Implements `batch_actions` per Spec 04 §8 + Spec 16 §2.1 — multi-action execution through CommandLayer with two transaction strategies.

- **`all_or_nothing`** (default): single shared DB transaction wraps every item; any failure rolls back every prior write. Reuses the existing `_txDataProvider` / `_parentPendingEvents` plumbing in `ActionExecutor.execute()`.
- **`partial`**: sequential, independent execution; per-item failures are reported but don't stop later items.

### Surfaces

- **Core**: `executeBatch()` in `packages/core/src/engine/batch-action-engine.ts`.
- **CommandLayer**: `executeBatch()` runs the full per-item pipeline (auth/exposure/permission/tenant/pre-action/post-action) and wraps the loop in one outer transaction for `all_or_nothing`.
- **REST**: `POST /api/actions/batch` registered before `/api/actions/:name` so the parametric route can't capture `batch`.

### Caps & observability

- `MAX_BATCH_SIZE = 500` — bounds outer-transaction lifetime and per-call fan-out cost.
- `parentExecutionId` plus non-underscored `batch.parentExecutionId` / `batch.index` meta keys propagate to every child execution log.
- `rolledBack` field on `BatchActionsResult` exposes items that ran successfully but were rolled back when a later item failed under `all_or_nothing`.

### Cross-model review fixes (commit 2)

Codex + Gemini review caught 3 issues, all fixed before merge:

1. **TransactionManager wiring** — production `createCommandLayer({ executor })` calls did not pass a TM, so default-strategy batch always failed. Added `transactionManager?` to `CommandLayerOptions` (factory-level), with per-call override still supported. CLI dev-wiring and cap-adapter-server runtime-context updated to thread it through.
2. **HTTP error sanitization** — batch route was returning raw per-item error messages (driver errors, etc.). Added `sanitizeBatchResult()` mirroring the single-action route's prod-mode sanitization (codes and field locators preserved).
3. **Reject array-valued `input`** — `typeof [] === "object"` previously slipped past validation; added explicit `Array.isArray()` check.

### Deferred to follow-ups (will file as separate issues post-merge)

- Rule-evaluation merging (Spec 04 §8.2 — collect rules once per batch, evaluate condition per record).
- Batch event merging into `record.batch_*` (Spec 04 §8.2 — Outbox volume reduction).
- HTTP 207 Multi-Status for partial mode with mixed outcomes.
- Bulk-edit UI integration in `cap-adapter-ui`.
- GraphQL batch mutation.

## Test plan

- [x] `packages/core/__tests__/batch-action-engine.test.ts` — 10 tests (partial / all_or_nothing happy paths, mid-batch failure rollback, default strategy, missing-TM throws, BATCH_EMPTY, BATCH_TOO_LARGE, parentExecutionId propagation, mixed action types)
- [x] `packages/core/__tests__/command-layer-batch.test.ts` — 7 tests (per-item permission denial, all_or_nothing rollback on permission denial, actor propagation, tenant scoping, structured failures, factory-level TM fallback)
- [x] `addons/adapter-server/cap-adapter-server/__tests__/batch-actions-api.test.ts` — 9 tests (valid 200, shape errors 400, unknown strategy 400, BATCH_EMPTY structured failure, all_or_nothing rollback returns `rolledBack`, route ordering, production sanitization, array-input rejection)
- [x] All quality gates pass: `bun run check` + `bun run typecheck` + `bun test` (4503 pass, 3 skip, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch action execution API with `partial` and `all_or_nothing` strategies, size limits, structured request/result types, and rollback observability
  * New REST endpoint to submit action batches, including production-mode sanitization of error messages
  * Server/CLI option to supply a transaction manager enabling all-or-nothing batches

* **Tests**
  * End-to-end and unit tests covering batch behaviors, transactions, validations, error codes, and routing order
<!-- end of auto-generated comment: release notes by coderabbit.ai -->