### PR TITLE
feat: MCP adapter auto-injects _mcp_client_id (Spec 65 §3.3, closes #217)

### DIFF
--- a/.changeset/mcp-client-id-injection.md
+++ b/.changeset/mcp-client-id-injection.md
@@ -1,0 +1,16 @@
+---
+"@linchkit/core": minor
+"@linchkit/cap-adapter-mcp": minor
+---
+
+feat: MCP adapter auto-injects `_mcp_client_id` into ExecutionMeta (Spec 65 §3.3)
+
+The MCP adapter now stamps the authenticated client's registration ID into
+`ctx.meta._mcp_client_id` at action dispatch, so handlers, rules, and
+EventHandlers can attribute MCP-originating calls to a specific client. Core
+gains a `systemMeta?: Record<string, unknown>` option on `CommandExecuteOptions`
+/ `ExecuteOptions` to allow trusted adapters to seed `_`-prefixed system keys
+(framework reserved keys `_channel` / `_execution_id` / `_depth` /
+`_source_action` are protected; non-`_` keys are silently dropped). When no
+authenticated client is present (stdio / open-access / simple-bearer-token),
+no fake ID is invented — the field is omitted.

--- a/addons/adapter-mcp/cap-adapter-mcp/__tests__/mcp-server.test.ts
+++ b/addons/adapter-mcp/cap-adapter-mcp/__tests__/mcp-server.test.ts
@@ -1124,3 +1124,129 @@ describe("createMcpAdapter — get_state_machine", () => {
     expect(tools.get_state_machine).toBeDefined();
   });
 });
+
+// ── ExecutionMeta injection (Spec 65 §3.3, issue #217) ─────────────────
+
+describe("createMcpAdapter — ExecutionMeta injection (Spec 65 §3.3)", () => {
+  test("does NOT inject _mcp_client_id when no session client is set", async () => {
+    const entityRegistry = createEntityRegistry();
+    entityRegistry.register(testEntity);
+
+    const actionRegistry = new ActionRegistry();
+    actionRegistry.register(testAction);
+
+    const commandLayer = createMockCommandLayer();
+
+    const { server } = await createMcpAdapter({
+      commandLayer,
+      entityRegistry,
+      actionRegistry,
+    });
+
+    const tools = getTools(server);
+    await tools.create_order?.handler({ customer_name: "Acme", amount: 1 }, {});
+
+    expect(commandLayer.execute).toHaveBeenCalledTimes(1);
+    const callArgs = (commandLayer.execute as ReturnType<typeof mock>).mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+
+    // Anonymous / open access — adapter must NOT invent a fake client id.
+    // systemMeta should either be omitted entirely or not include _mcp_client_id.
+    const systemMeta = callArgs.systemMeta as Record<string, unknown> | undefined;
+    if (systemMeta !== undefined) {
+      expect(systemMeta._mcp_client_id).toBeUndefined();
+    }
+  });
+
+  test("injects _mcp_client_id into systemMeta after session auth", async () => {
+    const entityRegistry = createEntityRegistry();
+    entityRegistry.register(testEntity);
+
+    const actionRegistry = new ActionRegistry();
+    actionRegistry.register(testAction);
+
+    const commandLayer = createMockCommandLayer();
+
+    const adapter = (await createMcpAdapter({
+      commandLayer,
+      entityRegistry,
+      actionRegistry,
+    })) as Awaited<ReturnType<typeof createMcpAdapter>> & {
+      setSessionAuth: (
+        actor: { type: string; id: string; name: string; groups: string[] },
+        toolPolicy?: unknown,
+        clientId?: string,
+      ) => void;
+    };
+
+    // Simulate the SSE transport authenticating an MCP client and binding
+    // the session to its registration ID.
+    adapter.setSessionAuth(
+      { type: "ai", id: "actor-42", name: "Test Bot", groups: ["ai_agent"] },
+      undefined,
+      "client-reg-001",
+    );
+
+    const tools = getTools(adapter.server);
+    await tools.create_order?.handler({ customer_name: "Globex", amount: 5 }, {});
+
+    expect(commandLayer.execute).toHaveBeenCalledTimes(1);
+    const callArgs = (commandLayer.execute as ReturnType<typeof mock>).mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+
+    expect(callArgs.channel).toBe("mcp");
+    const systemMeta = callArgs.systemMeta as Record<string, unknown>;
+    expect(systemMeta).toBeDefined();
+    expect(systemMeta._mcp_client_id).toBe("client-reg-001");
+
+    // The actor reflects the authenticated client.
+    const actor = callArgs.actor as Record<string, unknown>;
+    expect(actor.id).toBe("actor-42");
+  });
+
+  test("subsequent setSessionAuth without clientId clears the previous id", async () => {
+    const entityRegistry = createEntityRegistry();
+    entityRegistry.register(testEntity);
+
+    const actionRegistry = new ActionRegistry();
+    actionRegistry.register(testAction);
+
+    const commandLayer = createMockCommandLayer();
+
+    const adapter = (await createMcpAdapter({
+      commandLayer,
+      entityRegistry,
+      actionRegistry,
+    })) as Awaited<ReturnType<typeof createMcpAdapter>> & {
+      setSessionAuth: (
+        actor: { type: string; id: string; name: string; groups: string[] },
+        toolPolicy?: unknown,
+        clientId?: string,
+      ) => void;
+    };
+
+    adapter.setSessionAuth(
+      { type: "ai", id: "actor-1", name: "X", groups: ["ai_agent"] },
+      undefined,
+      "client-1",
+    );
+    // Re-bind without a clientId (e.g. simple bearer fallback).
+    adapter.setSessionAuth({ type: "ai", id: "mcp-client", name: "MCP", groups: ["ai_agent"] });
+
+    const tools = getTools(adapter.server);
+    await tools.create_order?.handler({ customer_name: "Y", amount: 1 }, {});
+
+    const callArgs = (commandLayer.execute as ReturnType<typeof mock>).mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    const systemMeta = callArgs.systemMeta as Record<string, unknown> | undefined;
+    if (systemMeta !== undefined) {
+      expect(systemMeta._mcp_client_id).toBeUndefined();
+    }
+  });
+});

--- a/addons/adapter-mcp/cap-adapter-mcp/src/mcp-server.ts
+++ b/addons/adapter-mcp/cap-adapter-mcp/src/mcp-server.ts
@@ -197,13 +197,19 @@ export async function createMcpAdapter(options: McpAdapterOptions): Promise<McpA
   // For stdio transport, defaults to MCP_ACTOR.
   let sessionActor: Actor = MCP_ACTOR;
   let sessionToolPolicy: ToolPolicy | undefined;
+  // Authenticated client's registration ID, used to populate
+  // `_mcp_client_id` in execution meta (Spec 65 §3.3). Undefined when no
+  // client registry is configured (open access / simple bearer fallback) —
+  // we never invent a fake ID.
+  let sessionClientId: string | undefined;
 
   /**
    * Set the session actor and tool policy (called by SSE transport after auth).
    */
-  const setSessionAuth = (actor: Actor, toolPolicy?: ToolPolicy) => {
+  const setSessionAuth = (actor: Actor, toolPolicy?: ToolPolicy, clientId?: string) => {
     sessionActor = actor;
     sessionToolPolicy = toolPolicy;
+    sessionClientId = clientId;
   };
 
   // Collect all tool names for filtering
@@ -242,12 +248,26 @@ export async function createMcpAdapter(options: McpAdapterOptions): Promise<McpA
           }
         }
 
+        // Spec 65 §3.3 — inject MCP-specific system meta. `_channel` is set
+        // by the engine from `channel: "mcp"`; only `_mcp_client_id` needs
+        // to flow via `systemMeta`. We omit it when no authenticated client
+        // is associated with the session (open access / simple bearer
+        // fallback) — the adapter never invents a fake ID.
+        // TODO(#217 follow-up): allow MCP clients to send custom meta
+        // through the tool invocation arguments — requires extending the
+        // MCP tool schema convention. Out of scope for this issue.
+        const systemMeta: Record<string, unknown> = {};
+        if (sessionClientId) {
+          systemMeta._mcp_client_id = sessionClientId;
+        }
+
         const result = await commandLayer.execute({
           command: tool.name,
           input: args as Record<string, unknown>,
           channel: "mcp",
           actor: sessionActor,
           tenantId,
+          ...(Object.keys(systemMeta).length > 0 ? { systemMeta } : {}),
         });
 
         return {
@@ -351,7 +371,7 @@ export async function createMcpAdapter(options: McpAdapterOptions): Promise<McpA
 
   const result: McpAdapterResult & {
     /** Set per-session auth (used by SSE transport after authentication) */
-    setSessionAuth: (actor: Actor, toolPolicy?: ToolPolicy) => void;
+    setSessionAuth: (actor: Actor, toolPolicy?: ToolPolicy, clientId?: string) => void;
     /** All registered tool names with categories (for filtering) */
     allToolNames: Array<{ name: string; category?: string }>;
   } = {

--- a/addons/adapter-mcp/cap-adapter-mcp/src/sse-transport.ts
+++ b/addons/adapter-mcp/cap-adapter-mcp/src/sse-transport.ts
@@ -14,7 +14,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import type { McpClientRegistry } from "./client-registry";
 import type { McpAdapterResult } from "./mcp-server";
-import type { ToolPolicy } from "./types";
+import type { McpClient, ToolPolicy } from "./types";
 
 export interface McpSseServerOptions {
   /**
@@ -36,9 +36,12 @@ export interface McpSseServerOptions {
   /**
    * Resolve an actor from a bearer token.
    * Used when clientRegistry is provided to get per-session actor.
+   * The resolved `client` (when present) carries the registration ID used
+   * to populate `_mcp_client_id` in ExecutionMeta (Spec 65 §3.3).
    */
   resolveActor?: (token: string | undefined) => Promise<{
     actor: Actor;
+    client?: McpClient;
     toolPolicy?: ToolPolicy;
   } | null>;
 }
@@ -126,14 +129,19 @@ export function createMcpSseServer(options: McpSseServerOptions): McpSseServerRe
             ? (adapterResult as McpAdapterResult).server
             : (adapterResult as McpServer);
 
-        // Resolve actor for this session if registry is available
+        // Resolve actor for this session if registry is available.
+        // The resolved client's registration ID is forwarded to setSessionAuth
+        // so the dispatch site can inject `_mcp_client_id` into ExecutionMeta
+        // (Spec 65 §3.3).
         if (resolveActor && token) {
           const resolved = await resolveActor(token);
           if (resolved && "setSessionAuth" in adapterResult) {
             const setAuth = (
-              adapterResult as { setSessionAuth: (a: Actor, p?: ToolPolicy) => void }
+              adapterResult as {
+                setSessionAuth: (a: Actor, p?: ToolPolicy, clientId?: string) => void;
+              }
             ).setSessionAuth;
-            setAuth(resolved.actor, resolved.toolPolicy);
+            setAuth(resolved.actor, resolved.toolPolicy, resolved.client?.id);
           }
         }
 

--- a/packages/core/__tests__/action-engine-meta-propagation.test.ts
+++ b/packages/core/__tests__/action-engine-meta-propagation.test.ts
@@ -771,3 +771,102 @@ describe("ActionEngine — ExecutionMeta propagation via ctx.execute", () => {
     expect(captured.user_key).toBe("x");
   });
 });
+
+// ── Adapter-supplied system meta (Spec 65 §3.3, issue #217) ────────────
+
+describe("ActionEngine — systemMeta injection (Spec 65 §3.3)", () => {
+  test("ExecuteOptions.systemMeta merges adapter system keys into ctx.meta", async () => {
+    const dp = createTestDataProvider();
+    const executor = createActionExecutor({ dataProvider: dp });
+    let captured: Record<string, unknown> = {};
+
+    executor.registry.register({
+      name: "noop",
+      entity: "x",
+      label: "noop",
+      policy: { mode: "sync", transaction: false },
+      exposure: "all",
+      handler: async (ctx) => {
+        captured = ctx.meta.toJSON();
+        return { ok: true };
+      },
+    });
+
+    const result = await executor.execute("noop", {}, defaultActor, {
+      channel: "mcp",
+      systemMeta: { _mcp_client_id: "client-reg-001" },
+    });
+
+    expect(result.success).toBe(true);
+    // Adapter-supplied system key survives.
+    expect(captured._mcp_client_id).toBe("client-reg-001");
+    // Reserved framework keys still set by engine.
+    expect(captured._channel).toBe("mcp");
+    expect(captured._depth).toBe(0);
+    expect(typeof captured._execution_id).toBe("string");
+  });
+
+  test("systemMeta cannot override reserved framework keys", async () => {
+    const dp = createTestDataProvider();
+    const executor = createActionExecutor({ dataProvider: dp });
+    let captured: Record<string, unknown> = {};
+
+    executor.registry.register({
+      name: "noop2",
+      entity: "x",
+      label: "noop2",
+      policy: { mode: "sync", transaction: false },
+      exposure: "all",
+      handler: async (ctx) => {
+        captured = ctx.meta.toJSON();
+        return { ok: true };
+      },
+    });
+
+    const result = await executor.execute("noop2", {}, defaultActor, {
+      channel: "mcp",
+      systemMeta: {
+        _mcp_client_id: "client-X",
+        // Adversarial: try to override engine-owned keys.
+        _channel: "rest",
+        _execution_id: "spoofed",
+        _depth: 99,
+        _source_action: "spoofed",
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(captured._mcp_client_id).toBe("client-X");
+    expect(captured._channel).toBe("mcp");
+    expect(captured._depth).toBe(0);
+    expect(captured._execution_id).not.toBe("spoofed");
+    expect(captured._source_action).toBeUndefined();
+  });
+
+  test("systemMeta entries without _ prefix are ignored", async () => {
+    const dp = createTestDataProvider();
+    const executor = createActionExecutor({ dataProvider: dp });
+    let captured: Record<string, unknown> = {};
+
+    executor.registry.register({
+      name: "noop3",
+      entity: "x",
+      label: "noop3",
+      policy: { mode: "sync", transaction: false },
+      exposure: "all",
+      handler: async (ctx) => {
+        captured = ctx.meta.toJSON();
+        return { ok: true };
+      },
+    });
+
+    const result = await executor.execute("noop3", {}, defaultActor, {
+      channel: "mcp",
+      systemMeta: { rogue: "value", _mcp_client_id: "ok" },
+    });
+
+    expect(result.success).toBe(true);
+    expect(captured._mcp_client_id).toBe("ok");
+    expect(captured.rogue).toBeUndefined();
+  });
+});

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -410,6 +410,9 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
         adapterSystemMeta[k] = v;
       }
     }
+    // Note: adapter-injected system keys (e.g. `_mcp_client_id`) are NOT
+    // currently preserved across approval suspend/replay — `ApprovalEngine`
+    // strips all `_`-prefixed keys when persisting. Tracked: #230.
 
     const rootSystemDefaults: Record<string, unknown> = {
       ...adapterSystemMeta,

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -132,6 +132,20 @@ export interface ExecuteOptions {
    * runtime with "x is not a function".
    */
   meta?: ExecutionMeta | Record<string, unknown>;
+  /**
+   * Framework-trusted system meta keys (Spec 65 §3.3, §4.4).
+   *
+   * Adapters set channel-specific system keys here (e.g. MCP injects
+   * `_mcp_client_id` after authenticating the caller). Unlike `meta`, keys
+   * placed here BYPASS the `_`-prefix strip applied to external input — they
+   * are merged into `rootSystemDefaults` server-side. Values are still
+   * filtered to JSON-serializable primitives by the meta factory.
+   *
+   * Reserved framework keys (`_channel`, `_execution_id`, `_depth`,
+   * `_source_action`) cannot be overridden — the engine's own assignments
+   * always win.
+   */
+  systemMeta?: Record<string, unknown>;
 }
 
 // ── ActionExecutor ──────────────────────────────────────────
@@ -374,7 +388,31 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
     // `_execution_id` is the ROOT execution record id (Spec 65 §4.4 — keyed
     // against ExecutionLogger.getById), NOT a tracing id. ActionEngine owns
     // its assignment.
+    // Adapter-supplied system keys (Spec 65 §3.3) — e.g. `_mcp_client_id`
+    // injected by the MCP adapter after authenticating the caller. Reserved
+    // framework keys (`_channel`, `_execution_id`, `_depth`, `_source_action`)
+    // are filtered out so the engine's own assignments always win regardless
+    // of what the adapter supplied.
+    const RESERVED_FRAMEWORK_KEYS = new Set([
+      "_channel",
+      "_execution_id",
+      "_depth",
+      "_source_action",
+    ]);
+    const adapterSystemMeta: Record<string, unknown> = {};
+    const providedSystemMeta = execOptions?.systemMeta;
+    if (providedSystemMeta && currentDepth === 0) {
+      for (const [k, v] of Object.entries(providedSystemMeta)) {
+        // Only `_`-prefixed keys are system keys; ignore non-system entries
+        // so adapters can't accidentally use this channel for user data.
+        if (!k.startsWith("_")) continue;
+        if (RESERVED_FRAMEWORK_KEYS.has(k)) continue;
+        adapterSystemMeta[k] = v;
+      }
+    }
+
     const rootSystemDefaults: Record<string, unknown> = {
+      ...adapterSystemMeta,
       _channel: channel,
       _execution_id: executionId,
       _depth: currentDepth,

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -47,6 +47,17 @@ import {
 } from "./action-helpers";
 import { ActionRegistry } from "./action-registry";
 
+/** Framework-managed `_`-prefixed system meta keys. Adapters using the
+ *  trusted `systemMeta` channel cannot override these — the engine's own
+ *  assignments always win. Hoisted to module scope so it's allocated once
+ *  rather than on every action dispatch. */
+const RESERVED_FRAMEWORK_KEYS: ReadonlySet<string> = new Set([
+  "_channel",
+  "_execution_id",
+  "_depth",
+  "_source_action",
+]);
+
 // ── DataProvider interface ──────────────────────────────────
 
 /** Options for data queries — tenant isolation, soft-delete control, and locale */
@@ -390,15 +401,8 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
     // its assignment.
     // Adapter-supplied system keys (Spec 65 §3.3) — e.g. `_mcp_client_id`
     // injected by the MCP adapter after authenticating the caller. Reserved
-    // framework keys (`_channel`, `_execution_id`, `_depth`, `_source_action`)
-    // are filtered out so the engine's own assignments always win regardless
-    // of what the adapter supplied.
-    const RESERVED_FRAMEWORK_KEYS = new Set([
-      "_channel",
-      "_execution_id",
-      "_depth",
-      "_source_action",
-    ]);
+    // framework keys are filtered out (see module-level
+    // `RESERVED_FRAMEWORK_KEYS`) so the engine's own assignments always win.
     const adapterSystemMeta: Record<string, unknown> = {};
     const providedSystemMeta = execOptions?.systemMeta;
     if (providedSystemMeta && currentDepth === 0) {

--- a/packages/core/src/engine/command-layer.ts
+++ b/packages/core/src/engine/command-layer.ts
@@ -177,6 +177,16 @@ export interface CommandExecuteOptions {
   locale?: string;
   meta?: Record<string, unknown>;
   /**
+   * Framework-trusted system meta keys (Spec 65 §3.3, §4.4).
+   *
+   * Set by transport adapters (e.g. MCP injects `_mcp_client_id` after
+   * authenticating the caller). Unlike `meta`, keys placed here bypass the
+   * external-input `_`-strip — they are merged into the engine's
+   * `rootSystemDefaults`. Reserved framework keys (`_channel`,
+   * `_execution_id`, `_depth`, `_source_action`) cannot be overridden.
+   */
+  systemMeta?: Record<string, unknown>;
+  /**
    * When set, this is an approval re-execution. The pipeline will:
    * - SKIP auth, exposure, permission slots (already checked on original submission)
    * - RUN pre, tenant, pre-action, post-action slots
@@ -508,6 +518,13 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
     }
     if (execOptions.includeDeleted) {
       executorOptions.includeDeleted = execOptions.includeDeleted;
+    }
+    // Forward adapter-supplied system meta (Spec 65 §3.3) — e.g. MCP's
+    // `_mcp_client_id`. Pre-built ExecutionMeta is propagated unchanged here;
+    // ActionEngine merges these into `rootSystemDefaults` at depth 0 so they
+    // bypass the external-input strip applied to `meta`.
+    if (execOptions.systemMeta) {
+      executorOptions.systemMeta = execOptions.systemMeta;
     }
     // Internal batch plumbing: forward shared transaction context when set
     // by `executeBatch`. Public callers do not set these (see


### PR DESCRIPTION
## Summary

- The MCP adapter now stamps the authenticated client's registration ID into `ctx.meta._mcp_client_id` at action dispatch (Spec 65 §3.3), so handlers / rules / event handlers can attribute MCP-originating calls to a specific client.
- Core gains a trusted `systemMeta?: Record<string, unknown>` option on `CommandExecuteOptions` / `ExecuteOptions` for adapters to seed `_`-prefixed system keys. Reserved framework keys (`_channel`, `_execution_id`, `_depth`, `_source_action`) are protected from override; non-`_` keys are silently dropped from this channel.
- `cap-adapter-mcp/src/sse-transport.ts` widens `resolveActor` to expose `client?: McpClient`, then passes the client ID through `setSessionAuth(actor, toolPolicy?, clientId?)`. `mcp-server.ts` only injects `systemMeta: { _mcp_client_id }` when an authenticated client is registered — stdio / open-access / simple-bearer-token paths never invent a fake ID.
- `_channel: "mcp"` continues to be auto-stamped by ActionEngine from the existing `channel: "mcp"` option, so the adapter does not double-set it.

## Codex review

- **P2 — approval replay drops `_mcp_client_id`** — when an MCP action is suspended by `require_approval`, `ApprovalEngine.sanitizeMetaForPersist` strips all `_`-prefixed keys. On approve, the persisted snapshot is replayed via the untrusted `meta` channel, so attribution disappears on the rerun. Fix needs ApprovalEngine to split persisted system keys into "framework-set" (drop) vs "adapter-set" (replay via `systemMeta`) — bigger than this PR's first-injection scope. Documented inline at `action-engine.ts` and tracked in #230.

## Deferred (out of scope)

- Forwarding MCP-client-supplied meta keys (TODO with `#217 follow-up` reference). MCP tool schemas have no convention for an arbitrary meta argument yet — separate spec/design call.

## Test plan

- [x] 3 new tests in `addons/adapter-mcp/cap-adapter-mcp/__tests__/mcp-server.test.ts`: no client → field absent; authenticated client → `_mcp_client_id` present; re-auth without client clears the id.
- [x] 3 new tests in `packages/core/__tests__/action-engine-meta-propagation.test.ts` covering the core `systemMeta` channel: merge into root meta; reserved-framework-key protection; non-`_` key drop.
- [x] Full repo: `4481 pass / 0 fail / 85 skip` (DB integrations skipped without live PG).
- [x] `bun run typecheck` clean.
- [x] `bun run check` clean.
- [x] `bun test addons/adapter-mcp` — 192 pass / 0 fail.

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)