### PR TITLE
feat(adapter-server): GraphQL batch_actions mutation (closes #212)

### DIFF
--- a/.changeset/graphql-batch-actions.md
+++ b/.changeset/graphql-batch-actions.md
@@ -1,0 +1,7 @@
+---
+"@linchkit/cap-adapter-server": minor
+---
+
+feat(adapter-server): GraphQL `batch_actions` mutation (closes #212)
+
+Adds a code-first `Mutation.batch_actions(actions: [BatchActionInputItem!]!, strategy: String, meta: String): BatchActionsResult!` that mirrors the REST `/api/actions/batch` contract. Per-item input is JSON-string-encoded for parity with the existing `executeAction` mutation (graphql-js code-first ships no JSON scalar), and `BatchActionsResult` exposes `success` / `parentExecutionId` / `strategy` / `succeeded` / `failed` / `rolledBack` / `summary`. Resolved through the same actor / tenant / locale path single-action mutations use; raw-executor fallback intentionally rejected so the permission slot is never bypassed. Optional `transactionManager` on `BuildGraphQLSchemaOptions` lets callers override the CommandLayer default for `executeBatch`.

--- a/addons/adapter-server/cap-adapter-server/__tests__/graphql-batch-actions.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/graphql-batch-actions.test.ts
@@ -1,0 +1,400 @@
+/**
+ * GraphQL `batch_actions` mutation integration tests (Spec 04 §8, issue #212).
+ *
+ * Mirrors the REST `POST /api/actions/batch` contract: per-item shape is
+ * `{ name, input }`, response is the structured `BatchActionsResult` envelope
+ * with succeeded / failed / rolledBack / summary. Verifies:
+ *   - happy-path partial batch with two items, results returned in order
+ *   - per-item failure surfaces with structured error code/message
+ *   - all_or_nothing rollback populates `rolledBack` and reverts state
+ *   - permission middleware on the CommandLayer protects every batch item
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import type {
+  ActionDefinition,
+  DataProvider,
+  EntityDefinition,
+  PendingEvent,
+  TransactionManager,
+} from "@linchkit/core";
+import { createActionExecutor, createCommandLayer, PipelineError } from "@linchkit/core/server";
+import { buildGraphQLSchema } from "../src/graphql/build-schema";
+import { createServer } from "../src/server";
+
+// ── Fixtures ──────────────────────────────────────────────
+
+const itemSchema: EntityDefinition = {
+  name: "item",
+  label: "Item",
+  fields: {
+    title: { type: "string", required: true, label: "Title" },
+  },
+};
+
+const createItem: ActionDefinition = {
+  name: "create_item",
+  entity: "item",
+  label: "Create Item",
+  policy: { mode: "sync", transaction: true },
+  exposure: "all",
+  handler: async (ctx) => ctx.create("item", { title: ctx.input.title }),
+};
+
+const failItem: ActionDefinition = {
+  name: "fail_item",
+  entity: "item",
+  label: "Fail Item",
+  policy: { mode: "sync", transaction: true },
+  exposure: "all",
+  handler: async () => {
+    throw new Error("intentional failure");
+  },
+};
+
+const adminOnly: ActionDefinition = {
+  name: "delete_item",
+  entity: "item",
+  label: "Delete Item",
+  policy: { mode: "sync", transaction: true },
+  exposure: "all",
+  handler: async () => ({ ok: true }),
+};
+
+// Snapshot-aware in-memory provider so we can verify rollback under
+// `all_or_nothing`. Mirrors the REST batch test fixture.
+function createSnapshotProvider() {
+  const records = new Map<string, Record<string, unknown>>();
+  let counter = 0;
+  const provider: DataProvider = {
+    async get(_schema, id) {
+      const found = records.get(id);
+      if (!found) throw new Error(`not found: ${id}`);
+      return found;
+    },
+    async query() {
+      return [];
+    },
+    async create(_schema, data) {
+      counter++;
+      const id = `rec_${counter}`;
+      const rec = { id, ...data };
+      records.set(id, rec);
+      return rec;
+    },
+    async update(_schema, id, data) {
+      const existing = records.get(id) ?? { id };
+      const updated = { ...existing, ...data };
+      records.set(id, updated);
+      return updated;
+    },
+    async delete(_schema, id) {
+      records.delete(id);
+    },
+    async count() {
+      return records.size;
+    },
+  };
+  return Object.assign(provider, {
+    records,
+    snapshot: () => new Map(records),
+  });
+}
+
+function createFakeTxManager(
+  provider: ReturnType<typeof createSnapshotProvider>,
+): TransactionManager {
+  return {
+    async runInTransaction<T>(
+      fn: (tx: DataProvider) => Promise<T>,
+      _pending: PendingEvent[],
+    ): Promise<T> {
+      const before = provider.snapshot();
+      try {
+        return await fn(provider);
+      } catch (err) {
+        provider.records.clear();
+        for (const [k, v] of before) provider.records.set(k, v);
+        throw err;
+      }
+    },
+  };
+}
+
+// ── Server setup ──────────────────────────────────────────
+
+const provider = createSnapshotProvider();
+const txManager = createFakeTxManager(provider);
+
+const executor = createActionExecutor({
+  dataProvider: provider,
+  transactionManager: txManager,
+});
+executor.registry.register(createItem);
+executor.registry.register(failItem);
+executor.registry.register(adminOnly);
+
+const commandLayer = createCommandLayer({ executor, transactionManager: txManager });
+commandLayer.use({
+  name: "test_permission",
+  slot: "permission",
+  handler: async (ctx, next) => {
+    if (ctx.command === "delete_item" && !ctx.actor.groups.includes("admin")) {
+      throw new PipelineError(
+        "Actor does not belong to required group: admin",
+        "PERMISSION.DENIED",
+      );
+    }
+    await next();
+  },
+});
+
+const graphqlSchema = buildGraphQLSchema([itemSchema], {
+  executor,
+  commandLayer,
+  dataProvider: provider,
+  actions: [createItem, failItem, adminOnly],
+  transactionManager: txManager,
+});
+
+// Resolve a non-elevated anonymous actor so the permission middleware can
+// actually deny `delete_item` in test (g). The default `NO_AUTH_ACTOR` used
+// when no resolver is configured carries the `admin` group, which would
+// trivially pass the `delete_item` check and defeat the test.
+const app = createServer(graphqlSchema, {
+  executor,
+  commandLayer,
+  transactionManager: txManager,
+  resolveRequestActor: () => ({ type: "system", id: "anonymous", groups: [] }),
+});
+
+const port = 4046;
+
+beforeAll(() => {
+  app.listen(port);
+});
+
+afterAll(() => {
+  app.stop();
+});
+
+// ── Helpers ───────────────────────────────────────────────
+
+interface BatchSucceededItem {
+  index: number;
+  executionId: string;
+  data: string | null;
+  record: string | null;
+  warnings: string[] | null;
+}
+
+interface BatchFailedItem {
+  index: number;
+  executionId: string | null;
+  error: { code: string; message: string; field: string | null };
+}
+
+interface BatchActionsResultGQL {
+  success: boolean;
+  parentExecutionId: string;
+  strategy: string;
+  succeeded: BatchSucceededItem[];
+  failed: BatchFailedItem[];
+  rolledBack: BatchSucceededItem[] | null;
+  summary: { total: number; succeeded: number; failed: number };
+}
+
+const BATCH_SELECTION = `
+  success
+  parentExecutionId
+  strategy
+  succeeded { index executionId data record warnings }
+  failed { index executionId error { code message field } }
+  rolledBack { index executionId data record warnings }
+  summary { total succeeded failed }
+`;
+
+async function gql(
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<{
+  data?: { batch_actions?: BatchActionsResultGQL } & Record<string, unknown>;
+  errors?: Array<{ message: string }>;
+}> {
+  const res = await fetch(`http://localhost:${port}/graphql`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ query, variables }),
+  });
+  return res.json() as Promise<{
+    data?: { batch_actions?: BatchActionsResultGQL } & Record<string, unknown>;
+    errors?: Array<{ message: string }>;
+  }>;
+}
+
+// ── Tests ────────────────────────────────────────────────
+
+describe("GraphQL batch_actions mutation", () => {
+  test("(a) partial batch runs both items and returns ordered results", async () => {
+    provider.records.clear();
+    const result = await gql(
+      `mutation Run($actions: [BatchActionInputItem!]!) {
+        batch_actions(actions: $actions, strategy: "partial") {
+          ${BATCH_SELECTION}
+        }
+      }`,
+      {
+        actions: [
+          { name: "create_item", input: JSON.stringify({ title: "first" }) },
+          { name: "create_item", input: JSON.stringify({ title: "second" }) },
+        ],
+      },
+    );
+    expect(result.errors).toBeUndefined();
+    const batch = result.data?.batch_actions;
+    expect(batch).toBeDefined();
+    if (!batch) return;
+    expect(batch.success).toBe(true);
+    expect(batch.strategy).toBe("partial");
+    expect(batch.succeeded.length).toBe(2);
+    expect(batch.failed.length).toBe(0);
+    expect(batch.summary).toEqual({ total: 2, succeeded: 2, failed: 0 });
+    // Results come back in the same order they were submitted.
+    expect(batch.succeeded[0]?.index).toBe(0);
+    expect(batch.succeeded[1]?.index).toBe(1);
+    // The action handler returns the created record via `ctx.create`, which
+    // surfaces as `data` on the per-item result. `record` is populated by the
+    // executor for write actions that resolve a persisted entity — both paths
+    // are JSON-encoded here, so we read whichever is set.
+    const decode = (item: BatchSucceededItem | undefined) => {
+      const raw = item?.data ?? item?.record;
+      return raw ? (JSON.parse(raw) as Record<string, unknown>) : undefined;
+    };
+    expect(decode(batch.succeeded[0])?.title).toBe("first");
+    expect(decode(batch.succeeded[1])?.title).toBe("second");
+  });
+
+  test("(b) per-item failure surfaces with structured error", async () => {
+    provider.records.clear();
+    const result = await gql(
+      `mutation Run($actions: [BatchActionInputItem!]!) {
+        batch_actions(actions: $actions, strategy: "partial") {
+          ${BATCH_SELECTION}
+        }
+      }`,
+      {
+        actions: [
+          { name: "create_item", input: JSON.stringify({ title: "ok" }) },
+          { name: "fail_item", input: JSON.stringify({}) },
+        ],
+      },
+    );
+    expect(result.errors).toBeUndefined();
+    const batch = result.data?.batch_actions;
+    expect(batch).toBeDefined();
+    if (!batch) return;
+    expect(batch.success).toBe(false);
+    expect(batch.strategy).toBe("partial");
+    expect(batch.succeeded.length).toBe(1);
+    expect(batch.succeeded[0]?.index).toBe(0);
+    expect(batch.failed.length).toBe(1);
+    expect(batch.failed[0]?.index).toBe(1);
+    expect(typeof batch.failed[0]?.error.code).toBe("string");
+    expect(batch.failed[0]?.error.message.length).toBeGreaterThan(0);
+    expect(batch.summary).toEqual({ total: 2, succeeded: 1, failed: 1 });
+  });
+
+  test("(c) all_or_nothing rollback populates rolledBack and reverts state", async () => {
+    provider.records.clear();
+    const result = await gql(
+      `mutation Run($actions: [BatchActionInputItem!]!) {
+        batch_actions(actions: $actions, strategy: "all_or_nothing") {
+          ${BATCH_SELECTION}
+        }
+      }`,
+      {
+        actions: [
+          { name: "create_item", input: JSON.stringify({ title: "A" }) },
+          { name: "fail_item", input: JSON.stringify({}) },
+        ],
+      },
+    );
+    expect(result.errors).toBeUndefined();
+    const batch = result.data?.batch_actions;
+    expect(batch).toBeDefined();
+    if (!batch) return;
+    expect(batch.success).toBe(false);
+    expect(batch.strategy).toBe("all_or_nothing");
+    expect(batch.succeeded.length).toBe(0);
+    expect(batch.failed.length).toBe(1);
+    expect(batch.rolledBack).not.toBeNull();
+    expect(batch.rolledBack?.length).toBe(1);
+    expect(batch.rolledBack?.[0]?.index).toBe(0);
+    expect(provider.records.size).toBe(0);
+  });
+
+  test("(d) empty actions array returns BATCH_EMPTY structured failure", async () => {
+    const result = await gql(
+      `mutation { batch_actions(actions: [], strategy: "partial") { ${BATCH_SELECTION} } }`,
+    );
+    expect(result.errors).toBeUndefined();
+    const batch = result.data?.batch_actions;
+    expect(batch).toBeDefined();
+    if (!batch) return;
+    expect(batch.success).toBe(false);
+    expect(batch.failed[0]?.error.code).toBe("BATCH_EMPTY");
+  });
+
+  test("(e) unknown strategy is rejected at the GraphQL boundary", async () => {
+    const result = await gql(
+      `mutation Run($actions: [BatchActionInputItem!]!) {
+        batch_actions(actions: $actions, strategy: "fast") {
+          success
+        }
+      }`,
+      { actions: [{ name: "create_item", input: JSON.stringify({ title: "x" }) }] },
+    );
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.[0]?.message).toContain("must be 'all_or_nothing' or 'partial'");
+  });
+
+  test("(f) malformed JSON in item input is rejected before dispatch", async () => {
+    const result = await gql(
+      `mutation Run($actions: [BatchActionInputItem!]!) {
+        batch_actions(actions: $actions, strategy: "partial") {
+          success
+        }
+      }`,
+      { actions: [{ name: "create_item", input: "not-json" }] },
+    );
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.[0]?.message).toContain("invalid JSON");
+  });
+
+  test("(g) permission middleware blocks unauthorized items per item", async () => {
+    provider.records.clear();
+    // Anonymous actor (no admin group) — `delete_item` should fail with
+    // PERMISSION.DENIED while the create_item call still succeeds.
+    const result = await gql(
+      `mutation Run($actions: [BatchActionInputItem!]!) {
+        batch_actions(actions: $actions, strategy: "partial") {
+          ${BATCH_SELECTION}
+        }
+      }`,
+      {
+        actions: [
+          { name: "create_item", input: JSON.stringify({ title: "ok" }) },
+          { name: "delete_item", input: JSON.stringify({ id: "rec_1" }) },
+        ],
+      },
+    );
+    expect(result.errors).toBeUndefined();
+    const batch = result.data?.batch_actions;
+    expect(batch).toBeDefined();
+    if (!batch) return;
+    expect(batch.success).toBe(false);
+    expect(batch.succeeded.length).toBe(1);
+    expect(batch.failed.length).toBe(1);
+    expect(batch.failed[0]?.error.code).toBe("PERMISSION.DENIED");
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/__tests__/graphql-batch-actions.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/graphql-batch-actions.test.ts
@@ -168,10 +168,15 @@ const app = createServer(graphqlSchema, {
   resolveRequestActor: () => ({ type: "system", id: "anonymous", groups: [] }),
 });
 
-const port = 4046;
+// Use OS-assigned port (0 → auto) so the suite isn't flaky when a parallel
+// worker already owns a fixed port. Captured after `listen()` returns.
+let port = 0;
 
 beforeAll(() => {
-  app.listen(port);
+  app.listen(0);
+  const server = (app as unknown as { server?: { port?: number } }).server;
+  if (!server?.port) throw new Error("Test server failed to bind to a port");
+  port = server.port;
 });
 
 afterAll(() => {
@@ -396,6 +401,38 @@ describe("GraphQL batch_actions mutation", () => {
     expect(batch.succeeded.length).toBe(1);
     expect(batch.failed.length).toBe(1);
     expect(batch.failed[0]?.error.code).toBe("PERMISSION.DENIED");
+  });
+
+  test("(i) per-item `input` is optional, omitted defaults to {} (REST parity)", async () => {
+    // Regression for CodeRabbit major (PR #234 review): the REST batch
+    // endpoint normalizes `{ name }` (no input) to `{ name, input: {} }`.
+    // The GraphQL boundary previously required `input` as NonNull, which
+    // broke parity for actions that take no input. After this fix, omitting
+    // `input` works the same way.
+    provider.records.clear();
+    const result = await gql(
+      `mutation Run($actions: [BatchActionInputItem!]!) {
+        batch_actions(actions: $actions, strategy: "partial") {
+          ${BATCH_SELECTION}
+        }
+      }`,
+      // No `input` field — mirrors REST's `{ name }`-only shape.
+      {
+        actions: [
+          { name: "create_item", input: JSON.stringify({ title: "from-omitted" }) },
+          { name: "fail_item" },
+        ],
+      },
+    );
+    expect(result.errors).toBeUndefined();
+    const batch = result.data?.batch_actions;
+    expect(batch).toBeDefined();
+    if (!batch) return;
+    // create_item succeeded (it does require title); fail_item ran with `{}`
+    // input and threw (consistent with the REST contract).
+    expect(batch.succeeded.length).toBe(1);
+    expect(batch.failed.length).toBe(1);
+    expect(batch.failed[0]?.index).toBe(1);
   });
 
   test("(h) production mode sanitizes per-item error.message but preserves error.code", async () => {

--- a/addons/adapter-server/cap-adapter-server/__tests__/graphql-batch-actions.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/graphql-batch-actions.test.ts
@@ -397,4 +397,44 @@ describe("GraphQL batch_actions mutation", () => {
     expect(batch.failed.length).toBe(1);
     expect(batch.failed[0]?.error.code).toBe("PERMISSION.DENIED");
   });
+
+  test("(h) production mode sanitizes per-item error.message but preserves error.code", async () => {
+    // Regression for codex P1: in production, raw handler / driver exception
+    // text must NOT leak through GraphQL `failed[*].error.message`. Codes
+    // and field locators stay intact so clients can still distinguish
+    // validation vs. permission failures. Mirrors the REST handler's
+    // `sanitizeBatchResult` in `routes/action-api.ts`.
+    provider.records.clear();
+    const originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      const result = await gql(
+        `mutation Run($actions: [BatchActionInputItem!]!) {
+          batch_actions(actions: $actions, strategy: "partial") {
+            ${BATCH_SELECTION}
+          }
+        }`,
+        {
+          actions: [
+            { name: "create_item", input: JSON.stringify({ title: "ok" }) },
+            { name: "fail_item", input: JSON.stringify({}) },
+          ],
+        },
+      );
+      expect(result.errors).toBeUndefined();
+      const batch = result.data?.batch_actions;
+      expect(batch).toBeDefined();
+      if (!batch) return;
+      expect(batch.success).toBe(false);
+      expect(batch.failed.length).toBe(1);
+      // The fixture's failItem throws `new Error("intentional failure")`.
+      // Production mode must replace that text but keep the code intact.
+      expect(batch.failed[0]?.error.message).not.toContain("intentional failure");
+      expect(batch.failed[0]?.error.message).toBe("Action execution failed");
+      expect(typeof batch.failed[0]?.error.code).toBe("string");
+      expect((batch.failed[0]?.error.code as string).length).toBeGreaterThan(0);
+    } finally {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
 });

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
@@ -181,8 +181,9 @@ const BatchActionInputItemType = new GraphQLInputObjectType({
       description: "Action name (verb_noun).",
     },
     input: {
-      type: new GraphQLNonNull(GraphQLString),
-      description: "JSON-encoded action input object.",
+      type: GraphQLString,
+      description:
+        "JSON-encoded action input object. Optional — omit (or send null) to invoke an action that takes no input, matching the REST batch contract.",
     },
   },
 });
@@ -1255,7 +1256,7 @@ export function buildGraphQLSchema(
       ? async (
           _root: unknown,
           args: {
-            actions: Array<{ name: string; input: string }>;
+            actions: Array<{ name: string; input?: string | null }>;
             strategy?: string;
             meta?: string;
           },
@@ -1273,10 +1274,15 @@ export function buildGraphQLSchema(
           }
           // Decode each item's JSON input — reject any malformed item early
           // so a single bad payload doesn't poison the whole batch with an
-          // engine-level "invalid input" code.
+          // engine-level "invalid input" code. `input` is optional to mirror
+          // the REST contract (POST /api/actions/batch normalizes a missing
+          // input to `{}`); null / undefined here means "no input".
           const items: BatchActionItem[] = args.actions.map((raw, index) => ({
             name: raw.name,
-            input: safeParseJSON(raw.input, `actions[${index}].input`),
+            input:
+              raw.input !== undefined && raw.input !== null
+                ? safeParseJSON(raw.input, `actions[${index}].input`)
+                : {},
           }));
           const meta =
             args.meta !== undefined && args.meta !== null

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
@@ -46,6 +46,7 @@ import {
   GraphQLSchema,
   GraphQLString,
 } from "graphql";
+import { sanitizeBatchResult } from "../lib/sanitize-batch-result";
 import { buildOnchangeMutationFields } from "./build-onchange-mutations";
 import { buildSubscriptionFields, createEventBusPubSub } from "./build-subscriptions";
 import {
@@ -1294,22 +1295,9 @@ export function buildGraphQLSchema(
             transactionManager: batchTransactionManager,
             meta,
           });
-          // Mirror the REST handler's sanitization (`sanitizeBatchResult`
-          // in routes/action-api.ts): in production, replace per-item
-          // `error.message` strings with a generic placeholder so handler
-          // / driver exception text never leaks over the public GraphQL
-          // surface. Codes and field locators are preserved.
-          const sanitized: BatchActionsResult =
-            process.env.NODE_ENV === "production"
-              ? {
-                  ...result,
-                  failed: result.failed.map((f) => ({
-                    ...f,
-                    error: { ...f.error, message: "Action execution failed" },
-                  })),
-                }
-              : result;
-          return serializeBatchResult(sanitized);
+          // Apply the same prod-mode sanitization the REST handler uses
+          // — see `lib/sanitize-batch-result.ts` for the contract.
+          return serializeBatchResult(sanitizeBatchResult(result));
         }
       : () => {
           throw new GraphQLError(

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
@@ -359,6 +359,11 @@ export interface BuildGraphQLSchemaOptions {
    * the CommandLayer's own default TM (set on `createCommandLayer`) is used;
    * if neither is available, `all_or_nothing` requests return a structured
    * `BATCH_TX_MANAGER_REQUIRED` failure — `partial` strategy still works.
+   *
+   * NOTE: If you also pass `transactionManager` to `createServer({...})`
+   * for the REST `/api/actions/batch` route, the GraphQL transport does
+   * NOT inherit it — the schema is built independently. Pass the same TM
+   * here, or set it on `createCommandLayer` so both transports pick it up.
    */
   transactionManager?: TransactionManager;
 }
@@ -1289,7 +1294,22 @@ export function buildGraphQLSchema(
             transactionManager: batchTransactionManager,
             meta,
           });
-          return serializeBatchResult(result);
+          // Mirror the REST handler's sanitization (`sanitizeBatchResult`
+          // in routes/action-api.ts): in production, replace per-item
+          // `error.message` strings with a generic placeholder so handler
+          // / driver exception text never leaks over the public GraphQL
+          // surface. Codes and field locators are preserved.
+          const sanitized: BatchActionsResult =
+            process.env.NODE_ENV === "production"
+              ? {
+                  ...result,
+                  failed: result.failed.map((f) => ({
+                    ...f,
+                    error: { ...f.error, message: "Action execution failed" },
+                  })),
+                }
+              : result;
+          return serializeBatchResult(sanitized);
         }
       : () => {
           throw new GraphQLError(

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
@@ -11,6 +11,10 @@ import type {
   ActionExecutor,
   ActionResult,
   Actor,
+  BatchActionItem,
+  BatchActionsInput,
+  BatchActionsResult,
+  BatchTransactionStrategy,
   CommandLayer,
   DataProvider,
   DataQueryOptions,
@@ -21,6 +25,7 @@ import type {
   PermissionGroupDefinition,
   RelationDefinition,
   StateDefinition,
+  TransactionManager,
 } from "@linchkit/core";
 import { normalizeTranslatableRow, resolveTranslatableRow } from "@linchkit/core";
 import type { CacheManager, OnchangeEvaluator, OverlayRegistry } from "@linchkit/core/server";
@@ -33,6 +38,7 @@ import {
   GraphQLError,
   type GraphQLFieldConfig,
   GraphQLID,
+  GraphQLInputObjectType,
   GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
@@ -155,6 +161,149 @@ const ActionResultType = new GraphQLObjectType({
   },
 });
 
+// ── Batch action GraphQL types (Spec 04 §8) ──────────────────
+//
+// Mirrors the REST `POST /api/actions/batch` contract:
+// - per-item shape: { name, input } (input as JSON-encoded string for parity
+//   with the existing `executeAction` mutation — graphql-js code-first has no
+//   built-in JSON scalar, and stringly-encoded payloads keep us off a new
+//   runtime dep).
+// - response shape: full `BatchActionsResult` with succeeded / failed /
+//   rolledBack / summary, with per-item `data` and `record` JSON-encoded.
+
+const BatchActionInputItemType = new GraphQLInputObjectType({
+  name: "BatchActionInputItem",
+  description: "A single action invocation within a batch (Spec 04 §8.1).",
+  fields: {
+    name: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "Action name (verb_noun).",
+    },
+    input: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "JSON-encoded action input object.",
+    },
+  },
+});
+
+const BatchSucceededItemType = new GraphQLObjectType({
+  name: "BatchSucceededItem",
+  fields: {
+    index: { type: new GraphQLNonNull(GraphQLInt) },
+    executionId: { type: new GraphQLNonNull(GraphQLString) },
+    data: { type: GraphQLString, description: "JSON-encoded handler return value" },
+    record: { type: GraphQLString, description: "JSON-encoded persisted record" },
+    warnings: { type: new GraphQLList(new GraphQLNonNull(GraphQLString)) },
+  },
+});
+
+const BatchFailedItemErrorType = new GraphQLObjectType({
+  name: "BatchFailedItemError",
+  fields: {
+    code: { type: new GraphQLNonNull(GraphQLString) },
+    message: { type: new GraphQLNonNull(GraphQLString) },
+    field: { type: GraphQLString },
+  },
+});
+
+const BatchFailedItemType = new GraphQLObjectType({
+  name: "BatchFailedItem",
+  fields: {
+    index: { type: new GraphQLNonNull(GraphQLInt) },
+    executionId: { type: GraphQLString },
+    error: { type: new GraphQLNonNull(BatchFailedItemErrorType) },
+  },
+});
+
+const BatchActionsSummaryType = new GraphQLObjectType({
+  name: "BatchActionsSummary",
+  fields: {
+    total: { type: new GraphQLNonNull(GraphQLInt) },
+    succeeded: { type: new GraphQLNonNull(GraphQLInt) },
+    failed: { type: new GraphQLNonNull(GraphQLInt) },
+  },
+});
+
+const BatchActionsResultType = new GraphQLObjectType({
+  name: "BatchActionsResult",
+  fields: {
+    success: { type: new GraphQLNonNull(GraphQLBoolean) },
+    parentExecutionId: { type: new GraphQLNonNull(GraphQLString) },
+    strategy: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "Strategy actually used: 'all_or_nothing' or 'partial'.",
+    },
+    succeeded: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(BatchSucceededItemType))),
+    },
+    failed: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(BatchFailedItemType))),
+    },
+    rolledBack: {
+      type: new GraphQLList(new GraphQLNonNull(BatchSucceededItemType)),
+      description:
+        "Items that succeeded but were rolled back when a later item failed (all_or_nothing only).",
+    },
+    summary: { type: new GraphQLNonNull(BatchActionsSummaryType) },
+  },
+});
+
+/**
+ * Serialize a BatchActionsResult into the GraphQL output shape — `data` and
+ * `record` are JSON-encoded so callers can decode arbitrary handler payloads
+ * without us guessing a scalar shape.
+ */
+function serializeBatchResult(result: BatchActionsResult): {
+  success: boolean;
+  parentExecutionId: string;
+  strategy: BatchTransactionStrategy;
+  succeeded: Array<{
+    index: number;
+    executionId: string;
+    data: string | null;
+    record: string | null;
+    warnings: string[] | null;
+  }>;
+  failed: Array<{
+    index: number;
+    executionId: string | null;
+    error: { code: string; message: string; field: string | null };
+  }>;
+  rolledBack: Array<{
+    index: number;
+    executionId: string;
+    data: string | null;
+    record: string | null;
+    warnings: string[] | null;
+  }> | null;
+  summary: { total: number; succeeded: number; failed: number };
+} {
+  const encodeSucceeded = (item: BatchActionsResult["succeeded"][number]) => ({
+    index: item.index,
+    executionId: item.executionId,
+    data: item.data !== undefined ? JSON.stringify(item.data) : null,
+    record: item.record ? JSON.stringify(item.record) : null,
+    warnings: item.warnings && item.warnings.length > 0 ? item.warnings : null,
+  });
+  return {
+    success: result.success,
+    parentExecutionId: result.parentExecutionId,
+    strategy: result.strategy,
+    succeeded: result.succeeded.map(encodeSucceeded),
+    failed: result.failed.map((item) => ({
+      index: item.index,
+      executionId: item.executionId ?? null,
+      error: {
+        code: item.error.code,
+        message: item.error.message,
+        field: item.error.field ?? null,
+      },
+    })),
+    rolledBack: result.rolledBack ? result.rolledBack.map(encodeSucceeded) : null,
+    summary: result.summary,
+  };
+}
+
 // ── Schema builder options ──────────────────────────────────
 
 export interface BuildGraphQLSchemaOptions {
@@ -204,6 +353,14 @@ export interface BuildGraphQLSchemaOptions {
    * the mutation entirely (mirrors REST 503 behavior of skipping the route).
    */
   onchangeEvaluator?: OnchangeEvaluator;
+  /**
+   * Transaction manager — used by the `batch_actions` mutation when the
+   * caller chooses the `all_or_nothing` strategy (Spec 04 §8.2). When omitted
+   * the CommandLayer's own default TM (set on `createCommandLayer`) is used;
+   * if neither is available, `all_or_nothing` requests return a structured
+   * `BATCH_TX_MANAGER_REQUIRED` failure — `partial` strategy still works.
+   */
+  transactionManager?: TransactionManager;
 }
 
 /**
@@ -1058,6 +1215,87 @@ export function buildGraphQLSchema(
           ],
           executionId: null,
         }),
+  };
+
+  // ── batch_actions mutation (Spec 04 §8) ───────────────────
+  // Mirrors `POST /api/actions/batch`: accepts an `actions` array of
+  // { name, input } items plus optional `strategy` and `meta`, and returns
+  // the full `BatchActionsResult` envelope. Requires a CommandLayer because
+  // executing without the permission slot would silently bypass auth — same
+  // guard the REST handler enforces. `all_or_nothing` strategy further
+  // requires a TransactionManager (either passed via this option or set on
+  // the CommandLayer); without one the engine returns a structured
+  // `BATCH_TX_MANAGER_REQUIRED` failure.
+  const batchTransactionManager = options?.transactionManager;
+  mutationFields.batch_actions = {
+    type: new GraphQLNonNull(BatchActionsResultType),
+    description:
+      "Execute multiple actions in one call (Spec 04 §8). Mirrors POST /api/actions/batch.",
+    args: {
+      actions: {
+        type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(BatchActionInputItemType))),
+      },
+      strategy: {
+        type: GraphQLString,
+        description:
+          "Transaction strategy: 'all_or_nothing' (default) or 'partial' (Spec 04 §8.2).",
+      },
+      meta: {
+        type: GraphQLString,
+        description: "JSON-encoded execution meta applied to every batch item (Spec 65 §3.2)",
+      },
+    },
+    resolve: commandLayer
+      ? async (
+          _root: unknown,
+          args: {
+            actions: Array<{ name: string; input: string }>;
+            strategy?: string;
+            meta?: string;
+          },
+          ctx: GraphQLContext,
+        ) => {
+          // Validate strategy at the GraphQL boundary so callers get a clear
+          // error instead of relying on the engine's runtime check (which
+          // would still catch it but with a less specific code).
+          if (
+            args.strategy !== undefined &&
+            args.strategy !== "all_or_nothing" &&
+            args.strategy !== "partial"
+          ) {
+            throw new GraphQLError("Argument \"strategy\" must be 'all_or_nothing' or 'partial'.");
+          }
+          // Decode each item's JSON input — reject any malformed item early
+          // so a single bad payload doesn't poison the whole batch with an
+          // engine-level "invalid input" code.
+          const items: BatchActionItem[] = args.actions.map((raw, index) => ({
+            name: raw.name,
+            input: safeParseJSON(raw.input, `actions[${index}].input`),
+          }));
+          const meta =
+            args.meta !== undefined && args.meta !== null
+              ? safeParseJSON(args.meta, "meta")
+              : undefined;
+          const batchInput: BatchActionsInput = { actions: items };
+          if (args.strategy !== undefined) {
+            batchInput.strategy = args.strategy as BatchTransactionStrategy;
+          }
+          const result = await commandLayer.executeBatch({
+            input: batchInput,
+            actor: ctx.actor,
+            channel: "http",
+            tenantId: ctx.tenantId,
+            locale: ctx.locale,
+            transactionManager: batchTransactionManager,
+            meta,
+          });
+          return serializeBatchResult(result);
+        }
+      : () => {
+          throw new GraphQLError(
+            "batch_actions mutation requires a CommandLayer to enforce permissions.",
+          );
+        },
   };
 
   // Auto-generate `<entity>_onchange` mutations for entities with an

--- a/addons/adapter-server/cap-adapter-server/src/lib/sanitize-batch-result.ts
+++ b/addons/adapter-server/cap-adapter-server/src/lib/sanitize-batch-result.ts
@@ -1,0 +1,30 @@
+/**
+ * Production-mode sanitization for batch action results.
+ *
+ * Replaces per-item `error.message` strings with a generic placeholder
+ * to avoid leaking internal details (driver errors, stack-trace fragments,
+ * handler exception text) over the wire. Codes and field locators are
+ * preserved so clients can still differentiate validation vs. permission
+ * failures. `rolledBack` items are successes (no error message), so they
+ * are passed through untouched.
+ *
+ * Shared by REST (`/api/actions/batch`) and GraphQL (`Mutation.batch_actions`)
+ * so both transports apply identical dev-mode parity (full message visible)
+ * and prod-mode safety.
+ */
+
+import type { BatchActionsResult } from "@linchkit/core";
+
+const GENERIC_FAILURE_MESSAGE = "Action execution failed";
+
+export function sanitizeBatchResult(result: BatchActionsResult): BatchActionsResult {
+  const isDevMode = process.env.NODE_ENV !== "production";
+  if (isDevMode) return result;
+  return {
+    ...result,
+    failed: result.failed.map((f) => ({
+      ...f,
+      error: { ...f.error, message: GENERIC_FAILURE_MESSAGE },
+    })),
+  };
+}

--- a/addons/adapter-server/cap-adapter-server/src/routes/action-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/action-api.ts
@@ -15,6 +15,7 @@ import type {
   BatchTransactionStrategy,
 } from "@linchkit/core";
 import type { Elysia } from "elysia";
+import { sanitizeBatchResult } from "../lib/sanitize-batch-result";
 import type { ServerOptions } from "../server";
 import {
   badRequest,
@@ -25,29 +26,6 @@ import {
   resolveStatusCode,
   serverError,
 } from "./shared";
-
-/**
- * In production mode, replace per-item `error.message` strings with a
- * generic placeholder to avoid leaking internal details (driver errors,
- * stack-trace fragments, etc.) over HTTP. Codes and field locators are
- * preserved so clients can still differentiate validation vs. permission
- * failures. `rolledBack` items are successes (no error message), so they
- * are passed through untouched.
- *
- * Mirrors the single-action sanitization at the bottom of `mountActionRoutes`
- * to keep dev-mode parity (full message visible) and prod-mode safety.
- */
-function sanitizeBatchResult(result: BatchActionsResult): BatchActionsResult {
-  const isDevMode = process.env.NODE_ENV !== "production";
-  if (isDevMode) return result;
-  return {
-    ...result,
-    failed: result.failed.map((f) => ({
-      ...f,
-      error: { ...f.error, message: "Action execution failed" },
-    })),
-  };
-}
 
 /** Validate the JSON body shape for `POST /api/actions/batch`. */
 function parseBatchBody(


### PR DESCRIPTION
## Summary

- New code-first GraphQL `Mutation.batch_actions(actions: [BatchActionInputItem!]!, strategy: String, meta: String): BatchActionsResult!` mirroring the REST `/api/actions/batch` contract (Spec 04 §8).
- Per-item input is JSON-string-encoded for parity with the existing `executeAction` mutation — graphql-js code-first ships no JSON scalar, and stringly-encoded payloads avoid a new runtime dep.
- `BatchActionsResult` exposes `success` / `parentExecutionId` / `strategy` / `succeeded` / `failed` / `rolledBack` / `summary`. `BatchSucceededItem.data` and `.record` are JSON-string-encoded for the same reason.
- Resolver decodes per-item input + top-level `meta`, validates `strategy` at the boundary, then calls `commandLayer.executeBatch({...})` — same actor / tenant / locale resolution path single-action mutations use. Raw-executor fallback is intentionally rejected so the permission slot is never bypassed (matches the REST handler's guard).

## Codex review

- **P1 — production error leakage** — the resolver returned `serializeBatchResult(result)` directly, so `failed[*].error.message` exposed raw handler / driver exception text over GraphQL in production. Now mirrors the REST handler's `sanitizeBatchResult`: in production, replace the message with a generic "Action execution failed"; codes and field locators are preserved. Dev mode passes through unchanged. New test (h) asserts the text "intentional failure" never reaches the GraphQL response under production mode.

- **P2 — TM wiring divergence vs REST** — `createServer({ transactionManager })` configures REST batch but doesn't propagate to a separately-built GraphQL schema. JSDoc on `BuildGraphQLSchemaOptions.transactionManager` now warns about this and points callers to either pass the same TM here or set it on `createCommandLayer` so both transports fall back to it. A full architectural unification would change the public API of either `createServer` or `buildGraphQLSchema`; deferred.

## Test plan

- [x] 8 tests in `addons/adapter-server/cap-adapter-server/__tests__/graphql-batch-actions.test.ts`: ordered partial success; per-item failure structure; `all_or_nothing` rollback (asserts `rolledBack` populated and provider state reverted); `BATCH_EMPTY` structured failure; strategy validation; malformed-JSON rejection; per-item permission denial; production-mode sanitization (new).
- [x] Full repo: `4483 pass / 0 fail / 85 skip`.
- [x] `bun run typecheck` clean.
- [x] `bun run check` clean.

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GraphQL `batch_actions` mutation for executing multiple actions in a single request, with support for partial success and all-or-nothing execution strategies.
  * Enhanced batch operation result reporting with detailed per-item success, failure, and rollback information.
  * Improved error handling in batch operations with environment-appropriate error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->