### PR TITLE
feat(core): persist ctx.meta across approval suspend/resume (Spec 65 §14 M6, closes #199)

### DIFF
--- a/drizzle/migrations/0003_massive_otto_octavius.sql
+++ b/drizzle/migrations/0003_massive_otto_octavius.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "_linchkit"."approvals" ADD COLUMN "meta" jsonb;

--- a/drizzle/migrations/meta/0003_snapshot.json
+++ b/drizzle/migrations/meta/0003_snapshot.json
@@ -1,0 +1,1069 @@
+{
+  "id": "82b9dd02-071e-4454-8b54-50de5af70d07",
+  "prevId": "9498d302-179d-4ef8-9cd9-ce4f32d36a9a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "_linchkit.approvals": {
+      "name": "approvals",
+      "schema": "_linchkit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capability": {
+          "name": "capability",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_rules": {
+          "name": "trigger_rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_type": {
+          "name": "assignee_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_value": {
+          "name": "assignee_value",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "approval_status",
+          "typeSchema": "_linchkit",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_note": {
+          "name": "decision_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_policy": {
+          "name": "timeout_policy",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reject'"
+        },
+        "original_execution_id": {
+          "name": "original_execution_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_error": {
+          "name": "execution_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.department": {
+      "name": "department",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_version": {
+          "name": "_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_extensions": {
+          "name": "_extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manager": {
+          "name": "manager",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budget_limit": {
+          "name": "budget_limit",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "department_name_unique": {
+          "name": "department_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        },
+        "department_code_unique": {
+          "name": "department_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["code"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "_linchkit.events": {
+      "name": "events",
+      "schema": "_linchkit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_action": {
+          "name": "source_action",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_execution_id": {
+          "name": "source_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_status",
+          "typeSchema": "_linchkit",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_events_type_status": {
+          "name": "idx_events_type_status",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_retry": {
+          "name": "idx_events_retry",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_tenant": {
+          "name": "idx_events_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "_linchkit.executions": {
+      "name": "executions",
+      "schema": "_linchkit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capability": {
+          "name": "capability",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "execution_status",
+          "typeSchema": "_linchkit",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_execution_id": {
+          "name": "parent_execution_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_executions_action_created": {
+          "name": "idx_executions_action_created",
+          "columns": [
+            {
+              "expression": "action_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executions_tenant": {
+          "name": "idx_executions_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_executions_idempotency_key": {
+          "name": "idx_executions_idempotency_key",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "_linchkit.field_overlays": {
+      "name": "field_overlays",
+      "schema": "_linchkit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_type": {
+          "name": "field_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "overlay_status",
+          "typeSchema": "_linchkit",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_field_overlays_entity_field": {
+          "name": "idx_field_overlays_entity_field",
+          "columns": [
+            {
+              "expression": "entity_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_item": {
+      "name": "purchase_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_version": {
+          "name": "_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_extensions": {
+          "name": "_extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specification": {
+          "name": "specification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_total": {
+          "name": "line_total",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_request_id": {
+          "name": "purchase_request_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_item_purchase_request_id_purchase_request_id_fk": {
+          "name": "purchase_item_purchase_request_id_purchase_request_id_fk",
+          "tableFrom": "purchase_item",
+          "tableTo": "purchase_request",
+          "columnsFrom": ["purchase_request_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_request": {
+      "name": "purchase_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_version": {
+          "name": "_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_extensions": {
+          "name": "_extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester": {
+          "name": "requester",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requester_email": {
+          "name": "requester_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audit_notes": {
+          "name": "audit_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department_id": {
+          "name": "department_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_request_department_id_department_id_fk": {
+          "name": "purchase_request_department_id_department_id_fk",
+          "tableFrom": "purchase_request",
+          "tableTo": "department",
+          "columnsFrom": ["department_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "_linchkit.approval_status": {
+      "name": "approval_status",
+      "schema": "_linchkit",
+      "values": ["pending", "approved", "rejected", "expired", "cancelled"]
+    },
+    "_linchkit.event_status": {
+      "name": "event_status",
+      "schema": "_linchkit",
+      "values": ["pending", "processing", "completed", "failed", "dead_letter"]
+    },
+    "_linchkit.execution_status": {
+      "name": "execution_status",
+      "schema": "_linchkit",
+      "values": ["succeeded", "failed", "blocked", "pending_approval"]
+    },
+    "_linchkit.overlay_status": {
+      "name": "overlay_status",
+      "schema": "_linchkit",
+      "values": ["active", "deprecated", "promoted"]
+    }
+  },
+  "schemas": {
+    "_linchkit": "_linchkit"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1777128126634,
       "tag": "0002_loving_kang",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1777280902455,
+      "tag": "0003_massive_otto_octavius",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/__tests__/approval.test.ts
+++ b/packages/core/__tests__/approval.test.ts
@@ -327,6 +327,38 @@ describe("ApprovalEngine", () => {
     expect(stored?.triggerRules).toEqual(["amount_check"]);
   });
 
+  it("persists meta on createRequest (Spec 65 §14 M6)", async () => {
+    const result = await engine.createRequest({
+      action: "submit_request",
+      entity: "purchase_request",
+      input: { title: "Laptop", amount: 15000 },
+      actor: defaultActor,
+      executionId: "exec-meta-1",
+      effect: { type: "require_approval", level: "manager" },
+      triggerRules: ["amount_check"],
+      meta: { source_view: "queue", bulk: true },
+    });
+
+    const stored = store.getById(result.approvalId);
+    expect(stored?.meta).toEqual({ source_view: "queue", bulk: true });
+    expect((stored?.meta as Record<string, unknown> | undefined)?.source_view).toBe("queue");
+  });
+
+  it("createRequest without meta leaves request.meta undefined (backwards compat)", async () => {
+    const result = await engine.createRequest({
+      action: "submit_request",
+      entity: "purchase_request",
+      input: { title: "Laptop", amount: 15000 },
+      actor: defaultActor,
+      executionId: "exec-meta-2",
+      effect: { type: "require_approval", level: "manager" },
+      triggerRules: ["amount_check"],
+    });
+
+    const stored = store.getById(result.approvalId);
+    expect(stored?.meta).toBeUndefined();
+  });
+
   it("emits approval.requested event on creation", async () => {
     await engine.createRequest({
       action: "submit_request",

--- a/packages/core/__tests__/approval.test.ts
+++ b/packages/core/__tests__/approval.test.ts
@@ -368,7 +368,15 @@ describe("ApprovalEngine", () => {
       executionId: "exec-meta-redact",
       effect: { type: "require_approval", level: "manager" },
       triggerRules: ["amount_check"],
-      meta: { source_view: "queue", password: "supersecret", token: "abc123" },
+      // Cover every key in DEFAULT_EXECUTION_META_MASKED_KEYS so a future
+      // shrink of the default set is caught here, not silently regressed.
+      meta: {
+        source_view: "queue",
+        password: "supersecret",
+        token: "abc123",
+        secret: "shh",
+        api_key: "k-001",
+      },
     });
 
     const stored = store.getById(result.approvalId);
@@ -376,6 +384,8 @@ describe("ApprovalEngine", () => {
     expect(storedMeta?.source_view).toBe("queue");
     expect(storedMeta?.password).toBe("***");
     expect(storedMeta?.token).toBe("***");
+    expect(storedMeta?.secret).toBe("***");
+    expect(storedMeta?.api_key).toBe("***");
   });
 
   it("createRequest strips _-prefixed system keys before persisting (Spec 65 §4.4)", async () => {

--- a/packages/core/__tests__/approval.test.ts
+++ b/packages/core/__tests__/approval.test.ts
@@ -359,6 +359,50 @@ describe("ApprovalEngine", () => {
     expect(stored?.meta).toBeUndefined();
   });
 
+  it("createRequest redacts well-known masked keys (Spec 65 §10.3)", async () => {
+    const result = await engine.createRequest({
+      action: "submit_request",
+      entity: "purchase_request",
+      input: { title: "Laptop", amount: 15000 },
+      actor: defaultActor,
+      executionId: "exec-meta-redact",
+      effect: { type: "require_approval", level: "manager" },
+      triggerRules: ["amount_check"],
+      meta: { source_view: "queue", password: "supersecret", token: "abc123" },
+    });
+
+    const stored = store.getById(result.approvalId);
+    const storedMeta = stored?.meta as Record<string, unknown> | undefined;
+    expect(storedMeta?.source_view).toBe("queue");
+    expect(storedMeta?.password).toBe("***");
+    expect(storedMeta?.token).toBe("***");
+  });
+
+  it("createRequest strips _-prefixed system keys before persisting (Spec 65 §4.4)", async () => {
+    const result = await engine.createRequest({
+      action: "submit_request",
+      entity: "purchase_request",
+      input: { title: "Laptop", amount: 15000 },
+      actor: defaultActor,
+      executionId: "exec-meta-strip",
+      effect: { type: "require_approval", level: "manager" },
+      triggerRules: ["amount_check"],
+      meta: {
+        source_view: "queue",
+        _execution_id: "stale",
+        _channel: "rest",
+        _depth: 2,
+      },
+    });
+
+    const stored = store.getById(result.approvalId);
+    const storedMeta = stored?.meta as Record<string, unknown> | undefined;
+    expect(storedMeta?.source_view).toBe("queue");
+    expect(storedMeta?._execution_id).toBeUndefined();
+    expect(storedMeta?._channel).toBeUndefined();
+    expect(storedMeta?._depth).toBeUndefined();
+  });
+
   it("emits approval.requested event on creation", async () => {
     await engine.createRequest({
       action: "submit_request",

--- a/packages/core/__tests__/e2e-approval-workflow.test.ts
+++ b/packages/core/__tests__/e2e-approval-workflow.test.ts
@@ -286,18 +286,27 @@ describe("E2E: Approval workflow", () => {
         executionId: "exec-replay-meta",
         effect: { type: "require_approval", level: "manager" },
         triggerRules: ["require_manager_approval"],
-        meta: { source_view: "approval_queue", triggered_by: "manager" },
+        // Stale system keys from the suspended attempt must NOT leak into the
+        // replay — sanitizeMetaForPersist strips them on creation (Spec 65
+        // §4.4) so `_execution_id` here should never reach the executor.
+        meta: {
+          source_view: "approval_queue",
+          triggered_by: "manager",
+          _execution_id: "stale-suspended-exec",
+        },
       });
 
       const result = await approvalEngine.approve({ approvalId: pending.approvalId }, manager);
       expect(result.success).toBe(true);
 
       // The re-execution must observe the persisted meta. The engine forwards
-      // the original plain-record meta to executor.execute() unchanged.
+      // the sanitized plain-record meta to executor.execute() — user keys pass
+      // through, system `_`-prefixed keys are stripped at the persist boundary.
       expect(capturedMeta).toBeDefined();
       const meta = capturedMeta as Record<string, unknown>;
       expect(meta.source_view).toBe("approval_queue");
       expect(meta.triggered_by).toBe("manager");
+      expect(meta._execution_id).toBeUndefined();
     });
   });
 

--- a/packages/core/__tests__/e2e-approval-workflow.test.ts
+++ b/packages/core/__tests__/e2e-approval-workflow.test.ts
@@ -13,7 +13,11 @@
  */
 
 import { beforeEach, describe, expect, it } from "bun:test";
-import { createActionExecutor } from "../src/engine/action-engine";
+import {
+  type ActionExecutor,
+  createActionExecutor,
+  type ExecuteOptions,
+} from "../src/engine/action-engine";
 import {
   createApprovalEngine,
   createApprovalVerifier,
@@ -247,6 +251,53 @@ describe("E2E: Approval workflow", () => {
 
       const approvedEvent = emittedEvents.find((e) => e.type === "approval.approved");
       expect(approvedEvent).toBeDefined();
+    });
+
+    it("approve replay carries meta to re-execution (Spec 65 §14 M6)", async () => {
+      // Build a fresh setup with a spy executor so we can capture the meta
+      // forwarded into the re-execution path.
+      const { bus: eventBus } = createEventBus();
+      const dp = createMemoryDataProvider();
+      const realExecutor = createActionExecutor({ dataProvider: dp });
+      realExecutor.registry.register(buildHighValueAction());
+
+      let capturedMeta: ExecuteOptions["meta"] | undefined;
+      const spyExecutor: ActionExecutor = {
+        registry: realExecutor.registry,
+        execute: async (actionName, input, actor, options) => {
+          capturedMeta = options?.meta;
+          return realExecutor.execute(actionName, input, actor, options);
+        },
+      };
+
+      const approvalStore = new InMemoryApprovalStore();
+      const approvalEngine = createApprovalEngine({
+        store: approvalStore,
+        eventBus,
+        enforceAssignee: false,
+        executor: spyExecutor,
+      });
+
+      const pending = await approvalEngine.createRequest({
+        action: "approve_purchase",
+        entity: "purchase",
+        input: { amount: 500, item: "monitor" },
+        actor: requestor,
+        executionId: "exec-replay-meta",
+        effect: { type: "require_approval", level: "manager" },
+        triggerRules: ["require_manager_approval"],
+        meta: { source_view: "approval_queue", triggered_by: "manager" },
+      });
+
+      const result = await approvalEngine.approve({ approvalId: pending.approvalId }, manager);
+      expect(result.success).toBe(true);
+
+      // The re-execution must observe the persisted meta. The engine forwards
+      // the original plain-record meta to executor.execute() unchanged.
+      expect(capturedMeta).toBeDefined();
+      const meta = capturedMeta as Record<string, unknown>;
+      expect(meta.source_view).toBe("approval_queue");
+      expect(meta.triggered_by).toBe("manager");
     });
   });
 

--- a/packages/core/src/engine/approval-engine.ts
+++ b/packages/core/src/engine/approval-engine.ts
@@ -171,6 +171,12 @@ export interface CreateApprovalOptions {
   assignee?: ApprovalAssignee;
   expiresAt?: Date;
   timeoutPolicy?: ApprovalTimeoutPolicy;
+  /**
+   * Original ExecutionMeta captured at suspend.
+   * Persisted with the request so handlers see the same meta on rerun
+   * as on the original submission (Spec 65 §14 M6).
+   */
+  meta?: Record<string, unknown>;
 }
 
 export interface ApprovalEngine {
@@ -316,6 +322,7 @@ export function createApprovalEngine(options: ApprovalEngineOptions): ApprovalEn
       timeoutPolicy: opts.timeoutPolicy ?? "none",
       originalExecutionId: opts.executionId,
       tenantId: opts.tenantId,
+      meta: opts.meta,
       createdAt: now,
       updatedAt: now,
     };
@@ -389,12 +396,8 @@ export function createApprovalEngine(options: ApprovalEngineOptions): ApprovalEn
     // Prefer CommandLayer (runs pre/tenant/pre-action/post-action, skips auth/exposure/permission).
     // Fall back to direct executor.execute() for backward compatibility.
     //
-    // TODO(spec-65 Phase 2): Approval records do NOT persist the original
-    // `ctx.meta` — handlers relying on meta (e.g., `source_view`,
-    // `triggered_by`) see different context before and after approval.
-    // Needs an approval-store schema extension to carry meta through the
-    // suspend/resume boundary. Deferred here because it requires a
-    // storage-layer change.
+    // Spec 65 §14 M6: replay the original ExecutionMeta captured at suspend
+    // so handlers see the same meta on rerun as on the original submission.
     let result: ActionResult;
 
     if (commandLayer) {
@@ -406,6 +409,7 @@ export function createApprovalEngine(options: ApprovalEngineOptions): ApprovalEn
         channel: "internal",
         approvalId: input.approvalId,
         skipRules: request.triggerRules,
+        meta: request.meta,
       });
     } else {
       // Backward-compatible fallback — direct executor call (deprecated path)
@@ -416,6 +420,7 @@ export function createApprovalEngine(options: ApprovalEngineOptions): ApprovalEn
         tenantId: request.tenantId,
         skipRules: request.triggerRules,
         approvalId: input.approvalId,
+        meta: request.meta,
       });
     }
 

--- a/packages/core/src/engine/approval-engine.ts
+++ b/packages/core/src/engine/approval-engine.ts
@@ -231,10 +231,13 @@ export function createApprovalEngine(options: ApprovalEngineOptions): ApprovalEn
     if (!configRegistry?.has("system:execution")) {
       return DEFAULT_EXECUTION_META_MASKED_KEYS;
     }
-    const cfg = configRegistry.get<{ meta: { maskedKeys: ReadonlyArray<string> } }>(
+    const cfg = configRegistry.get<{ meta?: { maskedKeys?: ReadonlyArray<string> } }>(
       "system:execution",
     );
-    return cfg.meta.maskedKeys;
+    // Defensive — a registered `system:execution` entry that omits `meta` or
+    // `meta.maskedKeys` (a misconfigured override) shouldn't crash engine
+    // construction. Fall back to the built-in defaults instead.
+    return cfg?.meta?.maskedKeys ?? DEFAULT_EXECUTION_META_MASKED_KEYS;
   })();
 
   /**

--- a/packages/core/src/engine/approval-engine.ts
+++ b/packages/core/src/engine/approval-engine.ts
@@ -9,6 +9,8 @@
  * See spec 35_approval_mechanism.md for full details.
  */
 
+import type { ConfigRegistry } from "../config/config-registry";
+import { DEFAULT_EXECUTION_META_MASKED_KEYS } from "../config/system-schemas";
 import type { EventBus } from "../event/event-bus";
 import { consoleLogger } from "../observability/console-logger";
 import type { ActionResult, Actor } from "../types/action";
@@ -24,6 +26,7 @@ import type {
   RejectInput,
 } from "../types/approval";
 import type { EventRecord } from "../types/event";
+import { redactMetaForLog, stripSystemKeys } from "../types/execution-meta";
 import type { RequireApprovalEffect } from "../types/rule";
 import type { ActionExecutor } from "./action-engine";
 import type { CommandLayer } from "./command-layer";
@@ -154,6 +157,12 @@ export interface ApprovalEngineOptions {
    * When not provided, falls back to basic checks (allow-all if enforceAssignee is false).
    */
   permissionRegistry?: PermissionRegistry;
+  /**
+   * Config registry for resolving `system:execution.meta.maskedKeys`.
+   * When omitted, falls back to DEFAULT_EXECUTION_META_MASKED_KEYS so
+   * the redaction guarantee (Spec 65 §10.3) holds in tests too.
+   */
+  configRegistry?: ConfigRegistry;
 }
 
 export interface CreateApprovalOptions {
@@ -205,12 +214,48 @@ export interface ApprovalEngine {
  * Create an ApprovalEngine instance.
  */
 export function createApprovalEngine(options: ApprovalEngineOptions): ApprovalEngine {
-  const { store, eventBus, permissionRegistry } = options;
+  const { store, eventBus, permissionRegistry, configRegistry } = options;
   // Auto-enable assignee enforcement when permissionRegistry is provided,
   // unless explicitly set to false
   const enforceAssignee = options.enforceAssignee ?? permissionRegistry !== undefined;
   let executor = options.executor;
   const commandLayer = options.commandLayer;
+
+  /**
+   * Resolve the configured `system:execution.meta.maskedKeys` list once at
+   * engine-construction time, mirroring action-engine's resolution. Falls
+   * back to DEFAULT_EXECUTION_META_MASKED_KEYS when no ConfigRegistry was
+   * injected so the redaction guarantee (Spec 65 §10.3) holds in tests.
+   */
+  const maskedKeys: ReadonlyArray<string> = (() => {
+    if (!configRegistry?.has("system:execution")) {
+      return DEFAULT_EXECUTION_META_MASKED_KEYS;
+    }
+    const cfg = configRegistry.get<{ meta: { maskedKeys: ReadonlyArray<string> } }>(
+      "system:execution",
+    );
+    return cfg.meta.maskedKeys;
+  })();
+
+  /**
+   * Sanitize caller-provided meta before persisting it on the ApprovalRequest:
+   *
+   * 1. Drop `_`-prefixed system keys — they belong to the *suspended* attempt
+   *    (e.g., `_execution_id`, `_channel`, `_depth` from the original
+   *    submission). On replay, CommandLayer middleware reads `c.meta` *before*
+   *    ActionEngine.createExecutionMeta re-stamps system keys, so leaving
+   *    these values in would feed stale correlation data to tenant /
+   *    pre-action / post-action middleware (Spec 65 §4.4).
+   * 2. Apply redaction so configured masked keys (e.g., "password", "token")
+   *    never live unredacted at rest (Spec 65 §10.3) — same redaction the
+   *    execution log applies before persisting.
+   */
+  function sanitizeMetaForPersist(
+    meta: Record<string, unknown> | undefined,
+  ): Record<string, unknown> | undefined {
+    if (meta === undefined) return undefined;
+    return redactMetaForLog(stripSystemKeys(meta), maskedKeys);
+  }
 
   // Fix #5: Counter scoped inside factory to avoid module-level shared state
   let approvalCounter = 0;
@@ -322,7 +367,7 @@ export function createApprovalEngine(options: ApprovalEngineOptions): ApprovalEn
       timeoutPolicy: opts.timeoutPolicy ?? "none",
       originalExecutionId: opts.executionId,
       tenantId: opts.tenantId,
-      meta: opts.meta,
+      meta: sanitizeMetaForPersist(opts.meta),
       createdAt: now,
       updatedAt: now,
     };

--- a/packages/core/src/persistence/drizzle-approval-store.ts
+++ b/packages/core/src/persistence/drizzle-approval-store.ts
@@ -49,6 +49,7 @@ export class DrizzleApprovalStore {
       executionId: request.executionId ?? null,
       executionError: request.executionError ?? null,
       metadata,
+      meta: request.meta ?? null,
       createdAt: request.createdAt,
       updatedAt: request.updatedAt,
     });
@@ -83,6 +84,7 @@ export class DrizzleApprovalStore {
     if (data.decisionNote !== undefined) updateValues.decisionNote = data.decisionNote;
     if (data.executionId !== undefined) updateValues.executionId = data.executionId;
     if (data.executionError !== undefined) updateValues.executionError = data.executionError;
+    if (data.meta !== undefined) updateValues.meta = data.meta;
 
     await this.db.update(approvalsTable).set(updateValues).where(eq(approvalsTable.id, id));
 
@@ -143,6 +145,7 @@ function rowToRequest(row: ApprovalRow): ApprovalRequest {
     executionId: row.executionId ?? undefined,
     executionError: row.executionError ?? undefined,
     tenantId: row.tenantId ?? undefined,
+    meta: (row.meta as Record<string, unknown>) ?? undefined,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };

--- a/packages/core/src/persistence/system-tables.ts
+++ b/packages/core/src/persistence/system-tables.ts
@@ -139,6 +139,8 @@ export const approvalsTable = linchkitSchema.table("approvals", {
   executionId: varchar("execution_id", { length: 255 }),
   executionError: text("execution_error"),
   metadata: jsonb("metadata"),
+  /** Spec 65 §14 M6 — Original ExecutionMeta captured at suspend, replayed on approve(). */
+  meta: jsonb("meta"),
   createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { mode: "date" }).notNull().defaultNow(),
 });

--- a/packages/core/src/types/approval.ts
+++ b/packages/core/src/types/approval.ts
@@ -80,6 +80,9 @@ export interface ApprovalRequest {
   /** Tenant context */
   tenantId?: string;
 
+  /** Original ExecutionMeta captured at suspend, replayed on approve(). */
+  meta?: Record<string, unknown>;
+
   createdAt: Date;
   updatedAt: Date;
 }

--- a/packages/core/src/types/execution-meta.ts
+++ b/packages/core/src/types/execution-meta.ts
@@ -143,7 +143,7 @@ function cloneAndFreezeEntries(entries: Record<string, unknown>): Record<string,
 }
 
 /** Strip `_`-prefixed keys from an input object (returns a shallow copy). */
-function stripSystemKeys(input: Record<string, unknown>): Record<string, unknown> {
+export function stripSystemKeys(input: Record<string, unknown>): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(input)) {
     if (k.startsWith("_")) continue;


### PR DESCRIPTION
## Summary
- Approval-gated actions previously dropped `ctx.meta` on the rerun. Handlers reading meta (e.g. `source_view`, `triggered_by`) saw different context before vs after approval.
- Persists the original ExecutionMeta on `ApprovalRequest`; `approve()` replays it via both `commandLayer.execute({ meta })` and the direct-executor fallback.
- Sanitizes meta at the engine boundary before persistence: redacts well-known masked keys (Spec 65 §10.3) so secrets never live unredacted at rest, and strips `_`-prefixed system keys (Spec 65 §4.4) so stale `_execution_id` / `_channel` / `_depth` from the suspended attempt cannot leak into CommandLayer middleware on replay.

## Changes
- `ApprovalRequest.meta` — new optional field
- `_linchkit.approvals.meta` — new nullable jsonb column (drizzle-generated migration `0003_massive_otto_octavius.sql`)
- `DrizzleApprovalStore` — round-trips meta on create/update/getById
- `createApprovalEngine(options)` — accepts `ConfigRegistry`, resolves `maskedKeys` at construction (mirrors action-engine pattern)
- `createRequest()` — sanitizes (`stripSystemKeys` + `redactMetaForLog`) then persists
- `approve()` — replays sanitized meta via both execution paths
- `stripSystemKeys` exported from `execution-meta.ts`

## Cross-model review
- codex round-1 flagged two issues on the parent commit; both fixed in commit 2:
  - **P1** secrets-at-rest in approvals.meta — accepted, applied same redaction the execution log uses
  - **P2** stale `_execution_id`/`_channel` leak into replay middleware — accepted, strip system keys at persist boundary
- gemini run hung; codex was sufficient.

## Tests
- `packages/core/__tests__/approval.test.ts` — 4 new unit tests
  - meta persisted (happy path)
  - backwards-compat: undefined when not provided
  - redaction of `password` / `token`
  - stripping of `_execution_id` / `_channel` / `_depth`
- `packages/core/__tests__/e2e-approval-workflow.test.ts` — 1 new e2e test asserting the executor receives the persisted meta during replay

## Test plan
- [x] `bun run check`
- [x] `bun run typecheck`
- [x] `bun test` — 4557 pass, 3 skip, 0 fail
- [x] Cross-model review (codex) — comments addressed in commit 2

## Related
- Spec 65 §14 M6 (closes #199)
- Sibling Phase 2 work: #200 (idempotency), #202 (entity-registry locks)
- Pre-existing CLI test flake observed during this work, filed as #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Approval requests now accept custom metadata that is automatically persisted and reused during re-execution. Sensitive fields are automatically redacted, and system-reserved fields are filtered out for secure metadata handling.

* **Tests**
  * Added comprehensive test coverage for metadata handling in approval workflows and end-to-end approval scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->