### PR TITLE
feat(adapter-server): GraphQL request headers parity with REST (closes #236)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/headers-propagation.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/headers-propagation.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Issue #236 — request headers propagate through CommandLayer for GraphQL,
+ * matching the REST contract.
+ *
+ * A CommandLayer middleware reads `ctx.headers["x-linch-trace"]` and writes
+ * it into the action's meta. The same trace value must be observable
+ * regardless of whether the action was invoked over REST `/api/actions/:name`
+ * or via the GraphQL `executeAction` / `batch_actions` / typed CRUD
+ * mutations / `<entity>_onchange` mutations.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import type { ActionContext, ActionDefinition, EntityDefinition } from "@linchkit/core";
+import {
+  createActionExecutor,
+  createCommandLayer,
+  createEntityRegistry,
+  createOnchangeEvaluator,
+  InMemoryStore,
+} from "@linchkit/core/server";
+import { buildGraphQLSchema, generateCrudActions } from "../src/graphql/build-schema";
+import { createServer } from "../src/server";
+
+// ── Fixtures ──────────────────────────────────────────────
+
+const taskEntity: EntityDefinition = {
+  name: "trace_task",
+  label: "TraceTask",
+  fields: {
+    title: { type: "string", required: true, label: "Title" },
+    code: { type: "string", label: "Code" },
+    description: { type: "string", label: "Description" },
+  },
+  onchange: {
+    code: {
+      updates: ["description"],
+      compute: (ctx) => ({ description: `code=${ctx.value}` }),
+    },
+  },
+};
+
+interface CapturedExecution {
+  action: string;
+  /** trace header observed by the permission middleware via ctx.headers */
+  observedTrace: string | undefined;
+  /** all headers seen by the middleware (lowercase keyed) */
+  allHeaders: Record<string, string> | undefined;
+}
+
+const captures: CapturedExecution[] = [];
+
+/**
+ * Standalone middleware-level trace captures — populated unconditionally
+ * regardless of whether the action handler runs. Used by the onchange test
+ * (skipActionSlots path) where no action handler executes.
+ */
+const middlewareTraces: Array<{ command: string; trace: string | undefined }> = [];
+
+function recordCapture(name: string, ctx: ActionContext): void {
+  const headers = ctx.meta.toJSON().captured_headers as Record<string, string> | undefined;
+  captures.push({
+    action: name,
+    observedTrace: headers?.["x-linch-trace"],
+    allHeaders: headers,
+  });
+}
+
+// A no-op handler that captures meta — used by GraphQL executeAction tests.
+const probeAction: ActionDefinition = {
+  name: "probe_headers",
+  entity: "trace_task",
+  label: "Probe Headers",
+  policy: { mode: "sync", transaction: false },
+  exposure: "all",
+  handler: async (ctx) => {
+    recordCapture("probe_headers", ctx);
+    return { ok: true };
+  },
+};
+
+const store = new InMemoryStore();
+const executor = createActionExecutor({ dataProvider: store });
+
+executor.registry.register(probeAction);
+for (const action of generateCrudActions(taskEntity)) {
+  // Wrap CRUD handlers so meta is captured under the CRUD action name.
+  const original = action.handler;
+  const wrapped: ActionDefinition = {
+    ...action,
+    handler: async (ctx) => {
+      recordCapture(action.name, ctx);
+      if (!original) return undefined;
+      return original(ctx);
+    },
+  };
+  executor.registry.register(wrapped);
+}
+
+const commandLayer = createCommandLayer({ executor });
+
+// Permission slot middleware that copies request headers into meta so the
+// action handler can observe what the pipeline saw. This is the exact
+// "branches on headers" pattern issue #236 calls out.
+commandLayer.use({
+  name: "header_capture",
+  slot: "permission",
+  handler: async (ctx, next) => {
+    // Record middleware-level visibility (independent of whether the action
+    // handler subsequently runs — needed for skipActionSlots paths like
+    // onchange).
+    middlewareTraces.push({
+      command: ctx.command,
+      trace: ctx.headers?.["x-linch-trace"],
+    });
+    if (ctx.headers) {
+      // Stash a snapshot under a non-system key. (`_`-prefixed keys are
+      // re-stripped by the action engine at root depth; user-meta keys
+      // survive intact.)
+      ctx.meta.captured_headers = { ...ctx.headers };
+    }
+    await next();
+  },
+});
+
+const entityRegistry = createEntityRegistry();
+entityRegistry.register(taskEntity);
+const onchangeEvaluator = createOnchangeEvaluator({ entityRegistry, dataProvider: store });
+
+const graphqlSchema = buildGraphQLSchema([taskEntity], {
+  executor,
+  commandLayer,
+  dataProvider: store,
+  actions: [probeAction],
+  onchangeEvaluator,
+});
+
+const app = createServer(graphqlSchema, {
+  executor,
+  commandLayer,
+  entityRegistry,
+  dataProvider: store,
+  onchangeEvaluator,
+});
+
+const port = 4321;
+
+beforeAll(() => {
+  app.listen(port);
+});
+
+afterAll(() => {
+  app.stop();
+});
+
+function clearCaptures(): void {
+  captures.length = 0;
+  middlewareTraces.length = 0;
+}
+
+async function postRest(
+  name: string,
+  body: Record<string, unknown> = {},
+  headers: Record<string, string> = {},
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const res = await fetch(`http://localhost:${port}/api/actions/${name}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+  const json = (await res.json()) as Record<string, unknown>;
+  return { status: res.status, body: json };
+}
+
+async function gql(
+  query: string,
+  variables: Record<string, unknown> | undefined,
+  headers: Record<string, string> = {},
+): Promise<{ data?: Record<string, unknown>; errors?: Array<Record<string, unknown>> }> {
+  const res = await fetch(`http://localhost:${port}/graphql`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify({ query, variables }),
+  });
+  return (await res.json()) as {
+    data?: Record<string, unknown>;
+    errors?: Array<Record<string, unknown>>;
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────
+
+describe("Issue #236 — request headers propagate through CommandLayer (REST + GraphQL parity)", () => {
+  test("REST single-action: middleware observes x-linch-trace header", async () => {
+    clearCaptures();
+    const { status } = await postRest(
+      "probe_headers",
+      {},
+      { "X-Linch-Trace": "rest-single-trace-1" },
+    );
+    expect(status).toBe(200);
+    expect(captures).toHaveLength(1);
+    expect(captures[0].observedTrace).toBe("rest-single-trace-1");
+  });
+
+  test("GraphQL executeAction: middleware observes x-linch-trace header (REST parity)", async () => {
+    clearCaptures();
+    const result = await gql(
+      `
+        mutation Run($name: String!, $input: String!) {
+          executeAction(name: $name, input: $input) {
+            success
+            executionId
+          }
+        }
+      `,
+      { name: "probe_headers", input: JSON.stringify({}) },
+      { "X-Linch-Trace": "gql-execute-trace-1" },
+    );
+    expect(result.errors).toBeUndefined();
+    expect(captures).toHaveLength(1);
+    expect(captures[0].observedTrace).toBe("gql-execute-trace-1");
+  });
+
+  test("GraphQL typed mutation (createTraceTask): headers propagate", async () => {
+    clearCaptures();
+    const result = await gql(
+      `
+        mutation Create($input: TraceTaskInput!) {
+          createTraceTask(input: $input) {
+            id
+            title
+          }
+        }
+      `,
+      { input: { title: "from-gql" } },
+      { "X-Linch-Trace": "gql-create-trace-1" },
+    );
+    expect(result.errors).toBeUndefined();
+    const createCap = captures.find((c) => c.action === "create_trace_task");
+    expect(createCap).toBeDefined();
+    expect(createCap?.observedTrace).toBe("gql-create-trace-1");
+  });
+
+  test("GraphQL batch_actions: headers propagate to every batch item", async () => {
+    clearCaptures();
+    const result = await gql(
+      `
+        mutation Batch($actions: [BatchActionInputItem!]!, $strategy: String) {
+          batch_actions(actions: $actions, strategy: $strategy) {
+            success
+            summary { total succeeded failed }
+          }
+        }
+      `,
+      {
+        actions: [
+          { name: "probe_headers", input: JSON.stringify({}) },
+          { name: "probe_headers", input: JSON.stringify({}) },
+        ],
+        strategy: "partial",
+      },
+      { "X-Linch-Trace": "gql-batch-trace-1" },
+    );
+    expect(result.errors).toBeUndefined();
+    expect(captures.length).toBeGreaterThanOrEqual(2);
+    expect(captures[0].observedTrace).toBe("gql-batch-trace-1");
+    expect(captures[1].observedTrace).toBe("gql-batch-trace-1");
+  });
+
+  test("REST and GraphQL produce identical trace observations for the same header value", async () => {
+    clearCaptures();
+    await postRest("probe_headers", {}, { "X-Linch-Trace": "parity-trace" });
+    const restTrace = captures[0].observedTrace;
+
+    clearCaptures();
+    await gql(
+      `
+        mutation Run($name: String!, $input: String!) {
+          executeAction(name: $name, input: $input) { success }
+        }
+      `,
+      { name: "probe_headers", input: JSON.stringify({}) },
+      { "X-Linch-Trace": "parity-trace" },
+    );
+    const gqlTrace = captures[0].observedTrace;
+
+    expect(restTrace).toBe("parity-trace");
+    expect(gqlTrace).toBe("parity-trace");
+    expect(restTrace).toBe(gqlTrace);
+  });
+
+  test("Headers are absent when not sent (transport doesn't fabricate values)", async () => {
+    clearCaptures();
+    await gql(
+      `
+        mutation Run($name: String!, $input: String!) {
+          executeAction(name: $name, input: $input) { success }
+        }
+      `,
+      { name: "probe_headers", input: JSON.stringify({}) },
+    );
+    expect(captures).toHaveLength(1);
+    expect(captures[0].observedTrace).toBeUndefined();
+  });
+
+  test("GraphQL <entity>_onchange mutation: headers propagate to skipActionSlots dispatch", async () => {
+    clearCaptures();
+    const result = await gql(
+      `
+        mutation Onchange($field: String!, $values: String!) {
+          trace_task_onchange(changedField: $field, values: $values) {
+            updates
+            warnings
+          }
+        }
+      `,
+      { field: "code", values: JSON.stringify({ code: "abc" }) },
+      { "X-Linch-Trace": "gql-onchange-trace-1" },
+    );
+    expect(result.errors).toBeUndefined();
+    // The onchange path uses `skipActionSlots: true`, so no action handler
+    // runs — assert directly via the middleware-level trace capture which
+    // fires regardless of whether the action runs.
+    const onchangeMw = middlewareTraces.find((m) => m.command === "trace_task.onchange");
+    expect(onchangeMw).toBeDefined();
+    expect(onchangeMw?.trace).toBe("gql-onchange-trace-1");
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-onchange-mutations.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-onchange-mutations.ts
@@ -151,6 +151,7 @@ export function buildOnchangeMutationFields(
           channel: "http",
           tenantId: ctx.tenantId,
           locale: ctx.locale,
+          headers: ctx.headers,
           meta: {
             onchange: {
               entity: entityName,

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
@@ -103,6 +103,13 @@ export interface GraphQLContext {
   tenantId?: string;
   /** Locale for resolving translatable fields (e.g., "zh-CN", "en") */
   locale?: string;
+  /**
+   * HTTP request headers (lowercase keys) — propagated through CommandLayer
+   * so middleware (rate-limit, trace, custom auth) sees the same surface for
+   * GraphQL as for REST. May be `undefined` for in-process / subscription
+   * contexts where there is no originating Request.
+   */
+  headers?: Record<string, string>;
   /** Data provider for link relation resolvers */
   dataProvider?: DataProvider;
   /** Permission groups for data masking unmask checks */
@@ -412,6 +419,7 @@ export function buildGraphQLSchema(
         channel: "http",
         tenantId: ctx.tenantId,
         locale: ctx.locale,
+        headers: ctx.headers,
         includeDeleted: extraOptions?.includeDeleted,
         meta: extraOptions?.meta,
       })) as ActionResult<T>;
@@ -1298,6 +1306,7 @@ export function buildGraphQLSchema(
             channel: "http",
             tenantId: ctx.tenantId,
             locale: ctx.locale,
+            headers: ctx.headers,
             transactionManager: batchTransactionManager,
             meta,
           });

--- a/addons/adapter-server/cap-adapter-server/src/server.ts
+++ b/addons/adapter-server/cap-adapter-server/src/server.ts
@@ -205,6 +205,14 @@ export function createServer(
         ? await resolveRequestTenantId(request, actor)
         : undefined;
       const locale = resolveRequestLocale(request);
+      // Forwarding policy (issue #236): collect every inbound HTTP header into
+      // a lowercase-keyed plain object so CommandLayer middleware sees the same
+      // surface for GraphQL as for REST (`routes/action-api.ts`). REST forwards
+      // every header verbatim — this keeps GraphQL on the same contract.
+      const headers: Record<string, string> = {};
+      for (const [key, value] of request.headers.entries()) {
+        headers[key] = value;
+      }
       // Wrap DataProvider with tenant isolation for this request so all GraphQL
       // resolvers (get, list, link traversal) enforce row-level tenant scoping.
       const scopedProvider =
@@ -219,6 +227,7 @@ export function createServer(
         actor,
         tenantId,
         locale,
+        headers,
         dataProvider: scopedProvider,
         permissionGroups,
         entityMap,


### PR DESCRIPTION
## Summary
Brings GraphQL transport to header-forwarding parity with REST so CommandLayer middleware sees identical headers regardless of transport (Spec 16 §3 requirement).

- `GraphQLContext` gains `headers?: Record<string, string>` (lowercase-keyed for HTTP semantics).
- Yoga context builder collects `request.headers` from the inbound request. Subscription / in-process callers get `undefined`.
- Forwarding policy: **forward every header verbatim, no denylist** — matches REST's existing behavior at `routes/action-api.ts:124-127, 191-194`. A denylist on one transport only would break parity.
- Plumbed into every `commandLayer.execute*` site:
  - `dispatchAction` (CRUD + custom + state transitions)
  - `batch_actions` (`executeBatch`)
  - `<entity>_onchange` (`execute`)
- The bare-`executor.execute` fallback in `dispatchAction` does NOT forward headers — matches REST's bare-executor branch.

## Test plan
- [x] New `headers-propagation.test.ts` — 7 tests, REST + GraphQL parity (single-action, batch, onchange)
- [x] Full adapter-server suite — 603/603 pass / 0 fail
- [x] `bun test` — 4704 pass / 0 fail
- [x] `bun run typecheck` / `bun run check` — clean

## Refs
- Spec 16 §3 (CommandLayer pipeline, transport adapters)
- Original tracking: #212 / parent PR #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)