### PR TITLE
chore(changeset): approval meta persistence — @linchkit/core minor (#222 follow-up)

### DIFF
--- a/.changeset/approval-replay-meta-spec65.md
+++ b/.changeset/approval-replay-meta-spec65.md
@@ -1,0 +1,5 @@
+---
+"@linchkit/core": minor
+---
+
+Persist `ctx.meta` across approval suspend/resume (Spec 65 §14 M6). Approval-gated actions now carry their original ExecutionMeta through the suspend boundary so handlers see the same `source_view` / `triggered_by` / `bulk` context on the approved rerun as on the original submission. New `ApprovalRequest.meta` field; new `_linchkit.approvals.meta` jsonb column; `createApprovalEngine()` accepts `configRegistry` for resolving `system:execution.meta.maskedKeys`. Meta is sanitized at persist (`_`-prefixed system keys stripped per §4.4; configured masked keys redacted to `***` per §10.3) so the approvals table never holds unredacted secrets and stale `_execution_id` / `_channel` cannot leak into CommandLayer middleware on replay.


### PR DESCRIPTION
## Summary
Forgot to bundle the changeset with #222. Adds the @linchkit/core minor entry for the approval meta persistence work that landed in commit f2db486.

## Test plan
- [x] \`bun run check\` / \`bun run typecheck\` / \`bun test\` — all green
- [x] Doc-only change; no code edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Approval workflows now preserve execution context metadata across suspend/resume cycles, ensuring handlers maintain consistent information during approved reruns.
  * Automatic sanitization of sensitive metadata prevents unredacted secrets and system identifiers from persisting through the approval layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->