### PR TITLE
feat(cli): linch exec runs an action with input + ExecutionMeta (Spec 65 §3.5, closes #218)

### DIFF
--- a/.changeset/cli-exec-command.md
+++ b/.changeset/cli-exec-command.md
@@ -1,0 +1,23 @@
+---
+"@linchkit/cli": minor
+"@linchkit/core": patch
+---
+
+feat(cli): `linch exec` runs a named Action with input + ExecutionMeta (Spec 65 §3.5)
+
+```
+linch exec approve_request --input '{"id":"pr_001"}' --meta '{"bulk":true}'
+```
+
+The new `exec` command boots a minimal in-process runtime (config / registries
+/ database / auth provider / ActionExecutor + CommandLayer; transports / Restate
+flow engine / AI service / sensors / cache manager are skipped — exec is one-
+shot) and dispatches the named Action through CommandLayer. `_`-prefixed meta
+keys are stripped pre-flight (Spec 65 §4.4) and JSON byte size is checked
+against `DEFAULT_META_MAX_BYTES` (8 KB; Spec 65 §10.2). Exit codes: 0 success,
+1 user input / validation errors, 2 action failure or bootstrap throw.
+Mutually exclusive `--input` / `--input-file` and `--meta` / `--meta-file`.
+
+Core also re-exports `DEFAULT_META_MAX_BYTES`, `MetaSizeError`,
+`createExecutionMeta`, `redactMetaForLog` as runtime exports so external
+runners (CLI, future scripting hosts) can construct meta safely.

--- a/packages/cli/src/commands/__tests__/exec.test.ts
+++ b/packages/cli/src/commands/__tests__/exec.test.ts
@@ -56,7 +56,11 @@ export default {
           handler: async (ctx) => {
             writeFileSync(
               SIDE_CHANNEL,
-              JSON.stringify({ meta: ctx.meta.toJSON(), input: ctx.input }),
+              JSON.stringify({
+                meta: ctx.meta.toJSON(),
+                input: ctx.input,
+                actor: { type: ctx.actor.type, id: ctx.actor.id },
+              }),
             );
             return { recorded: true };
           },
@@ -78,7 +82,11 @@ export default {
   writeFileSync(resolve(TEST_DIR, "linchkit.config.ts"), content);
 }
 
-function readSideChannel(): { meta: Record<string, unknown>; input: Record<string, unknown> } {
+function readSideChannel(): {
+  meta: Record<string, unknown>;
+  input: Record<string, unknown>;
+  actor: { type: string; id: string };
+} {
   return JSON.parse(readFileSync(SIDE_CHANNEL, "utf-8"));
 }
 
@@ -114,6 +122,8 @@ describe("linch exec", () => {
           _execution_id: "spoofed",
           _custom_secret: "hax",
         }),
+        "--tenant",
+        "default",
         "--json",
       ],
       { cwd: TEST_DIR, stdout: "pipe", stderr: "pipe" },
@@ -139,13 +149,140 @@ describe("linch exec", () => {
     expect(recorded.meta.bulk).toBe(true);
     // Framework-set system keys are present with framework values, not the
     // spoofed values the caller tried to inject.
-    expect(recorded.meta._channel).toBe("internal");
+    expect(recorded.meta._channel).toBe("cli");
     expect(recorded.meta._execution_id).not.toBe("spoofed");
     // Caller-prefixed `_`-keys that the framework does NOT manage are dropped
     // entirely (Spec 65 §4.4).
     expect(recorded.meta).not.toHaveProperty("_custom_secret");
+    // Default actor is human (NOT system) — see the Codex review fix on this
+    // PR. system/worker types intentionally bypass cap-permission and tenant
+    // isolation, so the safe default is human and bypasses are explicit.
+    expect(recorded.actor.type).toBe("human");
+    expect(recorded.actor.id).toBe("cli");
     // Surface stderr only if the test fails for context.
     if (proc.exitCode !== 0) console.error(stderr);
+  });
+
+  test("--actor-type system opts in to system actor (bypass aware)", async () => {
+    const proc = Bun.spawn(
+      [
+        "bun",
+        "run",
+        CLI_ENTRY,
+        "exec",
+        "record_meta",
+        "--actor-type",
+        "system",
+        "--actor",
+        "ci-bot",
+        "--json",
+      ],
+      { cwd: TEST_DIR, stdout: "pipe", stderr: "pipe" },
+    );
+    await proc.exited;
+    expect(proc.exitCode).toBe(0);
+    const recorded = readSideChannel();
+    expect(recorded.actor.type).toBe("system");
+    expect(recorded.actor.id).toBe("ci-bot");
+  });
+
+  test("human actor without --tenant fails through tenant isolation", async () => {
+    // Default actor is human; tenant isolation slot requires a tenant for
+    // non-system actors. Confirms the bypass-prevention codex flagged works.
+    const proc = Bun.spawn(["bun", "run", CLI_ENTRY, "exec", "record_meta", "--json"], {
+      cwd: TEST_DIR,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    await proc.exited;
+    const stdout = (await new Response(proc.stdout).text()).trim();
+
+    // Pipeline returns success:false with code security.tenant.not_resolved,
+    // CLI surfaces that as exit 2 (action-layer failure) rather than 1.
+    expect(proc.exitCode).toBe(2);
+    const lastLine =
+      stdout
+        .split("\n")
+        .filter((l) => l.trim().startsWith("{"))
+        .pop() ?? "";
+    const result = JSON.parse(lastLine);
+    expect(result.success).toBe(false);
+    expect(result.data.code).toContain("security.tenant");
+  });
+
+  test("invalid --actor-type rejected with exit 1", async () => {
+    const proc = Bun.spawn(
+      ["bun", "run", CLI_ENTRY, "exec", "record_meta", "--actor-type", "wizard"],
+      { cwd: TEST_DIR, stdout: "pipe", stderr: "pipe" },
+    );
+    await proc.exited;
+    const stderr = await new Response(proc.stderr).text();
+    expect(proc.exitCode).toBe(1);
+    expect(stderr).toContain("--actor-type must be one of");
+  });
+
+  test(".env values from project root populate process.env (DATABASE_URL preserved)", async () => {
+    // Write a project .env that sets a known marker the handler can echo back.
+    writeFileSync(resolve(TEST_DIR, ".env"), "EXEC_DOTENV_MARKER=loaded-from-dotenv\n");
+    // Update the fixture so the handler exposes process.env values it can see.
+    const augmented = `
+import { writeFileSync } from "node:fs";
+
+const SIDE_CHANNEL = ${JSON.stringify(SIDE_CHANNEL)};
+
+export default {
+  capabilities: [
+    {
+      name: "cap-exec-test",
+      label: "Exec Test",
+      type: "standard",
+      category: "business",
+      version: "0.0.1",
+      entities: [
+        {
+          name: "exec_test",
+          label: "ExecTest",
+          fields: { name: { type: "text", label: "Name" } },
+        },
+      ],
+      actions: [
+        {
+          name: "record_meta",
+          label: "Record meta",
+          entity: "exec_test",
+          type: "custom",
+          handler: async (ctx) => {
+            writeFileSync(
+              SIDE_CHANNEL,
+              JSON.stringify({
+                meta: ctx.meta.toJSON(),
+                input: ctx.input,
+                actor: { type: ctx.actor.type, id: ctx.actor.id },
+                envMarker: process.env.EXEC_DOTENV_MARKER,
+              }),
+            );
+            return { recorded: true };
+          },
+        },
+      ],
+    },
+  ],
+};
+`;
+    writeFileSync(resolve(TEST_DIR, "linchkit.config.ts"), augmented);
+
+    // Test runner shouldn't have EXEC_DOTENV_MARKER set — the .env loader is
+    // the only way for the value to land in the child process's env. Don't
+    // override `env`; full parent inheritance plus the absent-by-default
+    // marker is the realistic state.
+    const proc = Bun.spawn(
+      ["bun", "run", CLI_ENTRY, "exec", "record_meta", "--tenant", "default", "--json"],
+      { cwd: TEST_DIR, stdout: "pipe", stderr: "pipe" },
+    );
+    await proc.exited;
+    expect(proc.exitCode).toBe(0);
+    const raw = JSON.parse(readFileSync(SIDE_CHANNEL, "utf-8"));
+    expect(raw.envMarker).toBe("loaded-from-dotenv");
   });
 
   test("invalid --input JSON exits with code 1 and prints to stderr", async () => {

--- a/packages/cli/src/commands/__tests__/exec.test.ts
+++ b/packages/cli/src/commands/__tests__/exec.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Tests for `linch exec` (Spec 65 §3.5).
+ *
+ * Tests spawn the CLI as a subprocess against a fixture project so the full
+ * config-loading + capability-registration + CommandLayer dispatch path is
+ * exercised end-to-end. Action handlers communicate with the test process by
+ * writing their observed meta + input to a side-channel file under TEST_DIR.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const TEST_DIR = resolve(import.meta.dir, ".tmp-test-exec");
+const CLI_ENTRY = resolve(import.meta.dir, "../../index.ts");
+const SIDE_CHANNEL = resolve(TEST_DIR, "handler-output.json");
+
+/**
+ * Write a linchkit.config.ts that registers a single capability with two
+ * test actions:
+ * - `record_meta`: writes ctx.meta.toJSON() + ctx.input to SIDE_CHANNEL,
+ *   returns success.
+ * - `boom_action`: throws an Error to exercise the executor's failure path.
+ *
+ * The handlers use `node:fs` directly (not LinchKit primitives) to keep the
+ * fixture self-contained and free of cap-permission so unauthenticated CLI
+ * invocations succeed.
+ */
+function writeFixtureConfig(extras: { sideChannel: string }) {
+  const content = `
+import { writeFileSync } from "node:fs";
+
+const SIDE_CHANNEL = ${JSON.stringify(extras.sideChannel)};
+
+export default {
+  capabilities: [
+    {
+      name: "cap-exec-test",
+      label: "Exec Test",
+      type: "standard",
+      category: "business",
+      version: "0.0.1",
+      entities: [
+        {
+          name: "exec_test",
+          label: "ExecTest",
+          fields: { name: { type: "text", label: "Name" } },
+        },
+      ],
+      actions: [
+        {
+          name: "record_meta",
+          label: "Record meta",
+          entity: "exec_test",
+          type: "custom",
+          handler: async (ctx) => {
+            writeFileSync(
+              SIDE_CHANNEL,
+              JSON.stringify({ meta: ctx.meta.toJSON(), input: ctx.input }),
+            );
+            return { recorded: true };
+          },
+        },
+        {
+          name: "boom_action",
+          label: "Boom",
+          entity: "exec_test",
+          type: "custom",
+          handler: async () => {
+            throw new Error("intentional failure");
+          },
+        },
+      ],
+    },
+  ],
+};
+`;
+  writeFileSync(resolve(TEST_DIR, "linchkit.config.ts"), content);
+}
+
+function readSideChannel(): { meta: Record<string, unknown>; input: Record<string, unknown> } {
+  return JSON.parse(readFileSync(SIDE_CHANNEL, "utf-8"));
+}
+
+function cleanup() {
+  if (existsSync(TEST_DIR)) {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  }
+}
+
+describe("linch exec", () => {
+  beforeEach(() => {
+    cleanup();
+    mkdirSync(TEST_DIR, { recursive: true });
+    writeFixtureConfig({ sideChannel: SIDE_CHANNEL });
+  });
+
+  afterEach(cleanup);
+
+  test("happy path: dispatches action with input + meta, strips _-keys", async () => {
+    const proc = Bun.spawn(
+      [
+        "bun",
+        "run",
+        CLI_ENTRY,
+        "exec",
+        "record_meta",
+        "--input",
+        JSON.stringify({ id: "pr_001" }),
+        "--meta",
+        JSON.stringify({
+          bulk: true,
+          _channel: "spoofed",
+          _execution_id: "spoofed",
+          _custom_secret: "hax",
+        }),
+        "--json",
+      ],
+      { cwd: TEST_DIR, stdout: "pipe", stderr: "pipe" },
+    );
+    await proc.exited;
+    const stdout = (await new Response(proc.stdout).text()).trim();
+    const stderr = await new Response(proc.stderr).text();
+
+    expect(proc.exitCode).toBe(0);
+    // Result line is the last JSON output on stdout — bun run may print a banner.
+    const lastLine =
+      stdout
+        .split("\n")
+        .filter((l) => l.trim().startsWith("{"))
+        .pop() ?? "";
+    const result = JSON.parse(lastLine);
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ recorded: true });
+
+    const recorded = readSideChannel();
+    expect(recorded.input).toEqual({ id: "pr_001" });
+    // Caller-supplied `bulk` key visible to handler.
+    expect(recorded.meta.bulk).toBe(true);
+    // Framework-set system keys are present with framework values, not the
+    // spoofed values the caller tried to inject.
+    expect(recorded.meta._channel).toBe("internal");
+    expect(recorded.meta._execution_id).not.toBe("spoofed");
+    // Caller-prefixed `_`-keys that the framework does NOT manage are dropped
+    // entirely (Spec 65 §4.4).
+    expect(recorded.meta).not.toHaveProperty("_custom_secret");
+    // Surface stderr only if the test fails for context.
+    if (proc.exitCode !== 0) console.error(stderr);
+  });
+
+  test("invalid --input JSON exits with code 1 and prints to stderr", async () => {
+    const proc = Bun.spawn(
+      ["bun", "run", CLI_ENTRY, "exec", "record_meta", "--input", "{not-json"],
+      { cwd: TEST_DIR, stdout: "pipe", stderr: "pipe" },
+    );
+    await proc.exited;
+    const stderr = await new Response(proc.stderr).text();
+
+    expect(proc.exitCode).toBe(1);
+    expect(stderr).toContain("Invalid JSON for --input");
+  });
+
+  test("--input + --input-file together exit with code 1", async () => {
+    const inputFile = resolve(TEST_DIR, "input.json");
+    writeFileSync(inputFile, JSON.stringify({ id: "x" }));
+
+    const proc = Bun.spawn(
+      ["bun", "run", CLI_ENTRY, "exec", "record_meta", "--input", "{}", "--input-file", inputFile],
+      { cwd: TEST_DIR, stdout: "pipe", stderr: "pipe" },
+    );
+    await proc.exited;
+    const stderr = await new Response(proc.stderr).text();
+
+    expect(proc.exitCode).toBe(1);
+    expect(stderr).toContain("mutually exclusive");
+  });
+
+  test("action throws → exit 2 with failure result", async () => {
+    const proc = Bun.spawn(["bun", "run", CLI_ENTRY, "exec", "boom_action", "--json"], {
+      cwd: TEST_DIR,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    await proc.exited;
+    const stdout = (await new Response(proc.stdout).text()).trim();
+
+    expect(proc.exitCode).toBe(2);
+    // The pipeline returns ActionResult { success: false, ... } before the
+    // process exits with code 2 — confirm the failure was reported.
+    const lastLine =
+      stdout
+        .split("\n")
+        .filter((l) => l.trim().startsWith("{"))
+        .pop() ?? "";
+    const result = JSON.parse(lastLine);
+    expect(result.success).toBe(false);
+  });
+
+  test("--meta exceeding 8 KB exits with code 1", async () => {
+    // Generate a string just over 8 KB. JSON-encoded length includes quoting +
+    // wrapping object keys, so 9000 bytes of payload is comfortably oversize.
+    const big = "x".repeat(9000);
+    const proc = Bun.spawn(
+      ["bun", "run", CLI_ENTRY, "exec", "record_meta", "--meta", JSON.stringify({ blob: big })],
+      { cwd: TEST_DIR, stdout: "pipe", stderr: "pipe" },
+    );
+    await proc.exited;
+    const stderr = await new Response(proc.stderr).text();
+
+    expect(proc.exitCode).toBe(1);
+    expect(stderr).toContain("exceeds");
+  });
+});

--- a/packages/cli/src/commands/exec.ts
+++ b/packages/cli/src/commands/exec.ts
@@ -1,0 +1,328 @@
+/**
+ * linch exec — Run a registered Action with input + optional ExecutionMeta.
+ *
+ * Spec 65 §3.5. Boots a minimal in-process LinchKit runtime (CommandLayer
+ * + ActionExecutor + DataProvider + tenant/permission middleware) and
+ * dispatches the named action through the same pipeline that REST / GraphQL
+ * / MCP transports use. No transport startup, no flow engine, no AI service —
+ * exec is a one-shot CLI invocation, not a long-running process.
+ *
+ * Exit codes (Spec 65 §3.5):
+ *   0 — action returned success
+ *   1 — input/meta parsing or argument validation error
+ *   2 — action execution returned failure (or threw)
+ */
+
+import { readFileSync } from "node:fs";
+import type { ActionResult, Actor, CapabilityDefinition, LinchKitConfig } from "@linchkit/core";
+import { ConfigRegistry, DEFAULT_META_MAX_BYTES, initI18n } from "@linchkit/core";
+import {
+  type CommandLayer,
+  consoleLogger,
+  createActionExecutor,
+  createApprovalVerifier,
+  createCommandLayer,
+  createEventBus,
+  detectEnvironment,
+  InMemoryApprovalStore,
+  InMemoryExecutionLogger,
+} from "@linchkit/core/server";
+import { defineCommand } from "citty";
+import { loadConfig } from "../utils/load-config";
+import { buildRegistries, wireAuthProvider } from "./startup/build-registries";
+import { collectCapabilityDefinitions } from "./startup/collect-capabilities";
+import { setupDatabase } from "./startup/setup-database";
+
+// ── Helpers ─────────────────────────────────────────────────
+
+/**
+ * Drop `_`-prefixed keys from a record. Spec 65 §4.4 — external CLI callers
+ * cannot set system meta keys; the action engine also strips, but doing it
+ * pre-flight keeps the 8 KB size check honest about what will be sent over
+ * the wire.
+ */
+function stripSystemKeys(input: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(input)) {
+    if (k.startsWith("_")) continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+// ── Argument parsing helpers ────────────────────────────────
+
+/**
+ * Parse a JSON string. Throws a structured error suitable for stderr.
+ * `--input`/`--meta` always wrap user-supplied JSON; quote/escape mistakes
+ * are common, so the error needs the source label and the parser message.
+ */
+function parseJsonArg(label: string, raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error(`${label} must be a JSON object`);
+    }
+    return parsed as Record<string, unknown>;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`Invalid JSON for ${label}: ${msg}`);
+  }
+}
+
+/** Read a JSON file. Errors are tagged with the flag they came from. */
+function readJsonFile(label: string, path: string): Record<string, unknown> {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to read ${label} file "${path}": ${msg}`);
+  }
+  return parseJsonArg(label, raw);
+}
+
+// ── Bootstrap helpers ───────────────────────────────────────
+
+/**
+ * Build a minimal CommandLayer + executor in-process. Mirrors dev-wiring's
+ * registries and middleware setup but skips transport/flow/AI/cache
+ * machinery — exec only needs to dispatch one action and exit.
+ */
+async function bootstrapCommandLayer(): Promise<{
+  commandLayer: CommandLayer;
+  shutdown: () => Promise<void>;
+}> {
+  // Suppress runtime logger output so the CLI's stdout stays clean for the
+  // action result. CLI output (including errors) is emitted via console below.
+  process.env.LOG_LEVEL ??= "silent";
+
+  const environment = detectEnvironment();
+
+  let config: LinchKitConfig = {};
+  try {
+    const result = await loadConfig();
+    config = result.config;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.startsWith("Config file not found:")) {
+      throw new Error("No linchkit.config.ts found. Run from a LinchKit project directory.");
+    }
+    throw new Error(`Failed to load config: ${msg}`);
+  }
+
+  const capabilities = (config.capabilities ?? []) as CapabilityDefinition[];
+  const registry = ConfigRegistry.create(config, capabilities);
+
+  await initI18n();
+
+  const collected = collectCapabilityDefinitions(capabilities);
+  const { entities, actions, links, middlewares, interfaces } = collected;
+
+  const { entityRegistry, actionRegistry } = await buildRegistries({
+    capabilities,
+    interfaces,
+    schemas: entities,
+    actions,
+    links,
+    middlewares,
+    registry,
+    environment,
+  });
+
+  const { dataProvider, dbInstance } = await setupDatabase({
+    registry,
+    schemas: entities,
+    links,
+  });
+
+  await wireAuthProvider({
+    capabilities,
+    actionRegistry,
+    actions,
+    middlewares,
+    dataProvider,
+    registry,
+    usingDatabase: dbInstance !== undefined,
+    dbInstance,
+  });
+
+  const executionLogger = new InMemoryExecutionLogger();
+  const approvalStore = new InMemoryApprovalStore();
+  const { bus: eventBus } = createEventBus();
+  const capabilityNames = new Set(capabilities.map((c) => c.name));
+
+  const executor = createActionExecutor({
+    dataProvider,
+    executionLogger,
+    configRegistry: registry,
+    eventBus,
+    capabilityNames,
+    entityRegistry,
+    logger: consoleLogger,
+  });
+  for (const action of actionRegistry.getAll()) {
+    executor.registry.register(action);
+  }
+
+  const commandLayer = createCommandLayer({
+    executor,
+    verifyApproval: createApprovalVerifier(approvalStore),
+  });
+  for (const mw of middlewares) {
+    commandLayer.use(mw);
+  }
+
+  const shutdown = async (): Promise<void> => {
+    if (dbInstance) {
+      const { closeDatabase } = await import("@linchkit/core/server");
+      await closeDatabase();
+    }
+  };
+
+  return { commandLayer, shutdown };
+}
+
+// ── Command definition ──────────────────────────────────────
+
+export const execCommand = defineCommand({
+  meta: {
+    name: "exec",
+    description: "Run a registered Action with input and optional ExecutionMeta",
+  },
+  args: {
+    action: {
+      type: "positional",
+      description: "Action name to execute (verb_noun, e.g. submit_request)",
+      required: true,
+    },
+    input: {
+      type: "string",
+      description: "JSON string for action input (default: {})",
+    },
+    "input-file": {
+      type: "string",
+      description: "Read action input JSON from a file (mutually exclusive with --input)",
+    },
+    meta: {
+      type: "string",
+      description: "JSON string for ExecutionMeta (system keys with leading _ are stripped)",
+    },
+    "meta-file": {
+      type: "string",
+      description: "Read ExecutionMeta JSON from a file (mutually exclusive with --meta)",
+    },
+    actor: {
+      type: "string",
+      description: "Actor ID for the call (default: cli system actor)",
+    },
+    tenant: {
+      type: "string",
+      description: "Tenant ID (optional)",
+    },
+    json: {
+      type: "boolean",
+      description: "Output result as compact JSON",
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const actionName = args.action as string;
+    const outputJson = args.json as boolean;
+
+    // 1. Mutually-exclusive flag validation — surface before doing any work.
+    if (args.input !== undefined && args["input-file"] !== undefined) {
+      console.error("Error: --input and --input-file are mutually exclusive");
+      process.exit(1);
+    }
+    if (args.meta !== undefined && args["meta-file"] !== undefined) {
+      console.error("Error: --meta and --meta-file are mutually exclusive");
+      process.exit(1);
+    }
+
+    // 2. Parse input + meta JSON. Failures here are user errors → exit 1.
+    let input: Record<string, unknown>;
+    let rawMeta: Record<string, unknown> | undefined;
+    try {
+      if (args["input-file"] !== undefined) {
+        input = readJsonFile("--input-file", args["input-file"] as string);
+      } else if (args.input !== undefined) {
+        input = parseJsonArg("--input", args.input as string);
+      } else {
+        input = {};
+      }
+
+      if (args["meta-file"] !== undefined) {
+        rawMeta = readJsonFile("--meta-file", args["meta-file"] as string);
+      } else if (args.meta !== undefined) {
+        rawMeta = parseJsonArg("--meta", args.meta as string);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`Error: ${msg}`);
+      process.exit(1);
+    }
+
+    // 3. Strip `_`-prefixed keys (Spec 65 §4.4) — external callers must not
+    // set system meta keys. The action engine also strips, but doing it here
+    // keeps the size check below honest about the wire payload.
+    const meta = rawMeta !== undefined ? stripSystemKeys(rawMeta) : undefined;
+
+    // 4. Pre-flight 8 KB size enforcement (Spec 65 §10.2). The CommandLayer
+    // would also reject oversize meta, but failing fast here gives the user
+    // a clearer "validation error" exit code (1) instead of "execution
+    // failure" (2).
+    if (meta !== undefined) {
+      const serialized = JSON.stringify(meta);
+      const bytes = new TextEncoder().encode(serialized).length;
+      if (bytes > DEFAULT_META_MAX_BYTES) {
+        console.error(`Error: --meta exceeds ${DEFAULT_META_MAX_BYTES} bytes (got ${bytes})`);
+        process.exit(1);
+      }
+    }
+
+    // 5. Build the actor. Default is a system actor scoped to "cli" so audit
+    // trails can distinguish CLI-driven calls from internal flow calls (which
+    // use id "flow-engine").
+    const actor: Actor = {
+      type: "system",
+      id: (args.actor as string | undefined) ?? "cli",
+      groups: [],
+    };
+    const tenantId = args.tenant as string | undefined;
+
+    // 6. Bootstrap runtime + dispatch.
+    let result: ActionResult;
+    let shutdown: (() => Promise<void>) | undefined;
+    try {
+      const boot = await bootstrapCommandLayer();
+      shutdown = boot.shutdown;
+      result = await boot.commandLayer.execute({
+        command: actionName,
+        input,
+        channel: "internal",
+        actor,
+        tenantId,
+        meta,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`Error: ${msg}`);
+      if (shutdown) await shutdown().catch(() => undefined);
+      process.exit(2);
+    }
+
+    // 7. Emit result + exit code. Action-layer failures map to exit 2.
+    if (outputJson) {
+      console.log(JSON.stringify(result));
+    } else {
+      console.log(JSON.stringify(result, null, 2));
+    }
+
+    if (shutdown) await shutdown().catch(() => undefined);
+
+    if (!result.success) {
+      process.exit(2);
+    }
+  },
+});

--- a/packages/cli/src/commands/exec.ts
+++ b/packages/cli/src/commands/exec.ts
@@ -23,6 +23,9 @@ import {
   createApprovalVerifier,
   createCommandLayer,
   createEventBus,
+  createPersistentEventBus,
+  DrizzleDataProvider,
+  DrizzleTransactionManager,
   detectEnvironment,
   InMemoryApprovalStore,
   InMemoryExecutionLogger,
@@ -85,6 +88,26 @@ function readJsonFile(label: string, path: string): Record<string, unknown> {
 // ── Bootstrap helpers ───────────────────────────────────────
 
 /**
+ * Load `<cwd>/.env` into process.env without overriding values already set.
+ * Mirrors `linch dev` so exec sees the same DATABASE_URL / auth secrets.
+ */
+async function loadEnvFile(): Promise<void> {
+  const { existsSync, readFileSync } = await import("node:fs");
+  const envPath = `${process.cwd()}/.env`;
+  if (!existsSync(envPath)) return;
+  const content = readFileSync(envPath, "utf-8");
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eqIdx = trimmed.indexOf("=");
+    if (eqIdx === -1) continue;
+    const key = trimmed.slice(0, eqIdx).trim();
+    const value = trimmed.slice(eqIdx + 1).trim();
+    if (!process.env[key]) process.env[key] = value;
+  }
+}
+
+/**
  * Build a minimal CommandLayer + executor in-process. Mirrors dev-wiring's
  * registries and middleware setup but skips transport/flow/AI/cache
  * machinery — exec only needs to dispatch one action and exit.
@@ -93,6 +116,10 @@ async function bootstrapCommandLayer(): Promise<{
   commandLayer: CommandLayer;
   shutdown: () => Promise<void>;
 }> {
+  // Load .env BEFORE reading config / database settings so DATABASE_URL and
+  // auth secrets aren't silently missing. Mirrors what `linch dev` does.
+  await loadEnvFile();
+
   // Suppress runtime logger output so the CLI's stdout stays clean for the
   // action result. CLI output (including errors) is emitted via console below.
   process.env.LOG_LEVEL ??= "silent";
@@ -149,11 +176,20 @@ async function bootstrapCommandLayer(): Promise<{
 
   const executionLogger = new InMemoryExecutionLogger();
   const approvalStore = new InMemoryApprovalStore();
-  const { bus: eventBus } = createEventBus();
+  // Use PersistentEventBus + DrizzleTransactionManager when a real DB is wired
+  // so transactional actions roll back on handler failure (and pending events
+  // flush atomically with the commit). Falls back to in-memory wiring under
+  // InMemoryStore — same trade-off `linch dev` makes.
+  const { bus: eventBus } = dbInstance ? createPersistentEventBus(dbInstance) : createEventBus();
+  const transactionManager =
+    dbInstance && dataProvider instanceof DrizzleDataProvider
+      ? new DrizzleTransactionManager(dbInstance, dataProvider as DrizzleDataProvider)
+      : undefined;
   const capabilityNames = new Set(capabilities.map((c) => c.name));
 
   const executor = createActionExecutor({
     dataProvider,
+    transactionManager,
     executionLogger,
     configRegistry: registry,
     eventBus,
@@ -168,6 +204,7 @@ async function bootstrapCommandLayer(): Promise<{
   const commandLayer = createCommandLayer({
     executor,
     verifyApproval: createApprovalVerifier(approvalStore),
+    transactionManager,
   });
   for (const mw of middlewares) {
     commandLayer.use(mw);
@@ -214,11 +251,20 @@ export const execCommand = defineCommand({
     },
     actor: {
       type: "string",
-      description: "Actor ID for the call (default: cli system actor)",
+      description: "Actor ID for the call (default: cli)",
+    },
+    "actor-type": {
+      type: "string",
+      description:
+        "Actor type — human (default), ai, system, worker, timer, external. " +
+        "system/worker bypass cap-permission and tenant isolation; opt in only when scripted.",
     },
     tenant: {
       type: "string",
-      description: "Tenant ID (optional)",
+      description:
+        "Tenant ID. Required when actor type is human/ai/external (the tenant " +
+        "isolation slot rejects requests without one). System/worker actor " +
+        "types bypass tenant resolution.",
     },
     json: {
       type: "boolean",
@@ -281,15 +327,29 @@ export const execCommand = defineCommand({
       }
     }
 
-    // 5. Build the actor. Default is a system actor scoped to "cli" so audit
-    // trails can distinguish CLI-driven calls from internal flow calls (which
-    // use id "flow-engine").
+    // 5. Build the actor. Default is a *human* actor scoped to "cli" so the
+    // permission and tenant-isolation slots run normally — opting into the
+    // bypass-prone system/worker types is explicit (`--actor-type system`).
+    // Audits can still distinguish CLI-originated calls via `meta._channel`,
+    // which is auto-stamped to "cli" by ActionEngine.
+    const ALLOWED_ACTOR_TYPES = new Set(["human", "ai", "system", "worker", "timer", "external"]);
+    const actorTypeArg = args["actor-type"] as string | undefined;
+    if (actorTypeArg !== undefined && !ALLOWED_ACTOR_TYPES.has(actorTypeArg)) {
+      console.error(
+        `Error: --actor-type must be one of ${Array.from(ALLOWED_ACTOR_TYPES).join(", ")}`,
+      );
+      process.exit(1);
+    }
+    const tenantId = args.tenant as string | undefined;
     const actor: Actor = {
-      type: "system",
+      type: (actorTypeArg as Actor["type"] | undefined) ?? "human",
       id: (args.actor as string | undefined) ?? "cli",
       groups: [],
+      // The default tenant resolver reads tenantId from actor.tenantId, not
+      // from CommandExecuteOptions.tenantId. Plumb the flag onto both so the
+      // tenant slot can resolve and the data layer scopes correctly.
+      tenantId,
     };
-    const tenantId = args.tenant as string | undefined;
 
     // 6. Bootstrap runtime + dispatch.
     let result: ActionResult;
@@ -300,7 +360,7 @@ export const execCommand = defineCommand({
       result = await boot.commandLayer.execute({
         command: actionName,
         input,
-        channel: "internal",
+        channel: "cli",
         actor,
         tenantId,
         meta,

--- a/packages/cli/src/commands/exec.ts
+++ b/packages/cli/src/commands/exec.ts
@@ -13,9 +13,9 @@
  *   2 — action execution returned failure (or threw)
  */
 
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import type { ActionResult, Actor, CapabilityDefinition, LinchKitConfig } from "@linchkit/core";
-import { ConfigRegistry, DEFAULT_META_MAX_BYTES, initI18n } from "@linchkit/core";
+import { ConfigRegistry, DEFAULT_META_MAX_BYTES, initI18n, stripSystemKeys } from "@linchkit/core";
 import {
   type CommandLayer,
   consoleLogger,
@@ -37,21 +37,6 @@ import { collectCapabilityDefinitions } from "./startup/collect-capabilities";
 import { setupDatabase } from "./startup/setup-database";
 
 // ── Helpers ─────────────────────────────────────────────────
-
-/**
- * Drop `_`-prefixed keys from a record. Spec 65 §4.4 — external CLI callers
- * cannot set system meta keys; the action engine also strips, but doing it
- * pre-flight keeps the 8 KB size check honest about what will be sent over
- * the wire.
- */
-function stripSystemKeys(input: Record<string, unknown>): Record<string, unknown> {
-  const out: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(input)) {
-    if (k.startsWith("_")) continue;
-    out[k] = v;
-  }
-  return out;
-}
 
 // ── Argument parsing helpers ────────────────────────────────
 
@@ -92,7 +77,6 @@ function readJsonFile(label: string, path: string): Record<string, unknown> {
  * Mirrors `linch dev` so exec sees the same DATABASE_URL / auth secrets.
  */
 async function loadEnvFile(): Promise<void> {
-  const { existsSync, readFileSync } = await import("node:fs");
   const envPath = `${process.cwd()}/.env`;
   if (!existsSync(envPath)) return;
   const content = readFileSync(envPath, "utf-8");
@@ -103,7 +87,12 @@ async function loadEnvFile(): Promise<void> {
     if (eqIdx === -1) continue;
     const key = trimmed.slice(0, eqIdx).trim();
     const value = trimmed.slice(eqIdx + 1).trim();
-    if (!process.env[key]) process.env[key] = value;
+    // Use `=== undefined` so explicitly-set empty values (`FOO=`) aren't
+    // overridden by the .env file. Also a minimal parser by design — it
+    // does NOT handle quoted values, inline comments, or `export` keyword.
+    // Real apps that need those features should use a `dotenv` runner;
+    // this loader exists to mirror `linch dev` for fast CLI invocations.
+    if (process.env[key] === undefined) process.env[key] = value;
   }
 }
 
@@ -163,53 +152,10 @@ async function bootstrapCommandLayer(): Promise<{
     links,
   });
 
-  await wireAuthProvider({
-    capabilities,
-    actionRegistry,
-    actions,
-    middlewares,
-    dataProvider,
-    registry,
-    usingDatabase: dbInstance !== undefined,
-    dbInstance,
-  });
-
-  const executionLogger = new InMemoryExecutionLogger();
-  const approvalStore = new InMemoryApprovalStore();
-  // Use PersistentEventBus + DrizzleTransactionManager when a real DB is wired
-  // so transactional actions roll back on handler failure (and pending events
-  // flush atomically with the commit). Falls back to in-memory wiring under
-  // InMemoryStore — same trade-off `linch dev` makes.
-  const { bus: eventBus } = dbInstance ? createPersistentEventBus(dbInstance) : createEventBus();
-  const transactionManager =
-    dbInstance && dataProvider instanceof DrizzleDataProvider
-      ? new DrizzleTransactionManager(dbInstance, dataProvider as DrizzleDataProvider)
-      : undefined;
-  const capabilityNames = new Set(capabilities.map((c) => c.name));
-
-  const executor = createActionExecutor({
-    dataProvider,
-    transactionManager,
-    executionLogger,
-    configRegistry: registry,
-    eventBus,
-    capabilityNames,
-    entityRegistry,
-    logger: consoleLogger,
-  });
-  for (const action of actionRegistry.getAll()) {
-    executor.registry.register(action);
-  }
-
-  const commandLayer = createCommandLayer({
-    executor,
-    verifyApproval: createApprovalVerifier(approvalStore),
-    transactionManager,
-  });
-  for (const mw of middlewares) {
-    commandLayer.use(mw);
-  }
-
+  // Define shutdown up-front so any failure between here and the return
+  // statement still cleans up the DB connection. Without this, an error
+  // in `wireAuthProvider`, executor wiring, or middleware registration
+  // would leak the pool until the process exits.
   const shutdown = async (): Promise<void> => {
     if (dbInstance) {
       const { closeDatabase } = await import("@linchkit/core/server");
@@ -217,7 +163,59 @@ async function bootstrapCommandLayer(): Promise<{
     }
   };
 
-  return { commandLayer, shutdown };
+  try {
+    await wireAuthProvider({
+      capabilities,
+      actionRegistry,
+      actions,
+      middlewares,
+      dataProvider,
+      registry,
+      usingDatabase: dbInstance !== undefined,
+      dbInstance,
+    });
+
+    const executionLogger = new InMemoryExecutionLogger();
+    const approvalStore = new InMemoryApprovalStore();
+    // Use PersistentEventBus + DrizzleTransactionManager when a real DB is wired
+    // so transactional actions roll back on handler failure (and pending events
+    // flush atomically with the commit). Falls back to in-memory wiring under
+    // InMemoryStore — same trade-off `linch dev` makes.
+    const { bus: eventBus } = dbInstance ? createPersistentEventBus(dbInstance) : createEventBus();
+    const transactionManager =
+      dbInstance && dataProvider instanceof DrizzleDataProvider
+        ? new DrizzleTransactionManager(dbInstance, dataProvider as DrizzleDataProvider)
+        : undefined;
+    const capabilityNames = new Set(capabilities.map((c) => c.name));
+
+    const executor = createActionExecutor({
+      dataProvider,
+      transactionManager,
+      executionLogger,
+      configRegistry: registry,
+      eventBus,
+      capabilityNames,
+      entityRegistry,
+      logger: consoleLogger,
+    });
+    for (const action of actionRegistry.getAll()) {
+      executor.registry.register(action);
+    }
+
+    const commandLayer = createCommandLayer({
+      executor,
+      verifyApproval: createApprovalVerifier(approvalStore),
+      transactionManager,
+    });
+    for (const mw of middlewares) {
+      commandLayer.use(mw);
+    }
+
+    return { commandLayer, shutdown };
+  } catch (err) {
+    await shutdown().catch(() => undefined);
+    throw err;
+  }
 }
 
 // ── Command definition ──────────────────────────────────────

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -25,6 +25,7 @@ import { describeCommand } from "./commands/describe";
 import { devCommand } from "./commands/dev";
 import { docsCommand } from "./commands/docs";
 import { doctorCommand } from "./commands/doctor";
+import { execCommand } from "./commands/exec";
 import { infoCommand } from "./commands/info";
 import { initCommand } from "./commands/init";
 import { installCommand } from "./commands/install";
@@ -46,6 +47,7 @@ export const VERSION = "0.0.1";
 const RESERVED_NAMESPACES = new Set([
   "init",
   "dev",
+  "exec",
   "describe",
   "db",
   "create",
@@ -163,6 +165,7 @@ function buildCommandsManifest(
   const builtinDescriptions: Record<string, string> = {
     init: "Initialize a new LinchKit project",
     dev: "Start all LinchKit transports in development mode",
+    exec: "Run a registered Action with input and optional ExecutionMeta",
     describe: "Project introspection: overview, entity, action, or capability details",
     db: "Database management (generate, migrate, studio)",
     create: "Create a new capability scaffold",
@@ -215,6 +218,7 @@ async function run() {
   const builtinCommands = {
     init: initCommand,
     dev: devCommand,
+    exec: execCommand,
     describe: describeCommand,
     db: dbCommand,
     create: createCommand,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -346,6 +346,7 @@ export {
   ERROR_STATUS_MAP,
   MetaSizeError,
   redactMetaForLog,
+  stripSystemKeys,
   validateCapabilityMetadata,
 } from "./types";
 export type { ErrorContext } from "./types/error";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -341,7 +341,11 @@ export {
   capabilityCategoryEnum,
   capabilityMetadataSchema,
   capabilityTypeEnum,
+  createExecutionMeta,
+  DEFAULT_META_MAX_BYTES,
   ERROR_STATUS_MAP,
+  MetaSizeError,
+  redactMetaForLog,
   validateCapabilityMetadata,
 } from "./types";
 export type { ErrorContext } from "./types/error";

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -43,6 +43,7 @@ export {
   DEFAULT_META_MAX_BYTES,
   MetaSizeError,
   redactMetaForLog,
+  stripSystemKeys,
 } from "./execution-meta";
 export type * from "./flow";
 export type * from "./life-system";


### PR DESCRIPTION
## Summary

```
linch exec approve_request --input '{"id":"pr_001"}' --meta '{"bulk":true}' --tenant default
```

The new `exec` command boots a minimal in-process LinchKit runtime (config / registries / database / auth provider / ActionExecutor + CommandLayer) and dispatches the named Action through CommandLayer. It reuses `startup/*` helpers from `linch dev` but skips transports / Restate flow engine / AI service / sensors / cache manager — exec is one-shot.

Meta handling:

- `_`-prefixed keys stripped pre-flight (Spec 65 §4.4)
- JSON byte size enforced against `DEFAULT_META_MAX_BYTES` (8 KB; §10.2) with exit 1 fast-fail
- Mutually exclusive `--input` / `--input-file` and `--meta` / `--meta-file`
- Exit codes: 0 success, 1 user/validation errors, 2 action / bootstrap failure

`@linchkit/core` re-exports `DEFAULT_META_MAX_BYTES`, `MetaSizeError`, `createExecutionMeta`, `redactMetaForLog` as runtime values so the CLI (and future scripting hosts) can construct meta safely.

## Codex review (4 findings, all addressed)

- **P1 channel** — was `"internal"`, now `"cli"`. Actions with channel-specific exposure now route correctly.
- **P1 transactions** — bootstrap now wires `DrizzleTransactionManager` + `PersistentEventBus` when a real DB is present, so transactional actions roll back on handler failure (and pending events flush atomically).
- **P1 actor default** — was hard-coded `system` (bypasses cap-permission + tenant isolation). Now defaults to `human` with `id="cli"` and `tenantId` from `--tenant`. `--actor-type system|worker|...` opts into bypass types explicitly. Audits still distinguish CLI calls via `meta._channel: "cli"`.
- **P2 .env loading** — bootstrap now reads `<cwd>/.env` before resolving config / DB settings, mirroring `linch dev`.

## Test plan

- [x] 5 original tests + 4 new tests in `packages/cli/src/commands/__tests__/exec.test.ts` covering: default-actor is human; `--actor-type system` opt-in; invalid `--actor-type` rejected; human actor without `--tenant` fails through tenant isolation; `.env` values land in the action handler's `process.env`.
- [x] Full repo: `4484 pass / 0 fail / 85 skip` (DB integrations skipped without live PG).
- [x] `bun run typecheck` clean.
- [x] `bun run check` clean.

## Known scope

- Bootstrap doesn't initialize Flow engine or Ontology → actions that fan out via `ctx.execute` to nested flows / AI services will fail under exec. Acceptable v1 scope.
- MCP-style client-supplied meta forwarding is not part of exec (no transport hop).

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)