### PR TITLE
feat(adapter-ui): AutoForm onchange front-end integration (Spec 64 M6, closes #207)

### DIFF
--- a/.changeset/autoform-onchange.md
+++ b/.changeset/autoform-onchange.md
@@ -1,0 +1,20 @@
+---
+"@linchkit/cap-adapter-ui": minor
+---
+
+feat(adapter-ui): AutoForm calls the server-side onchange endpoint and applies returned field updates (Spec 64 M6, closes #207)
+
+User-initiated field changes now POST to `/api/entities/:entity/onchange` (with
+configurable debounce, default 300 ms per Spec 64 §6.1), and applied field
+updates / warnings come back through the form state. Programmatic writes via
+`registerSetField` skip the call (Spec 64 §10). Stale-response protection
+uses a monotonic seq + `AbortController` so out-of-order responses don't
+overwrite newer state. Network / 4xx / 5xx errors are logged and never block
+form submission — onchange is best-effort.
+
+New exports: `useEntityOnchange` hook, `OnchangeDispatcher` /
+`buildOnchangeIndex` / `OnchangeFetcher` framework-agnostic primitives,
+`requestEntityOnchange` API helper, and the `DEFAULT_ONCHANGE_DEBOUNCE_MS`
+constant. AutoForm gains additive props: `onchangeDebounceMs`,
+`onchangeFetcher`, `onOnchangeWarnings` — public AutoForm API is unchanged
+for callers that don't opt in.

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/onchange-api.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/onchange-api.test.ts
@@ -1,0 +1,149 @@
+/**
+ * `requestEntityOnchange` transport tests (Spec 64 §4.1).
+ *
+ * Covers the wire shape sent to `POST /api/entities/:name/onchange` and how the
+ * helper normalizes the response (`{ updates, warnings }` vs partial bodies).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+// Minimal localStorage shim — api.ts reads `linchkit:token` for auth headers.
+const _store = new Map<string, string>();
+if (typeof globalThis.localStorage === "undefined") {
+  Object.defineProperty(globalThis, "localStorage", {
+    value: {
+      getItem: (key: string) => _store.get(key) ?? null,
+      setItem: (key: string, value: string) => _store.set(key, value),
+      removeItem: (key: string) => _store.delete(key),
+      clear: () => _store.clear(),
+      get length() {
+        return _store.size;
+      },
+      key: (index: number) => [..._store.keys()][index] ?? null,
+    },
+    configurable: true,
+  });
+}
+
+import { requestEntityOnchange } from "../src/lib/api";
+
+interface CapturedRequest {
+  url: string;
+  method?: string;
+  body: unknown;
+  headers: Record<string, string>;
+  signal?: AbortSignal | null;
+}
+
+let captured: CapturedRequest | null;
+let originalFetch: typeof fetch;
+
+function installFetch(response: { status: number; body: unknown }) {
+  originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    captured = {
+      url: typeof input === "string" ? input : (input as URL).toString(),
+      method: init?.method,
+      body: init?.body ? JSON.parse(init.body as string) : undefined,
+      headers: (init?.headers as Record<string, string>) ?? {},
+      signal: (init?.signal as AbortSignal | null | undefined) ?? null,
+    };
+    return new Response(JSON.stringify(response.body), {
+      status: response.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+}
+
+beforeEach(() => {
+  captured = null;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("requestEntityOnchange", () => {
+  test("posts { changedField, values } to /api/entities/:name/onchange", async () => {
+    installFetch({ status: 200, body: { updates: { unit_price: 9.99 } } });
+    const result = await requestEntityOnchange({
+      entity: "purchase_item",
+      changedField: "product_id",
+      values: { product_id: "p1", quantity: 2 },
+    });
+    expect(captured?.url).toBe("/api/entities/purchase_item/onchange");
+    expect(captured?.method).toBe("POST");
+    expect(captured?.body).toEqual({
+      changedField: "product_id",
+      values: { product_id: "p1", quantity: 2 },
+    });
+    expect(result.updates).toEqual({ unit_price: 9.99 });
+  });
+
+  test("returns { updates: {} } when the response omits updates", async () => {
+    installFetch({ status: 200, body: {} });
+    const result = await requestEntityOnchange({
+      entity: "purchase_item",
+      changedField: "product_id",
+      values: {},
+    });
+    expect(result.updates).toEqual({});
+    expect(result.warnings).toBeUndefined();
+  });
+
+  test("forwards warnings array when present", async () => {
+    installFetch({
+      status: 200,
+      body: { updates: {}, warnings: ["budget exceeded"] },
+    });
+    const result = await requestEntityOnchange({
+      entity: "purchase_item",
+      changedField: "product_id",
+      values: {},
+    });
+    expect(result.warnings).toEqual(["budget exceeded"]);
+  });
+
+  test("URL-encodes the entity name", async () => {
+    installFetch({ status: 200, body: { updates: {} } });
+    await requestEntityOnchange({
+      entity: "weird name",
+      changedField: "x",
+      values: {},
+    });
+    expect(captured?.url).toBe("/api/entities/weird%20name/onchange");
+  });
+
+  test("throws with the server-provided error message on non-2xx", async () => {
+    installFetch({
+      status: 400,
+      body: { success: false, error: { code: "INVALID", message: "field unknown" } },
+    });
+    await expect(
+      requestEntityOnchange({ entity: "x", changedField: "y", values: {} }),
+    ).rejects.toThrow("field unknown");
+  });
+
+  test("throws a generic message when the error body is non-JSON", async () => {
+    globalThis.fetch = (async () =>
+      new Response("Internal Server Error", {
+        status: 500,
+        headers: { "Content-Type": "text/plain" },
+      })) as typeof fetch;
+    await expect(
+      requestEntityOnchange({ entity: "x", changedField: "y", values: {} }),
+    ).rejects.toThrow("Onchange request failed (500)");
+  });
+
+  test("forwards AbortSignal so callers can cancel stale requests", async () => {
+    installFetch({ status: 200, body: { updates: {} } });
+    const controller = new AbortController();
+    await requestEntityOnchange({
+      entity: "x",
+      changedField: "y",
+      values: {},
+      signal: controller.signal,
+    });
+    expect(captured?.signal).toBe(controller.signal);
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/onchange-dispatcher.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/onchange-dispatcher.test.ts
@@ -90,6 +90,17 @@ describe("buildOnchangeIndex", () => {
   test("returns empty map when onchange is undefined", () => {
     expect(buildOnchangeIndex(undefined).size).toBe(0);
   });
+
+  test("warning-only hooks (`updates: []`) still index their trigger", () => {
+    // Regression for codex P2: a hook that only emits warnings has an
+    // empty `updates` array — the index must still register the trigger
+    // so the dispatcher fires the request and warnings reach the UI.
+    const idx = buildOnchangeIndex({
+      stock_check: { updates: [], compute: () => ({}) },
+    });
+    expect(idx.has("stock_check")).toBe(true);
+    expect(idx.get("stock_check")).toEqual([]);
+  });
 });
 
 describe("OnchangeDispatcher.trigger", () => {
@@ -99,6 +110,46 @@ describe("OnchangeDispatcher.trigger", () => {
     fx.dispatcher.trigger("description"); // no hook
     await new Promise((r) => setTimeout(r, 5));
     expect(fetcher).toHaveBeenCalledTimes(0);
+  });
+
+  test("warning-only hooks dispatch even with empty `updates`", async () => {
+    // Regression for codex P2: the previous gate was `updates.length === 0`,
+    // which silently dropped warning-only hooks (e.g. budget / stock checks).
+    const calls: string[] = [];
+    const fetcher: OnchangeFetcher = async ({ changedField }) => {
+      calls.push(changedField);
+      return { updates: {}, warnings: ["Stock low"] };
+    };
+    const values: Record<string, unknown> = {};
+    const dispatcher = new OnchangeDispatcher({
+      entity: "purchase_item",
+      onchange: { stock_check: { updates: [], compute: () => ({}) } },
+      getValues: () => values,
+      onUpdates: () => {
+        // Won't be called for empty updates.
+      },
+      onWarnings: () => {
+        // Captured below.
+      },
+      fetcher,
+      debounceMs: 0,
+    });
+    const warnings: string[][] = [];
+    // Re-create with a real onWarnings collector so the assertion can read it.
+    const fx = new OnchangeDispatcher({
+      entity: "purchase_item",
+      onchange: { stock_check: { updates: [], compute: () => ({}) } },
+      getValues: () => values,
+      onUpdates: () => {},
+      onWarnings: (w) => warnings.push(w),
+      fetcher,
+      debounceMs: 0,
+    });
+    fx.trigger("stock_check");
+    await new Promise((r) => setTimeout(r, 10));
+    expect(calls).toEqual(["stock_check"]);
+    expect(warnings).toEqual([["Stock low"]]);
+    void dispatcher; // appease unused-binding lints; kept for readability above
   });
 
   test("debounce coalesces rapid calls into a single fetch with the LATEST field", async () => {

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/onchange-dispatcher.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/onchange-dispatcher.test.ts
@@ -1,0 +1,253 @@
+/**
+ * OnchangeDispatcher tests (Spec 64 §6.1 front-end integration).
+ *
+ * Covers:
+ *   - field changes fire the fetcher after debounce
+ *   - returned `updates` are applied; `warnings` are surfaced
+ *   - stale responses are dropped when a newer call lands first
+ *   - in-flight request is aborted when superseded
+ *   - network errors don't crash and the loading flag clears
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { OnchangeDefinition } from "@linchkit/core/types";
+import {
+  buildOnchangeIndex,
+  OnchangeDispatcher,
+  type OnchangeFetcher,
+} from "../src/lib/onchange-dispatcher";
+
+const onchangeMap: Record<string, OnchangeDefinition> = {
+  product_id: {
+    updates: ["unit_price", "uom"],
+    compute: () => ({}),
+  },
+  "quantity,unit_price": {
+    updates: ["subtotal"],
+    compute: () => ({}),
+  },
+};
+
+function makeFixture(overrides: { fetcher?: OnchangeFetcher; debounceMs?: number } = {}) {
+  let values: Record<string, unknown> = { quantity: 1, unit_price: 0, subtotal: 0 };
+  const updatesLog: Array<Record<string, unknown>> = [];
+  const warningsLog: string[][] = [];
+  const loadingLog: Array<{ loading: boolean; pending: string[] }> = [];
+  const defaultFetcher: OnchangeFetcher = async () => ({ updates: {} });
+
+  const dispatcher = new OnchangeDispatcher({
+    entity: "purchase_item",
+    onchange: onchangeMap,
+    getValues: () => values,
+    onUpdates: (u) => {
+      updatesLog.push(u);
+      values = { ...values, ...u };
+    },
+    onWarnings: (w) => warningsLog.push(w),
+    onLoadingChange: (l, p) =>
+      loadingLog.push({ loading: l, pending: [...p].sort((a, b) => a.localeCompare(b)) }),
+    fetcher: overrides.fetcher ?? defaultFetcher,
+    debounceMs: overrides.debounceMs ?? 0,
+  });
+
+  return {
+    dispatcher,
+    updatesLog,
+    warningsLog,
+    loadingLog,
+    setValues: (v: Record<string, unknown>) => {
+      values = v;
+    },
+    getValues: () => values,
+  };
+}
+
+describe("buildOnchangeIndex", () => {
+  test("indexes single-field triggers", () => {
+    const idx = buildOnchangeIndex({
+      product_id: { updates: ["unit_price"], compute: () => ({}) },
+    });
+    expect(idx.get("product_id")).toEqual(["unit_price"]);
+  });
+
+  test("explodes comma-separated triggers", () => {
+    const idx = buildOnchangeIndex(onchangeMap);
+    expect(idx.get("quantity")).toEqual(["subtotal"]);
+    expect(idx.get("unit_price")).toContain("subtotal");
+  });
+
+  test("merges updates when the same trigger appears in multiple keys", () => {
+    const idx = buildOnchangeIndex({
+      a: { updates: ["x"], compute: () => ({}) },
+      "a,b": { updates: ["y"], compute: () => ({}) },
+    });
+    const aUpdates = idx.get("a");
+    expect(aUpdates).toContain("x");
+    expect(aUpdates).toContain("y");
+    expect(idx.get("b")).toEqual(["y"]);
+  });
+
+  test("returns empty map when onchange is undefined", () => {
+    expect(buildOnchangeIndex(undefined).size).toBe(0);
+  });
+});
+
+describe("OnchangeDispatcher.trigger", () => {
+  test("no-op when no hook matches the field", async () => {
+    const fetcher = mock(async () => ({ updates: {} }));
+    const fx = makeFixture({ fetcher });
+    fx.dispatcher.trigger("description"); // no hook
+    await new Promise((r) => setTimeout(r, 5));
+    expect(fetcher).toHaveBeenCalledTimes(0);
+  });
+
+  test("debounce coalesces rapid calls into a single fetch with the LATEST field", async () => {
+    const calls: string[] = [];
+    const fetcher: OnchangeFetcher = async ({ changedField }) => {
+      calls.push(changedField);
+      return { updates: {} };
+    };
+    const fx = makeFixture({ fetcher, debounceMs: 20 });
+    fx.dispatcher.trigger("quantity");
+    fx.dispatcher.trigger("unit_price");
+    fx.dispatcher.trigger("product_id");
+    expect(calls).toEqual([]); // not flushed yet
+    await new Promise((r) => setTimeout(r, 40));
+    expect(calls).toEqual(["product_id"]);
+  });
+
+  test("applies returned `updates` to form state", async () => {
+    const fetcher: OnchangeFetcher = async () => ({
+      updates: { unit_price: 29.99, uom: "piece" },
+    });
+    const fx = makeFixture({ fetcher });
+    fx.dispatcher.trigger("product_id");
+    await new Promise((r) => setTimeout(r, 5));
+    expect(fx.updatesLog).toEqual([{ unit_price: 29.99, uom: "piece" }]);
+    expect(fx.getValues().unit_price).toBe(29.99);
+  });
+
+  test("forwards warnings to onWarnings", async () => {
+    const fetcher: OnchangeFetcher = async () => ({
+      updates: {},
+      warnings: ["Exchange rate is stale"],
+    });
+    const fx = makeFixture({ fetcher });
+    fx.dispatcher.trigger("product_id");
+    await new Promise((r) => setTimeout(r, 5));
+    expect(fx.warningsLog).toEqual([["Exchange rate is stale"]]);
+  });
+
+  test("toggles loading state around the request", async () => {
+    let resolve!: (value: { updates: Record<string, unknown> }) => void;
+    const fetcher: OnchangeFetcher = () =>
+      new Promise((r) => {
+        resolve = r;
+      });
+    const fx = makeFixture({ fetcher });
+    fx.dispatcher.trigger("product_id");
+    await new Promise((r) => setTimeout(r, 5));
+    expect(fx.loadingLog.at(-1)?.loading).toBe(true);
+    expect(fx.loadingLog.at(-1)?.pending).toEqual(["unit_price", "uom"].sort());
+    resolve({ updates: { unit_price: 1 } });
+    await new Promise((r) => setTimeout(r, 5));
+    expect(fx.loadingLog.at(-1)?.loading).toBe(false);
+  });
+});
+
+describe("OnchangeDispatcher race protection", () => {
+  test("stale response is dropped when a newer call lands first", async () => {
+    // First call resolves slowly with seq=1, second resolves quickly with seq=2.
+    let firstResolve!: (v: { updates: Record<string, unknown> }) => void;
+    let callIndex = 0;
+    const fetcher: OnchangeFetcher = () => {
+      const i = callIndex++;
+      if (i === 0) {
+        return new Promise((r) => {
+          firstResolve = r;
+        });
+      }
+      return Promise.resolve({ updates: { unit_price: 99 } });
+    };
+    const fx = makeFixture({ fetcher, debounceMs: 0 });
+    fx.dispatcher.trigger("product_id");
+    await new Promise((r) => setTimeout(r, 5));
+    // Second trigger fires while first is in-flight. Dispatcher aborts first.
+    fx.dispatcher.trigger("product_id");
+    await new Promise((r) => setTimeout(r, 5));
+    expect(fx.updatesLog).toEqual([{ unit_price: 99 }]);
+    // Late delivery of the FIRST request must NOT clobber form state.
+    firstResolve({ unit_price: 1, uom: "stale" } as unknown as {
+      updates: Record<string, unknown>;
+    });
+    await new Promise((r) => setTimeout(r, 5));
+    expect(fx.updatesLog).toEqual([{ unit_price: 99 }]);
+  });
+
+  test("AbortController is signaled when a request is superseded", async () => {
+    const aborted: boolean[] = [];
+    const fetcher: OnchangeFetcher = ({ signal }) =>
+      new Promise((_resolve, reject) => {
+        signal?.addEventListener("abort", () => {
+          aborted.push(true);
+          reject(new DOMException("aborted", "AbortError"));
+        });
+      });
+    const fx = makeFixture({ fetcher, debounceMs: 0 });
+    fx.dispatcher.trigger("product_id");
+    await new Promise((r) => setTimeout(r, 5));
+    fx.dispatcher.trigger("product_id"); // supersedes the first
+    await new Promise((r) => setTimeout(r, 5));
+    expect(aborted.length).toBe(1);
+  });
+
+  test("cancel() aborts pending debounce and in-flight request", async () => {
+    let aborted = false;
+    const fetcher: OnchangeFetcher = ({ signal }) =>
+      new Promise((_resolve, reject) => {
+        signal?.addEventListener("abort", () => {
+          aborted = true;
+          reject(new DOMException("aborted", "AbortError"));
+        });
+      });
+    const fx = makeFixture({ fetcher, debounceMs: 0 });
+    fx.dispatcher.trigger("product_id");
+    await new Promise((r) => setTimeout(r, 5));
+    fx.dispatcher.cancel();
+    await new Promise((r) => setTimeout(r, 5));
+    expect(aborted).toBe(true);
+    expect(fx.loadingLog.at(-1)?.loading).toBe(false);
+  });
+});
+
+describe("OnchangeDispatcher error tolerance", () => {
+  let originalError: typeof console.error;
+  beforeEach(() => {
+    originalError = console.error;
+    console.error = mock(() => {});
+  });
+  afterEach(() => {
+    console.error = originalError;
+  });
+
+  test("network error does not throw and clears loading", async () => {
+    const fetcher: OnchangeFetcher = async () => {
+      throw new Error("network down");
+    };
+    const fx = makeFixture({ fetcher });
+    fx.dispatcher.trigger("product_id");
+    await new Promise((r) => setTimeout(r, 5));
+    expect(fx.updatesLog).toEqual([]);
+    expect(fx.loadingLog.at(-1)?.loading).toBe(false);
+  });
+
+  test("abort errors are silent (no console output)", async () => {
+    const fetcher: OnchangeFetcher = async () => {
+      throw new DOMException("aborted", "AbortError");
+    };
+    const fx = makeFixture({ fetcher });
+    fx.dispatcher.trigger("product_id");
+    await new Promise((r) => setTimeout(r, 5));
+    expect((console.error as unknown as { mock: { calls: unknown[] } }).mock.calls.length).toBe(0);
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/tenant.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/tenant.test.ts
@@ -21,7 +21,11 @@ if (typeof globalThis.localStorage === "undefined") {
 
 describe("tenant utilities", () => {
   beforeEach(() => {
-    store.clear();
+    // Use localStorage.clear() rather than the local `store` Map so cleanup
+    // is robust against another test file installing its own shim first
+    // (e.g. `onchange-api.test.ts`). The active shim might be backed by a
+    // different store; `localStorage.clear()` always hits the live one.
+    localStorage.clear();
   });
 
   describe("getActiveTenantId", () => {

--- a/addons/adapter-ui/cap-adapter-ui/src/components/auto-form/auto-form.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/auto-form/auto-form.tsx
@@ -31,6 +31,7 @@ import { AlertCircle, Puzzle } from "lucide-react";
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { z } from "zod";
+import { useEntityOnchange } from "../../hooks/use-entity-onchange";
 import { buildRelationFieldMap } from "../../lib/entity-form-utils";
 import { evaluateVisibility } from "../../lib/field-visibility";
 import { isMaskedValue } from "../../lib/masking";
@@ -70,6 +71,9 @@ export function AutoForm({
   overlayFields,
   relations,
   formId: customFormId,
+  onchangeDebounceMs,
+  onchangeFetcher,
+  onOnchangeWarnings,
 }: AutoFormProps) {
   const { t } = useTranslation();
   const formId = customFormId ?? "auto-form";
@@ -125,6 +129,10 @@ export function AutoForm({
   });
 
   const initialDataRef = useRef<Record<string, unknown>>({ ...formData });
+  // Tracks the latest form data synchronously — onchange triggers must read the
+  // value JUST written by handleChange before React commits the next render.
+  const formDataRef = useRef<Record<string, unknown>>(formData);
+  formDataRef.current = formData;
   const [dirtyFields, setDirtyFields] = useState<Set<string>>(new Set());
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [touchedFields, setTouchedFields] = useState<Set<string>>(new Set());
@@ -134,6 +142,27 @@ export function AutoForm({
   const formRef = useRef<HTMLFormElement>(null);
 
   const isViewMode = mode === "view";
+
+  // ── Entity onchange (Spec 64) ──
+  // Server-driven interactive form computation. Fires after a debounced field
+  // change and merges returned `updates` into formData. Stale responses are
+  // dropped by the dispatcher so the user's latest edit always wins.
+  const onchange = useEntityOnchange({
+    entity: schema.name,
+    onchange: schema.onchange,
+    getValues: () => formDataRef.current,
+    applyUpdates: (updates) => {
+      setFormData((prev) => {
+        const next = { ...prev, ...updates };
+        formDataRef.current = next;
+        if (onValuesChange) queueMicrotask(() => onValuesChange(next));
+        return next;
+      });
+    },
+    onWarnings: onOnchangeWarnings ?? ((w) => console.warn("[AutoForm onchange]", ...w)),
+    debounceMs: onchangeDebounceMs,
+    fetcher: onchangeFetcher,
+  });
 
   // ── Record template state ──
   const [appliedTemplateId, setAppliedTemplateId] = useState<string | undefined>(undefined);
@@ -155,7 +184,7 @@ export function AutoForm({
   useEffect(() => {
     if (registerSetField) {
       registerSetField((fieldName: string, value: unknown) => {
-        handleChange(fieldName, value);
+        handleChange(fieldName, value, { programmatic: true });
       });
     }
     // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — only re-register on mount
@@ -320,9 +349,10 @@ export function AutoForm({
 
   // ── Handlers ──
 
-  function handleChange(fieldName: string, value: unknown) {
+  function handleChange(fieldName: string, value: unknown, options?: { programmatic?: boolean }) {
     setFormData((prev) => {
       const next = { ...prev, [fieldName]: value };
+      formDataRef.current = next;
       // Notify parent of value changes (deferred to avoid setState-during-render)
       if (onValuesChange) {
         queueMicrotask(() => onValuesChange(next));
@@ -350,6 +380,11 @@ export function AutoForm({
         }
         return next;
       });
+    }
+
+    // Spec 64 §10: only USER-initiated changes fire onchange.
+    if (!options?.programmatic) {
+      onchange.trigger(fieldName);
     }
   }
 

--- a/addons/adapter-ui/cap-adapter-ui/src/components/auto-form/auto-form.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/auto-form/auto-form.tsx
@@ -150,7 +150,30 @@ export function AutoForm({
   const onchange = useEntityOnchange({
     entity: schema.name,
     onchange: schema.onchange,
-    getValues: () => formDataRef.current,
+    // Translate relation semantic names (`department`) to their FK
+    // column (`department_id`) before sending — same normalization
+    // submit() does. Without it, the server endpoint sees unrecognized
+    // keys and the onchange definitions (which key on real columns)
+    // never match.
+    getValues: () => {
+      const raw = formDataRef.current;
+      let normalized: Record<string, unknown> | null = null;
+      for (const [semanticName, relInfo] of relationFieldMap) {
+        if (!(semanticName in raw)) continue;
+        if (relInfo.cardinality !== "many_to_one" && relInfo.cardinality !== "one_to_one") {
+          continue;
+        }
+        if (!normalized) normalized = { ...raw };
+        const val = raw[semanticName];
+        if (typeof val === "object" && val !== null && "id" in val) {
+          normalized[relInfo.fkColumn] = (val as Record<string, unknown>).id;
+        } else {
+          normalized[relInfo.fkColumn] = val ?? null;
+        }
+        delete normalized[semanticName];
+      }
+      return normalized ?? raw;
+    },
     applyUpdates: (updates) => {
       setFormData((prev) => {
         const next = { ...prev, ...updates };
@@ -158,6 +181,24 @@ export function AutoForm({
         if (onValuesChange) queueMicrotask(() => onValuesChange(next));
         return next;
       });
+      // Clear any stale client-side errors on fields the server just
+      // overwrote — without this, a previously-touched field that's now
+      // valid (e.g. `unit_price` auto-filled after `product_id` changed)
+      // would keep its old error and block submission.
+      const updatedKeys = Object.keys(updates);
+      if (updatedKeys.length > 0) {
+        setErrors((prev) => {
+          let mutated = false;
+          const next = { ...prev };
+          for (const k of updatedKeys) {
+            if (k in next) {
+              delete next[k];
+              mutated = true;
+            }
+          }
+          return mutated ? next : prev;
+        });
+      }
     },
     onWarnings: onOnchangeWarnings ?? ((w) => console.warn("[AutoForm onchange]", ...w)),
     debounceMs: onchangeDebounceMs,
@@ -383,8 +424,18 @@ export function AutoForm({
     }
 
     // Spec 64 §10: only USER-initiated changes fire onchange.
+    // Normalize relation semantic names (`department`) to their FK column
+    // (`department_id`) before dispatch — the server-side onchange
+    // endpoint operates on real entity columns, not the UI's semantic
+    // names. Same conversion happens to the values payload via
+    // `getValues` below.
     if (!options?.programmatic) {
-      onchange.trigger(fieldName);
+      const relInfo = relationFieldMap.get(fieldName);
+      const triggerField =
+        relInfo && (relInfo.cardinality === "many_to_one" || relInfo.cardinality === "one_to_one")
+          ? relInfo.fkColumn
+          : fieldName;
+      onchange.trigger(triggerField);
     }
   }
 

--- a/addons/adapter-ui/cap-adapter-ui/src/components/auto-form/types.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/auto-form/types.ts
@@ -9,6 +9,7 @@ import type {
   ViewDefinition,
 } from "@linchkit/core/types";
 import type { AiFieldSuggestion } from "../../lib/api";
+import type { OnchangeFetcher } from "../../lib/onchange-dispatcher";
 import type { FieldOverlayRecord } from "../../lib/overlay-types";
 
 export type { RecordTemplate };
@@ -100,4 +101,19 @@ export interface AutoFormProps {
    * and child record commands by cardinality rather than field type (Spec 61).
    */
   relations?: RelationDefinition[];
+  /**
+   * Debounce window (ms) before posting an onchange request to the server.
+   * Defaults to 300 ms (Spec 64 §6.1). Set to 0 in tests to fire immediately.
+   */
+  onchangeDebounceMs?: number;
+  /**
+   * Optional onchange request fetcher override (test seam). When omitted the
+   * default `requestEntityOnchange` is used.
+   */
+  onchangeFetcher?: OnchangeFetcher;
+  /**
+   * Optional handler invoked with non-blocking warnings returned by an
+   * onchange call. Defaults to logging via `console.warn`.
+   */
+  onOnchangeWarnings?: (warnings: string[]) => void;
 }

--- a/addons/adapter-ui/cap-adapter-ui/src/hooks/use-entity-onchange.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/hooks/use-entity-onchange.ts
@@ -1,0 +1,117 @@
+/**
+ * useEntityOnchange — Front-end glue for Spec 64 entity onchange.
+ *
+ * Thin React wrapper around `OnchangeDispatcher`. Handles the dispatcher
+ * lifecycle (mount / unmount / re-index on schema change) and exposes
+ * loading + pending-fields state for the UI.
+ */
+
+import type { OnchangeDefinition } from "@linchkit/core/types";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { requestEntityOnchange } from "../lib/api";
+import {
+  DEFAULT_ONCHANGE_DEBOUNCE_MS,
+  OnchangeDispatcher,
+  type OnchangeFetcher,
+} from "../lib/onchange-dispatcher";
+
+export { DEFAULT_ONCHANGE_DEBOUNCE_MS } from "../lib/onchange-dispatcher";
+
+export interface UseEntityOnchangeOptions {
+  /** Entity name (`schema.name`). When undefined the hook is a no-op. */
+  entity: string | undefined;
+  /** Onchange map from the entity definition. */
+  onchange: Record<string, OnchangeDefinition> | undefined;
+  /** Returns the current form values at call time. */
+  getValues: () => Record<string, unknown>;
+  /** Apply server-returned `updates` to form state. */
+  applyUpdates: (updates: Record<string, unknown>) => void;
+  /** Optional non-blocking warnings handler. */
+  onWarnings?: (warnings: string[]) => void;
+  /** Per-call debounce override. Falls back to {@link DEFAULT_ONCHANGE_DEBOUNCE_MS}. */
+  debounceMs?: number;
+  /** Test-only fetcher injection. */
+  fetcher?: OnchangeFetcher;
+}
+
+export interface UseEntityOnchangeReturn {
+  loading: boolean;
+  pendingFields: ReadonlySet<string>;
+  trigger: (changedField: string) => void;
+  cancel: () => void;
+}
+
+export function useEntityOnchange(options: UseEntityOnchangeOptions): UseEntityOnchangeReturn {
+  const {
+    entity,
+    onchange,
+    getValues,
+    applyUpdates,
+    onWarnings,
+    debounceMs = DEFAULT_ONCHANGE_DEBOUNCE_MS,
+    fetcher = requestEntityOnchange,
+  } = options;
+
+  // Ref-based callbacks so dispatcher captures fresh closures without re-init.
+  const getValuesRef = useRef(getValues);
+  const applyUpdatesRef = useRef(applyUpdates);
+  const onWarningsRef = useRef(onWarnings);
+  const fetcherRef = useRef(fetcher);
+  getValuesRef.current = getValues;
+  applyUpdatesRef.current = applyUpdates;
+  onWarningsRef.current = onWarnings;
+  fetcherRef.current = fetcher;
+
+  const [loading, setLoading] = useState(false);
+  const [pendingFields, setPendingFields] = useState<ReadonlySet<string>>(new Set());
+
+  const dispatcherRef = useRef<OnchangeDispatcher | null>(null);
+
+  // `onchange` is intentionally absent from this effect's deps: the
+  // dispatcher exposes `setOnchange` (called from the next effect) so
+  // identity churn on the onchange map doesn't tear down + rebuild the
+  // dispatcher (which would cancel the current debounce + abort an
+  // in-flight request). Captured-at-mount value is fine for the initial
+  // construction; subsequent updates flow through `setOnchange`.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: see comment above
+  useEffect(() => {
+    if (!entity) {
+      dispatcherRef.current?.cancel();
+      dispatcherRef.current = null;
+      return;
+    }
+    const dispatcher = new OnchangeDispatcher({
+      entity,
+      onchange,
+      getValues: () => getValuesRef.current(),
+      onUpdates: (updates) => applyUpdatesRef.current(updates),
+      onWarnings: (warnings) => onWarningsRef.current?.(warnings),
+      onLoadingChange: (l, p) => {
+        setLoading(l);
+        setPendingFields(p);
+      },
+      fetcher: (params) => fetcherRef.current(params),
+      debounceMs,
+    });
+    dispatcherRef.current = dispatcher;
+    return () => {
+      dispatcher.cancel();
+      if (dispatcherRef.current === dispatcher) dispatcherRef.current = null;
+    };
+  }, [entity, debounceMs]);
+
+  // Re-index when the onchange map identity changes without recreating dispatcher.
+  useEffect(() => {
+    dispatcherRef.current?.setOnchange(onchange);
+  }, [onchange]);
+
+  const trigger = useCallback((changedField: string) => {
+    dispatcherRef.current?.trigger(changedField);
+  }, []);
+
+  const cancel = useCallback(() => {
+    dispatcherRef.current?.cancel();
+  }, []);
+
+  return { loading, pendingFields, trigger, cancel };
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/index.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/index.ts
@@ -44,6 +44,11 @@ export { changeLanguage, default as i18n, languageNames, supportedLanguages } fr
 export { resolveEntityLabel, useEntityLabel, useSchemaLabel } from "./i18n/use-entity-label";
 // Layout components
 export { ShellLayout } from "./layouts/shell";
+export type { EntityOnchangeResult } from "./lib/api";
+export { requestEntityOnchange } from "./lib/api";
+// Onchange dispatcher (framework-agnostic primitives — useful for non-React hosts)
+export type { OnchangeFetcher } from "./lib/onchange-dispatcher";
+export { buildOnchangeIndex, OnchangeDispatcher } from "./lib/onchange-dispatcher";
 export type { AdminRouteRegistration } from "./lib/route-registry";
 // Admin route registry
 export { getAdminRoutes, registerAdminRoute } from "./lib/route-registry";

--- a/addons/adapter-ui/cap-adapter-ui/src/index.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/index.ts
@@ -30,6 +30,14 @@ export { capAdapterUiConfig } from "./config";
 // Hooks
 export { useBreadcrumb } from "./hooks/use-breadcrumb";
 export { BreadcrumbTitleProvider, useBreadcrumbTitle } from "./hooks/use-breadcrumb-title";
+export type {
+  UseEntityOnchangeOptions,
+  UseEntityOnchangeReturn,
+} from "./hooks/use-entity-onchange";
+export {
+  DEFAULT_ONCHANGE_DEBOUNCE_MS,
+  useEntityOnchange,
+} from "./hooks/use-entity-onchange";
 export type { SupportedLanguage } from "./i18n";
 // i18n
 export { changeLanguage, default as i18n, languageNames, supportedLanguages } from "./i18n";

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/api.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/api.ts
@@ -469,6 +469,62 @@ export async function fetchSemanticRelations(): Promise<SemanticRelation[]> {
   return json.data ?? [];
 }
 
+// ── Entity onchange (Spec 64) ───────────────────────────
+
+/** Result returned by `POST /api/entities/:name/onchange`. */
+export interface EntityOnchangeResult {
+  /** Field values the UI should apply to the unsaved form state. */
+  updates: Record<string, unknown>;
+  /** Optional non-blocking warnings to surface alongside the form. */
+  warnings?: string[];
+}
+
+/**
+ * Call the per-entity onchange endpoint. Returns the suggested form updates the
+ * UI should apply on top of `values`. Throws on HTTP / shape errors so callers
+ * can isolate transport failures from application warnings.
+ *
+ * Pass an `AbortSignal` (or `signal: undefined` to skip) so the caller can
+ * cancel stale requests when the user keeps typing — Spec 64 §6.1 race
+ * protection.
+ */
+export async function requestEntityOnchange(params: {
+  entity: string;
+  changedField: string;
+  values: Record<string, unknown>;
+  signal?: AbortSignal;
+}): Promise<EntityOnchangeResult> {
+  const { entity, changedField, values, signal } = params;
+  const res = await fetch(`/api/entities/${encodeURIComponent(entity)}/onchange`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...getAuthHeaders() },
+    body: JSON.stringify({ changedField, values }),
+    signal,
+  });
+  handleUnauthorized(res);
+  if (!res.ok) {
+    let message = `Onchange request failed (${res.status})`;
+    try {
+      const body = await res.json();
+      if (body && typeof body === "object") {
+        const error = (body as { error?: { message?: string } }).error;
+        if (error?.message) message = error.message;
+      }
+    } catch {
+      // Body was not JSON — keep default message.
+    }
+    throw new Error(message);
+  }
+  const json = (await res.json()) as Partial<EntityOnchangeResult> | null;
+  return {
+    updates:
+      json && typeof json === "object" && json.updates && typeof json.updates === "object"
+        ? (json.updates as Record<string, unknown>)
+        : {},
+    warnings: Array.isArray(json?.warnings) ? json.warnings : undefined,
+  };
+}
+
 // ── REST Action execution ───────────────────────────────
 
 export interface ActionResult {

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/onchange-dispatcher.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/onchange-dispatcher.ts
@@ -1,0 +1,178 @@
+/**
+ * OnchangeDispatcher — Framework-agnostic dispatcher for Spec 64 entity onchange.
+ *
+ * Encapsulates the debounce + sequence-number race protection so it can be
+ * tested without React. The React `useEntityOnchange` hook is a thin wrapper
+ * that wires this dispatcher to component state.
+ *
+ * Race protection: every dispatched call is tagged with a monotonically
+ * increasing sequence number. When a response arrives, the dispatcher checks
+ * the current sequence — older responses are dropped (`onUpdates` is not
+ * invoked). An AbortController is also signaled on supersession so the network
+ * request can be cut short by `requestEntityOnchange`.
+ */
+
+import type { OnchangeDefinition } from "@linchkit/core/types";
+import type { EntityOnchangeResult } from "./api";
+
+/** Default debounce — Spec 64 §6.1 mandates a 300ms minimum between calls. */
+export const DEFAULT_ONCHANGE_DEBOUNCE_MS = 300;
+
+export type OnchangeFetcher = (params: {
+  entity: string;
+  changedField: string;
+  values: Record<string, unknown>;
+  signal?: AbortSignal;
+}) => Promise<EntityOnchangeResult>;
+
+export interface OnchangeDispatcherOptions {
+  /** Entity name (`schema.name`). */
+  entity: string;
+  /** Onchange map from the entity definition. */
+  onchange: Record<string, OnchangeDefinition> | undefined;
+  /** Snapshot the current form values at call time. */
+  getValues: () => Record<string, unknown>;
+  /** Apply server-returned `updates`. Only invoked for the LATEST request. */
+  onUpdates: (updates: Record<string, unknown>) => void;
+  /** Optional non-blocking warnings handler. Only invoked for the latest request. */
+  onWarnings?: (warnings: string[]) => void;
+  /** Optional in-flight notifications — used by the React hook to drive a spinner. */
+  onLoadingChange?: (loading: boolean, pendingFields: ReadonlySet<string>) => void;
+  /** Network helper. Real callers leave this default; tests inject a mock. */
+  fetcher: OnchangeFetcher;
+  /** Debounce override. Defaults to {@link DEFAULT_ONCHANGE_DEBOUNCE_MS}. */
+  debounceMs?: number;
+}
+
+/**
+ * Build a `triggerField -> updates[]` index from the entity's onchange map.
+ *
+ * Comma-separated keys (`"quantity,unit_price"`) explode so each individual
+ * field maps to the same updates list. Pure function — exported for tests.
+ */
+export function buildOnchangeIndex(
+  onchange: Record<string, OnchangeDefinition> | undefined,
+): Map<string, string[]> {
+  const index = new Map<string, string[]>();
+  if (!onchange) return index;
+  for (const [key, def] of Object.entries(onchange)) {
+    const triggers = key
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    for (const trigger of triggers) {
+      const existing = index.get(trigger);
+      if (existing) {
+        for (const u of def.updates) if (!existing.includes(u)) existing.push(u);
+      } else {
+        index.set(trigger, [...def.updates]);
+      }
+    }
+  }
+  return index;
+}
+
+interface InFlight {
+  seq: number;
+  controller: AbortController;
+}
+
+export class OnchangeDispatcher {
+  private readonly options: OnchangeDispatcherOptions;
+  private index: Map<string, string[]>;
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private pendingField: string | null = null;
+  private seq = 0;
+  private lastAppliedSeq = 0;
+  private inFlight: InFlight | null = null;
+
+  constructor(options: OnchangeDispatcherOptions) {
+    this.options = options;
+    this.index = buildOnchangeIndex(options.onchange);
+  }
+
+  /** Re-index when the entity's onchange map changes (e.g. capability hot-reload). */
+  setOnchange(onchange: Record<string, OnchangeDefinition> | undefined): void {
+    this.index = buildOnchangeIndex(onchange);
+  }
+
+  /** Schedule an onchange call for the given field. No-op when no hook matches. */
+  trigger(changedField: string): void {
+    const updates = this.index.get(changedField);
+    if (!updates || updates.length === 0) return;
+    this.pendingField = changedField;
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    const ms = Math.max(0, this.options.debounceMs ?? DEFAULT_ONCHANGE_DEBOUNCE_MS);
+    this.debounceTimer = setTimeout(() => this.flush(), ms);
+  }
+
+  /** Cancel any pending or in-flight work. */
+  cancel(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+    this.pendingField = null;
+    if (this.inFlight) {
+      this.inFlight.controller.abort();
+      this.inFlight = null;
+    }
+    this.options.onLoadingChange?.(false, new Set());
+  }
+
+  /** Force the pending request to fire immediately. Test helper. */
+  flushNow(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+    this.flush();
+  }
+
+  private flush(): void {
+    this.debounceTimer = null;
+    const field = this.pendingField;
+    this.pendingField = null;
+    if (!field) return;
+
+    if (this.inFlight) this.inFlight.controller.abort();
+
+    const seq = ++this.seq;
+    const controller = new AbortController();
+    this.inFlight = { seq, controller };
+    const pendingFields = new Set(this.index.get(field) ?? []);
+    this.options.onLoadingChange?.(true, pendingFields);
+
+    const values = { ...this.options.getValues() };
+
+    this.options
+      .fetcher({
+        entity: this.options.entity,
+        changedField: field,
+        values,
+        signal: controller.signal,
+      })
+      .then((result) => {
+        // Drop stale responses — a newer call has overtaken us.
+        if (seq < this.lastAppliedSeq) return;
+        if (this.inFlight?.seq !== seq) return;
+        this.lastAppliedSeq = seq;
+        this.inFlight = null;
+        if (result.updates && Object.keys(result.updates).length > 0) {
+          this.options.onUpdates(result.updates);
+        }
+        if (result.warnings && result.warnings.length > 0) {
+          this.options.onWarnings?.(result.warnings);
+        }
+        this.options.onLoadingChange?.(false, new Set());
+      })
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        if (this.inFlight?.seq !== seq) return;
+        this.inFlight = null;
+        // Best-effort: log + recover. Onchange must never block submission.
+        console.error("[OnchangeDispatcher]", err);
+        this.options.onLoadingChange?.(false, new Set());
+      });
+  }
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/onchange-dispatcher.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/onchange-dispatcher.ts
@@ -96,10 +96,12 @@ export class OnchangeDispatcher {
     this.index = buildOnchangeIndex(onchange);
   }
 
-  /** Schedule an onchange call for the given field. No-op when no hook matches. */
+  /** Schedule an onchange call for the given field. No-op when no hook matches.
+   *  Note: warning-only hooks (`updates: []`) are dispatched too — the
+   *  decision is whether a hook exists for the trigger, NOT whether it
+   *  declares writable fields. */
   trigger(changedField: string): void {
-    const updates = this.index.get(changedField);
-    if (!updates || updates.length === 0) return;
+    if (!this.index.has(changedField)) return;
     this.pendingField = changedField;
     if (this.debounceTimer) clearTimeout(this.debounceTimer);
     const ms = Math.max(0, this.options.debounceMs ?? DEFAULT_ONCHANGE_DEBOUNCE_MS);


### PR DESCRIPTION
## Summary

User-initiated AutoForm field changes now POST to `/api/entities/:entity/onchange`; applied field updates and warnings flow back through form state. Programmatic writes via `registerSetField` skip the call (Spec 64 §10).

Layered design:

- **`OnchangeDispatcher`** (framework-agnostic): debounces calls per `DEFAULT_ONCHANGE_DEBOUNCE_MS` (300ms, Spec 64 §6.1) or a configured override; per-call monotonic seq + `AbortController` so out-of-order responses don't overwrite newer state. `buildOnchangeIndex` resolves which entity-level hooks trigger when a given field changes.
- **`useEntityOnchange`** (React wrapper): refs all callbacks so the dispatcher captures stable identities; `setOnchange` is called from a separate effect so onchange-map identity churn doesn't tear down the dispatcher.
- **`requestEntityOnchange`** (lib/api): handles both backend response shapes (success returns `{ updates, warnings }` directly; errors return `{ success: false, error }` with non-2xx status). On 401/4xx/5xx logs to console without rejecting submission — onchange is best-effort, never blocks form submit.
- **AutoForm**: wires `useEntityOnchange` into `handleChange`. Additive props: `onchangeDebounceMs`, `onchangeFetcher`, `onOnchangeWarnings`.

## Codex review (4 findings, all addressed)

- **P2 — Relation field normalization**. Trigger field name and `getValues()` payload now translate semantic relation names (`department`) to their FK column (`department_id`) before dispatch, since the server endpoint operates on real entity columns. Mirrors what `submit()` already did at the form's bottom edge.
- **P2 — Warning-only hooks dispatch**. The dispatcher gate now checks whether a hook EXISTS for the trigger, not whether it declares writable fields. Hooks like `{ updates: [], compute: () => ({ warnings: [...] }) }` (typical for stock / budget notices) reach the UI.
- **P2 — Stale client-side errors after server overwrite**. `applyUpdates` now clears `errors[k]` for keys the server overwrote, so a previously-touched field that becomes valid after auto-fill (e.g. `unit_price` after `product_id`) doesn't block submission with a stale error.
- **P3 — Missing public exports**. `OnchangeDispatcher`, `buildOnchangeIndex`, `OnchangeFetcher`, `requestEntityOnchange`, `EntityOnchangeResult` are now reachable through the package entrypoint.

## Test plan

- [x] 16 dispatcher tests covering debounce, race protection, abort, error tolerance — plus 2 new regression tests for warning-only-hook indexing + dispatch.
- [x] 7 API helper tests covering response shape parsing, error surfacing, AbortSignal forwarding, URL encoding.
- [x] Full repo: `4498 pass / 0 fail / 85 skip` (DB integrations skipped without live PG).
- [x] `bun run typecheck` clean.
- [x] `bun run check` clean.

## Backwards compatibility

AutoForm's public props are unchanged for callers that don't opt into the new behavior. Forms without `schema.onchange` defined skip the entire onchange path — no network calls, no behavior change.

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)