### PR TITLE
feat(adapter-ui): bulk-edit UI integration with /api/actions/batch (closes #211)

### DIFF
--- a/addons/adapter-ui/cap-adapter-ui/__tests__/batch-actions.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/batch-actions.test.ts
@@ -365,3 +365,86 @@ describe("executeBatchAction — error responses fold into failed", () => {
     expect(result.failed[0]?.error.message).toBe("Batch request failed (403)");
   });
 });
+
+describe("executeBatchAction — short-circuit on failure", () => {
+  test("all_or_nothing: stops after a chunk fails — no further requests", async () => {
+    let chunkCount = 0;
+    installFetch((req) => {
+      chunkCount++;
+      if (chunkCount === 1) {
+        return {
+          status: 200,
+          body: makeResult({
+            success: false,
+            strategy: "all_or_nothing",
+            failed: [{ index: 0, error: { code: "VAL.BAD", message: "rejected" } }],
+            rolledBack: req.body.actions.slice(1).map((_, i) => ({
+              index: i + 1,
+              executionId: `r-${i}`,
+            })),
+            summary: { total: req.body.actions.length, succeeded: 0, failed: 1 },
+          }),
+        };
+      }
+      // We must never get here — fail loudly if a second chunk fires.
+      throw new Error("second chunk should have been skipped");
+    });
+    const ids = Array.from({ length: 750 }, (_, i) => `id-${i}`);
+    const result = await executeBatchAction({
+      actionName: "process_payment",
+      recordIds: ids,
+      strategy: "all_or_nothing",
+    });
+    expect(chunkCount).toBe(1);
+    expect(result.success).toBe(false);
+    // Only the first chunk's failures/rollbacks should be present — no
+    // synthetic transport entries for the skipped chunk.
+    expect(result.failed.every((f) => f.error.code !== "BATCH.TRANSPORT")).toBe(true);
+  });
+
+  test("partial: a chunk failure does NOT stop subsequent chunks", async () => {
+    let chunkCount = 0;
+    installFetch(() => {
+      chunkCount++;
+      return {
+        status: 200,
+        body: makeResult({
+          success: chunkCount > 1,
+          strategy: "partial",
+          failed:
+            chunkCount === 1 ? [{ index: 0, error: { code: "VAL.BAD", message: "rejected" } }] : [],
+          summary: {
+            total: 1,
+            succeeded: chunkCount > 1 ? 1 : 0,
+            failed: chunkCount === 1 ? 1 : 0,
+          },
+        }),
+      };
+    });
+    const ids = Array.from({ length: 750 }, (_, i) => `id-${i}`);
+    const result = await executeBatchAction({
+      actionName: "approve_order",
+      recordIds: ids,
+      strategy: "partial",
+    });
+    expect(chunkCount).toBe(2);
+    expect(result.failed).toHaveLength(1);
+  });
+
+  test("transport error stops further chunks regardless of strategy", async () => {
+    let chunkCount = 0;
+    installFetch(() => {
+      chunkCount++;
+      if (chunkCount === 1) return { throw: new Error("connection refused") };
+      throw new Error("second chunk should have been skipped after transport error");
+    });
+    const ids = Array.from({ length: 750 }, (_, i) => `id-${i}`);
+    const result = await executeBatchAction({
+      actionName: "approve_order",
+      recordIds: ids,
+      strategy: "partial",
+    });
+    expect(chunkCount).toBe(1);
+    expect(result.failed[0]?.error.code).toBe("BATCH.TRANSPORT");
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/batch-actions.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/batch-actions.test.ts
@@ -1,0 +1,367 @@
+/**
+ * Tests for the bulk-action client (Spec 16 §3.1).
+ *
+ * Covers the pure chunking helper plus the fetch-mocked transport:
+ *  - single-chunk path (≤ 500 ids)
+ *  - multi-chunk path (> 500 ids → multiple requests)
+ *  - aggregation under the `partial` strategy
+ *  - aggregation under the `all_or_nothing` strategy (rolledBack surfaces)
+ *  - HTTP / network errors fold into the `failed` list (never throw)
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+// Minimal localStorage shim — the api wrappers read `linchkit:token` for auth.
+const _store = new Map<string, string>();
+if (typeof globalThis.localStorage === "undefined") {
+  Object.defineProperty(globalThis, "localStorage", {
+    value: {
+      getItem: (key: string) => _store.get(key) ?? null,
+      setItem: (key: string, value: string) => _store.set(key, value),
+      removeItem: (key: string) => _store.delete(key),
+      clear: () => _store.clear(),
+      get length() {
+        return _store.size;
+      },
+      key: (index: number) => [..._store.keys()][index] ?? null,
+    },
+    configurable: true,
+  });
+}
+
+import type { BatchActionsResult } from "@linchkit/core/types";
+import {
+  aggregateBatchResults,
+  BATCH_CHUNK_SIZE,
+  chunkIds,
+  executeBatchAction,
+} from "../src/lib/batch-actions";
+
+// ── Fetch capture helper ────────────────────────────────────
+
+interface CapturedRequest {
+  url: string;
+  method: string;
+  body: { actions: { name: string; input: Record<string, unknown> }[]; strategy: string };
+  headers: Record<string, string>;
+}
+
+let captured: CapturedRequest[] = [];
+let originalFetch: typeof fetch | undefined;
+
+function installFetch(
+  responder: (req: CapturedRequest) => { status: number; body: unknown } | { throw: Error },
+) {
+  originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const req: CapturedRequest = {
+      url: typeof input === "string" ? input : (input as URL).toString(),
+      method: init?.method ?? "GET",
+      body: init?.body
+        ? (JSON.parse(init.body as string) as CapturedRequest["body"])
+        : ({ actions: [], strategy: "" } as CapturedRequest["body"]),
+      headers: (init?.headers as Record<string, string>) ?? {},
+    };
+    captured.push(req);
+    const decision = responder(req);
+    if ("throw" in decision) throw decision.throw;
+    return new Response(JSON.stringify(decision.body), {
+      status: decision.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+}
+
+beforeEach(() => {
+  captured = [];
+});
+
+afterEach(() => {
+  if (originalFetch) globalThis.fetch = originalFetch;
+});
+
+// ── chunkIds ────────────────────────────────────────────────
+
+describe("chunkIds", () => {
+  test("returns empty array for empty input", () => {
+    expect(chunkIds([])).toEqual([]);
+  });
+
+  test("returns a single chunk for inputs at or below the cap", () => {
+    const ids = Array.from({ length: 500 }, (_, i) => `id-${i}`);
+    const chunks = chunkIds(ids);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toHaveLength(500);
+  });
+
+  test("splits into 500-sized chunks (default cap mirrors server MAX_BATCH_SIZE)", () => {
+    expect(BATCH_CHUNK_SIZE).toBe(500);
+    const ids = Array.from({ length: 750 }, (_, i) => `id-${i}`);
+    const chunks = chunkIds(ids);
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toHaveLength(500);
+    expect(chunks[1]).toHaveLength(250);
+    expect(chunks[0]?.[0]).toBe("id-0");
+    expect(chunks[0]?.[499]).toBe("id-499");
+    expect(chunks[1]?.[0]).toBe("id-500");
+    expect(chunks[1]?.[249]).toBe("id-749");
+  });
+
+  test("respects an explicit smaller chunk size", () => {
+    const chunks = chunkIds(["a", "b", "c", "d", "e"], 2);
+    expect(chunks).toEqual([["a", "b"], ["c", "d"], ["e"]]);
+  });
+
+  test("rejects a non-positive size", () => {
+    expect(() => chunkIds(["a"], 0)).toThrow();
+    expect(() => chunkIds(["a"], -1)).toThrow();
+  });
+});
+
+// ── aggregateBatchResults ───────────────────────────────────
+
+function makeResult(overrides: Partial<BatchActionsResult>): BatchActionsResult {
+  return {
+    success: true,
+    parentExecutionId: "parent",
+    strategy: "partial",
+    succeeded: [],
+    failed: [],
+    summary: { total: 0, succeeded: 0, failed: 0 },
+    ...overrides,
+  };
+}
+
+describe("aggregateBatchResults", () => {
+  test("returns a neutral envelope for an empty result list", () => {
+    const merged = aggregateBatchResults([]);
+    expect(merged.success).toBe(true);
+    expect(merged.summary).toEqual({ total: 0, succeeded: 0, failed: 0 });
+    expect(merged.succeeded).toEqual([]);
+    expect(merged.failed).toEqual([]);
+    expect(merged.rolledBack).toBeUndefined();
+  });
+
+  test("concatenates succeeded/failed and sums counts", () => {
+    const a = makeResult({
+      parentExecutionId: "parent-a",
+      succeeded: [{ index: 0, executionId: "x0" }],
+      failed: [{ index: 1, error: { code: "E", message: "oops" } }],
+      summary: { total: 2, succeeded: 1, failed: 1 },
+      success: false,
+    });
+    const b = makeResult({
+      parentExecutionId: "parent-b",
+      succeeded: [{ index: 0, executionId: "x1" }],
+      summary: { total: 1, succeeded: 1, failed: 0 },
+    });
+    const merged = aggregateBatchResults([a, b]);
+    expect(merged.parentExecutionId).toBe("parent-a");
+    expect(merged.succeeded).toHaveLength(2);
+    expect(merged.failed).toHaveLength(1);
+    expect(merged.summary).toEqual({ total: 3, succeeded: 2, failed: 1 });
+    expect(merged.success).toBe(false);
+  });
+
+  test("flattens rolledBack only when present", () => {
+    const a = makeResult({
+      strategy: "all_or_nothing",
+      succeeded: [],
+      failed: [{ index: 4, error: { code: "E", message: "boom" } }],
+      rolledBack: [{ index: 0, executionId: "r0" }],
+      summary: { total: 5, succeeded: 0, failed: 1 },
+      success: false,
+    });
+    const b = makeResult({ strategy: "all_or_nothing" });
+    const merged = aggregateBatchResults([a, b]);
+    expect(merged.rolledBack).toHaveLength(1);
+    expect(merged.strategy).toBe("all_or_nothing");
+  });
+});
+
+// ── executeBatchAction ─────────────────────────────────────
+
+describe("executeBatchAction — single chunk", () => {
+  test("posts a single request when ids ≤ cap, defaults to partial strategy", async () => {
+    installFetch(() => ({
+      status: 200,
+      body: makeResult({
+        succeeded: [
+          { index: 0, executionId: "e0" },
+          { index: 1, executionId: "e1" },
+        ],
+        summary: { total: 2, succeeded: 2, failed: 0 },
+      }),
+    }));
+    const result = await executeBatchAction({
+      actionName: "approve_order",
+      recordIds: ["a", "b"],
+    });
+    expect(captured).toHaveLength(1);
+    const req = captured[0];
+    if (!req) throw new Error("no captured request");
+    expect(req.url).toBe("/api/actions/batch");
+    expect(req.method).toBe("POST");
+    expect(req.body.strategy).toBe("partial");
+    expect(req.body.actions).toEqual([
+      { name: "approve_order", input: { id: "a" } },
+      { name: "approve_order", input: { id: "b" } },
+    ]);
+    expect(result.summary).toEqual({ total: 2, succeeded: 2, failed: 0 });
+  });
+
+  test("merges extraInput into every per-record payload (id wins on collision)", async () => {
+    installFetch(() => ({
+      status: 200,
+      body: makeResult({ summary: { total: 2, succeeded: 2, failed: 0 } }),
+    }));
+    await executeBatchAction({
+      actionName: "approve_order",
+      recordIds: ["a", "b"],
+      extraInput: { reason: "qa", id: "ignored" },
+    });
+    expect(captured[0]?.body.actions).toEqual([
+      { name: "approve_order", input: { reason: "qa", id: "a" } },
+      { name: "approve_order", input: { reason: "qa", id: "b" } },
+    ]);
+  });
+});
+
+describe("executeBatchAction — multi-chunk", () => {
+  test("750 ids → 2 sequential requests of 500 + 250, indices re-based", async () => {
+    let calls = 0;
+    installFetch((req) => {
+      calls++;
+      const items = req.body.actions;
+      // Server-local indices: each item index is its position within the chunk.
+      // The first chunk fully succeeds; the second has one failure at local index 10.
+      const local = items.map((_, i) => i);
+      if (calls === 1) {
+        return {
+          status: 200,
+          body: makeResult({
+            succeeded: local.map((i) => ({ index: i, executionId: `e-${i}` })),
+            summary: { total: items.length, succeeded: items.length, failed: 0 },
+          }),
+        };
+      }
+      // chunk 2 — fail item at local index 10
+      const succeeded = local
+        .filter((i) => i !== 10)
+        .map((i) => ({ index: i, executionId: `e-${i}` }));
+      return {
+        status: 200,
+        body: makeResult({
+          success: false,
+          succeeded,
+          failed: [{ index: 10, error: { code: "E.X", message: "nope" } }],
+          summary: { total: items.length, succeeded: succeeded.length, failed: 1 },
+        }),
+      };
+    });
+
+    const ids = Array.from({ length: 750 }, (_, i) => `id-${i}`);
+    const result = await executeBatchAction({ actionName: "ship", recordIds: ids });
+
+    expect(captured).toHaveLength(2);
+    expect(captured[0]?.body.actions).toHaveLength(500);
+    expect(captured[1]?.body.actions).toHaveLength(250);
+    // First chunk's first item is id-0; second chunk's first is id-500.
+    expect(captured[0]?.body.actions[0]?.input).toEqual({ id: "id-0" });
+    expect(captured[1]?.body.actions[0]?.input).toEqual({ id: "id-500" });
+
+    expect(result.summary).toEqual({ total: 750, succeeded: 749, failed: 1 });
+    // Failure index is re-based into the absolute selection: local 10 in the
+    // second chunk → 500 + 10 = 510.
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0]?.index).toBe(510);
+    // Succeeded indices include items from both chunks.
+    expect(result.succeeded).toHaveLength(749);
+  });
+});
+
+describe("executeBatchAction — strategy-specific aggregation", () => {
+  test("all_or_nothing: aggregates rolledBack across chunks", async () => {
+    installFetch((req) => ({
+      status: 200,
+      body: makeResult({
+        success: false,
+        strategy: "all_or_nothing",
+        failed: [{ index: 0, error: { code: "E", message: "boom" } }],
+        rolledBack: req.body.actions.slice(1).map((_, i) => ({
+          index: i + 1,
+          executionId: `r-${i}`,
+        })),
+        summary: { total: req.body.actions.length, succeeded: 0, failed: 1 },
+      }),
+    }));
+    const result = await executeBatchAction({
+      actionName: "process_payment",
+      recordIds: ["a", "b", "c"],
+      strategy: "all_or_nothing",
+    });
+    expect(captured[0]?.body.strategy).toBe("all_or_nothing");
+    expect(result.strategy).toBe("all_or_nothing");
+    expect(result.rolledBack).toHaveLength(2);
+    expect(result.failed).toHaveLength(1);
+    expect(result.success).toBe(false);
+  });
+
+  test("partial: per-item failures stay isolated; aggregate flags success=false", async () => {
+    installFetch(() => ({
+      status: 200,
+      body: makeResult({
+        success: false,
+        strategy: "partial",
+        succeeded: [{ index: 0, executionId: "ok" }],
+        failed: [{ index: 1, error: { code: "VAL.BAD", message: "bad input" } }],
+        summary: { total: 2, succeeded: 1, failed: 1 },
+      }),
+    }));
+    const result = await executeBatchAction({
+      actionName: "approve_order",
+      recordIds: ["a", "b"],
+      // strategy intentionally omitted to verify default
+    });
+    expect(captured[0]?.body.strategy).toBe("partial");
+    expect(result.success).toBe(false);
+    expect(result.succeeded).toHaveLength(1);
+    expect(result.failed[0]?.error.code).toBe("VAL.BAD");
+  });
+});
+
+describe("executeBatchAction — error responses fold into failed", () => {
+  test("HTTP 500 produces a synthetic failed entry per item, never throws", async () => {
+    installFetch(() => ({
+      status: 500,
+      body: { error: { code: "SYS", message: "server exploded" } },
+    }));
+    const ids = ["a", "b", "c"];
+    const result = await executeBatchAction({ actionName: "noop", recordIds: ids });
+    expect(result.failed).toHaveLength(3);
+    expect(result.failed[0]?.error.code).toBe("BATCH.TRANSPORT");
+    expect(result.failed[0]?.error.message).toBe("server exploded");
+    expect(result.summary).toEqual({ total: 3, succeeded: 0, failed: 3 });
+  });
+
+  test("network error (fetch throws) folds into failed, never throws", async () => {
+    installFetch(() => ({ throw: new Error("connection refused") }));
+    const result = await executeBatchAction({
+      actionName: "noop",
+      recordIds: ["a", "b"],
+    });
+    expect(result.failed).toHaveLength(2);
+    expect(result.failed[0]?.error.code).toBe("BATCH.TRANSPORT");
+    expect(result.failed[0]?.error.message).toBe("connection refused");
+  });
+
+  test("HTTP 4xx without JSON body falls back to status-derived reason", async () => {
+    installFetch(() => ({ status: 403, body: "forbidden" as unknown }));
+    const result = await executeBatchAction({
+      actionName: "noop",
+      recordIds: ["a"],
+    });
+    // Body parses as a JSON string; no `.error.message` → fallback used.
+    expect(result.failed[0]?.error.message).toBe("Batch request failed (403)");
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/src/components/auto-list/auto-list.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/auto-list/auto-list.tsx
@@ -40,6 +40,7 @@ import { useEntityLabel } from "../../i18n/use-entity-label";
 import { useDataTableFilters } from "../data-table-filter";
 import type { FiltersState } from "../data-table-filter/core/types";
 import { EmptyState } from "../empty-state";
+import { BulkActionDialog } from "./bulk-action-dialog";
 import { BulkEditDialog } from "./bulk-edit-dialog";
 import { buildColumns, buildSelectionColumn } from "./columns";
 import { exportCsv } from "./csv-export";
@@ -365,6 +366,7 @@ export function AutoList({
   const setGlobalFilter = onGlobalFilterChangeProp ?? setInternalGlobalFilter;
   const [importOpen, setImportOpen] = useState(false);
   const [bulkEditOpen, setBulkEditOpen] = useState(false);
+  const [bulkActionOpen, setBulkActionOpen] = useState(false);
 
   // ── AI search (schema mode only) ────────────────────────────────────────
 
@@ -637,6 +639,13 @@ export function AutoList({
         setBulkEditOpen(true);
         return;
       }
+      // Sentinel that opens the action chooser → /api/actions/batch dispatcher
+      // (Spec 16 §3.1). Distinct from `'edit'` which opens the field-level
+      // bulk-edit dialog.
+      if (actionName === "run_action") {
+        setBulkActionOpen(true);
+        return;
+      }
       onBulkAction?.(actionName, selectedIds);
     },
     [handleExportSelected, onBulkAction, selectedIds],
@@ -724,6 +733,9 @@ export function AutoList({
         onImport={isSchemaMode ? () => setImportOpen(true) : undefined}
         onBulkAction={isSchemaMode ? handleBulkAction : undefined}
         onClearSelection={isSchemaMode ? () => setRowSelection({}) : undefined}
+        hasBatchActions={
+          isSchemaMode && (view?.actions ?? []).some((a) => (a.position ?? "row") !== "form-header")
+        }
         bazzaColumns={isSchemaMode ? bazzaColumns : undefined}
         bazzaFilters={isSchemaMode ? bazzaFilterState : undefined}
         bazzaActions={isSchemaMode ? bazzaActions : undefined}
@@ -759,6 +771,17 @@ export function AutoList({
             schema={schema}
             selectedIds={selectedIds}
             queryFields={queryFields}
+            onCompleted={() => {
+              setRowSelection({});
+              onRefresh?.();
+            }}
+          />
+
+          <BulkActionDialog
+            open={bulkActionOpen}
+            onOpenChange={setBulkActionOpen}
+            selectedIds={selectedIds}
+            actions={view?.actions ?? []}
             onCompleted={() => {
               setRowSelection({});
               onRefresh?.();

--- a/addons/adapter-ui/cap-adapter-ui/src/components/auto-list/bulk-action-dialog.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/auto-list/bulk-action-dialog.tsx
@@ -1,0 +1,288 @@
+/**
+ * BulkActionDialog — Run a chosen action against every selected record.
+ *
+ * Wraps `POST /api/actions/batch` (Spec 16 §3.1) via `executeBatchAction`,
+ * which handles the 500-item server cap by chunking client-side. Three
+ * outcome buckets are rendered: succeeded (green), failed (red, with the
+ * server-provided reason), rolledBack (yellow, only present under
+ * `all_or_nothing` strategy when a later item triggered a rollback).
+ */
+
+import type {
+  BatchActionsResult,
+  BatchTransactionStrategy,
+  ViewAction,
+} from "@linchkit/core/types";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@linchkit/ui-kit/components";
+import { AlertCircle, CheckCircle2, PlayCircle, Undo2 } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useEntityLabel } from "../../i18n/use-entity-label";
+import { executeBatchAction } from "../../lib/batch-actions";
+
+// ── Types ────────────────────────────────────────────────────
+
+type Phase = "select" | "running" | "done";
+
+export interface BulkActionDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Selected record ids fed into the batch. */
+  selectedIds: string[];
+  /** Actions exposed for this list's entity (typically `view.actions`). */
+  actions: ViewAction[];
+  /**
+   * Optional resolver that returns a per-action transaction strategy. When
+   * the action declaration has a transactional contract, return
+   * `'all_or_nothing'`; otherwise return `'partial'` (or omit / return
+   * `undefined` to fall back to the default).
+   */
+  resolveStrategy?: (actionName: string) => BatchTransactionStrategy | undefined;
+  /** Called after a successful run so callers can refresh data. */
+  onCompleted?: (result: BatchActionsResult) => void;
+}
+
+// ── Component ────────────────────────────────────────────────
+
+export function BulkActionDialog({
+  open,
+  onOpenChange,
+  selectedIds,
+  actions,
+  resolveStrategy,
+  onCompleted,
+}: BulkActionDialogProps) {
+  const { t } = useTranslation();
+  const { resolveLabel } = useEntityLabel();
+
+  const [phase, setPhase] = useState<Phase>("select");
+  const [actionName, setActionName] = useState<string>("");
+  const [result, setResult] = useState<BatchActionsResult | null>(null);
+
+  // Filter to actions a list-page operator can reasonably invoke per row.
+  // Form-only actions (e.g. wizards) are excluded — they need a single record
+  // context, not a batch one.
+  const applicableActions = useMemo(
+    () => actions.filter((a) => (a.position ?? "row") !== "form-header"),
+    [actions],
+  );
+
+  const reset = useCallback(() => {
+    setPhase("select");
+    setActionName("");
+    setResult(null);
+  }, []);
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (!next) reset();
+      onOpenChange(next);
+    },
+    [onOpenChange, reset],
+  );
+
+  const handleRun = useCallback(async () => {
+    if (!actionName || selectedIds.length === 0) return;
+    setPhase("running");
+    const strategy = resolveStrategy?.(actionName) ?? "partial";
+    const aggregated = await executeBatchAction({
+      actionName,
+      recordIds: selectedIds,
+      strategy,
+    });
+    setResult(aggregated);
+    setPhase("done");
+  }, [actionName, selectedIds, resolveStrategy]);
+
+  const handleClose = useCallback(() => {
+    if (result) onCompleted?.(result);
+    handleOpenChange(false);
+  }, [result, onCompleted, handleOpenChange]);
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-lg max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <PlayCircle className="size-4" />
+            {t("bulkAction.title", "Run batch action")}
+          </DialogTitle>
+          <DialogDescription>
+            {t(
+              "bulkAction.description",
+              "Choose an action to run against {{count}} selected records.",
+              { count: selectedIds.length },
+            )}
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* ── Choose action ───────────────────────────────────── */}
+        {phase === "select" && (
+          <div className="space-y-4">
+            {applicableActions.length === 0 ? (
+              <p className="text-sm text-muted-foreground py-4 text-center">
+                {t("bulkAction.noActions", "No actions available for the selected records.")}
+              </p>
+            ) : (
+              <div className="space-y-2">
+                <Label htmlFor="bulk-action-select" className="text-sm font-medium">
+                  {t("bulkAction.action", "Action")}
+                </Label>
+                <Select value={actionName} onValueChange={setActionName}>
+                  <SelectTrigger id="bulk-action-select">
+                    <SelectValue
+                      placeholder={t("bulkAction.choosePlaceholder", "Select an action…")}
+                    />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {applicableActions.map((a) => (
+                      <SelectItem key={a.action} value={a.action}>
+                        {resolveLabel(a.label, a.action)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
+            <DialogFooter>
+              <Button variant="outline" onClick={() => handleOpenChange(false)}>
+                {t("common.cancel")}
+              </Button>
+              <Button disabled={!actionName || applicableActions.length === 0} onClick={handleRun}>
+                {t("bulkAction.runOnCount", "Run on {{count}} records", {
+                  count: selectedIds.length,
+                })}
+              </Button>
+            </DialogFooter>
+          </div>
+        )}
+
+        {/* ── Running ─────────────────────────────────────────── */}
+        {phase === "running" && (
+          <div className="space-y-2 py-8">
+            <div className="text-center text-sm text-muted-foreground">
+              {t("bulkAction.running", "Running action against selected records…")}
+            </div>
+          </div>
+        )}
+
+        {/* ── Done ────────────────────────────────────────────── */}
+        {phase === "done" && result && (
+          <BulkActionResultPanel result={result} onClose={handleClose} />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Result panel ────────────────────────────────────────────
+
+interface BulkActionResultPanelProps {
+  result: BatchActionsResult;
+  onClose: () => void;
+}
+
+function BulkActionResultPanel({ result, onClose }: BulkActionResultPanelProps) {
+  const { t } = useTranslation();
+  const succeededCount = result.succeeded.length;
+  const failedCount = result.failed.length;
+  const rolledBackCount = result.rolledBack?.length ?? 0;
+
+  // Headline icon: green if everything succeeded, yellow on rollback, red on
+  // any net failure, neutral when there's nothing to report.
+  const Headline = (() => {
+    if (failedCount === 0 && rolledBackCount === 0 && succeededCount > 0) {
+      return <CheckCircle2 className="size-10 text-green-500" />;
+    }
+    if (rolledBackCount > 0) {
+      return <Undo2 className="size-10 text-yellow-500" />;
+    }
+    return <AlertCircle className="size-10 text-destructive" />;
+  })();
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col items-center gap-3 py-2">
+        {Headline}
+        <p className="text-sm font-medium">
+          {t("bulkAction.summary", "{{ok}} succeeded, {{fail}} failed", {
+            ok: succeededCount,
+            fail: failedCount,
+          })}
+        </p>
+      </div>
+
+      {succeededCount > 0 && (
+        <section
+          aria-label="succeeded"
+          className="rounded-md border border-green-500/30 bg-green-500/5 p-3"
+        >
+          <h4 className="mb-1 text-sm font-medium text-green-600 dark:text-green-400">
+            {t("bulkAction.succeeded", "Succeeded ({{count}})", { count: succeededCount })}
+          </h4>
+          <p className="text-xs text-muted-foreground">
+            {t("bulkAction.succeededDescription", "Records updated successfully.")}
+          </p>
+        </section>
+      )}
+
+      {failedCount > 0 && (
+        <section
+          aria-label="failed"
+          className="rounded-md border border-destructive/30 bg-destructive/5 p-3"
+        >
+          <h4 className="mb-2 text-sm font-medium text-destructive">
+            {t("bulkAction.failed", "Failed ({{count}})", { count: failedCount })}
+          </h4>
+          <ul className="max-h-36 space-y-1 overflow-y-auto">
+            {result.failed.map((f) => (
+              <li key={`${f.index}-${f.error.code}`} className="text-xs text-muted-foreground">
+                <span className="font-mono">#{f.index}</span>:{" "}
+                <span className="font-medium text-destructive">{f.error.code}</span>{" "}
+                {f.error.message}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {rolledBackCount > 0 && (
+        <section
+          aria-label="rolled-back"
+          className="rounded-md border border-yellow-500/30 bg-yellow-500/5 p-3"
+        >
+          <h4 className="mb-1 text-sm font-medium text-yellow-700 dark:text-yellow-400">
+            {t("bulkAction.rolledBack", "Rolled back ({{count}})", {
+              count: rolledBackCount,
+            })}
+          </h4>
+          <p className="text-xs text-muted-foreground">
+            {t(
+              "bulkAction.rolledBackDescription",
+              "These items succeeded but were undone because a later item failed.",
+            )}
+          </p>
+        </section>
+      )}
+
+      <DialogFooter>
+        <Button onClick={onClose}>{t("common.close")}</Button>
+      </DialogFooter>
+    </div>
+  );
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/components/auto-list/list-toolbar.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/auto-list/list-toolbar.tsx
@@ -13,6 +13,7 @@ import {
   Download,
   MoreHorizontal,
   Pencil,
+  PlayCircle,
   RefreshCw,
   Trash2,
   Upload,
@@ -41,6 +42,12 @@ interface ListToolbarProps {
   selectedCount?: number;
   onBulkAction?: (actionName: string) => void;
   onClearSelection?: () => void;
+  /**
+   * Whether the entity exposes any view-level actions runnable in batch.
+   * When true, a "Run action…" menu item appears in the bulk dropdown that
+   * opens the action chooser bound to `/api/actions/batch`.
+   */
+  hasBatchActions?: boolean;
   /** bazza filter props passed through to SearchBar */
   bazzaColumns?: Column<Record<string, unknown>>[] | undefined;
   bazzaFilters?: FiltersState | undefined;
@@ -80,6 +87,7 @@ export function ListToolbar({
   selectedCount = 0,
   onBulkAction,
   onClearSelection,
+  hasBatchActions = false,
   bazzaColumns,
   bazzaFilters,
   bazzaActions,
@@ -146,6 +154,12 @@ export function ListToolbar({
                   <Pencil className="mr-2 size-3.5" />
                   {t("bulkEdit.title", "Bulk Edit")}
                 </DropdownMenuItem>
+                {hasBatchActions && (
+                  <DropdownMenuItem onClick={() => onBulkAction?.("run_action")}>
+                    <PlayCircle className="mr-2 size-3.5" />
+                    {t("bulkAction.menu", "Run action…")}
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuItem onClick={() => onBulkAction?.("export")}>
                   <Download className="mr-2 size-3.5" />
                   {t("common.export")}

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
@@ -410,6 +410,22 @@
     "errorDetails": "Error details",
     "noEditableFields": "No editable fields available."
   },
+  "bulkAction": {
+    "menu": "Run action…",
+    "title": "Run batch action",
+    "description": "Choose an action to run against {{count}} selected records.",
+    "action": "Action",
+    "choosePlaceholder": "Select an action…",
+    "runOnCount": "Run on {{count}} records",
+    "running": "Running action against selected records…",
+    "summary": "{{ok}} succeeded, {{fail}} failed",
+    "succeeded": "Succeeded ({{count}})",
+    "succeededDescription": "Records updated successfully.",
+    "failed": "Failed ({{count}})",
+    "rolledBack": "Rolled back ({{count}})",
+    "rolledBackDescription": "These items succeeded but were undone because a later item failed.",
+    "noActions": "No actions available for the selected records."
+  },
   "states": {
     "draft": "Draft",
     "pending": "Pending",

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
@@ -410,6 +410,22 @@
     "errorDetails": "错误详情",
     "noEditableFields": "没有可编辑的字段。"
   },
+  "bulkAction": {
+    "menu": "运行动作…",
+    "title": "运行批量动作",
+    "description": "选择一个动作以应用到 {{count}} 条已选记录。",
+    "action": "动作",
+    "choosePlaceholder": "选择一个动作…",
+    "runOnCount": "应用到 {{count}} 条记录",
+    "running": "正在对选中的记录执行动作…",
+    "summary": "{{ok}} 成功，{{fail}} 失败",
+    "succeeded": "成功 ({{count}})",
+    "succeededDescription": "记录已成功更新。",
+    "failed": "失败 ({{count}})",
+    "rolledBack": "已回滚 ({{count}})",
+    "rolledBackDescription": "这些项目原本成功，但因后续项目失败而被回滚。",
+    "noActions": "没有可批量运行的动作。"
+  },
   "states": {
     "draft": "草稿",
     "pending": "待审批",

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/batch-actions.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/batch-actions.ts
@@ -230,6 +230,17 @@ export async function executeBatchAction(
     const chunkResult = await postBatchChunk(items, strategy, baseIndex, fetchImpl);
     results.push(chunkResult);
     baseIndex += chunk.length;
+
+    if (!chunkResult.success) {
+      // Stop iterating when atomicity is at stake or the network is gone.
+      // - `all_or_nothing`: a failed chunk was rolled back server-side. Any
+      //   subsequent chunk that succeeds would violate the strategy's
+      //   contract by leaving partial state across the full selection.
+      // - Transport error: the system is unreachable; queueing more
+      //   requests just generates more synthetic transport failures.
+      const isTransportError = chunkResult.failed.some((f) => f.error.code === "BATCH.TRANSPORT");
+      if (strategy === "all_or_nothing" || isTransportError) break;
+    }
   }
 
   return aggregateBatchResults(results);

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/batch-actions.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/batch-actions.ts
@@ -1,0 +1,236 @@
+/**
+ * Batch action client (Spec 16 §3.1, Spec 04 §8).
+ *
+ * Wraps `POST /api/actions/batch` with:
+ *  - Client-side chunking to honor the 500-item server cap (MAX_BATCH_SIZE).
+ *  - Sequential chunk execution so server backpressure is preserved.
+ *  - Result aggregation across chunks into one `BatchActionsResult` shape.
+ *
+ * Errors thrown by the transport (network/HTTP) are surfaced into the
+ * `failed` list so callers can render them inline rather than catching at
+ * the call site.
+ */
+
+import type {
+  BatchActionItem,
+  BatchActionsResult,
+  BatchTransactionStrategy,
+} from "@linchkit/core/types";
+import { getTenantHeaders } from "./tenant";
+
+/**
+ * Maximum items per `/api/actions/batch` call. Mirrors `MAX_BATCH_SIZE` in
+ * `@linchkit/core` (`packages/core/src/engine/batch-action-engine.ts`). The
+ * UI chunks larger selections client-side so users never see the server
+ * cap as a failure.
+ */
+export const BATCH_CHUNK_SIZE = 500;
+
+/** Pure chunking helper. Splits an array into evenly-sized contiguous slices. */
+export function chunkIds(ids: string[], size: number = BATCH_CHUNK_SIZE): string[][] {
+  if (size <= 0) {
+    throw new Error("chunkIds: size must be > 0");
+  }
+  if (ids.length === 0) return [];
+  const out: string[][] = [];
+  for (let i = 0; i < ids.length; i += size) {
+    out.push(ids.slice(i, i + size));
+  }
+  return out;
+}
+
+/**
+ * Aggregate per-chunk batch results into a single result envelope.
+ *
+ * - `succeeded` / `failed` / `rolledBack` are concatenated.
+ * - `summary` counts are summed.
+ * - `success` is `true` iff every chunk succeeded.
+ * - `parentExecutionId` is taken from the first chunk (each chunk is
+ *   independently a parent batch on the server; we surface the first for
+ *   correlation in toasts/logs).
+ * - `strategy` is taken from the first chunk (every chunk requested the same).
+ */
+export function aggregateBatchResults(results: BatchActionsResult[]): BatchActionsResult {
+  if (results.length === 0) {
+    return {
+      success: true,
+      parentExecutionId: "",
+      strategy: "partial",
+      succeeded: [],
+      failed: [],
+      summary: { total: 0, succeeded: 0, failed: 0 },
+    };
+  }
+  const first = results[0] as BatchActionsResult;
+  const succeeded = results.flatMap((r) => r.succeeded);
+  const failed = results.flatMap((r) => r.failed);
+  const rolledBack = results.flatMap((r) => r.rolledBack ?? []);
+  const summary = results.reduce(
+    (acc, r) => ({
+      total: acc.total + r.summary.total,
+      succeeded: acc.succeeded + r.summary.succeeded,
+      failed: acc.failed + r.summary.failed,
+    }),
+    { total: 0, succeeded: 0, failed: 0 },
+  );
+  const merged: BatchActionsResult = {
+    success: results.every((r) => r.success),
+    parentExecutionId: first.parentExecutionId,
+    strategy: first.strategy,
+    succeeded,
+    failed,
+    summary,
+  };
+  if (rolledBack.length > 0) {
+    merged.rolledBack = rolledBack;
+  }
+  return merged;
+}
+
+// ── Fetch ──────────────────────────────────────────────────
+
+/** Auth/tenant headers — mirrors api.ts to keep wire conventions identical. */
+function getAuthHeaders(): Record<string, string> {
+  const token = typeof localStorage !== "undefined" ? localStorage.getItem("linchkit:token") : null;
+  const tenantHeaders = getTenantHeaders();
+  if (token) {
+    return { Authorization: `Bearer ${token}`, ...tenantHeaders };
+  }
+  return { ...tenantHeaders };
+}
+
+/** Build a synthetic failed item for transport errors so callers see them inline. */
+function buildTransportFailure(
+  items: BatchActionItem[],
+  reason: string,
+  baseIndex: number,
+): BatchActionsResult {
+  return {
+    success: false,
+    parentExecutionId: "",
+    strategy: "partial",
+    succeeded: [],
+    failed: items.map((_, i) => ({
+      index: baseIndex + i,
+      error: { code: "BATCH.TRANSPORT", message: reason },
+    })),
+    summary: { total: items.length, succeeded: 0, failed: items.length },
+  };
+}
+
+/**
+ * Send a single chunk to `/api/actions/batch`. Transport / HTTP failures are
+ * folded into a synthetic `BatchActionsResult` so the caller's aggregation
+ * stays uniform — never throws.
+ */
+async function postBatchChunk(
+  items: BatchActionItem[],
+  strategy: BatchTransactionStrategy,
+  baseIndex: number,
+  fetchImpl: typeof fetch,
+): Promise<BatchActionsResult> {
+  let res: Response;
+  try {
+    res = await fetchImpl("/api/actions/batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...getAuthHeaders() },
+      body: JSON.stringify({ actions: items, strategy }),
+    });
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : "Network error";
+    return buildTransportFailure(items, reason, baseIndex);
+  }
+
+  if (!res.ok) {
+    let reason = `Batch request failed (${res.status})`;
+    try {
+      const body = (await res.json()) as { error?: { message?: string } } | null;
+      if (body?.error?.message) reason = body.error.message;
+    } catch {
+      // Body wasn't JSON — keep status-derived reason.
+    }
+    return buildTransportFailure(items, reason, baseIndex);
+  }
+
+  const body = (await res.json()) as BatchActionsResult;
+  // Re-base per-item indices into the absolute selection so UIs that show
+  // "row N failed" stay correct across chunk boundaries.
+  if (baseIndex !== 0) {
+    return {
+      ...body,
+      succeeded: body.succeeded.map((s) => ({ ...s, index: s.index + baseIndex })),
+      failed: body.failed.map((f) => ({ ...f, index: f.index + baseIndex })),
+      ...(body.rolledBack
+        ? { rolledBack: body.rolledBack.map((s) => ({ ...s, index: s.index + baseIndex })) }
+        : {}),
+    };
+  }
+  return body;
+}
+
+// ── Public API ─────────────────────────────────────────────
+
+export interface ExecuteBatchActionOptions {
+  /** Action name to invoke for every selected record. */
+  actionName: string;
+  /** Selected record ids — chunked client-side at `BATCH_CHUNK_SIZE`. */
+  recordIds: string[];
+  /**
+   * Transaction strategy. Defaults to `'partial'` so a single failing record
+   * does not undo successful peers. Pass `'all_or_nothing'` when the action
+   * declares a transactional contract that must hold across the whole batch.
+   */
+  strategy?: BatchTransactionStrategy;
+  /**
+   * Field name used to bind the record id into the action input. Defaults to
+   * `'id'` — the meta-model convention. Override for actions that take a
+   * different key (e.g. `record_id`).
+   */
+  idField?: string;
+  /**
+   * Extra static input merged into every per-record payload — useful when
+   * the action also needs values picked from the chooser (e.g. a target
+   * status). Per-record `idField` always wins on key collision.
+   */
+  extraInput?: Record<string, unknown>;
+  /** Fetch override for tests. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Execute an action against many record ids via `/api/actions/batch`.
+ *
+ * - Chunks `recordIds` into batches of `BATCH_CHUNK_SIZE` (500) and sends
+ *   them sequentially. Sequential matters for `all_or_nothing`: each chunk
+ *   is its own server-side transaction, but per-chunk ordering is preserved.
+ * - Aggregates per-chunk results into one `BatchActionsResult`.
+ * - Never throws; transport / HTTP failures appear in `failed`.
+ */
+export async function executeBatchAction(
+  options: ExecuteBatchActionOptions,
+): Promise<BatchActionsResult> {
+  const {
+    actionName,
+    recordIds,
+    strategy = "partial",
+    idField = "id",
+    extraInput,
+    fetchImpl = fetch,
+  } = options;
+
+  const chunks = chunkIds(recordIds);
+  const results: BatchActionsResult[] = [];
+
+  let baseIndex = 0;
+  for (const chunk of chunks) {
+    const items: BatchActionItem[] = chunk.map((id) => ({
+      name: actionName,
+      input: { ...(extraInput ?? {}), [idField]: id },
+    }));
+    const chunkResult = await postBatchChunk(items, strategy, baseIndex, fetchImpl);
+    results.push(chunkResult);
+    baseIndex += chunk.length;
+  }
+
+  return aggregateBatchResults(results);
+}


### PR DESCRIPTION
## Summary
- Wires checkbox-driven multi-select on auto-list pages to `/api/actions/batch` (delivered in #234).
- "Run action…" entry added to list-toolbar bulk dropdown; opens `BulkActionDialog` which runs the chosen action against every selected record.
- Tri-color result panel: green (succeeded), red (failed + server reason), yellow (rolledBack — only on `all_or_nothing`).
- Chunks selections client-side at 500 items (the documented batch cap), walks chunks sequentially to preserve server backpressure, re-bases per-chunk indices into absolute positions before aggregation.
- HTTP/network failures fold into synthetic `failed` entries (`BATCH.TRANSPORT`) — callers never see thrown errors.
- `resolveStrategy` prop defers per-action strategy resolution (default `partial`); `ActionDefinition` doesn't yet carry a `batchStrategy` field.

## Test plan
- [x] 16 new tests in `batch-actions.test.ts` (chunking, aggregation, single + multi-chunk fetch, both strategies, transport errors)
- [x] Full cap-adapter-ui suite — 280/280
- [x] `bun test` — 4573 pass / 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean

## Refs
- Server-side batch endpoint: #234 (gh #129)
- Spec 16 §3.1 (Batch operations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)