### PR TITLE
feat(core): ExecutionMeta transports + log recording (Spec 65 Phase 2A, refs #149)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/exec-meta-transports.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/exec-meta-transports.test.ts
@@ -1,0 +1,420 @@
+/**
+ * Spec 65 Phase 2A — REST `X-Linch-Meta` header + GraphQL `meta` argument
+ * end-to-end transport tests.
+ *
+ * Verifies that:
+ *  - REST single-action handler parses the header and threads meta to the
+ *    action handler's `ctx.meta`.
+ *  - REST batch handler parses the header once and applies it to every item.
+ *  - GraphQL `executeAction` and CRUD mutations accept the `meta` arg, parse
+ *    it via the same `safeParseJSON` helper used for `input`, and surface
+ *    errors as GraphQL errors.
+ *  - System-key spoofing through either transport is silently re-stamped by
+ *    the action engine (Phase 1 contract).
+ *  - Malformed headers / args produce structured error responses, not 500s.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import type { ActionContext, ActionDefinition, EntityDefinition } from "@linchkit/core";
+import {
+  createActionExecutor,
+  createCommandLayer,
+  InMemoryExecutionLogger,
+  InMemoryStore,
+} from "@linchkit/core/server";
+import { buildGraphQLSchema, generateCrudActions } from "../src/graphql/build-schema";
+import { createServer } from "../src/server";
+
+// ── Fixtures ──────────────────────────────────────────────
+
+const taskSchema: EntityDefinition = {
+  name: "task",
+  label: "Task",
+  fields: {
+    title: { type: "string", required: true, label: "Title" },
+  },
+};
+
+/** Captures every handler invocation's meta snapshot and execution id. */
+interface CapturedExecution {
+  action: string;
+  meta: Record<string, unknown>;
+  executionId: string;
+}
+const captures: CapturedExecution[] = [];
+
+function recordCapture(name: string, ctx: ActionContext): void {
+  captures.push({
+    action: name,
+    meta: ctx.meta.toJSON(),
+    executionId: ctx.executionId,
+  });
+}
+
+const captureMetaAction: ActionDefinition = {
+  name: "capture_meta",
+  entity: "task",
+  label: "Capture Meta",
+  policy: { mode: "sync", transaction: false },
+  exposure: "all",
+  handler: async (ctx) => {
+    recordCapture("capture_meta", ctx);
+    return { ok: true };
+  },
+};
+
+const store = new InMemoryStore();
+const executionLogger = new InMemoryExecutionLogger();
+const executor = createActionExecutor({
+  dataProvider: store,
+  executionLogger,
+});
+
+// Register a small set of actions: capture_meta + auto-generated CRUD.
+executor.registry.register(captureMetaAction);
+for (const action of generateCrudActions(taskSchema)) {
+  // Wrap CRUD handlers so the meta is also captured under the CRUD action name.
+  // This avoids redefining CRUD logic — we only need to observe meta flow.
+  const original = action.handler;
+  const wrapped: ActionDefinition = {
+    ...action,
+    handler: async (ctx) => {
+      recordCapture(action.name, ctx);
+      if (!original) return undefined;
+      return original(ctx);
+    },
+  };
+  executor.registry.register(wrapped);
+}
+
+const commandLayer = createCommandLayer({ executor });
+
+const graphqlSchema = buildGraphQLSchema([taskSchema], {
+  executor,
+  commandLayer,
+  dataProvider: store,
+  actions: [captureMetaAction],
+});
+const app = createServer(graphqlSchema, { executor, commandLayer });
+const port = 4099;
+
+beforeAll(() => {
+  app.listen(port);
+});
+
+afterAll(() => {
+  app.stop();
+});
+
+function clearCaptures(): void {
+  captures.length = 0;
+}
+
+async function postAction(
+  name: string,
+  body: Record<string, unknown> = {},
+  headers: Record<string, string> = {},
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const res = await fetch(`http://localhost:${port}/api/actions/${name}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+  const json = (await res.json()) as Record<string, unknown>;
+  return { status: res.status, body: json };
+}
+
+async function postBatch(
+  payload: Record<string, unknown>,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const res = await fetch(`http://localhost:${port}/api/actions/batch`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(payload),
+  });
+  const json = (await res.json()) as Record<string, unknown>;
+  return { status: res.status, body: json };
+}
+
+async function gql(
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<{ data?: Record<string, unknown>; errors?: Array<Record<string, unknown>> }> {
+  const res = await fetch(`http://localhost:${port}/graphql`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ query, variables }),
+  });
+  return res.json() as Promise<{
+    data?: Record<string, unknown>;
+    errors?: Array<Record<string, unknown>>;
+  }>;
+}
+
+// ── Tests: REST X-Linch-Meta single-action ────────────────
+
+describe("REST single-action — X-Linch-Meta header (Spec 65 §3.1)", () => {
+  test("valid JSON object header surfaces in handler ctx.meta", async () => {
+    clearCaptures();
+    const { status, body } = await postAction(
+      "capture_meta",
+      {},
+      { "X-Linch-Meta": JSON.stringify({ source_view: "queue", bulk: true }) },
+    );
+
+    expect(status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(captures).toHaveLength(1);
+    expect(captures[0].meta.source_view).toBe("queue");
+    expect(captures[0].meta.bulk).toBe(true);
+    expect(captures[0].meta._channel).toBe("http");
+  });
+
+  test("missing header → ctx.meta has no caller keys (system keys still set)", async () => {
+    clearCaptures();
+    const { status } = await postAction("capture_meta", {});
+    expect(status).toBe(200);
+    expect(captures).toHaveLength(1);
+    expect(captures[0].meta.source_view).toBeUndefined();
+    expect(captures[0].meta.bulk).toBeUndefined();
+    // Phase 1 system keys still flow through.
+    expect(captures[0].meta._channel).toBe("http");
+    expect(typeof captures[0].meta._execution_id).toBe("string");
+  });
+
+  test("_-prefixed keys in header are stripped (system keys win)", async () => {
+    clearCaptures();
+    await postAction(
+      "capture_meta",
+      {},
+      {
+        "X-Linch-Meta": JSON.stringify({
+          _channel: "spoofed",
+          _execution_id: "fake_id",
+          legit: "yes",
+        }),
+      },
+    );
+    const meta = captures[0]?.meta ?? {};
+    expect(meta._channel).toBe("http");
+    expect(meta._execution_id).not.toBe("fake_id");
+    expect(meta.legit).toBe("yes");
+  });
+
+  test("non-JSON header → 400 META.PARSE.INVALID_JSON", async () => {
+    const { status, body } = await postAction(
+      "capture_meta",
+      {},
+      { "X-Linch-Meta": "this-is-not-json" },
+    );
+    expect(status).toBe(400);
+    expect(body.success).toBe(false);
+    const err = body.error as Record<string, unknown>;
+    expect(err.code).toBe("META.PARSE.INVALID_JSON");
+  });
+
+  test("array (non-object) header → 400 META.PARSE.NOT_OBJECT", async () => {
+    const { status, body } = await postAction(
+      "capture_meta",
+      {},
+      { "X-Linch-Meta": JSON.stringify([1, 2, 3]) },
+    );
+    expect(status).toBe(400);
+    const err = body.error as Record<string, unknown>;
+    expect(err.code).toBe("META.PARSE.NOT_OBJECT");
+  });
+
+  test("oversized header (>8 KB) → 400 META.PARSE.OVERSIZE", async () => {
+    const huge = JSON.stringify({ blob: "x".repeat(9000) });
+    const { status, body } = await postAction("capture_meta", {}, { "X-Linch-Meta": huge });
+    expect(status).toBe(400);
+    const err = body.error as Record<string, unknown>;
+    expect(err.code).toBe("META.PARSE.OVERSIZE");
+  });
+});
+
+// ── Tests: REST batch ─────────────────────────────────────
+
+describe("REST batch — X-Linch-Meta header (Spec 65 §3.1)", () => {
+  test("header applies to every batch item via ctx.meta", async () => {
+    clearCaptures();
+    const { status, body } = await postBatch(
+      {
+        actions: [
+          { name: "capture_meta", input: {} },
+          { name: "capture_meta", input: {} },
+        ],
+        strategy: "partial",
+      },
+      { "X-Linch-Meta": JSON.stringify({ run_id: "batch-1" }) },
+    );
+
+    expect(status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(captures).toHaveLength(2);
+    expect(captures[0].meta.run_id).toBe("batch-1");
+    expect(captures[1].meta.run_id).toBe("batch-1");
+    // Phase 1 batch keys also stamped on each item.
+    expect(captures[0].meta["batch.index"]).toBe(0);
+    expect(captures[1].meta["batch.index"]).toBe(1);
+  });
+
+  test("malformed batch header → 400 even before batch validation runs", async () => {
+    const { status, body } = await postBatch(
+      { actions: [{ name: "capture_meta", input: {} }], strategy: "partial" },
+      { "X-Linch-Meta": "{not-json" },
+    );
+    expect(status).toBe(400);
+    const err = body.error as Record<string, unknown>;
+    expect(err.code).toBe("META.PARSE.INVALID_JSON");
+  });
+});
+
+// ── Tests: GraphQL meta argument ──────────────────────────
+
+describe("GraphQL — meta argument (Spec 65 §3.2)", () => {
+  test("executeAction with meta arg surfaces in handler ctx.meta", async () => {
+    clearCaptures();
+    const result = await gql(
+      `
+        mutation Run($name: String!, $input: String!, $meta: String) {
+          executeAction(name: $name, input: $input, meta: $meta) {
+            success
+            executionId
+          }
+        }
+      `,
+      {
+        name: "capture_meta",
+        input: JSON.stringify({}),
+        meta: JSON.stringify({ source_view: "graphql_explorer", bulk: false }),
+      },
+    );
+
+    expect(result.errors).toBeUndefined();
+    expect(captures).toHaveLength(1);
+    expect(captures[0].meta.source_view).toBe("graphql_explorer");
+    expect(captures[0].meta.bulk).toBe(false);
+  });
+
+  test("createTask mutation with meta arg threads through to action handler", async () => {
+    clearCaptures();
+    const result = await gql(
+      `
+        mutation Create($input: TaskInput!, $meta: String) {
+          createTask(input: $input, meta: $meta) {
+            id
+            title
+          }
+        }
+      `,
+      {
+        input: { title: "From GraphQL with meta" },
+        meta: JSON.stringify({ source_view: "task_form" }),
+      },
+    );
+
+    expect(result.errors).toBeUndefined();
+    const created = (captures.find((c) => c.action === "create_task")?.meta ?? {}) as Record<
+      string,
+      unknown
+    >;
+    expect(created.source_view).toBe("task_form");
+    expect(created._channel).toBe("http");
+  });
+
+  test("updateTask mutation with meta arg threads through", async () => {
+    clearCaptures();
+    await store.create("task", { id: "gql_meta_update", title: "Initial" });
+
+    const result = await gql(
+      `
+        mutation Upd($id: ID!, $input: TaskInput!, $meta: String) {
+          updateTask(id: $id, input: $input, meta: $meta) {
+            id
+            title
+          }
+        }
+      `,
+      {
+        id: "gql_meta_update",
+        input: { title: "Updated" },
+        meta: JSON.stringify({ triggered_by: "test" }),
+      },
+    );
+
+    expect(result.errors).toBeUndefined();
+    const updateCap = captures.find((c) => c.action === "update_task");
+    expect(updateCap).toBeDefined();
+    expect(updateCap?.meta.triggered_by).toBe("test");
+  });
+
+  test("invalid JSON in meta arg → GraphQL error", async () => {
+    const result = await gql(
+      `
+        mutation Run($name: String!, $input: String!, $meta: String) {
+          executeAction(name: $name, input: $input, meta: $meta) {
+            success
+          }
+        }
+      `,
+      {
+        name: "capture_meta",
+        input: JSON.stringify({}),
+        meta: "not valid json",
+      },
+    );
+
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.[0]?.message).toContain("invalid JSON");
+  });
+
+  test("non-object meta arg → GraphQL error", async () => {
+    const result = await gql(
+      `
+        mutation Run($name: String!, $input: String!, $meta: String) {
+          executeAction(name: $name, input: $input, meta: $meta) {
+            success
+          }
+        }
+      `,
+      {
+        name: "capture_meta",
+        input: JSON.stringify({}),
+        meta: JSON.stringify([1, 2, 3]),
+      },
+    );
+
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.[0]?.message).toContain("must be a JSON object");
+  });
+
+  test("_-prefixed keys in meta arg are stripped (system keys win)", async () => {
+    clearCaptures();
+    const result = await gql(
+      `
+        mutation Run($name: String!, $input: String!, $meta: String) {
+          executeAction(name: $name, input: $input, meta: $meta) {
+            success
+          }
+        }
+      `,
+      {
+        name: "capture_meta",
+        input: JSON.stringify({}),
+        meta: JSON.stringify({
+          _channel: "evil",
+          _execution_id: "spoofed",
+          allowed: 1,
+        }),
+      },
+    );
+
+    expect(result.errors).toBeUndefined();
+    const meta = captures[0]?.meta ?? {};
+    expect(meta._channel).toBe("http");
+    expect(meta._execution_id).not.toBe("spoofed");
+    expect(meta.allowed).toBe(1);
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/__tests__/exec-meta-transports.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/exec-meta-transports.test.ts
@@ -390,6 +390,65 @@ describe("GraphQL — meta argument (Spec 65 §3.2)", () => {
     expect(result.errors?.[0]?.message).toContain("must be a JSON object");
   });
 
+  // Cross-model review: empty string IS supplied and should flow into
+  // safeParseJSON, not be silently treated as no-meta. Spec contract: "if
+  // supplied, parse it." Empty string fails JSON.parse → GraphQL error,
+  // matching `"{not_json"` behavior.
+  test("empty-string meta arg → GraphQL invalid-JSON error (matches malformed JSON)", async () => {
+    const malformed = await gql(
+      `
+        mutation Run($name: String!, $input: String!, $meta: String) {
+          executeAction(name: $name, input: $input, meta: $meta) {
+            success
+          }
+        }
+      `,
+      {
+        name: "capture_meta",
+        input: JSON.stringify({}),
+        meta: "{not_json",
+      },
+    );
+    const empty = await gql(
+      `
+        mutation Run($name: String!, $input: String!, $meta: String) {
+          executeAction(name: $name, input: $input, meta: $meta) {
+            success
+          }
+        }
+      `,
+      {
+        name: "capture_meta",
+        input: JSON.stringify({}),
+        meta: "",
+      },
+    );
+
+    expect(malformed.errors).toBeDefined();
+    expect(empty.errors).toBeDefined();
+    expect(empty.errors?.[0]?.message).toBe(malformed.errors?.[0]?.message);
+    expect(empty.errors?.[0]?.message).toContain("invalid JSON");
+  });
+
+  test("empty-string meta arg on createTask mutation → GraphQL invalid-JSON error", async () => {
+    const result = await gql(
+      `
+        mutation Create($input: TaskInput!, $meta: String) {
+          createTask(input: $input, meta: $meta) {
+            id
+          }
+        }
+      `,
+      {
+        input: { title: "should fail before action runs" },
+        meta: "",
+      },
+    );
+
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.[0]?.message).toContain("invalid JSON");
+  });
+
   test("_-prefixed keys in meta arg are stripped (system keys win)", async () => {
     clearCaptures();
     const result = await gql(

--- a/addons/adapter-server/cap-adapter-server/__tests__/exec-meta-transports.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/exec-meta-transports.test.ts
@@ -96,7 +96,7 @@ const graphqlSchema = buildGraphQLSchema([taskSchema], {
   actions: [captureMetaAction],
 });
 const app = createServer(graphqlSchema, { executor, commandLayer });
-const port = 4099;
+const port = 4032;
 
 beforeAll(() => {
   app.listen(port);

--- a/addons/adapter-server/cap-adapter-server/__tests__/graphql-execution-log.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/graphql-execution-log.test.ts
@@ -355,6 +355,47 @@ describe("GraphQL executionLogList query", () => {
     const entry = logs.items[0];
     expect(entry.channel).toBe("graphql");
   });
+
+  // Spec 65 §9 — meta surfaces through the system entity layer so admin UIs
+  // can render the recorded ExecutionMeta snapshot. The serializeJsonFields
+  // step stringifies the object for the GraphQL String column.
+  test("exposes meta field as JSON-encoded string", async () => {
+    await seedLog({
+      meta: JSON.stringify({
+        source_view: "queue",
+        bulk: true,
+        _channel: "http",
+        _depth: 0,
+      }),
+    });
+
+    const result = await gql(`
+      query {
+        executionLogList {
+          items {
+            id
+            meta
+          }
+          total
+        }
+      }
+    `);
+
+    expect(result.errors).toBeUndefined();
+    const logs = result.data.executionLogList as {
+      items: Array<Record<string, unknown>>;
+      total: number;
+    };
+    expect(logs.total).toBe(1);
+    const entry = logs.items[0];
+    expect(entry.meta).toBeDefined();
+    expect(typeof entry.meta).toBe("string");
+    const parsedMeta = JSON.parse(entry.meta as string);
+    expect(parsedMeta.source_view).toBe("queue");
+    expect(parsedMeta.bulk).toBe(true);
+    expect(parsedMeta._channel).toBe("http");
+    expect(parsedMeta._depth).toBe(0);
+  });
 });
 
 describe("GraphQL executionLog single entry query", () => {

--- a/addons/adapter-server/cap-adapter-server/__tests__/server.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/server.test.ts
@@ -81,7 +81,12 @@ describe("buildGraphQLSchema", () => {
     expect(sdl).toContain("task(");
     expect(sdl).toContain("id: ID!");
     expect(sdl).toContain("): TaskListResult!");
-    expect(sdl).toContain("createTask(input: TaskInput!): Task");
+    // createTask is multiline in SDL because the `meta` arg carries a
+    // description string (Spec 65 §3.2); verify key parts rather than the
+    // single-line shape.
+    expect(sdl).toContain("createTask(");
+    expect(sdl).toContain("input: TaskInput!");
+    expect(sdl).toContain("meta: String");
     // updateTask is multiline in SDL due to arg descriptions; verify key parts
     expect(sdl).toContain("updateTask(");
     expect(sdl).toContain("id: ID!");

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
@@ -234,7 +234,7 @@ export function buildGraphQLSchema(
     name: string,
     input: Record<string, unknown>,
     ctx: GraphQLContext,
-    extraOptions?: { includeDeleted?: boolean },
+    extraOptions?: { includeDeleted?: boolean; meta?: Record<string, unknown> },
   ): Promise<ActionResult<T>> => {
     // Prefer CommandLayer so cap-permission and other slot middleware
     // protect every GraphQL mutation, including restore_* flows. The
@@ -249,6 +249,7 @@ export function buildGraphQLSchema(
         tenantId: ctx.tenantId,
         locale: ctx.locale,
         includeDeleted: extraOptions?.includeDeleted,
+        meta: extraOptions?.meta,
       })) as ActionResult<T>;
     }
     if (!executor) {
@@ -259,6 +260,7 @@ export function buildGraphQLSchema(
       tenantId: ctx.tenantId,
       locale: ctx.locale,
       includeDeleted: extraOptions?.includeDeleted,
+      meta: extraOptions?.meta,
     }) as Promise<ActionResult<T>>;
   };
 
@@ -593,12 +595,23 @@ export function buildGraphQLSchema(
       type: objectType,
       args: {
         input: { type: new GraphQLNonNull(inputType) },
+        meta: {
+          type: GraphQLString,
+          description: "JSON-encoded execution meta (Spec 65 §3.2)",
+        },
       },
       resolve: hasDispatcher
-        ? async (_root: unknown, args: { input: Record<string, unknown> }, ctx: GraphQLContext) => {
+        ? async (
+            _root: unknown,
+            args: { input: Record<string, unknown>; meta?: string },
+            ctx: GraphQLContext,
+          ) => {
             const locale = ctx.locale;
             const normalizedInput = normalizeTranslatableRow(args.input, entity, locale);
-            const result = await dispatchAction(`create_${entityName}`, normalizedInput, ctx);
+            const meta = args.meta ? safeParseJSON(args.meta, "meta") : undefined;
+            const result = await dispatchAction(`create_${entityName}`, normalizedInput, ctx, {
+              meta,
+            });
             if (!result.success) {
               const errData = result.data as Record<string, unknown> | undefined;
               throw new Error((errData?.error as string) ?? "Create action failed");
@@ -624,11 +637,20 @@ export function buildGraphQLSchema(
           type: GraphQLInt,
           description: "Expected record version for optimistic locking",
         },
+        meta: {
+          type: GraphQLString,
+          description: "JSON-encoded execution meta (Spec 65 §3.2)",
+        },
       },
       resolve: hasDispatcher
         ? async (
             _root: unknown,
-            args: { id: string; input: Record<string, unknown>; _version?: number },
+            args: {
+              id: string;
+              input: Record<string, unknown>;
+              _version?: number;
+              meta?: string;
+            },
             ctx: GraphQLContext,
           ) => {
             const locale = ctx.locale;
@@ -646,7 +668,8 @@ export function buildGraphQLSchema(
             if (args._version !== undefined && args._version !== null) {
               input._version = args._version;
             }
-            const result = await dispatchAction(`update_${entityName}`, input, ctx);
+            const meta = args.meta ? safeParseJSON(args.meta, "meta") : undefined;
+            const result = await dispatchAction(`update_${entityName}`, input, ctx, { meta });
             if (!result.success) {
               const errData = result.data as Record<string, unknown> | undefined;
               const errorMessage = (errData?.error as string) ?? "Update action failed";
@@ -685,10 +708,17 @@ export function buildGraphQLSchema(
       type: GraphQLBoolean,
       args: {
         id: { type: new GraphQLNonNull(GraphQLID) },
+        meta: {
+          type: GraphQLString,
+          description: "JSON-encoded execution meta (Spec 65 §3.2)",
+        },
       },
       resolve: hasDispatcher
-        ? async (_root: unknown, args: { id: string }, ctx: GraphQLContext) => {
-            const result = await dispatchAction(`delete_${entityName}`, { id: args.id }, ctx);
+        ? async (_root: unknown, args: { id: string; meta?: string }, ctx: GraphQLContext) => {
+            const meta = args.meta ? safeParseJSON(args.meta, "meta") : undefined;
+            const result = await dispatchAction(`delete_${entityName}`, { id: args.id }, ctx, {
+              meta,
+            });
             if (result.success) invalidateEntityCache(entityName);
             return result.success;
           }
@@ -700,12 +730,18 @@ export function buildGraphQLSchema(
       type: objectType,
       args: {
         id: { type: new GraphQLNonNull(GraphQLID) },
+        meta: {
+          type: GraphQLString,
+          description: "JSON-encoded execution meta (Spec 65 §3.2)",
+        },
       },
       resolve: hasDispatcher
-        ? async (_root: unknown, args: { id: string }, ctx: GraphQLContext) => {
+        ? async (_root: unknown, args: { id: string; meta?: string }, ctx: GraphQLContext) => {
             const locale = ctx.locale;
+            const meta = args.meta ? safeParseJSON(args.meta, "meta") : undefined;
             const result = await dispatchAction(`restore_${entityName}`, { id: args.id }, ctx, {
               includeDeleted: true,
+              meta,
             });
             if (!result.success) {
               const errData = result.data as Record<string, unknown> | undefined;
@@ -793,10 +829,18 @@ export function buildGraphQLSchema(
         args: {
           id: { type: new GraphQLNonNull(GraphQLID) },
           to: { type: new GraphQLNonNull(GraphQLString) },
+          meta: {
+            type: GraphQLString,
+            description: "JSON-encoded execution meta (Spec 65 §3.2)",
+          },
         },
         resolve:
           executor && dataProvider
-            ? async (_root: unknown, args: { id: string; to: string }, ctx: GraphQLContext) => {
+            ? async (
+                _root: unknown,
+                args: { id: string; to: string; meta?: string },
+                ctx: GraphQLContext,
+              ) => {
                 const opts: DataQueryOptions = {
                   ...(ctx.tenantId ? { tenantId: ctx.tenantId } : {}),
                 };
@@ -830,7 +874,8 @@ export function buildGraphQLSchema(
                   id: args.id,
                   [stateFieldName]: args.to,
                 };
-                const result = await dispatchAction(`update_${entityName}`, input, ctx);
+                const meta = args.meta ? safeParseJSON(args.meta, "meta") : undefined;
+                const result = await dispatchAction(`update_${entityName}`, input, ctx, { meta });
                 if (!result.success) {
                   const errData = result.data as Record<string, unknown> | undefined;
                   throw new GraphQLError((errData?.error as string) ?? `State transition failed`);
@@ -860,9 +905,14 @@ export function buildGraphQLSchema(
         : ActionResultType;
     const returnsSchemaType = returnType !== ActionResultType;
 
-    // Build args: always include id (ID!), optionally include typed input
+    // Build args: always include id (ID!), optionally include typed input,
+    // always include `meta` (Spec 65 §3.2 — JSON-encoded execution meta).
     const args: Record<string, unknown> = {
       id: { type: new GraphQLNonNull(GraphQLID) },
+      meta: {
+        type: GraphQLString,
+        description: "JSON-encoded execution meta (Spec 65 §3.2)",
+      },
     };
     if (actionInputType) {
       args.input = { type: new GraphQLNonNull(actionInputType) };
@@ -878,7 +928,7 @@ export function buildGraphQLSchema(
       resolve: hasDispatcher
         ? async (
             _root: unknown,
-            resolverArgs: { id: string; input?: Record<string, unknown> },
+            resolverArgs: { id: string; input?: Record<string, unknown>; meta?: string },
             ctx: GraphQLContext,
           ) => {
             const locale = ctx.locale;
@@ -887,7 +937,8 @@ export function buildGraphQLSchema(
               ...resolverArgs.input,
               id: resolverArgs.id,
             };
-            const result = await dispatchAction(actionName, input, ctx);
+            const meta = resolverArgs.meta ? safeParseJSON(resolverArgs.meta, "meta") : undefined;
+            const result = await dispatchAction(actionName, input, ctx, { meta });
             if (returnsSchemaType) {
               if (!result.success) {
                 const errData = result.data as Record<string, unknown> | undefined;
@@ -944,11 +995,20 @@ export function buildGraphQLSchema(
         type: new GraphQLNonNull(GraphQLString),
         description: "JSON-encoded input object",
       },
+      meta: {
+        type: GraphQLString,
+        description: "JSON-encoded execution meta (Spec 65 §3.2)",
+      },
     },
     resolve: hasDispatcher
-      ? async (_root: unknown, args: { name: string; input: string }, ctx: GraphQLContext) => {
+      ? async (
+          _root: unknown,
+          args: { name: string; input: string; meta?: string },
+          ctx: GraphQLContext,
+        ) => {
           const input = safeParseJSON(args.input, "input") as Record<string, unknown>;
-          const result = await dispatchAction(args.name, input, ctx);
+          const meta = args.meta ? safeParseJSON(args.meta, "meta") : undefined;
+          const result = await dispatchAction(args.name, input, ctx, { meta });
           const errors = !result.success
             ? [
                 {

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
@@ -608,7 +608,10 @@ export function buildGraphQLSchema(
           ) => {
             const locale = ctx.locale;
             const normalizedInput = normalizeTranslatableRow(args.input, entity, locale);
-            const meta = args.meta ? safeParseJSON(args.meta, "meta") : undefined;
+            const meta =
+              args.meta !== undefined && args.meta !== null
+                ? safeParseJSON(args.meta, "meta")
+                : undefined;
             const result = await dispatchAction(`create_${entityName}`, normalizedInput, ctx, {
               meta,
             });
@@ -668,7 +671,10 @@ export function buildGraphQLSchema(
             if (args._version !== undefined && args._version !== null) {
               input._version = args._version;
             }
-            const meta = args.meta ? safeParseJSON(args.meta, "meta") : undefined;
+            const meta =
+              args.meta !== undefined && args.meta !== null
+                ? safeParseJSON(args.meta, "meta")
+                : undefined;
             const result = await dispatchAction(`update_${entityName}`, input, ctx, { meta });
             if (!result.success) {
               const errData = result.data as Record<string, unknown> | undefined;
@@ -715,7 +721,10 @@ export function buildGraphQLSchema(
       },
       resolve: hasDispatcher
         ? async (_root: unknown, args: { id: string; meta?: string }, ctx: GraphQLContext) => {
-            const meta = args.meta ? safeParseJSON(args.meta, "meta") : undefined;
+            const meta =
+              args.meta !== undefined && args.meta !== null
+                ? safeParseJSON(args.meta, "meta")
+                : undefined;
             const result = await dispatchAction(`delete_${entityName}`, { id: args.id }, ctx, {
               meta,
             });
@@ -738,7 +747,10 @@ export function buildGraphQLSchema(
       resolve: hasDispatcher
         ? async (_root: unknown, args: { id: string; meta?: string }, ctx: GraphQLContext) => {
             const locale = ctx.locale;
-            const meta = args.meta ? safeParseJSON(args.meta, "meta") : undefined;
+            const meta =
+              args.meta !== undefined && args.meta !== null
+                ? safeParseJSON(args.meta, "meta")
+                : undefined;
             const result = await dispatchAction(`restore_${entityName}`, { id: args.id }, ctx, {
               includeDeleted: true,
               meta,
@@ -874,7 +886,10 @@ export function buildGraphQLSchema(
                   id: args.id,
                   [stateFieldName]: args.to,
                 };
-                const meta = args.meta ? safeParseJSON(args.meta, "meta") : undefined;
+                const meta =
+                  args.meta !== undefined && args.meta !== null
+                    ? safeParseJSON(args.meta, "meta")
+                    : undefined;
                 const result = await dispatchAction(`update_${entityName}`, input, ctx, { meta });
                 if (!result.success) {
                   const errData = result.data as Record<string, unknown> | undefined;
@@ -937,7 +952,10 @@ export function buildGraphQLSchema(
               ...resolverArgs.input,
               id: resolverArgs.id,
             };
-            const meta = resolverArgs.meta ? safeParseJSON(resolverArgs.meta, "meta") : undefined;
+            const meta =
+              resolverArgs.meta !== undefined && resolverArgs.meta !== null
+                ? safeParseJSON(resolverArgs.meta, "meta")
+                : undefined;
             const result = await dispatchAction(actionName, input, ctx, { meta });
             if (returnsSchemaType) {
               if (!result.success) {
@@ -1007,7 +1025,10 @@ export function buildGraphQLSchema(
           ctx: GraphQLContext,
         ) => {
           const input = safeParseJSON(args.input, "input") as Record<string, unknown>;
-          const meta = args.meta ? safeParseJSON(args.meta, "meta") : undefined;
+          const meta =
+            args.meta !== undefined && args.meta !== null
+              ? safeParseJSON(args.meta, "meta")
+              : undefined;
           const result = await dispatchAction(args.name, input, ctx, { meta });
           const errors = !result.success
             ? [

--- a/addons/adapter-server/cap-adapter-server/src/routes/action-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/action-api.ts
@@ -18,6 +18,8 @@ import type { Elysia } from "elysia";
 import type { ServerOptions } from "../server";
 import {
   badRequest,
+  isMetaHeaderFailure,
+  parseMetaHeader,
   resolveActor,
   resolveRequestLocale,
   resolveStatusCode,
@@ -122,6 +124,22 @@ export function mountActionRoutes(app: Elysia, options: ServerOptions): void {
         return badRequest(set, parsed.reason);
       }
 
+      // Parse X-Linch-Meta once and apply to every batch item via
+      // CommandBatchExecuteOptions.meta. Phase 1's executeBatch merges this
+      // record with `batch.parentExecutionId` / `batch.index` per item.
+      const metaResult = parseMetaHeader(request);
+      if (isMetaHeaderFailure(metaResult)) {
+        set.status = 400;
+        return {
+          success: false as const,
+          error: {
+            code: `META.PARSE.${metaResult.code}`,
+            message: metaResult.message,
+          },
+        };
+      }
+      const meta = metaResult?.ok === true ? metaResult.meta : undefined;
+
       const locale = resolveRequestLocale(request);
       const actor = await resolveActor(request, resolveRequestActor);
       const incomingTraceId = request.headers.get("x-trace-id") ?? undefined;
@@ -138,6 +156,7 @@ export function mountActionRoutes(app: Elysia, options: ServerOptions): void {
         headers,
         traceId: incomingTraceId,
         transactionManager,
+        meta,
       });
 
       // v1 returns 200 for any structurally valid request — clients inspect
@@ -170,6 +189,23 @@ export function mountActionRoutes(app: Elysia, options: ServerOptions): void {
       // Accept external trace ID for distributed tracing propagation
       const incomingTraceId = request.headers.get("x-trace-id") ?? undefined;
 
+      // Parse the optional X-Linch-Meta header (Spec 65 §3.1). Reject early
+      // with a 400 on a malformed payload so the action engine never sees a
+      // half-validated meta — its own size check still runs as a defense-in-
+      // depth guard against system-key spoofing and serialization issues.
+      const metaResult = parseMetaHeader(request);
+      if (isMetaHeaderFailure(metaResult)) {
+        set.status = 400;
+        return {
+          success: false as const,
+          error: {
+            code: `META.PARSE.${metaResult.code}`,
+            message: metaResult.message,
+          },
+        };
+      }
+      const meta = metaResult?.ok === true ? metaResult.meta : undefined;
+
       // Use CommandLayer pipeline when available, otherwise direct executor
       let result: ActionResult;
       if (commandLayer) {
@@ -186,6 +222,7 @@ export function mountActionRoutes(app: Elysia, options: ServerOptions): void {
           locale,
           headers,
           traceId: incomingTraceId,
+          meta,
         });
       } else {
         if (!executor) {
@@ -202,6 +239,7 @@ export function mountActionRoutes(app: Elysia, options: ServerOptions): void {
         result = await executor.execute(params.name, input, actor, {
           channel: "http",
           locale,
+          meta,
         });
       }
 

--- a/addons/adapter-server/cap-adapter-server/src/routes/shared.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/shared.ts
@@ -270,7 +270,26 @@ export function parseMetaHeader(
   request: Request,
 ): { ok: true; meta: Record<string, unknown> } | MetaHeaderParseFailure | undefined {
   const raw = request.headers.get("x-linch-meta");
+  // Treat absent / empty header as "no meta supplied". Note this differs
+  // from the GraphQL `meta: ""` contract (which IS an explicit empty
+  // value and gets rejected as invalid JSON): per HTTP convention an
+  // empty header value is indistinguishable from an absent header, and
+  // most clients cannot even emit a truly empty header. The asymmetry
+  // is deliberate.
   if (!raw || raw.length === 0) return undefined;
+
+  // Pre-screen with a cheap string-length check before invoking
+  // TextEncoder, so a pathological multi-MB payload isn't allocated
+  // through the encoder just to be rejected. UTF-8 is at most 4 bytes
+  // per JS char, so any string longer than max*4 chars is guaranteed
+  // oversized regardless of encoding.
+  if (raw.length > META_HEADER_MAX_BYTES * 4) {
+    return {
+      ok: false,
+      code: "OVERSIZE",
+      message: `X-Linch-Meta header exceeds the limit of ${META_HEADER_MAX_BYTES} bytes`,
+    };
+  }
 
   // Byte-length check (UTF-8 aware). Headers are typically ASCII but the
   // spec doesn't forbid multi-byte content, so use TextEncoder for parity

--- a/addons/adapter-server/cap-adapter-server/src/routes/shared.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/shared.ts
@@ -226,3 +226,89 @@ export async function resolveActor(
   if (!resolveRequestActor) return NO_AUTH_ACTOR;
   return (await resolveRequestActor(request)) ?? ANONYMOUS_ACTOR;
 }
+
+// ── X-Linch-Meta header parsing (Spec 65 §3.1) ────────────────────────
+
+/**
+ * Hard ceiling on `X-Linch-Meta` payload size at the transport boundary
+ * (Spec 65 §10.2). The action-engine enforces the same 8 KB limit on the
+ * fully-merged meta (raw + system keys) via `MetaSizeError`; matching the
+ * cap here prevents pathological 50 MB headers from doing JSON.parse work
+ * just to be rejected later.
+ */
+const META_HEADER_MAX_BYTES = 8192;
+
+/**
+ * Tagged failure shape returned by {@link parseMetaHeader} for a malformed
+ * `X-Linch-Meta` header. Routes inspect `code` to render a structured 400
+ * response.
+ */
+export interface MetaHeaderParseFailure {
+  ok: false;
+  /** Stable error code suffixed onto `META.PARSE.` for the response envelope. */
+  code: "OVERSIZE" | "INVALID_JSON" | "NOT_OBJECT";
+  message: string;
+}
+
+/**
+ * Parse the `X-Linch-Meta` HTTP header into a meta payload (Spec 65 §3.1).
+ *
+ * Returns:
+ * - `undefined` when the header is absent or empty (most common case).
+ * - `{ ok: true, meta }` with the parsed object when the header is valid.
+ * - `{ ok: false, code, message }` when the header violates one of:
+ *   - Size > 8 KB (rejected pre-parse to bound CPU)
+ *   - Body is not valid JSON
+ *   - Body is JSON but not a plain object (array / string / number / null)
+ *
+ * `_`-prefixed keys are NOT stripped here — that's `createExecutionMeta`'s
+ * job (Spec 65 §4.4). Returning the raw object keeps this helper transport-
+ * neutral; the action-engine remains the single source of truth for system-
+ * key namespace protection.
+ */
+export function parseMetaHeader(
+  request: Request,
+): { ok: true; meta: Record<string, unknown> } | MetaHeaderParseFailure | undefined {
+  const raw = request.headers.get("x-linch-meta");
+  if (!raw || raw.length === 0) return undefined;
+
+  // Byte-length check (UTF-8 aware). Headers are typically ASCII but the
+  // spec doesn't forbid multi-byte content, so use TextEncoder for parity
+  // with the action-engine size enforcement.
+  const byteLength = new TextEncoder().encode(raw).length;
+  if (byteLength > META_HEADER_MAX_BYTES) {
+    return {
+      ok: false,
+      code: "OVERSIZE",
+      message: `X-Linch-Meta header is ${byteLength} bytes, exceeds the limit of ${META_HEADER_MAX_BYTES} bytes`,
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {
+      ok: false,
+      code: "INVALID_JSON",
+      message: "X-Linch-Meta header is not valid JSON",
+    };
+  }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      code: "NOT_OBJECT",
+      message: "X-Linch-Meta header must be a JSON object",
+    };
+  }
+
+  return { ok: true, meta: parsed as Record<string, unknown> };
+}
+
+/** True when the `parseMetaHeader` result is a structured failure. */
+export function isMetaHeaderFailure(
+  result: ReturnType<typeof parseMetaHeader>,
+): result is MetaHeaderParseFailure {
+  return result !== undefined && result.ok === false;
+}

--- a/addons/adapter-server/cap-adapter-server/src/system-data-provider.ts
+++ b/addons/adapter-server/cap-adapter-server/src/system-data-provider.ts
@@ -234,6 +234,10 @@ function executionEntryToRecord(e: ExecutionLogEntry): Record<string, unknown> {
           ? e.output
           : JSON.stringify(e.output)
         : null,
+    // Spec 65 §9 — surface ExecutionMeta snapshot through the system entity layer
+    // so /api/entities/execution_log and admin UIs can render meta. The
+    // serializeJsonFields step downstream will stringify the object for GraphQL.
+    meta: e.meta ?? null,
     started_at: e.startedAt instanceof Date ? e.startedAt.toISOString() : (e.startedAt ?? null),
     completed_at:
       e.completedAt instanceof Date ? e.completedAt.toISOString() : (e.completedAt ?? null),

--- a/addons/adapter-server/cap-adapter-server/src/system-schemas.ts
+++ b/addons/adapter-server/cap-adapter-server/src/system-schemas.ts
@@ -82,6 +82,10 @@ export const executionLogSchema: EntityDefinition = {
       type: "json",
       label: "t:entities.execution_log.fields.output",
     },
+    meta: {
+      type: "json",
+      label: "t:entities.execution_log.fields.meta",
+    },
     state_transition_from: {
       type: "string",
       label: "t:entities.execution_log.fields.state_transition_from",

--- a/drizzle/migrations/0002_loving_kang.sql
+++ b/drizzle/migrations/0002_loving_kang.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "_linchkit"."executions" ADD COLUMN "meta" jsonb;

--- a/drizzle/migrations/meta/0002_snapshot.json
+++ b/drizzle/migrations/meta/0002_snapshot.json
@@ -1,0 +1,1063 @@
+{
+  "id": "9498d302-179d-4ef8-9cd9-ce4f32d36a9a",
+  "prevId": "9d6382e1-e3eb-41f8-8981-c95bdb6df939",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "_linchkit.approvals": {
+      "name": "approvals",
+      "schema": "_linchkit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capability": {
+          "name": "capability",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_rules": {
+          "name": "trigger_rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_type": {
+          "name": "assignee_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_value": {
+          "name": "assignee_value",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "approval_status",
+          "typeSchema": "_linchkit",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_note": {
+          "name": "decision_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_policy": {
+          "name": "timeout_policy",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reject'"
+        },
+        "original_execution_id": {
+          "name": "original_execution_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_error": {
+          "name": "execution_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.department": {
+      "name": "department",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_version": {
+          "name": "_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_extensions": {
+          "name": "_extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manager": {
+          "name": "manager",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budget_limit": {
+          "name": "budget_limit",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "department_name_unique": {
+          "name": "department_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        },
+        "department_code_unique": {
+          "name": "department_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["code"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "_linchkit.events": {
+      "name": "events",
+      "schema": "_linchkit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_action": {
+          "name": "source_action",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_execution_id": {
+          "name": "source_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_status",
+          "typeSchema": "_linchkit",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_events_type_status": {
+          "name": "idx_events_type_status",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_retry": {
+          "name": "idx_events_retry",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_tenant": {
+          "name": "idx_events_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "_linchkit.executions": {
+      "name": "executions",
+      "schema": "_linchkit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capability": {
+          "name": "capability",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "execution_status",
+          "typeSchema": "_linchkit",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_execution_id": {
+          "name": "parent_execution_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_executions_action_created": {
+          "name": "idx_executions_action_created",
+          "columns": [
+            {
+              "expression": "action_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executions_tenant": {
+          "name": "idx_executions_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executions_idempotency_key": {
+          "name": "idx_executions_idempotency_key",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "_linchkit.field_overlays": {
+      "name": "field_overlays",
+      "schema": "_linchkit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_type": {
+          "name": "field_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "overlay_status",
+          "typeSchema": "_linchkit",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_field_overlays_entity_field": {
+          "name": "idx_field_overlays_entity_field",
+          "columns": [
+            {
+              "expression": "entity_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_item": {
+      "name": "purchase_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_version": {
+          "name": "_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_extensions": {
+          "name": "_extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specification": {
+          "name": "specification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_total": {
+          "name": "line_total",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_request_id": {
+          "name": "purchase_request_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_item_purchase_request_id_purchase_request_id_fk": {
+          "name": "purchase_item_purchase_request_id_purchase_request_id_fk",
+          "tableFrom": "purchase_item",
+          "tableTo": "purchase_request",
+          "columnsFrom": ["purchase_request_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_request": {
+      "name": "purchase_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_version": {
+          "name": "_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_extensions": {
+          "name": "_extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester": {
+          "name": "requester",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requester_email": {
+          "name": "requester_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audit_notes": {
+          "name": "audit_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department_id": {
+          "name": "department_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_request_department_id_department_id_fk": {
+          "name": "purchase_request_department_id_department_id_fk",
+          "tableFrom": "purchase_request",
+          "tableTo": "department",
+          "columnsFrom": ["department_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "_linchkit.approval_status": {
+      "name": "approval_status",
+      "schema": "_linchkit",
+      "values": ["pending", "approved", "rejected", "expired", "cancelled"]
+    },
+    "_linchkit.event_status": {
+      "name": "event_status",
+      "schema": "_linchkit",
+      "values": ["pending", "processing", "completed", "failed", "dead_letter"]
+    },
+    "_linchkit.execution_status": {
+      "name": "execution_status",
+      "schema": "_linchkit",
+      "values": ["succeeded", "failed", "blocked", "pending_approval"]
+    },
+    "_linchkit.overlay_status": {
+      "name": "overlay_status",
+      "schema": "_linchkit",
+      "values": ["active", "deprecated", "promoted"]
+    }
+  },
+  "schemas": {
+    "_linchkit": "_linchkit"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1775733762343,
       "tag": "0001_greedy_king_bedlam",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1777128126634,
+      "tag": "0002_loving_kang",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/__tests__/action-engine-meta-propagation.test.ts
+++ b/packages/core/__tests__/action-engine-meta-propagation.test.ts
@@ -12,6 +12,7 @@
 import { describe, expect, test } from "bun:test";
 import { createActionExecutor } from "../src/engine/action-engine";
 import { createCommandLayer } from "../src/engine/command-layer";
+import { InMemoryMetricsCollector } from "../src/observability/metrics";
 import type { ActionContext, ActionDefinition, Actor } from "../src/types/action";
 import { createExecutionMeta, DEFAULT_META_MAX_BYTES } from "../src/types/execution-meta";
 import { createTestDataProvider } from "./command-layer-helpers";
@@ -585,6 +586,45 @@ describe("ActionEngine — ExecutionMeta propagation via ctx.execute", () => {
     expect(logEntries.length).toBe(1);
     expect(logEntries[0].status).toBe("failed");
     expect(logEntries[0].id).toBe(result.executionId);
+  });
+
+  // Gemini Phase 2A review: MetaSizeError must increment action.executed{status:failed}
+  // and record duration so monitoring dashboards see meta-size rejections.
+  test("MetaSizeError path emits action.executed and action.duration_ms metrics", async () => {
+    const dp = createTestDataProvider();
+    const metrics = new InMemoryMetricsCollector();
+    const executor = createActionExecutor({ dataProvider: dp, metrics });
+
+    executor.registry.register({
+      name: "root_oversize_metrics",
+      entity: "item",
+      label: "Root Oversize Metrics",
+      policy: { mode: "sync", transaction: false },
+      exposure: "all",
+      handler: async () => ({ ok: true }),
+    });
+
+    const result = await executor.execute("root_oversize_metrics", {}, defaultActor, {
+      meta: { big: "x".repeat(DEFAULT_META_MAX_BYTES + 100) } as Record<string, unknown>,
+    });
+    expect(result.success).toBe(false);
+
+    // Counter increment on failed
+    const failedCount = metrics.getCounter("action.executed", {
+      action: "root_oversize_metrics",
+      entity: "",
+      status: "failed",
+    });
+    expect(failedCount).toBe(1);
+    // Histogram entry recorded for duration
+    const snapshots = metrics.getMetrics();
+    const durationSnapshot = snapshots.find(
+      (s) =>
+        s.name === "action.duration_ms" &&
+        s.tags?.action === "root_oversize_metrics" &&
+        s.tags?.entity === "",
+    );
+    expect(durationSnapshot).toBeDefined();
   });
 
   // Codex round-3 P3: don't record a fake child execution id when meta size

--- a/packages/core/__tests__/drizzle-execution-logger.test.ts
+++ b/packages/core/__tests__/drizzle-execution-logger.test.ts
@@ -1,0 +1,171 @@
+/**
+ * DrizzleExecutionLogger meta-persistence tests.
+ *
+ * Spec 65 §9 — meta is recorded on every execution log entry. The Drizzle
+ * adapter must persist meta to a dedicated jsonb column (not lump it into the
+ * existing `metadata` blob) so production queries / admin UIs can index and
+ * filter on `_channel`, `_depth`, caller-supplied `source_view`, etc.
+ *
+ * The full integration suite (real PostgreSQL) lives in
+ * `drizzle-data-provider.integration.test.ts` and skips when no DB is
+ * available. These tests use a stub PostgresJsDatabase that captures the
+ * `.values(...)` payload and replays it back through the same Drizzle table
+ * column shape to verify both the write path and the rowToEntry hydration.
+ */
+import { describe, expect, test } from "bun:test";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import { DrizzleExecutionLogger } from "../src/persistence/drizzle-execution-logger";
+import type { executionsTable } from "../src/persistence/system-tables";
+import type { ExecutionLogEntry } from "../src/types/execution-log";
+
+// Captures every `.values(...)` call so we can inspect what Drizzle would
+// have written to the row. We don't run a real INSERT; we hand the captured
+// row right back to `getById` so rowToEntry exercises the same parsing it
+// would on a Postgres-returned row.
+function createStubDb(): {
+  db: PostgresJsDatabase;
+  inserted: Array<Record<string, unknown>>;
+} {
+  const inserted: Array<Record<string, unknown>> = [];
+  const db = {
+    insert: (_table: unknown) => ({
+      values: async (vals: Record<string, unknown>) => {
+        inserted.push(vals);
+      },
+    }),
+    select: () => ({
+      from: (_t: unknown) => ({
+        where: (_c: unknown) => ({
+          limit: async (_n: number) => {
+            // Replay captured values as a row — Drizzle's $inferSelect uses
+            // the same JS column names the executionsTable was declared with.
+            return inserted.map((v) => normalizeForRowToEntry(v));
+          },
+        }),
+        orderBy: (_o: unknown) => ({
+          limit: async (_n: number) => inserted.map((v) => normalizeForRowToEntry(v)),
+        }),
+      }),
+    }),
+  } as unknown as PostgresJsDatabase;
+  return { db, inserted };
+}
+
+/**
+ * Map the values payload back to the shape Drizzle returns from a SELECT.
+ * Drizzle's `$inferSelect` uses the JS field names from `pgTable(...)`, which
+ * match the column keys passed to `.values(...)` for this table. Defaults
+ * (started_at, completed_at) are already concrete in the entry, so this is
+ * largely a passthrough; the only adjustment is hydrating columns the row
+ * shape declares but the test entry omits.
+ */
+function normalizeForRowToEntry(v: Record<string, unknown>): typeof executionsTable.$inferSelect {
+  return {
+    id: v.id,
+    tenantId: v.tenantId ?? null,
+    actionName: v.actionName,
+    entityName: v.entityName ?? null,
+    recordId: v.recordId ?? null,
+    capability: v.capability ?? null,
+    input: v.input ?? null,
+    output: v.output ?? null,
+    actorId: v.actorId ?? null,
+    actorType: v.actorType ?? null,
+    status: v.status,
+    errorCode: v.errorCode ?? null,
+    errorMessage: v.errorMessage ?? null,
+    durationMs: v.durationMs ?? null,
+    channel: v.channel ?? null,
+    parentExecutionId: v.parentExecutionId ?? null,
+    idempotencyKey: v.idempotencyKey ?? null,
+    metadata: v.metadata ?? null,
+    meta: v.meta ?? null,
+    startedAt: v.startedAt ?? new Date(),
+    completedAt: v.completedAt ?? null,
+    createdAt: v.startedAt ?? new Date(),
+  } as typeof executionsTable.$inferSelect;
+}
+
+const baseEntry: ExecutionLogEntry = {
+  id: "exec_drizzle_meta_1",
+  action: "create_order",
+  entity: "order",
+  actor: { type: "human", id: "u1", groups: [] },
+  input: { title: "Test" },
+  status: "succeeded",
+  duration: 12,
+  startedAt: new Date("2025-01-01T00:00:00Z"),
+  completedAt: new Date("2025-01-01T00:00:00.012Z"),
+};
+
+describe("DrizzleExecutionLogger — meta jsonb column (Spec 65 §9)", () => {
+  test("persists caller-supplied meta into the dedicated meta column", async () => {
+    const { db, inserted } = createStubDb();
+    const logger = new DrizzleExecutionLogger(db);
+
+    await logger.log({
+      ...baseEntry,
+      meta: {
+        source_view: "queue",
+        bulk: true,
+        _channel: "http",
+        _depth: 0,
+        _execution_id: "exec_drizzle_meta_1",
+      },
+    });
+
+    expect(inserted).toHaveLength(1);
+    const written = inserted[0] as Record<string, unknown>;
+    expect(written.meta).toEqual({
+      source_view: "queue",
+      bulk: true,
+      _channel: "http",
+      _depth: 0,
+      _execution_id: "exec_drizzle_meta_1",
+    });
+    // metadata column is for non-meta JSON (actor, rules, etc.) — meta must
+    // not piggy-back on it.
+    expect(written.metadata).not.toMatchObject({ source_view: "queue" });
+  });
+
+  test("writes null when meta is omitted", async () => {
+    const { db, inserted } = createStubDb();
+    const logger = new DrizzleExecutionLogger(db);
+
+    await logger.log({ ...baseEntry, id: "exec_no_meta" });
+
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]?.meta).toBeNull();
+  });
+
+  test("rowToEntry hydrates meta on read (round-trip)", async () => {
+    const { db } = createStubDb();
+    const logger = new DrizzleExecutionLogger(db);
+
+    const recordedMeta = {
+      source_view: "graphql_explorer",
+      _channel: "http",
+      _depth: 0,
+      _execution_id: "exec_roundtrip",
+    };
+    await logger.log({ ...baseEntry, id: "exec_roundtrip", meta: recordedMeta });
+
+    const retrieved = await logger.getById("exec_roundtrip");
+    expect(retrieved).toBeDefined();
+    expect(retrieved?.meta).toEqual(recordedMeta);
+    // Other passthrough fields still hydrate correctly.
+    expect(retrieved?.action).toBe("create_order");
+    expect(retrieved?.entity).toBe("order");
+  });
+
+  test("rowToEntry returns undefined meta when column is null", async () => {
+    const { db } = createStubDb();
+    const logger = new DrizzleExecutionLogger(db);
+
+    await logger.log({ ...baseEntry, id: "exec_meta_null" });
+
+    const retrieved = await logger.getById("exec_meta_null");
+    expect(retrieved).toBeDefined();
+    expect(retrieved?.meta).toBeUndefined();
+  });
+});

--- a/packages/core/__tests__/execution-logger.test.ts
+++ b/packages/core/__tests__/execution-logger.test.ts
@@ -294,3 +294,108 @@ describe("ActionExecutor with ExecutionLogger", () => {
     expect(result.success).toBe(true);
   });
 });
+
+// ── Spec 65 §9 — Execution log records meta snapshot ──────
+
+describe("ExecutionLogger — meta snapshot recording (Spec 65 §9)", () => {
+  it("records caller-provided meta on a successful execution", async () => {
+    const logger = new InMemoryExecutionLogger();
+    const executor = createActionExecutor({
+      dataProvider: createMockDataProvider(),
+      executionLogger: logger,
+    });
+
+    executor.registry.register(createOrderAction);
+    await executor.execute("create_order", { title: "Bulk Order", amount: 100 }, defaultActor, {
+      meta: { bulk: true, source_view: "queue" },
+      channel: "http",
+    });
+
+    const entry = logger.getAll()[0];
+    expect(entry.meta).toBeDefined();
+    expect(entry.meta?.bulk).toBe(true);
+    expect(entry.meta?.source_view).toBe("queue");
+    // System keys stamped by ActionEngine flow into the log too.
+    expect(entry.meta?._channel).toBe("http");
+    expect(entry.meta?._depth).toBe(0);
+    expect(entry.meta?._execution_id).toBe(entry.id);
+  });
+
+  it("records meta on a failed execution (handler throws)", async () => {
+    const logger = new InMemoryExecutionLogger();
+    const executor = createActionExecutor({
+      dataProvider: createMockDataProvider(),
+      executionLogger: logger,
+    });
+
+    executor.registry.register(failingAction);
+    await executor.execute("failing_action", {}, defaultActor, {
+      meta: { triggered_by: "scheduler" },
+    });
+
+    const entry = logger.getAll()[0];
+    expect(entry.status).toBe("failed");
+    expect(entry.meta?.triggered_by).toBe("scheduler");
+  });
+
+  it("records meta when the action is not found", async () => {
+    const logger = new InMemoryExecutionLogger();
+    const executor = createActionExecutor({
+      dataProvider: createMockDataProvider(),
+      executionLogger: logger,
+    });
+
+    await executor.execute("missing_action", {}, defaultActor, {
+      meta: { source_view: "console" },
+    });
+
+    const entry = logger.getAll()[0];
+    expect(entry.status).toBe("failed");
+    expect(entry.meta?.source_view).toBe("console");
+  });
+
+  it("strips _-prefixed external keys from logged meta (system keys win)", async () => {
+    const logger = new InMemoryExecutionLogger();
+    const executor = createActionExecutor({
+      dataProvider: createMockDataProvider(),
+      executionLogger: logger,
+    });
+
+    executor.registry.register(createOrderAction);
+    await executor.execute("create_order", { title: "x" }, defaultActor, {
+      meta: { _channel: "spoofed", _execution_id: "fake", source_view: "real" },
+      channel: "http",
+    });
+
+    const entry = logger.getAll()[0];
+    // External _channel attempt rejected; framework re-stamps from execOptions.channel.
+    expect(entry.meta?._channel).toBe("http");
+    expect(entry.meta?._execution_id).toBe(entry.id);
+    expect(entry.meta?.source_view).toBe("real");
+  });
+
+  it("propagates parent meta into child execution log entries", async () => {
+    const logger = new InMemoryExecutionLogger();
+    const executor = createActionExecutor({
+      dataProvider: createMockDataProvider(),
+      executionLogger: logger,
+    });
+
+    executor.registry.register(parentAction);
+    executor.registry.register(childAction);
+
+    await executor.execute("parent_action", {}, defaultActor, {
+      meta: { bulk: true },
+    });
+
+    const parentEntry = logger.getByAction("parent_action")[0];
+    const childEntry = logger.getByAction("child_action")[0];
+
+    expect(parentEntry.meta?.bulk).toBe(true);
+    // Child inherits parent's meta keys via extendExecutionMeta.
+    expect(childEntry.meta?.bulk).toBe(true);
+    // Child has its own _depth + _source_action.
+    expect(childEntry.meta?._depth).toBe(1);
+    expect(childEntry.meta?._source_action).toBe("parent_action");
+  });
+});

--- a/packages/core/__tests__/execution-logger.test.ts
+++ b/packages/core/__tests__/execution-logger.test.ts
@@ -399,3 +399,61 @@ describe("ExecutionLogger — meta snapshot recording (Spec 65 §9)", () => {
     expect(childEntry.meta?._source_action).toBe("parent_action");
   });
 });
+
+// ── Early-failure log entries stamp `entity` once action is resolved ──
+//
+// Once the executor has resolved the ActionDefinition, every subsequent
+// early-rejection path (exposure, actor-type, input validation, lock
+// preflight, state transition) must record the action's entity so admin
+// queries filtering by entity do not miss authorization-style rejections.
+
+describe("ExecutionLogger — early-failure entity stamping", () => {
+  it("stamps entity on input-validation failures", async () => {
+    const logger = new InMemoryExecutionLogger();
+    const executor = createActionExecutor({
+      dataProvider: createMockDataProvider(),
+      executionLogger: logger,
+    });
+
+    executor.registry.register(createOrderAction);
+    // Missing required `title` triggers input validation rejection.
+    const result = await executor.execute("create_order", {}, defaultActor);
+    expect(result.success).toBe(false);
+
+    const entry = logger.getAll()[0];
+    expect(entry).toBeDefined();
+    expect(entry.status).toBe("failed");
+    expect(entry.entity).toBe("order");
+    expect(entry.error?.message).toBe("Input validation failed");
+  });
+
+  it("stamps entity on exposure-blocked entries", async () => {
+    const logger = new InMemoryExecutionLogger();
+    const executor = createActionExecutor({
+      dataProvider: createMockDataProvider(),
+      executionLogger: logger,
+    });
+
+    // Action with http channel explicitly disabled — exposure check rejects
+    // when called via the http channel before the handler runs.
+    const internalOnlyAction: ActionDefinition = {
+      name: "internal_only",
+      entity: "order",
+      label: "Internal Only",
+      policy: { mode: "sync", transaction: false },
+      exposure: { http: false, mcp: false, cli: false, ui: false, internal: true },
+      handler: async () => ({ ok: true }),
+    };
+    executor.registry.register(internalOnlyAction);
+
+    const result = await executor.execute("internal_only", {}, defaultActor, {
+      channel: "http",
+    });
+    expect(result.success).toBe(false);
+
+    const entry = logger.getAll()[0];
+    expect(entry).toBeDefined();
+    expect(entry.status).toBe("blocked");
+    expect(entry.entity).toBe("order");
+  });
+});

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -301,9 +301,107 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
   ): Promise<ActionResult<T>> {
     const executionId = generateExecutionId();
     const startedAt = new Date();
+    const currentDepth = execOptions?._depth ?? 0;
+    // Default channel matches the value used by the rest of the executor —
+    // also used for stamping `_channel` into meta.
+    const channel: ExecutionChannel = execOptions?.channel ?? "internal";
+
+    // Resolve execution meta. Spec 65 §9: every execution log entry — success,
+    // validation failure, recursion-check rejection, etc. — records the meta
+    // snapshot for audit / debugging / analytics. Resolving meta UP FRONT (before
+    // the depth check, action lookup, and validation steps) lets every
+    // `logExecution(...)` call thread `meta: metaSnapshot` through without
+    // reaching for the not-yet-built ExecutionMeta. Resolution itself can fail
+    // with `MetaSizeError` (oversize plain record at root, or oversize parent
+    // meta arriving via a duck-typed implementation); we surface that as a
+    // failed ActionResult so direct-executor callers see the same shape as
+    // other failures regardless of entry point.
+    //
+    // ### Root-vs-nested trust boundary (Gemini PR #201 review)
+    //
+    // At `currentDepth === 0` the provided meta comes from an **untrusted**
+    // external surface — a direct-executor call, a CommandLayer forward, a
+    // duck-typed ExecutionMeta, whatever. We always re-run through
+    // `createExecutionMeta` with the raw snapshot so:
+    //  1. `_`-prefixed keys are stripped (external callers cannot spoof
+    //     `_channel`, `_execution_id`, etc.).
+    //  2. Non-JSON-serializable values are filtered.
+    //  3. Framework-owned `rootSystemDefaults` always win.
+    //
+    // At `currentDepth > 0` the provided meta was built by the engine itself
+    // via `extendExecutionMeta` in `ctx.execute`, so it is framework-trusted;
+    // passing it through unchanged preserves the parent's `_execution_id`
+    // and other system keys across the chain.
+    //
+    // `_execution_id` is the ROOT execution record id (Spec 65 §4.4 — keyed
+    // against ExecutionLogger.getById), NOT a tracing id. ActionEngine owns
+    // its assignment.
+    const rootSystemDefaults: Record<string, unknown> = {
+      _channel: channel,
+      _execution_id: executionId,
+      _depth: currentDepth,
+    };
+    const providedMeta = execOptions?.meta;
+    let resolvedMeta: ExecutionMeta;
+    try {
+      if (!providedMeta) {
+        resolvedMeta = createExecutionMeta({ systemKeys: rootSystemDefaults });
+      } else if (currentDepth === 0) {
+        // Root entry — treat any provided meta as external input. Extract
+        // its raw snapshot (handles both ExecutionMeta and plain records)
+        // and push it through the untrusted-input factory.
+        const rawSnapshot = isExecutionMeta(providedMeta)
+          ? providedMeta.toJSON()
+          : (providedMeta as Record<string, unknown>);
+        resolvedMeta = createExecutionMeta({
+          raw: rawSnapshot,
+          systemKeys: rootSystemDefaults,
+        });
+      } else {
+        // Nested call — provided meta is framework-built via extend.
+        // Trust it, only filling system keys that somehow went missing
+        // (defensive — expected to be a no-op in practice).
+        resolvedMeta = isExecutionMeta(providedMeta)
+          ? fillMissingSystemKeys(providedMeta, rootSystemDefaults)
+          : createExecutionMeta({
+              raw: providedMeta as Record<string, unknown>,
+              systemKeys: rootSystemDefaults,
+            });
+      }
+    } catch (err) {
+      if (err instanceof MetaSizeError) {
+        // Meta resolution itself failed — no `metaSnapshot` is available yet.
+        // Record the system-default frame plus the rejected payload size as
+        // diagnostic context so audit can reconstruct what was attempted.
+        await logExecution({
+          id: executionId,
+          action: actionName,
+          actor,
+          input,
+          status: "failed",
+          error: { message: err.message, code: err.code },
+          meta: {
+            ...rootSystemDefaults,
+            _meta_rejected: { sizeBytes: err.sizeBytes, maxBytes: err.maxBytes },
+          },
+          startedAt,
+        });
+        return {
+          success: false,
+          data: { error: err.message, code: err.code } as T,
+          executionId,
+        };
+      }
+      throw err;
+    }
+    /**
+     * Frozen JSON snapshot of the resolved meta. Recorded on every execution
+     * log entry per Spec 65 §9. Captured once (not per log call) — meta is
+     * immutable after construction, so reusing the snapshot is safe.
+     */
+    const metaSnapshot = resolvedMeta.toJSON();
 
     // Step 0: Recursion depth check
-    const currentDepth = execOptions?._depth ?? 0;
     if (currentDepth > MAX_CHILD_DEPTH) {
       await logExecution({
         id: executionId,
@@ -312,6 +410,7 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
         input,
         status: "failed",
         error: { message: `Maximum child action recursion depth (${MAX_CHILD_DEPTH}) exceeded` },
+        meta: metaSnapshot,
         startedAt,
       });
       return {
@@ -359,6 +458,7 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
         input,
         status: "failed",
         error: { message: `Action "${actionName}" not found` },
+        meta: metaSnapshot,
         startedAt,
       });
       return {
@@ -384,8 +484,7 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
     // direct internal execute) so actor-type gating can't be bypassed.
     const skipExposure = execOptions?.skipExposureCheck ?? false;
 
-    // Exposure check — default channel to "internal" so the check always runs
-    const channel: ExecutionChannel = execOptions?.channel ?? "internal";
+    // `channel` was hoisted above for early meta resolution — reuse here.
     if (!skipExposure) {
       if (!isExposed(action.exposure, channel)) {
         const errorMsg = `Action "${actionName}" is not exposed for channel "${channel}"`;
@@ -397,6 +496,7 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
           input,
           status: "blocked",
           error: { message: errorMsg },
+          meta: metaSnapshot,
           startedAt,
         });
         return {
@@ -431,6 +531,7 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
         input,
         status: "blocked",
         error: { message: actorTypeError },
+        meta: metaSnapshot,
         startedAt,
       });
       return {
@@ -452,6 +553,7 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
         input,
         status: "failed",
         error: { message: "Input validation failed" },
+        meta: metaSnapshot,
         startedAt,
       });
       return {
@@ -627,6 +729,7 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
         input,
         status: "blocked",
         error: { message: errorMsg, code: "validation.field.locked" },
+        meta: metaSnapshot,
         startedAt,
       });
       // Metrics parity with Step 7's catch: declarative-path lock rejects
@@ -693,6 +796,7 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
         input,
         status: "blocked",
         error: { message: errorMsg, code: errorCode },
+        meta: metaSnapshot,
         startedAt,
       });
       // Metrics parity with Step 7's catch: declarative-path lock rejects
@@ -742,90 +846,9 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
     // retains only the existing-record fetch needed for Step 6 state
     // transition gating.
 
-    // Resolve execution meta. `execOptions.meta` is typed as
-    // `ExecutionMeta | Record<string, unknown>` so direct-executor callers can
-    // pass a plain record (e.g., `executor.execute(..., { meta: { foo: 1 } })`)
-    // without constructing an ExecutionMeta themselves — the natural call
-    // shape. Internally we always normalize to an ExecutionMeta before
-    // exposing on ctx.meta.
-    //
-    // `_execution_id` is the ROOT execution record id (Spec 65 §4.4 — keyed
-    // against ExecutionLogger.getById), NOT a tracing id. ActionEngine owns
-    // its assignment.
-    //
-    // ### Root-vs-nested trust boundary (Gemini PR #201 review)
-    //
-    // At `currentDepth === 0` the provided meta comes from an **untrusted**
-    // external surface — a direct-executor call, a CommandLayer forward, a
-    // duck-typed ExecutionMeta, whatever. We always re-run through
-    // `createExecutionMeta` with the raw snapshot so:
-    //  1. `_`-prefixed keys are stripped (external callers cannot spoof
-    //     `_channel`, `_execution_id`, etc.).
-    //  2. Non-JSON-serializable values are filtered.
-    //  3. Framework-owned `rootSystemDefaults` always win.
-    //
-    // At `currentDepth > 0` the provided meta was built by the engine itself
-    // via `extendExecutionMeta` in `ctx.execute`, so it is framework-trusted;
-    // passing it through unchanged preserves the parent's `_execution_id`
-    // and other system keys across the chain.
-    const rootSystemDefaults: Record<string, unknown> = {
-      _channel: channel,
-      _execution_id: executionId,
-      _depth: currentDepth,
-    };
-    const providedMeta = execOptions?.meta;
-    // Meta construction can throw MetaSizeError (plain-record wrap + size
-    // enforcement, or an already-oversized ExecutionMeta reaching the limit
-    // after system keys are added). Direct-executor callers bypass the
-    // CommandLayer's catch, so without handling here the exception would
-    // escape as unhandled. Return a normal failed ActionResult and log it
-    // so callers see the same shape regardless of entry point.
-    let resolvedMeta: ExecutionMeta;
-    try {
-      if (!providedMeta) {
-        resolvedMeta = createExecutionMeta({ systemKeys: rootSystemDefaults });
-      } else if (currentDepth === 0) {
-        // Root entry — treat any provided meta as external input. Extract
-        // its raw snapshot (handles both ExecutionMeta and plain records)
-        // and push it through the untrusted-input factory.
-        const rawSnapshot = isExecutionMeta(providedMeta)
-          ? providedMeta.toJSON()
-          : (providedMeta as Record<string, unknown>);
-        resolvedMeta = createExecutionMeta({
-          raw: rawSnapshot,
-          systemKeys: rootSystemDefaults,
-        });
-      } else {
-        // Nested call — provided meta is framework-built via extend.
-        // Trust it, only filling system keys that somehow went missing
-        // (defensive — expected to be a no-op in practice).
-        resolvedMeta = isExecutionMeta(providedMeta)
-          ? fillMissingSystemKeys(providedMeta, rootSystemDefaults)
-          : createExecutionMeta({
-              raw: providedMeta as Record<string, unknown>,
-              systemKeys: rootSystemDefaults,
-            });
-      }
-    } catch (err) {
-      if (err instanceof MetaSizeError) {
-        await logExecution({
-          id: executionId,
-          action: actionName,
-          entity: action.entity,
-          actor,
-          input,
-          status: "failed",
-          error: { message: err.message, code: err.code },
-          startedAt,
-        });
-        return {
-          success: false,
-          data: { error: err.message, code: err.code } as T,
-          executionId,
-        };
-      }
-      throw err;
-    }
+    // Meta was resolved at the top of `execute(...)` so every early-failure
+    // log entry (depth check, action lookup, exposure, validation) records
+    // the meta snapshot. `resolvedMeta` and `metaSnapshot` are in scope here.
 
     const ctx: ActionContext = {
       input,
@@ -966,6 +989,7 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
         input,
         status: "failed",
         error: { message: "Validation failed" },
+        meta: metaSnapshot,
         startedAt,
       });
       return {
@@ -1013,6 +1037,7 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
             input,
             status: "failed",
             error: { message: errorMsg },
+            meta: metaSnapshot,
             startedAt,
           });
           return {
@@ -1036,6 +1061,7 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
             input,
             status: "blocked",
             error: { message: errorMsg },
+            meta: metaSnapshot,
             startedAt,
           });
           return {
@@ -1068,6 +1094,7 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
             input,
             status: "blocked",
             error: { message: errorMsg },
+            meta: metaSnapshot,
             startedAt,
           });
           return {
@@ -1214,6 +1241,7 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
         stateTransition: stateTransitionRecord,
         childExecutionIds: childExecutionIds.length > 0 ? childExecutionIds : undefined,
         idempotencyKey,
+        meta: metaSnapshot,
         startedAt,
       });
 
@@ -1315,6 +1343,7 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
         error: { message: err instanceof Error ? err.message : String(err) },
         stateTransition: stateTransitionRecord,
         childExecutionIds: childExecutionIds.length > 0 ? childExecutionIds : undefined,
+        meta: metaSnapshot,
         startedAt,
       });
 

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -373,6 +373,18 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
         // Meta resolution itself failed — no `metaSnapshot` is available yet.
         // Record the system-default frame plus the rejected payload size as
         // diagnostic context so audit can reconstruct what was attempted.
+        // Mirror the early-failure metric pattern used by exposure / validation
+        // paths so monitoring dashboards see meta-size rejections.
+        const durationMs = Date.now() - startedAt.getTime();
+        metrics.increment("action.executed", {
+          action: actionName,
+          entity: "",
+          status: "failed",
+        });
+        metrics.timing("action.duration_ms", durationMs, {
+          action: actionName,
+          entity: "",
+        });
         await logExecution({
           id: executionId,
           action: actionName,

--- a/packages/core/src/persistence/drizzle-execution-logger.ts
+++ b/packages/core/src/persistence/drizzle-execution-logger.ts
@@ -54,6 +54,10 @@ export class DrizzleExecutionLogger {
       parentExecutionId: entry.parentExecutionId ?? null,
       idempotencyKey: entry.idempotencyKey ?? null,
       metadata: Object.keys(metadata).length > 0 ? metadata : null,
+      // Spec 65 §9 — ExecutionMeta snapshot. `entry.meta` is already a
+      // serializable record (from `ExecutionMeta.toJSON()`); Drizzle's jsonb
+      // column accepts the object directly and pg-driver handles serialization.
+      meta: entry.meta ?? null,
       startedAt: entry.startedAt,
       completedAt: entry.completedAt,
     });
@@ -185,6 +189,10 @@ function rowToEntry(row: ExecutionRow): ExecutionLogEntry {
     startedAt: row.startedAt,
     channel: row.channel ?? undefined,
     completedAt: row.completedAt ?? undefined,
+    // Spec 65 §9 — Drizzle returns jsonb columns as parsed JS objects, so we
+    // pass through directly. Returning `undefined` for null keeps round-trip
+    // shape parity with InMemoryExecutionLogger (which never sets meta to null).
+    meta: (row.meta as Record<string, unknown> | null) ?? undefined,
   };
 }
 

--- a/packages/core/src/persistence/system-tables.ts
+++ b/packages/core/src/persistence/system-tables.ts
@@ -71,6 +71,8 @@ export const executionsTable = linchkitSchema.table(
     parentExecutionId: varchar("parent_execution_id", { length: 255 }),
     idempotencyKey: varchar("idempotency_key", { length: 255 }),
     metadata: jsonb("metadata"),
+    /** Spec 65 §9 — ExecutionMeta snapshot recorded for every execution log entry */
+    meta: jsonb("meta"),
     startedAt: timestamp("started_at", { mode: "date" }).notNull().defaultNow(),
     completedAt: timestamp("completed_at", { mode: "date" }),
     createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),

--- a/packages/core/src/types/execution-log.ts
+++ b/packages/core/src/types/execution-log.ts
@@ -70,6 +70,18 @@ export interface ExecutionLogEntry {
   // Transport channel (e.g. "rest", "graphql", "mcp")
   channel?: string;
 
+  /**
+   * Execution metadata snapshot recorded at the time of execution (Spec 65 §9).
+   *
+   * Mirrors the JSON-friendly shape from `ExecutionMeta.toJSON()` rather than
+   * holding the live `ExecutionMeta` instance — log entries are persisted and
+   * cross process / network boundaries, so they need a serializable view.
+   * System keys (`_channel`, `_execution_id`, `_depth`, `_source_action`,
+   * etc.) are included so audits can reconstruct caller intent without
+   * re-deriving from other fields.
+   */
+  meta?: Record<string, unknown>;
+
   // Data change snapshots for audit trail
   changes?: Array<{
     entity: string;


### PR DESCRIPTION
## Summary

Phase 2A of Spec 65 (refs #149) wires the external transport entry points and observability for the `ExecutionMeta` machinery delivered in Phase 1 (PR #201).

### Surfaces

- **REST `X-Linch-Meta` header** (Spec 65 §3.1) — \`POST /api/actions/:name\` and \`POST /api/actions/batch\` parse the header into a JSON object and forward it through the pipeline. Malformed headers return 400 with structured codes \`META.PARSE.OVERSIZE\` / \`META.PARSE.INVALID_JSON\` / \`META.PARSE.NOT_OBJECT\`. 8 KB cap is enforced pre-parse to bound CPU.
- **GraphQL \`meta\` arg** (Spec 65 §3.2) — every action mutation (\`executeAction\`, \`create_*\`, \`update_*\`, \`delete_*\`, \`restore_*\`, \`transition_*\`, custom action mutations) now accepts an optional \`meta: GraphQLString\` JSON-encoded argument. \`dispatchAction()\` is the chokepoint, so this propagates uniformly. Empty-string \`meta: \"\"\` is rejected as invalid JSON for contract parity.
- **Execution log recording** (Spec 65 §9) — \`ExecutionLogEntry.meta\` populated on every log frame (success / validation failure / recursion check / exposure block / lock violations / state-transition failures). Meta-size rejections record a synthetic frame with \`_meta_rejected: { sizeBytes, maxBytes }\`.
- **Drizzle persistence + query surface** — \`_linchkit.executions.meta\` JSONB column added (migration 0002_loving_kang.sql); \`DrizzleExecutionLogger\` writes/hydrates meta; \`executionLogSchema\` exposes the field so \`/api/entities/execution_log\` and admin UIs can show it.

### Cross-model review fixes (commit 2)

- Codex P2: Drizzle logger persisting meta — fixed via column + serialization round-trip.
- Codex P2: execution_log entity exposing meta — fixed via schema field + record converter.
- Codex P3: Empty GraphQL meta string strict parse — fixed at 7 resolver sites.
- Gemini P2: Entity stamping on early-failure logs — verified existing coverage; added 2 regression tests.

### Out of scope (Phase 2B + follow-ups)

- CLI \`--meta\` flag (§3.5)
- MCP \`_mcp_client_id\` auto-inject (§3.3)
- Rule \`meta.*\` condition resolution (§6)
- \`EventHandlerContext.meta\` (§7)
- \`execution.meta.maskedKeys\` config wiring for log redaction (§9, §10.3)

## Test plan

- [x] \`packages/core/__tests__/execution-logger.test.ts\` — meta snapshot recording (success / failure / size-reject / no-meta / entity-stamp regressions)
- [x] \`packages/core/__tests__/drizzle-execution-logger.test.ts\` (new) — write/hydrate round-trip
- [x] \`addons/adapter-server/cap-adapter-server/__tests__/exec-meta-transports.test.ts\` (new, 16 cases) — REST single + batch + GraphQL all mutation types
- [x] \`addons/adapter-server/cap-adapter-server/__tests__/graphql-execution-log.test.ts\` — meta surfaces through executionLogList
- [x] All quality gates pass: \`bun run check\` + \`bun run typecheck\` + \`bun test\` (4533 pass / 3 skip / 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added metadata support to actions: pass custom metadata through GraphQL mutations via the `meta` argument or REST API using the `X-Linch-Meta` header.
  * Execution metadata is now automatically captured and persisted in execution logs for improved traceability and auditing.
  * Built-in validation ensures metadata is properly formatted and size-limited, with automatic system metadata management.

* **Tests**
  * Added comprehensive test coverage for metadata handling across GraphQL and REST transports, including validation and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->