### PR TITLE
feat(core): rule conditions resolve meta.* field paths (Spec 65 §6, closes #215)

### DIFF
--- a/.changeset/rule-meta-conditions.md
+++ b/.changeset/rule-meta-conditions.md
@@ -1,0 +1,12 @@
+---
+"@linchkit/core": minor
+---
+
+feat(core): rule conditions resolve `meta.*` field paths against `ExecutionMeta` (Spec 65 §6)
+
+`RuleEvalInput` gains an optional `meta?: ExecutionMeta` field, threaded into
+the per-rule `ConditionContext`. Field paths in rule conditions that begin with
+`meta.` now resolve against `ctx.meta?.get(...)` instead of the entity record,
+with one level of dotted nesting after the meta key (`meta.source.channel`).
+Missing keys return `undefined` — same shape as missing entity fields, so
+existing rules without `meta.*` references keep working unchanged.

--- a/packages/core/__tests__/rule-engine.test.ts
+++ b/packages/core/__tests__/rule-engine.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { evaluateCondition } from "../src/engine/condition-evaluator";
 import type { RuleEvalInput } from "../src/engine/rule-engine";
 import { evaluateRules } from "../src/engine/rule-engine";
+import { createExecutionMeta } from "../src/types/execution-meta";
 import type { RuleDefinition } from "../src/types/rule";
 
 // ── Helpers ─────────────────────────────────────────
@@ -606,5 +607,120 @@ describe("evaluateRules", () => {
     const result = await evaluateRules([rule], defaultInput);
     expect(result.duration).toBeGreaterThanOrEqual(0);
     expect(result.results[0].duration).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ── meta.* field resolution (Spec 65 §6) ─────────────
+
+describe("meta.* field path resolution", () => {
+  it("resolves meta.<key> against ctx.meta.get(key)", () => {
+    const meta = createExecutionMeta({ raw: { bulk: true } });
+    expect(
+      evaluateCondition(
+        { field: "meta.bulk", operator: "eq", value: true },
+        { target: {}, context: {}, actor: { type: "human", id: "u", groups: [] }, meta },
+      ),
+    ).toBe(true);
+    expect(
+      evaluateCondition(
+        { field: "meta.bulk", operator: "eq", value: false },
+        { target: {}, context: {}, actor: { type: "human", id: "u", groups: [] }, meta },
+      ),
+    ).toBe(false);
+  });
+
+  it("missing meta key returns undefined (is_null matches)", () => {
+    const meta = createExecutionMeta({ raw: { bulk: true } });
+    const ctx = {
+      target: {},
+      context: {},
+      actor: { type: "human" as const, id: "u", groups: [] },
+      meta,
+    };
+    expect(evaluateCondition({ field: "meta.unknown", operator: "is_null" }, ctx)).toBe(true);
+    expect(evaluateCondition({ field: "meta.unknown", operator: "eq", value: true }, ctx)).toBe(
+      false,
+    );
+  });
+
+  it("absent meta on context resolves all meta.* fields to undefined", () => {
+    const ctx = {
+      target: {},
+      context: {},
+      actor: { type: "human" as const, id: "u", groups: [] },
+    };
+    expect(evaluateCondition({ field: "meta.bulk", operator: "is_null" }, ctx)).toBe(true);
+  });
+
+  it("resolves one level of nesting after meta.<key>", () => {
+    const meta = createExecutionMeta({ raw: { source: { channel: "rest", view: "queue" } } });
+    const ctx = {
+      target: {},
+      context: {},
+      actor: { type: "human" as const, id: "u", groups: [] },
+      meta,
+    };
+    expect(
+      evaluateCondition({ field: "meta.source.channel", operator: "eq", value: "rest" }, ctx),
+    ).toBe(true);
+    expect(evaluateCondition({ field: "meta.source.missing", operator: "is_null" }, ctx)).toBe(
+      true,
+    );
+  });
+
+  it("combined entity field + meta field via and-condition (spec 65 §6 example)", async () => {
+    const rule: RuleDefinition = {
+      name: "skip_approval_for_bulk",
+      label: "skip_approval_for_bulk",
+      trigger: { action: "submit_request" },
+      condition: {
+        operator: "and",
+        conditions: [
+          { field: "meta.bulk", operator: "eq", value: true },
+          { field: "target.amount", operator: "lt", value: 1000 },
+        ],
+      },
+      effect: { type: "warn", message: "Bulk imports under 1000 skip approval" },
+    };
+
+    const matchInput: RuleEvalInput = {
+      target: { amount: 500 },
+      actor: { type: "human", id: "u", groups: [] },
+      meta: createExecutionMeta({ raw: { bulk: true } }),
+    };
+    const matchResult = await evaluateRules([rule], matchInput);
+    expect(matchResult.triggered).toBe(true);
+    expect(matchResult.warnings).toHaveLength(1);
+
+    // meta.bulk missing -> condition fails
+    const noMetaInput: RuleEvalInput = {
+      target: { amount: 500 },
+      actor: { type: "human", id: "u", groups: [] },
+      meta: createExecutionMeta({ raw: {} }),
+    };
+    expect((await evaluateRules([rule], noMetaInput)).triggered).toBe(false);
+
+    // amount over threshold -> condition fails
+    const overThresholdInput: RuleEvalInput = {
+      target: { amount: 2000 },
+      actor: { type: "human", id: "u", groups: [] },
+      meta: createExecutionMeta({ raw: { bulk: true } }),
+    };
+    expect((await evaluateRules([rule], overThresholdInput)).triggered).toBe(false);
+  });
+
+  it("rules without meta.* references are unaffected by missing meta input", async () => {
+    const rule: RuleDefinition = {
+      name: "warn-large",
+      label: "warn-large",
+      trigger: { action: "submit" },
+      condition: { field: "target.amount", operator: "gt", value: 1000 },
+      effect: { type: "warn", message: "Large amount" },
+    };
+    const result = await evaluateRules([rule], {
+      target: { amount: 5000 },
+      actor: { type: "human", id: "u", groups: [] },
+    });
+    expect(result.triggered).toBe(true);
   });
 });

--- a/packages/core/__tests__/rule-engine.test.ts
+++ b/packages/core/__tests__/rule-engine.test.ts
@@ -709,6 +709,87 @@ describe("meta.* field path resolution", () => {
     expect((await evaluateRules([rule], overThresholdInput)).triggered).toBe(false);
   });
 
+  it("flat meta keys with dots in the name (e.g. batch.parentExecutionId) resolve correctly", () => {
+    // Regression for codex P2: the framework emits flat keys whose names
+    // contain dots (`batch.parentExecutionId`, `batch.index` from
+    // batch-action-engine). A rule written against `meta.batch.parentExecutionId`
+    // must look up the joined key first and only fall back to nested
+    // POJO access if no flat key matches.
+    const meta = createExecutionMeta({
+      raw: { "batch.parentExecutionId": "exec_root", "batch.index": 3 },
+    });
+    const ctx = {
+      target: {},
+      context: {},
+      actor: { type: "human" as const, id: "u", groups: [] },
+      meta,
+    };
+    expect(
+      evaluateCondition(
+        { field: "meta.batch.parentExecutionId", operator: "eq", value: "exec_root" },
+        ctx,
+      ),
+    ).toBe(true);
+    expect(evaluateCondition({ field: "meta.batch.index", operator: "eq", value: 3 }, ctx)).toBe(
+      true,
+    );
+  });
+
+  it("flat keys take precedence over POJO-nested interpretation", () => {
+    // Greedy match means the flat key wins. Two equally-named meta entries
+    // (one flat, one nested) shouldn't realistically coexist; assert which
+    // one is honored if they did.
+    const meta = createExecutionMeta({
+      raw: { "a.b": "flat-wins", a: { b: "nested-loses" } },
+    });
+    const ctx = {
+      target: {},
+      context: {},
+      actor: { type: "human" as const, id: "u", groups: [] },
+      meta,
+    };
+    expect(evaluateCondition({ field: "meta.a.b", operator: "eq", value: "flat-wins" }, ctx)).toBe(
+      true,
+    );
+  });
+
+  it("code-based conditions receive ctx.meta", async () => {
+    // Regression for codex P2: code conditions used to receive only
+    // {target, context, actor, signal}, so they had no way to read
+    // ExecutionMeta. The condition callback signature now exposes meta.
+    const calls: Array<Record<string, unknown> | undefined> = [];
+    const rule: RuleDefinition = {
+      name: "code-cond-reads-meta",
+      label: "code-cond-reads-meta",
+      trigger: { action: "submit" },
+      condition: (cctx) => {
+        calls.push(cctx.meta?.toJSON());
+        return cctx.meta?.get("dry_run") === true;
+      },
+      effect: { type: "warn", message: "Dry-run requested" },
+    };
+
+    const dryInput: RuleEvalInput = {
+      target: { amount: 1 },
+      actor: { type: "human", id: "u", groups: [] },
+      meta: createExecutionMeta({ raw: { dry_run: true } }),
+    };
+    expect((await evaluateRules([rule], dryInput)).triggered).toBe(true);
+
+    const liveInput: RuleEvalInput = {
+      target: { amount: 1 },
+      actor: { type: "human", id: "u", groups: [] },
+      meta: createExecutionMeta({ raw: { dry_run: false } }),
+    };
+    expect((await evaluateRules([rule], liveInput)).triggered).toBe(false);
+
+    // Both runs received a meta value (not undefined) — confirms the
+    // engine wiring, not just a happy-path on the first call.
+    expect(calls.length).toBe(2);
+    expect(calls[0]).toBeDefined();
+    expect(calls[1]).toBeDefined();
+  });
+
   it("rules without meta.* references are unaffected by missing meta input", async () => {
     const rule: RuleDefinition = {
       name: "warn-large",

--- a/packages/core/__tests__/rule-engine.test.ts
+++ b/packages/core/__tests__/rule-engine.test.ts
@@ -790,6 +790,38 @@ describe("meta.* field path resolution", () => {
     expect(calls[1]).toBeDefined();
   });
 
+  it("dangerous path segments (__proto__, constructor, prototype) short-circuit to undefined", () => {
+    // Regression for gemini PR #233 security-medium: a malicious rule
+    // definition must not be able to walk through Object.prototype via
+    // `meta.foo.constructor.prototype.something`. resolveField returns
+    // undefined as soon as any segment is in DANGEROUS_PATH_SEGMENTS.
+    const meta = createExecutionMeta({
+      raw: { source: { channel: "rest", info: { name: "ok" } } },
+    });
+    const ctx = {
+      target: {},
+      context: {},
+      actor: { type: "human" as const, id: "u", groups: [] },
+      meta,
+    };
+    // meta-side traversal via constructor / prototype / __proto__ → undefined
+    expect(evaluateCondition({ field: "meta.source.constructor", operator: "is_null" }, ctx)).toBe(
+      true,
+    );
+    expect(evaluateCondition({ field: "meta.source.__proto__", operator: "is_null" }, ctx)).toBe(
+      true,
+    );
+    expect(
+      evaluateCondition({ field: "meta.source.constructor.prototype", operator: "is_null" }, ctx),
+    ).toBe(true);
+    // Non-meta side too
+    expect(evaluateCondition({ field: "target.constructor", operator: "is_null" }, ctx)).toBe(true);
+    // Sanity: legitimate nested path still works
+    expect(
+      evaluateCondition({ field: "meta.source.channel", operator: "eq", value: "rest" }, ctx),
+    ).toBe(true);
+  });
+
   it("rules without meta.* references are unaffected by missing meta input", async () => {
     const rule: RuleDefinition = {
       name: "warn-large",

--- a/packages/core/src/engine/condition-evaluator.ts
+++ b/packages/core/src/engine/condition-evaluator.ts
@@ -79,21 +79,35 @@ function evaluateSimple(condition: SimpleCondition, ctx: ConditionContext): bool
 /**
  * Resolve a dot-separated field path against the context object.
  *
- * - `meta.<key>[.<nested>...]` — resolves against `ctx.meta` (Spec 65 §6).
- *   Missing meta or missing key returns `undefined` (no throw).
+ * - `meta.<rest>` — resolves against `ctx.meta` (Spec 65 §6). Tries the full
+ *   remaining path as a single ExecutionMeta key first (so flat dotted keys
+ *   like `batch.parentExecutionId` still resolve), then falls back to
+ *   progressively shorter prefixes with the unresolved suffix walked as
+ *   nested object access. Missing meta or missing key returns `undefined`
+ *   (no throw).
  * - Otherwise — walks `ctx` (e.g. `target.department.name` -> `ctx.target.department.name`).
  */
 export function resolveField(path: string, ctx: ConditionContext): unknown {
   const parts = path.split(".");
 
   if (parts[0] === "meta" && parts.length > 1) {
-    const key = parts[1] as string;
-    let current: unknown = ctx.meta?.get(key);
-    for (let i = 2; i < parts.length; i++) {
-      if (current === null || current === undefined) return undefined;
-      current = (current as Record<string, unknown>)[parts[i] as string];
+    if (!ctx.meta) return undefined;
+    const restParts = parts.slice(1);
+    // Greedy match: try the longest joined key first so flat keys whose
+    // names contain dots (e.g. `batch.parentExecutionId`) win over the
+    // POJO-nesting interpretation. Fall back to shorter prefixes, walking
+    // the leftover segments as nested object access.
+    for (let prefixLen = restParts.length; prefixLen >= 1; prefixLen--) {
+      const candidateKey = restParts.slice(0, prefixLen).join(".");
+      if (!ctx.meta.has(candidateKey)) continue;
+      let current: unknown = ctx.meta.get(candidateKey);
+      for (let i = prefixLen; i < restParts.length; i++) {
+        if (current === null || current === undefined) return undefined;
+        current = (current as Record<string, unknown>)[restParts[i] as string];
+      }
+      return current;
     }
-    return current;
+    return undefined;
   }
 
   let current: unknown = ctx;

--- a/packages/core/src/engine/condition-evaluator.ts
+++ b/packages/core/src/engine/condition-evaluator.ts
@@ -77,6 +77,15 @@ function evaluateSimple(condition: SimpleCondition, ctx: ConditionContext): bool
 }
 
 /**
+ * Path segments that could leak prototype internals if walked as plain
+ * property access — gemini PR review on #233 (security-medium). Any path
+ * that traverses through one of these returns `undefined` so a
+ * caller-controlled rule definition cannot probe `Object.prototype` or
+ * the constructor chain via `meta.foo.constructor.prototype...`.
+ */
+const DANGEROUS_PATH_SEGMENTS = new Set(["__proto__", "constructor", "prototype"]);
+
+/**
  * Resolve a dot-separated field path against the context object.
  *
  * - `meta.<rest>` — resolves against `ctx.meta` (Spec 65 §6). Tries the full
@@ -86,6 +95,9 @@ function evaluateSimple(condition: SimpleCondition, ctx: ConditionContext): bool
  *   nested object access. Missing meta or missing key returns `undefined`
  *   (no throw).
  * - Otherwise — walks `ctx` (e.g. `target.department.name` -> `ctx.target.department.name`).
+ *
+ * Dangerous segments (`__proto__`, `constructor`, `prototype`) short-circuit
+ * to `undefined` to prevent prototype-chain probing.
  */
 export function resolveField(path: string, ctx: ConditionContext): unknown {
   const parts = path.split(".");
@@ -93,17 +105,16 @@ export function resolveField(path: string, ctx: ConditionContext): unknown {
   if (parts[0] === "meta" && parts.length > 1) {
     if (!ctx.meta) return undefined;
     const restParts = parts.slice(1);
-    // Greedy match: try the longest joined key first so flat keys whose
-    // names contain dots (e.g. `batch.parentExecutionId`) win over the
-    // POJO-nesting interpretation. Fall back to shorter prefixes, walking
-    // the leftover segments as nested object access.
     for (let prefixLen = restParts.length; prefixLen >= 1; prefixLen--) {
       const candidateKey = restParts.slice(0, prefixLen).join(".");
       if (!ctx.meta.has(candidateKey)) continue;
       let current: unknown = ctx.meta.get(candidateKey);
       for (let i = prefixLen; i < restParts.length; i++) {
-        if (current === null || current === undefined) return undefined;
-        current = (current as Record<string, unknown>)[restParts[i] as string];
+        const part = restParts[i] as string;
+        if (current === null || current === undefined || DANGEROUS_PATH_SEGMENTS.has(part)) {
+          return undefined;
+        }
+        current = (current as Record<string, unknown>)[part];
       }
       return current;
     }
@@ -112,7 +123,9 @@ export function resolveField(path: string, ctx: ConditionContext): unknown {
 
   let current: unknown = ctx;
   for (const part of parts) {
-    if (current === null || current === undefined) return undefined;
+    if (current === null || current === undefined || DANGEROUS_PATH_SEGMENTS.has(part)) {
+      return undefined;
+    }
     current = (current as Record<string, unknown>)[part];
   }
   return current;

--- a/packages/core/src/engine/condition-evaluator.ts
+++ b/packages/core/src/engine/condition-evaluator.ts
@@ -5,6 +5,7 @@
  * against a flat context object with support for nested field paths.
  */
 
+import type { ExecutionMeta } from "../types/execution-meta";
 import type {
   CompositeCondition,
   DeclarativeCondition,
@@ -16,6 +17,8 @@ export interface ConditionContext {
   target: Record<string, unknown>;
   context: Record<string, unknown>;
   actor: { type: string; id: string; groups: string[] };
+  /** Current execution meta — resolves `meta.*` field paths (Spec 65 §6). */
+  meta?: ExecutionMeta;
 }
 
 /**
@@ -75,16 +78,28 @@ function evaluateSimple(condition: SimpleCondition, ctx: ConditionContext): bool
 
 /**
  * Resolve a dot-separated field path against the context object.
- * E.g. "target.department.name" resolves ctx.target.department.name
+ *
+ * - `meta.<key>[.<nested>...]` — resolves against `ctx.meta` (Spec 65 §6).
+ *   Missing meta or missing key returns `undefined` (no throw).
+ * - Otherwise — walks `ctx` (e.g. `target.department.name` -> `ctx.target.department.name`).
  */
 export function resolveField(path: string, ctx: ConditionContext): unknown {
   const parts = path.split(".");
-  let current: unknown = ctx;
 
+  if (parts[0] === "meta" && parts.length > 1) {
+    const key = parts[1] as string;
+    let current: unknown = ctx.meta?.get(key);
+    for (let i = 2; i < parts.length; i++) {
+      if (current === null || current === undefined) return undefined;
+      current = (current as Record<string, unknown>)[parts[i] as string];
+    }
+    return current;
+  }
+
+  let current: unknown = ctx;
   for (const part of parts) {
     if (current === null || current === undefined) return undefined;
     current = (current as Record<string, unknown>)[part];
   }
-
   return current;
 }

--- a/packages/core/src/engine/rule-engine.ts
+++ b/packages/core/src/engine/rule-engine.ts
@@ -10,6 +10,7 @@
 import type { MetricsCollector } from "../observability/metrics";
 import { noopMetricsCollector } from "../observability/metrics";
 import type { ErrorContext } from "../types/error";
+import type { ExecutionMeta } from "../types/execution-meta";
 import type {
   BlockEffect,
   CodeCondition,
@@ -68,6 +69,8 @@ export interface RuleEvalInput {
   target: Record<string, unknown>;
   actor: { type: string; id: string; groups: string[] };
   context?: Record<string, unknown>;
+  /** Current execution meta — resolves `meta.*` field paths in conditions (Spec 65 §6). */
+  meta?: ExecutionMeta;
 }
 
 export interface RuleEvalOutput {
@@ -134,6 +137,7 @@ export async function evaluateRules(
     target: input.target,
     context: input.context ?? {},
     actor: input.actor,
+    meta: input.meta,
   };
 
   for (const rule of sorted) {

--- a/packages/core/src/engine/rule-engine.ts
+++ b/packages/core/src/engine/rule-engine.ts
@@ -165,6 +165,7 @@ export async function evaluateRules(
           target: ctx.target,
           context: ctx.context,
           actor: ctx.actor,
+          meta: ctx.meta,
           signal: controller?.signal,
         });
 

--- a/packages/core/src/types/rule.ts
+++ b/packages/core/src/types/rule.ts
@@ -5,6 +5,8 @@
  * Rule = Trigger + Context (optional) + Condition + Effect
  */
 
+import type { ExecutionMeta } from "./execution-meta";
+
 // ── Comparison operators ──────────────────────────────────────
 
 export type ComparisonOperator =
@@ -53,6 +55,12 @@ export interface RuleConditionContext {
   target: Record<string, unknown>;
   context: Record<string, unknown>;
   actor: { type: string; id: string; groups: string[] };
+  /**
+   * Current execution meta (Spec 65 §6). Code-based conditions can branch
+   * on caller hints (`bulk`, `dry_run`, `_channel`, …) the same way
+   * declarative `meta.*` field paths can.
+   */
+  meta?: ExecutionMeta;
   /** AbortSignal propagated when a timeout is configured */
   signal?: AbortSignal;
 }


### PR DESCRIPTION
## Summary

- `RuleEvalInput` gains an optional `meta?: ExecutionMeta` field, threaded into the per-rule `ConditionContext`.
- Field paths in declarative rule conditions that begin with `meta.` resolve against `ctx.meta?.get(...)`. Greedy match: the longest joined key wins (so flat keys like `batch.parentExecutionId` take precedence), then falls back to shorter prefixes with the leftover walked as nested-object access. One level of dotted POJO nesting is supported (`meta.source.channel`).
- `RuleConditionContext` (the code-based condition signature) now also exposes `meta?: ExecutionMeta`, so function conditions can branch on caller hints the same way declarative ones can.
- Missing keys / absent meta return `undefined` — same shape as missing entity fields, so existing rules without `meta.*` references keep working unchanged.

## Codex review

- **P2 — code-based conditions** lacked meta. Fixed by extending `RuleConditionContext` and threading `meta` through the function-call invocation site.
- **P2 — dotted flat meta keys** (`batch.parentExecutionId`, `batch.index` emitted by the framework itself) were unreachable. Fixed with greedy-match resolution that tries the full remaining path as a single key first.

## Test plan

- [x] 9 new tests in `packages/core/__tests__/rule-engine.test.ts` — top-level meta keys; `is_null` on missing; absent meta context; one-level POJO nesting; declarative + entity-field combo (Spec 65 §6 example); flat dotted keys; flat-vs-nested precedence; code-based condition meta access; rules without `meta.*` references unaffected by missing input.
- [x] Full core suite: `4484 pass / 0 fail / 85 skip`.
- [x] `bun run typecheck` clean.
- [x] `bun run check` clean.

## Notes

`evaluateRules` is invoked only by external callers in this codebase (no internal action-engine call site). Action engine wiring (passing `ctx.meta` from `ActionContext` into the rule input on its evaluation site) would naturally come the moment such a call site is added — no API change needed there.

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)