### PR TITLE
feat(core): execution.meta.maskedKeys redaction (Spec 65 §10.3, closes #214)

### DIFF
--- a/packages/core/__tests__/drizzle-execution-logger.test.ts
+++ b/packages/core/__tests__/drizzle-execution-logger.test.ts
@@ -168,4 +168,33 @@ describe("DrizzleExecutionLogger — meta jsonb column (Spec 65 §9)", () => {
     expect(retrieved).toBeDefined();
     expect(retrieved?.meta).toBeUndefined();
   });
+
+  // Spec 65 §10.3 regression: redaction is applied by the ActionEngine BEFORE
+  // the entry reaches the Drizzle logger, so masked values must persist as
+  // `"***"` and survive the JSONB hydration round-trip unchanged. This guards
+  // against any future logger-side serializer that might second-guess the
+  // value (e.g., re-write `"***"` to null).
+  test("masked '***' values survive write -> hydrate round-trip", async () => {
+    const { db } = createStubDb();
+    const logger = new DrizzleExecutionLogger(db);
+
+    const redactedMeta = {
+      // Already redacted by the engine — logger persists what it receives.
+      password: "***",
+      auth_token: "***",
+      // Plaintext non-sensitive fields untouched.
+      source_view: "queue",
+      _channel: "http",
+      _depth: 0,
+      _execution_id: "exec_redact_roundtrip",
+    };
+    await logger.log({ ...baseEntry, id: "exec_redact_roundtrip", meta: redactedMeta });
+
+    const retrieved = await logger.getById("exec_redact_roundtrip");
+    expect(retrieved).toBeDefined();
+    expect(retrieved?.meta).toEqual(redactedMeta);
+    expect(retrieved?.meta?.password).toBe("***");
+    expect(retrieved?.meta?.auth_token).toBe("***");
+    expect(retrieved?.meta?.source_view).toBe("queue");
+  });
 });

--- a/packages/core/__tests__/execution-logger.test.ts
+++ b/packages/core/__tests__/execution-logger.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { ConfigRegistry } from "../src/config/config-registry";
 import { createActionExecutor, type DataProvider } from "../src/engine/action-engine";
 import { InMemoryExecutionLogger } from "../src/observability/execution-logger";
 import type { ActionDefinition, Actor } from "../src/types/action";
@@ -455,5 +456,181 @@ describe("ExecutionLogger — early-failure entity stamping", () => {
     expect(entry).toBeDefined();
     expect(entry.status).toBe("blocked");
     expect(entry.entity).toBe("order");
+  });
+});
+
+// ── Spec 65 §10.3 — Meta redaction at log boundary ─────────
+//
+// Sensitive meta keys configured via `system:execution.meta.maskedKeys` must
+// be replaced with `"***"` in persisted log entries. The in-memory
+// ExecutionMeta itself stays plaintext so handlers reading mid-execution
+// still see real values. Defaults apply when no config is wired.
+
+describe("ExecutionLogger — meta redaction (Spec 65 §10.3)", () => {
+  /**
+   * Action that asserts the in-memory ctx.meta view is NOT redacted, then
+   * returns the resolved value so callers can assert it from the outside.
+   */
+  const readMetaAction: ActionDefinition = {
+    name: "read_meta",
+    entity: "order",
+    label: "Read Meta",
+    policy: { mode: "sync", transaction: false },
+    handler: async (ctx) => {
+      // Spec 65 §10.3 — handler still sees real value mid-execution. Read
+      // both casings the call sites use so per-test assertions can pick the
+      // right one without forking the action definition.
+      return {
+        auth_token_in_handler: ctx.meta.get("auth_token"),
+        password_in_handler: ctx.meta.get("password"),
+        Password_in_handler: ctx.meta.get("Password"),
+      };
+    },
+  };
+
+  it("redacts default-listed keys (password/token/secret/api_key) in log entries", async () => {
+    const logger = new InMemoryExecutionLogger();
+    // No configRegistry provided — built-in defaults must still apply.
+    const executor = createActionExecutor({
+      dataProvider: createMockDataProvider(),
+      executionLogger: logger,
+    });
+
+    executor.registry.register(readMetaAction);
+    const result = await executor.execute("read_meta", {}, defaultActor, {
+      meta: {
+        auth_token: "real-token",
+        password: "hunter2",
+        secret: "shhh",
+        api_key: "k-123",
+        source_view: "queue",
+      },
+    });
+
+    expect(result.success).toBe(true);
+
+    const entry = logger.getAll()[0];
+    // `auth_token` is NOT in the default list — only literal "token" is.
+    // The default list intentionally errs on the side of fewer matches; users
+    // configure additional keys via system:execution.meta.maskedKeys.
+    expect(entry.meta?.auth_token).toBe("real-token");
+    expect(entry.meta?.password).toBe("***");
+    expect(entry.meta?.secret).toBe("***");
+    expect(entry.meta?.api_key).toBe("***");
+    // Non-matched keys preserved verbatim.
+    expect(entry.meta?.source_view).toBe("queue");
+    // Handler saw the real values mid-execution.
+    expect((result.data as Record<string, unknown>).password_in_handler).toBe("hunter2");
+  });
+
+  it("masks case-insensitively (Password matches default 'password')", async () => {
+    const logger = new InMemoryExecutionLogger();
+    const executor = createActionExecutor({
+      dataProvider: createMockDataProvider(),
+      executionLogger: logger,
+    });
+
+    executor.registry.register(readMetaAction);
+    const result = await executor.execute("read_meta", {}, defaultActor, {
+      meta: { Password: "uppercase-secret" },
+    });
+
+    expect(result.success).toBe(true);
+    const entry = logger.getAll()[0];
+    expect(entry.meta?.Password).toBe("***");
+    // Handler still saw the original casing/value (uppercase key).
+    expect((result.data as Record<string, unknown>).Password_in_handler).toBe("uppercase-secret");
+  });
+
+  it("respects custom maskedKeys via configRegistry", async () => {
+    const logger = new InMemoryExecutionLogger();
+    // Configure a non-default list — only `auth_token` is masked.
+    const configRegistry = ConfigRegistry.create(
+      {
+        execution: {
+          meta: {
+            maskedKeys: ["auth_token"],
+          },
+        },
+      },
+      [],
+    );
+    const executor = createActionExecutor({
+      dataProvider: createMockDataProvider(),
+      executionLogger: logger,
+      configRegistry,
+    });
+
+    executor.registry.register(readMetaAction);
+    await executor.execute("read_meta", {}, defaultActor, {
+      meta: {
+        auth_token: "should-mask",
+        // `password` is in defaults but NOT in this custom list — preserved.
+        password: "should-NOT-mask",
+      },
+    });
+
+    const entry = logger.getAll()[0];
+    expect(entry.meta?.auth_token).toBe("***");
+    expect(entry.meta?.password).toBe("should-NOT-mask");
+  });
+
+  it("does not mask anything when configured maskedKeys is empty", async () => {
+    const logger = new InMemoryExecutionLogger();
+    const configRegistry = ConfigRegistry.create(
+      {
+        execution: {
+          meta: {
+            maskedKeys: [],
+          },
+        },
+      },
+      [],
+    );
+    const executor = createActionExecutor({
+      dataProvider: createMockDataProvider(),
+      executionLogger: logger,
+      configRegistry,
+    });
+
+    executor.registry.register(readMetaAction);
+    await executor.execute("read_meta", {}, defaultActor, {
+      meta: { password: "leak" },
+    });
+
+    const entry = logger.getAll()[0];
+    expect(entry.meta?.password).toBe("leak");
+  });
+
+  it("preserves non-matching keys verbatim alongside masked keys", async () => {
+    const logger = new InMemoryExecutionLogger();
+    const configRegistry = ConfigRegistry.create(
+      {
+        execution: {
+          meta: {
+            maskedKeys: ["password"],
+          },
+        },
+      },
+      [],
+    );
+    const executor = createActionExecutor({
+      dataProvider: createMockDataProvider(),
+      executionLogger: logger,
+      configRegistry,
+    });
+
+    executor.registry.register(readMetaAction);
+    await executor.execute("read_meta", {}, defaultActor, {
+      meta: { password: "p", username: "alice", source_view: "queue" },
+      channel: "http",
+    });
+
+    const entry = logger.getAll()[0];
+    expect(entry.meta?.password).toBe("***");
+    expect(entry.meta?.username).toBe("alice");
+    expect(entry.meta?.source_view).toBe("queue");
+    // System keys flow through untouched.
+    expect(entry.meta?._channel).toBe("http");
   });
 });

--- a/packages/core/__tests__/execution-meta.test.ts
+++ b/packages/core/__tests__/execution-meta.test.ts
@@ -521,4 +521,30 @@ describe("redactMetaForLog", () => {
     const out = redactMetaForLog(nested, ["credentials"]);
     expect(out).toEqual({ credentials: "***", other: "o" });
   });
+
+  // Codex + Gemini Phase 2A maskedKeys review: out[key] = ... for key
+  // === "__proto__" mutates the destination's prototype on a plain
+  // object. Verify the helper's null-prototype output prevents both
+  // pollution and key loss.
+  test("preserves a literal __proto__ key without polluting the prototype", () => {
+    const input = JSON.parse('{"__proto__":{"polluted":true},"normal":"n"}') as Record<
+      string,
+      unknown
+    >;
+    const out = redactMetaForLog(input, ["password"]);
+    expect(out).toBeDefined();
+    // The literal __proto__ key survives as data, not a prototype mutation.
+    expect(Object.hasOwn(out as object, "__proto__")).toBe(true);
+    expect(Object.hasOwn(out as object, "normal")).toBe(true);
+    // Pollution check — Object.prototype is not modified.
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    // JSON.stringify still works on the null-prototype output.
+    expect(typeof JSON.stringify(out)).toBe("string");
+  });
+
+  test("preserves a literal constructor key when not in the masked list", () => {
+    const input = { constructor: "user-data", normal: "n" };
+    const out = redactMetaForLog(input, ["password"]);
+    expect((out as Record<string, unknown>).constructor).toBe("user-data");
+  });
 });

--- a/packages/core/__tests__/execution-meta.test.ts
+++ b/packages/core/__tests__/execution-meta.test.ts
@@ -14,6 +14,7 @@ import {
   ExecutionMetaImpl,
   extendExecutionMeta,
   MetaSizeError,
+  redactMetaForLog,
 } from "../src/types/execution-meta";
 
 describe("ExecutionMetaImpl", () => {
@@ -448,5 +449,76 @@ describe("ExecutionMetaImpl constructor self-enforcement", () => {
     });
     expect(meta.has("bad")).toBe(false);
     expect(meta.get("okay")).toEqual({ inner: 1 });
+  });
+});
+
+// Spec 65 §10.3 — redactMetaForLog: log-time masking of sensitive keys.
+// Document the v1 design choices (top-level only, case-insensitive exact match,
+// non-mutating).
+describe("redactMetaForLog", () => {
+  test("returns undefined when meta is undefined", () => {
+    expect(redactMetaForLog(undefined, ["password"])).toBeUndefined();
+  });
+
+  test("returns input unchanged when maskedKeys is empty", () => {
+    const input = { a: 1, password: "secret" };
+    expect(redactMetaForLog(input, [])).toBe(input);
+  });
+
+  test("masks exact case matches with '***'", () => {
+    const out = redactMetaForLog({ password: "hunter2", source: "queue" }, ["password"]);
+    expect(out).toEqual({ password: "***", source: "queue" });
+  });
+
+  test("matches case-insensitively (Password matches password)", () => {
+    const out = redactMetaForLog({ Password: "p", API_KEY: "k", normal: "n" }, [
+      "password",
+      "api_key",
+    ]);
+    expect(out).toEqual({ Password: "***", API_KEY: "***", normal: "n" });
+  });
+
+  test("non-matched keys are preserved verbatim", () => {
+    const out = redactMetaForLog({ password: "p", username: "alice", _channel: "http" }, [
+      "password",
+    ]);
+    expect(out).toEqual({ password: "***", username: "alice", _channel: "http" });
+  });
+
+  test("does not mutate the input object", () => {
+    const input = { password: "p", other: "o" };
+    const before = { ...input };
+    const out = redactMetaForLog(input, ["password"]);
+    expect(input).toEqual(before);
+    expect(out).not.toBe(input);
+  });
+
+  test("preserves _-prefixed system keys unchanged when not in maskedKeys", () => {
+    const out = redactMetaForLog({ _channel: "http", _execution_id: "exec_1", source: "queue" }, [
+      "password",
+    ]);
+    expect(out?._channel).toBe("http");
+    expect(out?._execution_id).toBe("exec_1");
+    expect(out?.source).toBe("queue");
+  });
+
+  test("masks _-prefixed keys when explicitly listed", () => {
+    // Defensive symmetry — the helper does not special-case system keys.
+    const out = redactMetaForLog({ _secret_token: "x" }, ["_secret_token"]);
+    expect(out).toEqual({ _secret_token: "***" });
+  });
+
+  test("does NOT recurse into nested objects (top-level only)", () => {
+    // Spec 65 §10.3 talks about "keys", not "paths". A nested
+    // `{ user: { password } }` is preserved unless `user` itself is masked.
+    const nested = { user: { password: "p" }, other: "o" };
+    const out = redactMetaForLog(nested, ["password"]);
+    expect(out).toEqual({ user: { password: "p" }, other: "o" });
+  });
+
+  test("masks the entire nested object when its top-level key matches", () => {
+    const nested = { credentials: { user: "a", password: "p" }, other: "o" };
+    const out = redactMetaForLog(nested, ["credentials"]);
+    expect(out).toEqual({ credentials: "***", other: "o" });
   });
 });

--- a/packages/core/src/config/config-registry.ts
+++ b/packages/core/src/config/config-registry.ts
@@ -9,7 +9,13 @@ import { LinchKitError } from "../errors";
 import type { CapabilityDefinition } from "../types/capability";
 import type { LinchKitConfig } from "../types/config";
 import { resolveEnvVars } from "../utils/env";
-import { databaseConfig, queueConfig, securityConfig, serverConfig } from "./system-schemas";
+import {
+  databaseConfig,
+  executionConfig,
+  queueConfig,
+  securityConfig,
+  serverConfig,
+} from "./system-schemas";
 
 /** Deep-freeze an object recursively */
 function deepFreeze<T>(obj: T): Readonly<T> {
@@ -31,6 +37,7 @@ const SYSTEM_SCHEMAS = [
   { key: "database", ref: databaseConfig },
   { key: "queue", ref: queueConfig },
   { key: "security", ref: securityConfig },
+  { key: "execution", ref: executionConfig },
 ] as const;
 
 /** Format a single Zod error into human-readable lines */

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -16,4 +16,11 @@ export type { ConfigSchemaRef } from "./define-config-schema";
 export { defineConfigSchema } from "./define-config-schema";
 export type { ConfigValueHistoryEntry } from "./runtime-config-registry";
 export { ConfigValidationError, RuntimeConfigRegistry } from "./runtime-config-registry";
-export { databaseConfig, queueConfig, securityConfig, serverConfig } from "./system-schemas";
+export {
+  DEFAULT_EXECUTION_META_MASKED_KEYS,
+  databaseConfig,
+  executionConfig,
+  queueConfig,
+  securityConfig,
+  serverConfig,
+} from "./system-schemas";

--- a/packages/core/src/config/system-schemas.ts
+++ b/packages/core/src/config/system-schemas.ts
@@ -32,3 +32,36 @@ export const securityConfig = defineConfigSchema("system:security", {
     })
     .optional(),
 });
+
+/**
+ * Built-in default list of meta keys to mask in execution-log output (Spec 65 §10.3).
+ *
+ * Matched case-insensitively against top-level meta keys at log-write time.
+ * Values are replaced with `"***"` only in the persisted log entry — the
+ * in-memory `ctx.meta.get("auth_token")` view stays plaintext for handlers.
+ */
+export const DEFAULT_EXECUTION_META_MASKED_KEYS: ReadonlyArray<string> = [
+  "password",
+  "token",
+  "secret",
+  "api_key",
+] as const;
+
+export const executionConfig = defineConfigSchema("system:execution", {
+  meta: z
+    .object({
+      /**
+       * Top-level meta keys to redact when an execution log entry is written.
+       * Matching is case-insensitive (`"Password"` in meta hits a `"password"`
+       * entry here). Values for matched keys become the literal string `"***"`
+       * in the persisted log; the in-memory ExecutionMeta value is unchanged
+       * so handlers that read sensitive context mid-execution still see the
+       * real value.
+       *
+       * Nested-path masking (`user.password`) and glob/regex matching are
+       * deliberately out of scope for v1 (Spec 65 §10.3 — "keys" not "paths").
+       */
+      maskedKeys: z.array(z.string()).default([...DEFAULT_EXECUTION_META_MASKED_KEYS]),
+    })
+    .default({ maskedKeys: [...DEFAULT_EXECUTION_META_MASKED_KEYS] }),
+});

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -301,7 +301,9 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
     if (!configRegistry?.has("system:execution")) {
       return DEFAULT_EXECUTION_META_MASKED_KEYS;
     }
-    const cfg = configRegistry.get<{ meta: { maskedKeys: string[] } }>("system:execution");
+    const cfg = configRegistry.get<{ meta: { maskedKeys: ReadonlyArray<string> } }>(
+      "system:execution",
+    );
     return cfg.meta.maskedKeys;
   })();
 

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -7,6 +7,7 @@
  */
 
 import { ConfigRegistry } from "../config/config-registry";
+import { DEFAULT_EXECUTION_META_MASKED_KEYS } from "../config/system-schemas";
 import type { EntityRegistry } from "../entity/entity-registry";
 import type { EventBus } from "../event/event-bus";
 import type { MetricsCollector } from "../observability/metrics";
@@ -18,7 +19,12 @@ import type { AIService } from "../types/ai";
 import type { FieldDefinition } from "../types/entity";
 import type { ExecutionLogEntry, ExecutionLogger } from "../types/execution-log";
 import type { ExecutionMeta } from "../types/execution-meta";
-import { createExecutionMeta, extendExecutionMeta, MetaSizeError } from "../types/execution-meta";
+import {
+  createExecutionMeta,
+  extendExecutionMeta,
+  MetaSizeError,
+  redactMetaForLog,
+} from "../types/execution-meta";
 import type { Logger } from "../types/logger";
 import {
   checkFieldLocks,
@@ -280,14 +286,44 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
   const noopLogger: Logger = { debug: noopFn, info: noopFn, warn: noopFn, error: noopFn };
   const logger: Logger = injectedLogger ?? noopLogger;
 
-  /** Helper: build and log an execution entry */
+  /**
+   * Resolve the configured `system:execution.meta.maskedKeys` list once at
+   * executor-construction time. Falls back to the built-in default list when
+   * no ConfigRegistry was injected (test path) — the redaction guarantee
+   * (Spec 65 §10.3) must hold regardless of whether the runtime configured
+   * the namespace explicitly.
+   *
+   * Resolved at construction (not per-execute) because the registry is
+   * immutable after creation — re-reading on every call would just be lost
+   * work.
+   */
+  const maskedKeys: ReadonlyArray<string> = (() => {
+    if (!configRegistry?.has("system:execution")) {
+      return DEFAULT_EXECUTION_META_MASKED_KEYS;
+    }
+    const cfg = configRegistry.get<{ meta: { maskedKeys: string[] } }>("system:execution");
+    return cfg.meta.maskedKeys;
+  })();
+
+  /**
+   * Build and log an execution entry. Applies meta redaction (Spec 65 §10.3)
+   * at the log boundary so the persisted entry replaces configured sensitive
+   * keys with `"***"`. The in-memory `metaSnapshot` callers pass in remains
+   * plaintext — only the value handed to the logger is redacted.
+   */
   async function logExecution(
     entry: Omit<ExecutionLogEntry, "completedAt" | "duration"> & { startedAt: Date },
   ): Promise<void> {
     if (!executionLogger) return;
     const completedAt = new Date();
     const duration = completedAt.getTime() - entry.startedAt.getTime();
-    await executionLogger.log({ ...entry, completedAt, duration } as ExecutionLogEntry);
+    const redactedMeta = redactMetaForLog(entry.meta, maskedKeys);
+    await executionLogger.log({
+      ...entry,
+      meta: redactedMeta,
+      completedAt,
+      duration,
+    } as ExecutionLogEntry);
   }
 
   /** Maximum recursion depth for child action execution */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -85,8 +85,10 @@ export type {
 export {
   ConfigRegistry,
   ConfigValidationError,
+  DEFAULT_EXECUTION_META_MASKED_KEYS,
   databaseConfig,
   defineConfigSchema,
+  executionConfig,
   InMemoryConfigStore,
   queueConfig,
   RuntimeConfigRegistry,

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -43,6 +43,20 @@ export interface LinchKitConfig {
     };
   };
 
+  /**
+   * Execution-context configuration (Spec 65).
+   *
+   * Currently only `meta.maskedKeys` is supported — top-level keys whose
+   * values are replaced with `"***"` when written to the execution log.
+   * In-memory `ctx.meta.get(...)` reads stay plaintext.
+   */
+  execution?: {
+    meta?: {
+      /** Top-level meta keys to redact in execution log entries (case-insensitive). */
+      maskedKeys?: string[];
+    };
+  };
+
   /** GitHub integration */
   github?: {
     repo?: string;

--- a/packages/core/src/types/execution-meta.ts
+++ b/packages/core/src/types/execution-meta.ts
@@ -298,6 +298,48 @@ export function extendExecutionMeta(
   return impl.extend(extra, systemOverrides);
 }
 
+/**
+ * Produce a redacted shallow copy of `meta` suitable for writing to an
+ * ExecutionLogger entry (Spec 65 §10.3).
+ *
+ * Behavior:
+ * - Returns `undefined` when `meta` is `undefined`.
+ * - Returns the input unchanged when `maskedKeys` is empty.
+ * - Top-level keys only — nested-path matching is out of scope for v1
+ *   (Spec 65 §10.3 — "keys", not "paths"). A nested `{ user: { password } }`
+ *   is preserved verbatim unless `user` itself is in `maskedKeys`.
+ * - Case-insensitive exact match (`"Password"` in input matches `"password"`
+ *   in `maskedKeys`).
+ * - System keys (`_`-prefixed) are preserved unchanged unless explicitly
+ *   listed in `maskedKeys`.
+ * - Replaces matched values with the literal string `"***"`.
+ * - Never mutates the input — always returns a new object on the masking path.
+ *
+ * Storage of the in-memory `ExecutionMeta` itself stays plaintext: this
+ * helper applies only at the moment a log entry is constructed, so handlers
+ * reading `ctx.meta.get("auth_token")` mid-execution still see the real value.
+ *
+ * @param meta - The execution-meta snapshot (typically from `ExecutionMeta.toJSON()`).
+ * @param maskedKeys - List of keys to redact, matched case-insensitively.
+ */
+export function redactMetaForLog(
+  meta: Record<string, unknown> | undefined,
+  maskedKeys: ReadonlyArray<string>,
+): Record<string, unknown> | undefined {
+  if (meta === undefined) return undefined;
+  if (maskedKeys.length === 0) return meta;
+
+  // Build a Set of lowercase masked keys for O(1) per-key lookup.
+  const maskedSet = new Set<string>();
+  for (const k of maskedKeys) maskedSet.add(k.toLowerCase());
+
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(meta)) {
+    out[key] = maskedSet.has(key.toLowerCase()) ? "***" : value;
+  }
+  return out;
+}
+
 export interface CreateExecutionMetaOptions {
   /** Caller-provided raw meta (external input). `_`-prefixed keys stripped. */
   raw?: Record<string, unknown>;

--- a/packages/core/src/types/execution-meta.ts
+++ b/packages/core/src/types/execution-meta.ts
@@ -333,7 +333,12 @@ export function redactMetaForLog(
   const maskedSet = new Set<string>();
   for (const k of maskedKeys) maskedSet.add(k.toLowerCase());
 
-  const out: Record<string, unknown> = {};
+  // Use a null-prototype object so a meta payload containing a literal
+  // `__proto__` key (or `constructor` / `prototype`) cannot mutate the
+  // output's prototype chain via `out[key] = ...`. JSON.stringify and
+  // Object.entries treat null-prototype objects identically to plain
+  // objects, so log consumers see no behavioral difference.
+  const out: Record<string, unknown> = Object.create(null);
   for (const [key, value] of Object.entries(meta)) {
     out[key] = maskedSet.has(key.toLowerCase()) ? "***" : value;
   }

--- a/packages/core/src/types/execution-meta.ts
+++ b/packages/core/src/types/execution-meta.ts
@@ -330,8 +330,7 @@ export function redactMetaForLog(
   if (maskedKeys.length === 0) return meta;
 
   // Build a Set of lowercase masked keys for O(1) per-key lookup.
-  const maskedSet = new Set<string>();
-  for (const k of maskedKeys) maskedSet.add(k.toLowerCase());
+  const maskedSet = new Set(maskedKeys.map((k) => k.toLowerCase()));
 
   // Use a null-prototype object so a meta payload containing a literal
   // `__proto__` key (or `constructor` / `prototype`) cannot mutate the

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -42,6 +42,7 @@ export {
   createExecutionMeta,
   DEFAULT_META_MAX_BYTES,
   MetaSizeError,
+  redactMetaForLog,
 } from "./execution-meta";
 export type * from "./flow";
 export type * from "./life-system";


### PR DESCRIPTION
## Summary

Closes #214 — wires \`execution.meta.maskedKeys\` config (Spec 65 §10.3) for execution-log redaction. Resolves the security follow-up gemini flagged on PR #213 Phase 2A.

In-memory \`ctx.meta.get(...)\` continues to return real values during execution; redaction applies **only at log time** before the entry hits ExecutionLogger.

### Surfaces

- **Config** — new \`executionConfig\` schema (\`system:execution\`) with \`meta.maskedKeys: string[]\`. Defaults: \`[\"password\", \"token\", \"secret\", \"api_key\"]\`. Case-insensitive exact-key match. Wired into \`LinchKitConfig\` for typed \`defineConfig\` consumers.
- **Helper** — pure \`redactMetaForLog(meta, maskedKeys)\` in \`types/execution-meta.ts\`. Top-level only (Spec 65 §10.3 talks about \"keys\" not paths). Returns a fresh object without mutating input.
- **ActionEngine** — \`maskedKeys\` resolved once at executor construction, redaction applied inside the \`logExecution()\` helper so every call site (success / failed / blocked / MetaSizeError synthetic frame) is uniformly redacted.

### Cross-model review fix

Both codex and gemini flagged a prototype-pollution issue: a meta payload containing a literal \`__proto__\` key would mutate the output's prototype via \`out[key] = ...\`. Fixed by using \`Object.create(null)\` for the output (commit 054aefe). Two regression tests added covering \`__proto__\` and \`constructor\` keys.

## Test plan

- [x] \`execution-meta.test.ts\` — 12 cases covering redactMetaForLog (identity, exact match, case-insensitive, no mutation, no recursion, prototype pollution, etc.)
- [x] \`execution-logger.test.ts\` — 5 cases covering integration (default list, custom list, handler still sees real value, etc.)
- [x] \`drizzle-execution-logger.test.ts\` — \`***\` round-trip through JSONB column
- [x] All quality gates pass: \`bun run check\` + \`bun run typecheck\` + \`bun test\` (4552 pass / 3 skip / 0 fail)

## Out of scope (v2 follow-ups noted in #214)

- Glob/regex key matching
- Nested-path masking (\`user.password\`)
- Per-entity / per-action override

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Execution logs now automatically redact configured sensitive metadata keys; masked values appear as "***" in persisted logs while handlers see the unredacted meta.
  * System configuration now includes an execution section to customize masked keys and defaults are provided.

* **Tests**
  * Added comprehensive unit and integration tests covering redaction behavior, case-insensitivity, configuration overrides, disabling masking, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->