### PR TITLE
feat(core): proposal pre-analysis stage 2 — conflict analyzer (closes #204)

### DIFF
--- a/packages/core/src/life-system/proposal-preanalysis/__tests__/conflict-analyzer.test.ts
+++ b/packages/core/src/life-system/proposal-preanalysis/__tests__/conflict-analyzer.test.ts
@@ -343,6 +343,40 @@ describe("createConflictAnalyzer", () => {
     expect(result.notes).toContain("update definition missing or malformed");
   });
 
+  test("treats state update with non-string state entries as malformed", async () => {
+    const liveState = makeStateDef({
+      name: "purchase_request_status",
+      states: ["draft", "submitted"],
+      transitions: [{ from: "draft", to: "submitted", action: "submit" }],
+    });
+    const candidate = makeProposal({
+      id: "prop_candidate",
+      changes: [
+        {
+          target: "state",
+          operation: "update",
+          name: "purchase_request_status",
+          // states contains a non-string entry — must NOT be parsed as a real
+          // StateDefinition or the analyzer will emit false transition conflicts.
+          definition: {
+            name: "purchase_request_status",
+            states: ["draft", 42, "submitted"],
+            transitions: [],
+          } as unknown as StateDefinition,
+        },
+      ],
+    });
+    const analyzer = createConflictAnalyzer({
+      pendingProposals: makeStore([]),
+      liveStates: makeStateStore([liveState]),
+    });
+
+    const result = await analyzer.analyze(candidate);
+
+    expect(result.conflicts).toHaveLength(0);
+    expect(result.notes).toContain("update definition missing or malformed");
+  });
+
   test("supports synchronous live stores (returning arrays directly)", async () => {
     const candidate = makeProposal({
       id: "prop_candidate",

--- a/packages/core/src/life-system/proposal-preanalysis/__tests__/conflict-analyzer.test.ts
+++ b/packages/core/src/life-system/proposal-preanalysis/__tests__/conflict-analyzer.test.ts
@@ -1,0 +1,478 @@
+import { describe, expect, test } from "bun:test";
+import type { ProposalDefinition } from "../../../types/proposal";
+import type { RuleDefinition } from "../../../types/rule";
+import type { StateDefinition } from "../../../types/state";
+import {
+  createConflictAnalyzer,
+  type LiveRuleStore,
+  type LiveStateStore,
+} from "../conflict-analyzer";
+import type { PendingProposalStore } from "../types";
+import { makeProposal } from "./fixtures";
+
+function makeStore(proposals: ProposalDefinition[]): PendingProposalStore {
+  return {
+    async listPending() {
+      return proposals;
+    },
+  };
+}
+
+function makeRuleStore(rules: RuleDefinition[]): LiveRuleStore {
+  return {
+    async listRules() {
+      return rules;
+    },
+  };
+}
+
+function makeStateStore(states: StateDefinition[]): LiveStateStore {
+  return {
+    async listStates() {
+      return states;
+    },
+  };
+}
+
+function makeRule(name: string): RuleDefinition {
+  return {
+    name,
+    label: name,
+    trigger: { event: "noop" },
+    condition: { field: "x", operator: "eq", value: 1 },
+    effect: { type: "warn", message: "test" },
+  };
+}
+
+function makeStateDef(opts: {
+  name: string;
+  states: string[];
+  transitions?: Array<{ from: string | string[]; to: string; action: string }>;
+}): StateDefinition {
+  return {
+    name: opts.name,
+    entity: "purchase_request",
+    field: "status",
+    initial: opts.states[0] ?? "draft",
+    states: opts.states,
+    transitions: opts.transitions ?? [],
+  };
+}
+
+describe("createConflictAnalyzer", () => {
+  test("returns no conflicts when every store is empty", async () => {
+    const analyzer = createConflictAnalyzer({
+      pendingProposals: makeStore([]),
+      liveRules: makeRuleStore([]),
+      liveStates: makeStateStore([]),
+    });
+    const candidate = makeProposal({ id: "prop_candidate" });
+
+    const result = await analyzer.analyze(candidate);
+
+    expect(result.conflicts).toHaveLength(0);
+    expect(result.notes).toContain("checked: pendingProposals");
+  });
+
+  test("flags a proposal-vs-proposal conflict when peers share an artifact", async () => {
+    const peer = makeProposal({
+      id: "prop_peer",
+      changes: [
+        {
+          target: "entity",
+          operation: "update",
+          name: "purchase_request",
+          diff: "rename priority",
+        },
+      ],
+    });
+    const candidate = makeProposal({ id: "prop_candidate" });
+    const analyzer = createConflictAnalyzer({
+      pendingProposals: makeStore([peer]),
+    });
+
+    const result = await analyzer.analyze(candidate);
+
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0]?.kind).toBe("proposal");
+    expect(result.conflicts[0]?.targetId).toBe("prop_peer");
+    expect(result.conflicts[0]?.message).toContain("purchase_request");
+  });
+
+  test("ignores the candidate itself when present in the pending store", async () => {
+    const candidate = makeProposal({ id: "prop_self" });
+    const analyzer = createConflictAnalyzer({
+      pendingProposals: makeStore([candidate]),
+    });
+
+    const result = await analyzer.analyze(candidate);
+
+    expect(result.conflicts).toHaveLength(0);
+  });
+
+  test("ignores peers in non-pending statuses", async () => {
+    const approved = makeProposal({ id: "prop_approved", status: "approved" });
+    const candidate = makeProposal({ id: "prop_candidate" });
+    const analyzer = createConflictAnalyzer({
+      pendingProposals: makeStore([approved]),
+    });
+
+    const result = await analyzer.analyze(candidate);
+
+    expect(result.conflicts).toHaveLength(0);
+  });
+
+  test("ignores peers whose changes are payload-empty (no definition, no diff)", async () => {
+    const peer = makeProposal({
+      id: "prop_peer",
+      changes: [
+        {
+          target: "entity",
+          operation: "update",
+          name: "purchase_request",
+          // no diff, no definition — nothing to actually compare against
+        },
+      ],
+    });
+    const candidate = makeProposal({ id: "prop_candidate" });
+    const analyzer = createConflictAnalyzer({
+      pendingProposals: makeStore([peer]),
+    });
+
+    const result = await analyzer.analyze(candidate);
+
+    expect(result.conflicts).toHaveLength(0);
+  });
+
+  test("flags a rule conflict when the proposed rule name already exists live", async () => {
+    const candidate = makeProposal({
+      id: "prop_candidate",
+      changes: [
+        {
+          target: "rule",
+          operation: "create",
+          name: "budget_block",
+          diff: "block over budget",
+        },
+      ],
+    });
+    const analyzer = createConflictAnalyzer({
+      pendingProposals: makeStore([]),
+      liveRules: makeRuleStore([makeRule("budget_block")]),
+    });
+
+    const result = await analyzer.analyze(candidate);
+
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0]?.kind).toBe("rule");
+    expect(result.conflicts[0]?.targetId).toBe("budget_block");
+  });
+
+  test("does not flag a rule conflict for unrelated live rules", async () => {
+    const candidate = makeProposal({
+      id: "prop_candidate",
+      changes: [
+        {
+          target: "rule",
+          operation: "create",
+          name: "new_rule",
+          diff: "add",
+        },
+      ],
+    });
+    const analyzer = createConflictAnalyzer({
+      pendingProposals: makeStore([]),
+      liveRules: makeRuleStore([makeRule("other_rule")]),
+    });
+
+    const result = await analyzer.analyze(candidate);
+
+    expect(result.conflicts).toHaveLength(0);
+  });
+
+  test("notes when rule changes are present but liveRules store is missing", async () => {
+    const candidate = makeProposal({
+      id: "prop_candidate",
+      changes: [
+        {
+          target: "rule",
+          operation: "create",
+          name: "new_rule",
+          diff: "add",
+        },
+      ],
+    });
+    const analyzer = createConflictAnalyzer({
+      pendingProposals: makeStore([]),
+    });
+
+    const result = await analyzer.analyze(candidate);
+
+    expect(result.conflicts).toHaveLength(0);
+    expect(result.notes).toContain("liveRules: store not provided");
+  });
+
+  test("flags state_transition conflict when proposed update removes a state used by a transition", async () => {
+    const liveState = makeStateDef({
+      name: "purchase_request_status",
+      states: ["draft", "submitted", "approved"],
+      transitions: [
+        { from: "draft", to: "submitted", action: "submit" },
+        { from: "submitted", to: "approved", action: "approve" },
+      ],
+    });
+    const proposedDef = makeStateDef({
+      name: "purchase_request_status",
+      // "submitted" removed — both live transitions reference it
+      states: ["draft", "approved"],
+      transitions: [{ from: "draft", to: "approved", action: "approve" }],
+    });
+    const candidate = makeProposal({
+      id: "prop_candidate",
+      changes: [
+        {
+          target: "state",
+          operation: "update",
+          name: "purchase_request_status",
+          definition: proposedDef as never,
+        },
+      ],
+    });
+    const analyzer = createConflictAnalyzer({
+      pendingProposals: makeStore([]),
+      liveStates: makeStateStore([liveState]),
+    });
+
+    const result = await analyzer.analyze(candidate);
+
+    expect(result.conflicts.length).toBeGreaterThanOrEqual(1);
+    for (const finding of result.conflicts) {
+      expect(finding.kind).toBe("state_transition");
+      expect(finding.targetId).toBe("purchase_request_status");
+      expect(finding.message).toContain("submitted");
+    }
+  });
+
+  test("does not flag state_transition conflict when proposed states keep all referenced ones", async () => {
+    const liveState = makeStateDef({
+      name: "purchase_request_status",
+      states: ["draft", "submitted"],
+      transitions: [{ from: "draft", to: "submitted", action: "submit" }],
+    });
+    const proposedDef = makeStateDef({
+      name: "purchase_request_status",
+      // adding a new state but keeping the old ones
+      states: ["draft", "submitted", "approved"],
+      transitions: [{ from: "draft", to: "submitted", action: "submit" }],
+    });
+    const candidate = makeProposal({
+      id: "prop_candidate",
+      changes: [
+        {
+          target: "state",
+          operation: "update",
+          name: "purchase_request_status",
+          definition: proposedDef as never,
+        },
+      ],
+    });
+    const analyzer = createConflictAnalyzer({
+      pendingProposals: makeStore([]),
+      liveStates: makeStateStore([liveState]),
+    });
+
+    const result = await analyzer.analyze(candidate);
+
+    expect(result.conflicts).toHaveLength(0);
+  });
+
+  test("flags state_transition when deleting a state machine that has live transitions", async () => {
+    const liveState = makeStateDef({
+      name: "purchase_request_status",
+      states: ["draft", "submitted"],
+      transitions: [{ from: "draft", to: "submitted", action: "submit" }],
+    });
+    const candidate = makeProposal({
+      id: "prop_candidate",
+      changes: [
+        {
+          target: "state",
+          operation: "delete",
+          name: "purchase_request_status",
+          diff: "remove status machine",
+        },
+      ],
+    });
+    const analyzer = createConflictAnalyzer({
+      pendingProposals: makeStore([]),
+      liveStates: makeStateStore([liveState]),
+    });
+
+    const result = await analyzer.analyze(candidate);
+
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0]?.kind).toBe("state_transition");
+    expect(result.conflicts[0]?.targetId).toBe("purchase_request_status");
+  });
+
+  test("notes when state update has no parsable definition", async () => {
+    const liveState = makeStateDef({
+      name: "purchase_request_status",
+      states: ["draft", "submitted"],
+      transitions: [{ from: "draft", to: "submitted", action: "submit" }],
+    });
+    const candidate = makeProposal({
+      id: "prop_candidate",
+      changes: [
+        {
+          target: "state",
+          operation: "update",
+          name: "purchase_request_status",
+          diff: "tweak meta only",
+        },
+      ],
+    });
+    const analyzer = createConflictAnalyzer({
+      pendingProposals: makeStore([]),
+      liveStates: makeStateStore([liveState]),
+    });
+
+    const result = await analyzer.analyze(candidate);
+
+    expect(result.conflicts).toHaveLength(0);
+    expect(result.notes).toContain("update definition missing or malformed");
+  });
+
+  test("supports synchronous live stores (returning arrays directly)", async () => {
+    const candidate = makeProposal({
+      id: "prop_candidate",
+      changes: [
+        {
+          target: "rule",
+          operation: "create",
+          name: "sync_rule",
+          diff: "add",
+        },
+      ],
+    });
+    const liveRules: LiveRuleStore = {
+      // Synchronous return — analyzer must `await` either way
+      listRules: () => [makeRule("sync_rule")],
+    };
+    const analyzer = createConflictAnalyzer({
+      pendingProposals: makeStore([]),
+      liveRules,
+    });
+
+    const result = await analyzer.analyze(candidate);
+
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0]?.kind).toBe("rule");
+  });
+
+  test("captures a thrown analyzer source into notes without panicking", async () => {
+    const failingStore: PendingProposalStore = {
+      async listPending() {
+        throw new Error("db unreachable");
+      },
+    };
+    const failingRules: LiveRuleStore = {
+      listRules() {
+        throw new Error("rule registry boom");
+      },
+    };
+    const candidate = makeProposal({
+      id: "prop_candidate",
+      changes: [
+        {
+          target: "rule",
+          operation: "create",
+          name: "any_rule",
+          diff: "add",
+        },
+      ],
+    });
+    const analyzer = createConflictAnalyzer({
+      pendingProposals: failingStore,
+      liveRules: failingRules,
+    });
+
+    const result = await analyzer.analyze(candidate);
+
+    expect(result.conflicts).toHaveLength(0);
+    expect(result.notes).toContain("pendingProposals: db unreachable");
+    expect(result.notes).toContain("liveRules: rule registry boom");
+  });
+
+  test("respects custom pendingStatuses override", async () => {
+    const peer = makeProposal({
+      id: "prop_peer",
+      status: "committed",
+      changes: [
+        {
+          target: "entity",
+          operation: "update",
+          name: "purchase_request",
+          diff: "rename priority",
+        },
+      ],
+    });
+    const candidate = makeProposal({ id: "prop_candidate" });
+    const analyzer = createConflictAnalyzer({
+      pendingProposals: makeStore([peer]),
+      pendingStatuses: new Set(["committed"]),
+    });
+
+    const result = await analyzer.analyze(candidate);
+
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0]?.kind).toBe("proposal");
+    expect(result.conflicts[0]?.targetId).toBe("prop_peer");
+  });
+
+  test("emits one finding per peer per shared artifact", async () => {
+    const peer = makeProposal({
+      id: "prop_peer",
+      changes: [
+        {
+          target: "entity",
+          operation: "update",
+          name: "purchase_request",
+          diff: "first edit",
+        },
+        {
+          target: "rule",
+          operation: "create",
+          name: "shared_rule",
+          diff: "rule edit",
+        },
+      ],
+    });
+    const candidate = makeProposal({
+      id: "prop_candidate",
+      changes: [
+        {
+          target: "entity",
+          operation: "update",
+          name: "purchase_request",
+          diff: "second edit",
+        },
+        {
+          target: "rule",
+          operation: "create",
+          name: "shared_rule",
+          diff: "rule edit",
+        },
+      ],
+    });
+    const analyzer = createConflictAnalyzer({
+      pendingProposals: makeStore([peer]),
+    });
+
+    const result = await analyzer.analyze(candidate);
+
+    expect(result.conflicts).toHaveLength(2);
+    expect(result.conflicts.every((c) => c.kind === "proposal")).toBe(true);
+    expect(result.conflicts.every((c) => c.targetId === "prop_peer")).toBe(true);
+  });
+});

--- a/packages/core/src/life-system/proposal-preanalysis/conflict-analyzer.ts
+++ b/packages/core/src/life-system/proposal-preanalysis/conflict-analyzer.ts
@@ -110,6 +110,7 @@ function readStateDefinition(value: unknown): StateDefinition | null {
   if (!value || typeof value !== "object") return null;
   const def = value as Partial<StateDefinition>;
   if (!Array.isArray(def.states)) return null;
+  if (!def.states.every((s) => typeof s === "string")) return null;
   if (typeof def.name !== "string") return null;
   return def as StateDefinition;
 }
@@ -232,15 +233,15 @@ export function createConflictAnalyzer(
             }
 
             const proposedStateSet = new Set(proposed.states);
-            const removed: string[] = [];
+            const removed = new Set<string>();
             for (const liveState of existing.states) {
-              if (!proposedStateSet.has(liveState)) removed.push(liveState);
+              if (!proposedStateSet.has(liveState)) removed.add(liveState);
             }
-            if (removed.length === 0) continue;
+            if (removed.size === 0) continue;
 
             for (const transition of existing.transitions) {
               const refs = statesReferencedByTransition(transition);
-              const dropped = refs.filter((r) => removed.includes(r));
+              const dropped = refs.filter((r) => removed.has(r));
               if (dropped.length === 0) continue;
               conflicts.push({
                 kind: "state_transition",

--- a/packages/core/src/life-system/proposal-preanalysis/conflict-analyzer.ts
+++ b/packages/core/src/life-system/proposal-preanalysis/conflict-analyzer.ts
@@ -1,0 +1,275 @@
+/**
+ * Conflict analyzer — Spec 55 §7.3 stage 2.
+ *
+ * Detects contradictions between a candidate Proposal and the surrounding
+ * environment so a reviewer can be warned before the proposal is approved.
+ *
+ * Three conflict sources are checked, each opt-in via the corresponding option:
+ *
+ *   1. proposal-vs-proposal — another pending proposal already targets the same
+ *      `(change.target, change.name)` artifact with non-empty changes.
+ *   2. proposal-vs-rule — the candidate proposes a Rule whose `name` collides
+ *      with an existing live Rule (the proposed rule would replace it).
+ *   3. proposal-vs-state — the candidate proposes a State definition update that
+ *      removes a state still referenced by an existing transition's `from`/`to`,
+ *      which would invalidate the live transition.
+ *
+ * Design rules:
+ *   - Each source is checked independently. A failure in one source is captured
+ *     into `notes` and the analyzer keeps going — never throws from `analyze`.
+ *   - The analyzer is side-effect-free and only reads from the supplied stores.
+ *   - Heuristics are deliberately simple. Where a target shape doesn't expose
+ *     enough info to detect a clean conflict (e.g. `definition` may be undefined
+ *     on `update` operations) the analyzer documents the limitation in `notes`
+ *     instead of guessing.
+ */
+
+import type {
+  ProposalChange,
+  ProposalChangeTarget,
+  ProposalDefinition,
+} from "../../types/proposal";
+import type { RuleDefinition } from "../../types/rule";
+import type { StateDefinition, Transition } from "../../types/state";
+import type { ConflictFinding, ConflictResult, PendingProposalStore, PreAnalyzer } from "./types";
+
+/** Read-only view over the live Rule registry. Sync or async. */
+export interface LiveRuleStore {
+  listRules(): Promise<RuleDefinition[]> | RuleDefinition[];
+}
+
+/** Read-only view over the live State-definition registry. Sync or async. */
+export interface LiveStateStore {
+  listStates(): Promise<StateDefinition[]> | StateDefinition[];
+}
+
+export interface CreateConflictAnalyzerOptions {
+  /** Pending peers to check for proposal-vs-proposal conflicts. */
+  pendingProposals: PendingProposalStore;
+  /** Optional read-only registry of currently-active rules. */
+  liveRules?: LiveRuleStore;
+  /** Optional read-only registry of currently-active state definitions. */
+  liveStates?: LiveStateStore;
+  /**
+   * Optional override for which proposal statuses count as "pending review".
+   * Defaults to `draft|validating|validated` (matches Spec 55).
+   */
+  pendingStatuses?: ReadonlySet<string>;
+}
+
+/** Status values considered "pending" when a store returns all proposals. */
+const DEFAULT_PENDING_STATUSES: ReadonlySet<string> = new Set(["draft", "validating", "validated"]);
+
+/** Pluralize the source name for the error/skip note. */
+function describeSource(source: string, err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  return `${source}: ${msg}`;
+}
+
+/** Build a stable artifact key for proposal-vs-proposal grouping. */
+function artifactKey(change: ProposalChange): string {
+  return `${change.target}:${change.name}`;
+}
+
+/** A change is "non-empty" when it has either a definition or a diff payload. */
+function isNonEmptyChange(change: ProposalChange): boolean {
+  return change.definition !== undefined || (change.diff !== undefined && change.diff !== "");
+}
+
+/** Collect every artifact this proposal touches, keyed by `target:name`. */
+function collectArtifacts(proposal: ProposalDefinition): Map<string, ProposalChange[]> {
+  const out = new Map<string, ProposalChange[]>();
+  for (const change of proposal.changes) {
+    if (!change.name) continue;
+    if (!isNonEmptyChange(change)) continue;
+    const key = artifactKey(change);
+    const bucket = out.get(key);
+    if (bucket) {
+      bucket.push(change);
+    } else {
+      out.set(key, [change]);
+    }
+  }
+  return out;
+}
+
+/** Filter rule-target changes from the candidate. */
+function ruleChanges(proposal: ProposalDefinition): ProposalChange[] {
+  return proposal.changes.filter((c) => c.target === "rule" && c.operation !== "delete" && c.name);
+}
+
+/** Filter state-target update/delete changes (creates can't invalidate transitions). */
+function stateChanges(proposal: ProposalDefinition): ProposalChange[] {
+  return proposal.changes.filter(
+    (c) => c.target === "state" && (c.operation === "update" || c.operation === "delete") && c.name,
+  );
+}
+
+/** Try to read a `StateDefinition`-shaped object out of an unknown change definition. */
+function readStateDefinition(value: unknown): StateDefinition | null {
+  if (!value || typeof value !== "object") return null;
+  const def = value as Partial<StateDefinition>;
+  if (!Array.isArray(def.states)) return null;
+  if (typeof def.name !== "string") return null;
+  return def as StateDefinition;
+}
+
+/** Collect every state name referenced by a transition's `from` or `to`. */
+function statesReferencedByTransition(transition: Transition): string[] {
+  const refs: string[] = [];
+  if (Array.isArray(transition.from)) {
+    refs.push(...transition.from);
+  } else if (typeof transition.from === "string") {
+    refs.push(transition.from);
+  }
+  if (typeof transition.to === "string") {
+    refs.push(transition.to);
+  }
+  return refs;
+}
+
+export function createConflictAnalyzer(
+  options: CreateConflictAnalyzerOptions,
+): PreAnalyzer<"conflict", ConflictResult> {
+  const pendingStatuses = options.pendingStatuses ?? DEFAULT_PENDING_STATUSES;
+
+  return {
+    stage: "conflict",
+    name: "default-conflict-analyzer",
+    async analyze(proposal: ProposalDefinition): Promise<ConflictResult> {
+      const conflicts: ConflictFinding[] = [];
+      const noteFragments: string[] = [];
+      const sourcesChecked: string[] = [];
+
+      const candidateArtifacts = collectArtifacts(proposal);
+
+      // ── 1. proposal-vs-proposal ────────────────────────────
+      sourcesChecked.push("pendingProposals");
+      try {
+        const peers = await options.pendingProposals.listPending();
+        for (const peer of peers) {
+          if (peer.id === proposal.id) continue;
+          if (!pendingStatuses.has(peer.status)) continue;
+
+          const peerArtifacts = collectArtifacts(peer);
+          for (const [key, peerChanges] of peerArtifacts) {
+            const candidateChanges = candidateArtifacts.get(key);
+            if (!candidateChanges || candidateChanges.length === 0) continue;
+            // Both proposals touch the same artifact with payload — emit one
+            // finding per (peer, artifact) pair so reviewers can see the breakdown.
+            const [target, name] = splitArtifactKey(key);
+            conflicts.push({
+              kind: "proposal",
+              targetId: peer.id,
+              message: `Pending proposal "${peer.title}" (${peer.id}) also modifies ${target} "${name}" (${peerChanges.length} change(s))`,
+            });
+          }
+        }
+      } catch (err) {
+        noteFragments.push(describeSource("pendingProposals", err));
+      }
+
+      // ── 2. proposal-vs-rule ────────────────────────────────
+      const proposedRules = ruleChanges(proposal);
+      if (options.liveRules && proposedRules.length > 0) {
+        sourcesChecked.push("liveRules");
+        try {
+          const rules = await options.liveRules.listRules();
+          const byName = new Map<string, RuleDefinition>();
+          for (const r of rules) byName.set(r.name, r);
+
+          for (const change of proposedRules) {
+            const existing = byName.get(change.name);
+            if (!existing) continue;
+            conflicts.push({
+              kind: "rule",
+              targetId: existing.name,
+              message: `Proposed rule "${change.name}" would replace existing live rule with the same name`,
+            });
+          }
+        } catch (err) {
+          noteFragments.push(describeSource("liveRules", err));
+        }
+      } else if (proposedRules.length > 0 && !options.liveRules) {
+        noteFragments.push("liveRules: store not provided — skipped rule conflict checks");
+      }
+
+      // ── 3. proposal-vs-state ───────────────────────────────
+      const proposedStates = stateChanges(proposal);
+      if (options.liveStates && proposedStates.length > 0) {
+        sourcesChecked.push("liveStates");
+        try {
+          const states = await options.liveStates.listStates();
+          const byName = new Map<string, StateDefinition>();
+          for (const s of states) byName.set(s.name, s);
+
+          for (const change of proposedStates) {
+            const existing = byName.get(change.name);
+            if (!existing) continue;
+
+            if (change.operation === "delete") {
+              // Whole state-machine is being removed — every existing transition
+              // referencing it becomes invalid by definition.
+              if (existing.transitions.length > 0) {
+                conflicts.push({
+                  kind: "state_transition",
+                  targetId: existing.name,
+                  message: `Deleting state machine "${change.name}" would invalidate ${existing.transitions.length} live transition(s)`,
+                });
+              }
+              continue;
+            }
+
+            // operation === "update": inspect proposed states against live transitions.
+            const proposed = readStateDefinition(change.definition);
+            if (!proposed) {
+              // Update with no parsable definition — can't check; record so the
+              // reviewer knows we couldn't analyze this change.
+              noteFragments.push(
+                `liveStates: skipped "${change.name}" — update definition missing or malformed`,
+              );
+              continue;
+            }
+
+            const proposedStateSet = new Set(proposed.states);
+            const removed: string[] = [];
+            for (const liveState of existing.states) {
+              if (!proposedStateSet.has(liveState)) removed.push(liveState);
+            }
+            if (removed.length === 0) continue;
+
+            for (const transition of existing.transitions) {
+              const refs = statesReferencedByTransition(transition);
+              const dropped = refs.filter((r) => removed.includes(r));
+              if (dropped.length === 0) continue;
+              conflicts.push({
+                kind: "state_transition",
+                targetId: existing.name,
+                message: `Proposed update to state machine "${change.name}" removes state(s) [${dropped.join(", ")}] still used by transition action "${transition.action}"`,
+              });
+            }
+          }
+        } catch (err) {
+          noteFragments.push(describeSource("liveStates", err));
+        }
+      } else if (proposedStates.length > 0 && !options.liveStates) {
+        noteFragments.push("liveStates: store not provided — skipped state conflict checks");
+      }
+
+      const result: ConflictResult = { conflicts };
+      if (noteFragments.length > 0) {
+        result.notes = `checked: ${sourcesChecked.join(", ")}; ${noteFragments.join("; ")}`;
+      } else {
+        result.notes = `checked: ${sourcesChecked.join(", ") || "none"}`;
+      }
+      return result;
+    },
+  };
+}
+
+/** Inverse of `artifactKey`. The `target` is always one segment; `name` may contain colons. */
+function splitArtifactKey(key: string): [ProposalChangeTarget, string] {
+  const idx = key.indexOf(":");
+  if (idx === -1) return [key as ProposalChangeTarget, ""];
+  return [key.slice(0, idx) as ProposalChangeTarget, key.slice(idx + 1)];
+}

--- a/packages/core/src/life-system/proposal-preanalysis/index.ts
+++ b/packages/core/src/life-system/proposal-preanalysis/index.ts
@@ -1,11 +1,17 @@
 /**
  * Proposal Pre-Analysis public surface (Spec 55 §7.3).
  *
- * Ships stages 1 (dedup) and 3 (impact). Types for stages 2 (conflict) and 4
- * (backtest) are exported so follow-up analyzers can plug into the pipeline
+ * Ships stages 1 (dedup), 2 (conflict) and 3 (impact). Types for stage 4
+ * (backtest) are exported so a follow-up analyzer can plug into the pipeline
  * without touching core.
  */
 
+export type {
+  CreateConflictAnalyzerOptions,
+  LiveRuleStore,
+  LiveStateStore,
+} from "./conflict-analyzer";
+export { createConflictAnalyzer } from "./conflict-analyzer";
 export type { CreateDedupAnalyzerOptions } from "./dedup-analyzer";
 export { createDedupAnalyzer } from "./dedup-analyzer";
 export type { CreateImpactAnalyzerOptions } from "./impact-analyzer";


### PR DESCRIPTION
## Summary
- Replaces `ConflictPreAnalyzerStub` with a working stage-2 analyzer (Spec 55 §7.3).
- Detects three conflict shapes:
  - proposal-vs-proposal (shared `(target, name)` artifact, both with non-empty payloads)
  - proposal-vs-rule (proposed rule name collides with live rule)
  - proposal-vs-state (state-definition update/delete that orphans an existing transition)
- Optional `liveRules` / `liveStates` stores; analyzer skips probes whose store is omitted and records that in `notes`.
- Source-level failures captured into `notes` rather than thrown — one bad registry never nukes the pipeline.
- Both sync and async list functions accepted (Promise<T[]> | T[]).

## Test plan
- [x] `bun test packages/core/src/life-system/proposal-preanalysis/` — 39/39 (15 new)
- [x] `bun test` — 4573 pass / 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean

## Refs
- Spec 55 §7.3 (`docs/specs/55_evolution_system.md`)
- Parent PR: #190
- Parent issue: #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Proposals now include conflict detection against existing rules and state definitions.
  * Added robust validation to identify proposal overlaps with pending submissions.

* **Tests**
  * Comprehensive test suite for conflict detection scenarios, including edge cases and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->