### PR TITLE
feat(core): AI-friendly errors with structured context (Spec 60 Phase 5)

### DIFF
--- a/packages/core/__tests__/error-context.test.ts
+++ b/packages/core/__tests__/error-context.test.ts
@@ -5,7 +5,7 @@
  * for AI agents to understand and fix issues autonomously.
  */
 
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import type { DataProvider } from "../src/engine/action-engine";
 import { createActionExecutor } from "../src/engine/action-engine";
 import { evaluateRules } from "../src/engine/rule-engine";
@@ -13,10 +13,13 @@ import { createStateMachine, transition } from "../src/engine/state-machine";
 import {
   BusinessRuleError,
   ConflictError,
+  isAiAgentCaller,
   LinchKitError,
   NotFoundError,
+  shouldIncludeErrorContext,
   ValidationError,
 } from "../src/errors";
+import type { Actor } from "../src/types/action";
 import type { ErrorContext } from "../src/types/error";
 import type { RuleDefinition } from "../src/types/rule";
 
@@ -367,5 +370,258 @@ describe("RuleEngine evaluation output", () => {
     expect(output.blockReasons).toEqual([]);
     expect(output.results.length).toBe(1);
     expect(output.results[0].triggered).toBe(false);
+  });
+});
+
+// ── ErrorContext extended fields (Spec 60 Phase 5) ─────────
+
+describe("ErrorContext extended fields", () => {
+  it("should accept relatedDocs", () => {
+    const err = new LinchKitError({
+      code: "rule.business.budget",
+      message: "Budget exceeded",
+      context: {
+        entity: "purchase_request",
+        action: "submit_request",
+        suggestion: "Reduce amount or split into multiple requests",
+        relatedDocs: ["docs/specs/60_observability.md", "docs/rules/budget.md"],
+      },
+    });
+
+    expect(err.context?.relatedDocs).toEqual([
+      "docs/specs/60_observability.md",
+      "docs/rules/budget.md",
+    ]);
+  });
+
+  it("should accept non-string expected and actual values", () => {
+    const err = new LinchKitError({
+      code: "validation.field.range",
+      message: "Out of range",
+      context: {
+        field: "amount",
+        constraint: "max",
+        expected: 50000,
+        actual: 75000,
+      },
+    });
+
+    expect(err.context?.expected).toBe(50000);
+    expect(err.context?.actual).toBe(75000);
+  });
+
+  it("should accept structured expected values (e.g. enum lists)", () => {
+    const err = new LinchKitError({
+      code: "validation.field.enum",
+      message: "Invalid status",
+      context: {
+        field: "status",
+        constraint: "enum",
+        expected: ["draft", "submitted", "approved"],
+        actual: "shipped",
+      },
+    });
+
+    expect(err.context?.expected).toEqual(["draft", "submitted", "approved"]);
+  });
+});
+
+// ── toResponse({ includeContext }) gating ──────────────────
+
+describe("LinchKitError.toResponse includeContext option", () => {
+  const buildErr = () =>
+    new LinchKitError({
+      code: "rule.business.budget",
+      message: "Budget exceeded",
+      context: {
+        entity: "purchase_request",
+        action: "submit_request",
+        suggestion: "Reduce amount",
+      },
+    });
+
+  it("includes context by default (legacy behavior)", () => {
+    const res = buildErr().toResponse();
+    expect(res.error.context).toBeDefined();
+  });
+
+  it("includes context when includeContext: true", () => {
+    const res = buildErr().toResponse({ includeContext: true });
+    expect(res.error.context).toBeDefined();
+    expect(res.error.context?.entity).toBe("purchase_request");
+  });
+
+  it("omits context when includeContext: false", () => {
+    const res = buildErr().toResponse({ includeContext: false });
+    expect(res.error).not.toHaveProperty("context");
+  });
+
+  it("preserves subclass details when includeContext: false", () => {
+    const err = new ValidationError({
+      code: "user.validation.fields",
+      message: "Validation failed",
+      fields: [{ field: "email", message: "required" }],
+      context: { entity: "user", field: "email", suggestion: "Provide email" },
+    });
+    const res = err.toResponse({ includeContext: false });
+    expect(res.error).not.toHaveProperty("context");
+    // Subclass payload (fields) survives the redaction
+    expect(res.error.fields).toEqual([{ field: "email", message: "required" }]);
+  });
+
+  it("preserves NotFoundError resource details when includeContext: false", () => {
+    const err = new NotFoundError({
+      code: "record.not_found.order",
+      message: "Order not found",
+      resource: "order",
+      resourceId: "ord_42",
+      context: { entity: "order", suggestion: "Verify ID" },
+    });
+    const res = err.toResponse({ includeContext: false });
+    expect(res.error).not.toHaveProperty("context");
+    expect(res.error.details).toEqual({ resource: "order", resourceId: "ord_42" });
+  });
+});
+
+// ── isAiAgentCaller helper ────────────────────────────────
+
+describe("isAiAgentCaller", () => {
+  const baseGroups: string[] = [];
+
+  it("returns true for actor.type === 'ai'", () => {
+    const actor: Actor = { type: "ai", id: "agent-1", groups: baseGroups };
+    expect(isAiAgentCaller(actor)).toBe(true);
+  });
+
+  it("returns true when metadata.channel === 'mcp'", () => {
+    const actor: Actor = {
+      type: "human",
+      id: "u1",
+      groups: baseGroups,
+      metadata: { channel: "mcp" },
+    };
+    expect(isAiAgentCaller(actor)).toBe(true);
+  });
+
+  it("returns true when metadata.channel === 'ai'", () => {
+    const actor: Actor = {
+      type: "system",
+      id: "svc",
+      groups: baseGroups,
+      metadata: { channel: "ai" },
+    };
+    expect(isAiAgentCaller(actor)).toBe(true);
+  });
+
+  it("returns false for human actors with no AI metadata", () => {
+    const actor: Actor = { type: "human", id: "u1", groups: baseGroups };
+    expect(isAiAgentCaller(actor)).toBe(false);
+  });
+
+  it("returns false for system actors with no AI metadata", () => {
+    const actor: Actor = { type: "system", id: "svc", groups: baseGroups };
+    expect(isAiAgentCaller(actor)).toBe(false);
+  });
+
+  it("returns false for null/undefined actors", () => {
+    expect(isAiAgentCaller(null)).toBe(false);
+    expect(isAiAgentCaller(undefined)).toBe(false);
+  });
+});
+
+// ── shouldIncludeErrorContext policy ──────────────────────
+
+describe("shouldIncludeErrorContext", () => {
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env.NODE_ENV;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalEnv;
+    }
+  });
+
+  it("returns true in non-production for any actor", () => {
+    process.env.NODE_ENV = "development";
+    expect(shouldIncludeErrorContext({ type: "human", id: "u1", groups: [] })).toBe(true);
+    expect(shouldIncludeErrorContext(null)).toBe(true);
+  });
+
+  it("returns true in production only for AI/agent callers", () => {
+    process.env.NODE_ENV = "production";
+    expect(shouldIncludeErrorContext({ type: "ai", id: "agent", groups: [] })).toBe(true);
+    expect(
+      shouldIncludeErrorContext({
+        type: "human",
+        id: "u1",
+        groups: [],
+        metadata: { channel: "mcp" },
+      }),
+    ).toBe(true);
+    expect(shouldIncludeErrorContext({ type: "human", id: "u1", groups: [] })).toBe(false);
+    expect(shouldIncludeErrorContext(null)).toBe(false);
+  });
+
+  it("returns true in test env (NODE_ENV !== production)", () => {
+    process.env.NODE_ENV = "test";
+    expect(shouldIncludeErrorContext(null)).toBe(true);
+  });
+});
+
+// ── Integration: ConflictError context survives toResponse ─
+
+describe("ConflictError context plumbing", () => {
+  it("passes structured context for state-conflict errors", () => {
+    const err = new ConflictError({
+      code: "order.conflict.state",
+      message: "Cannot ship a draft order",
+      currentState: "draft",
+      expectedState: "approved",
+      context: {
+        entity: "order",
+        action: "ship_order",
+        field: "status",
+        constraint: "state_transition",
+        expected: "approved",
+        actual: "draft",
+        suggestion: "Approve the order before shipping",
+      },
+    });
+
+    const res = err.toResponse({ includeContext: true });
+    expect(res.error.context).toBeDefined();
+    expect(res.error.context?.constraint).toBe("state_transition");
+    expect(res.error.currentState).toBe("draft");
+  });
+});
+
+// ── Integration: BusinessRuleError context plumbing ────────
+
+describe("BusinessRuleError context plumbing", () => {
+  it("populates context with rule constraint and expected/actual", () => {
+    const err = new BusinessRuleError({
+      code: "purchase.rule.budget",
+      message: "Amount exceeds budget",
+      rules: [{ rule: "budget_check", effect: "block", message: "Over $50,000" }],
+      context: {
+        entity: "purchase_request",
+        action: "submit_request",
+        constraint: "budget_check",
+        expected: 50000,
+        actual: 75000,
+        suggestion: "Reduce the amount or split the request",
+        relatedDocs: ["docs/rules/budget.md"],
+      },
+    });
+
+    const res = err.toResponse({ includeContext: true });
+    expect(res.error.context?.constraint).toBe("budget_check");
+    expect(res.error.context?.expected).toBe(50000);
+    expect(res.error.context?.relatedDocs).toEqual(["docs/rules/budget.md"]);
   });
 });

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -43,7 +43,9 @@ export function isAiAgentCaller(actor: Actor | undefined | null): boolean {
   if (actor.type === "ai") return true;
   // Accept future literal "mcp" actor type without TS complaint.
   if ((actor.type as string) === "mcp") return true;
-  const channel = actor.metadata?.channel;
+  // Bracket notation keeps this resilient to `noPropertyAccessFromIndexSignature`
+  // (Record<string, unknown> can't be dot-accessed under that flag).
+  const channel = actor.metadata?.["channel"];
   return channel === "mcp" || channel === "ai";
 }
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -5,6 +5,7 @@
  * 401 = authentication (who are you?), 403 = authorization (no permission).
  */
 
+import type { Actor } from "./types/action";
 import type {
   AuthorizationErrorData,
   BusinessRuleErrorData,
@@ -19,6 +20,51 @@ import type {
   ValidationErrorData,
 } from "./types/error";
 import { ERROR_STATUS_MAP } from "./types/error";
+
+// ── Helpers ─────────────────────────────────────────────
+
+/**
+ * Returns true when the actor represents an autonomous AI agent (or an MCP
+ * caller that proxies AI requests). Used by `LinchKitError.toResponse` to
+ * decide whether to surface the structured `context` field in production
+ * responses (Spec 60 §3.4).
+ *
+ * The current `ActorType` union does not include a literal `"mcp"` value
+ * (see `packages/core/src/types/action.ts`). MCP callers identify themselves
+ * via `actor.metadata.channel === "mcp"` after CommandLayer dispatch — we
+ * detect that as a fallback. When/if a dedicated `"mcp"` actor type is
+ * introduced, this helper will start matching it without changes elsewhere.
+ *
+ * TODO(spec-60): widen `ActorType` to include `"mcp"` so this discriminant
+ * does not depend on the metadata fallback.
+ */
+export function isAiAgentCaller(actor: Actor | undefined | null): boolean {
+  if (!actor) return false;
+  if (actor.type === "ai") return true;
+  // Accept future literal "mcp" actor type without TS complaint.
+  if ((actor.type as string) === "mcp") return true;
+  const channel = actor.metadata?.channel;
+  return channel === "mcp" || channel === "ai";
+}
+
+/**
+ * Default policy for whether to include `context` in a serialized error
+ * response: always in non-production, otherwise only for AI/agent callers.
+ */
+export function shouldIncludeErrorContext(actor?: Actor | null): boolean {
+  if (process.env.NODE_ENV !== "production") return true;
+  return isAiAgentCaller(actor ?? null);
+}
+
+/** Options for `LinchKitError.toResponse`. */
+export interface ToResponseOptions {
+  /**
+   * Controls whether the AI-friendly `context` field is serialized into the
+   * wire response. Defaults to `true` (matches legacy behavior). Callers in
+   * production paths should pass `shouldIncludeErrorContext(actor)`.
+   */
+  includeContext?: boolean;
+}
 
 // ── Base error ──────────────────────────────────────────
 
@@ -48,8 +94,17 @@ export class LinchKitError extends Error {
     this.context = options.context;
   }
 
-  /** Convert to a standardized error response object. */
-  toResponse(): LinchKitErrorResponse {
+  /**
+   * Convert to a standardized error response object.
+   *
+   * `options.includeContext` controls whether the AI-friendly `context`
+   * field is serialized. Defaults to `true` for backwards compatibility;
+   * call sites that ship responses to untrusted callers in production should
+   * pass `shouldIncludeErrorContext(actor)` to gate the field on AI/agent
+   * callers only.
+   */
+  toResponse(options: ToResponseOptions = {}): LinchKitErrorResponse {
+    const { includeContext = true } = options;
     return {
       success: false,
       error: {
@@ -59,7 +114,7 @@ export class LinchKitError extends Error {
         ...(this.details !== undefined && { details: this.details }),
         ...(this.messageKey !== undefined && { messageKey: this.messageKey }),
         ...(this.messageParams !== undefined && { messageParams: this.messageParams }),
-        ...(this.context !== undefined && { context: this.context }),
+        ...(includeContext && this.context !== undefined && { context: this.context }),
       },
     };
   }
@@ -76,8 +131,8 @@ export class ValidationError extends LinchKitError {
     this.fields = options.fields;
   }
 
-  override toResponse(): LinchKitErrorResponse {
-    const base = super.toResponse();
+  override toResponse(options: ToResponseOptions = {}): LinchKitErrorResponse {
+    const base = super.toResponse(options);
     if (this.fields) {
       base.error.fields = this.fields;
     }
@@ -98,8 +153,8 @@ export class NotFoundError extends LinchKitError {
     this.resourceId = options.resourceId;
   }
 
-  override toResponse(): LinchKitErrorResponse {
-    const base = super.toResponse();
+  override toResponse(options: ToResponseOptions = {}): LinchKitErrorResponse {
+    const base = super.toResponse(options);
     if (this.resource || this.resourceId) {
       base.error.details = {
         ...base.error.details,
@@ -133,8 +188,8 @@ export class AuthorizationError extends LinchKitError {
     this.requiredPermissions = options.requiredPermissions;
   }
 
-  override toResponse(): LinchKitErrorResponse {
-    const base = super.toResponse();
+  override toResponse(options: ToResponseOptions = {}): LinchKitErrorResponse {
+    const base = super.toResponse(options);
     if (this.requiredGroups || this.requiredPermissions) {
       base.error.details = {
         ...base.error.details,
@@ -161,8 +216,8 @@ export class BusinessRuleError extends LinchKitError {
     this.approvalId = options.approvalId;
   }
 
-  override toResponse(): LinchKitErrorResponse {
-    const base = super.toResponse();
+  override toResponse(options: ToResponseOptions = {}): LinchKitErrorResponse {
+    const base = super.toResponse(options);
     if (this.rules) {
       base.error.rules = this.rules;
     }
@@ -188,8 +243,8 @@ export class ConflictError extends LinchKitError {
     this.expectedState = options.expectedState;
   }
 
-  override toResponse(): LinchKitErrorResponse {
-    const base = super.toResponse();
+  override toResponse(options: ToResponseOptions = {}): LinchKitErrorResponse {
+    const base = super.toResponse(options);
     if (this.currentVersion !== undefined) {
       base.error.currentVersion = this.currentVersion;
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -222,15 +222,18 @@ export {
   generateGinIndex,
   generateTranslatableIndexes,
 } from "./entity/translatable-index";
+export type { ToResponseOptions } from "./errors";
 // Error classes
 export {
   AuthenticationError,
   AuthorizationError,
   BusinessRuleError,
   ConflictError,
+  isAiAgentCaller,
   LinchKitError,
   NotFoundError,
   SystemError,
+  shouldIncludeErrorContext,
   ValidationError,
 } from "./errors";
 export type { EventBus, EventHandlerRegistry } from "./event/event-bus";

--- a/packages/core/src/types/error.ts
+++ b/packages/core/src/types/error.ts
@@ -28,6 +28,11 @@ export type ErrorType =
 /**
  * Structured context for AI agents to understand and fix errors autonomously.
  * Populated by engines (ActionEngine, RuleEngine, StateMachine, ValidationEngine).
+ *
+ * Visibility: see `LinchKitError.toResponse({ includeContext })`. In production
+ * this field is only serialized for AI/agent callers (`isAiAgentCaller`).
+ *
+ * Sensitive values: callers MUST redact secrets before populating `actual`.
  */
 export interface ErrorContext {
   /** Which entity was involved */
@@ -36,14 +41,16 @@ export interface ErrorContext {
   action?: string;
   /** Which field caused the issue */
   field?: string;
-  /** Which constraint failed (rule name, validation name) */
+  /** Which constraint failed (rule name, validation name, e.g. "required", "enum", "min", "format") */
   constraint?: string;
-  /** What was expected */
-  expected?: string;
-  /** What was provided */
-  actual?: string;
-  /** What to change (human-readable suggestion) */
+  /** What was expected (constraint value) */
+  expected?: unknown;
+  /** What was provided — already redacted if sensitive */
+  actual?: unknown;
+  /** What to change (one short, human-readable sentence) */
   suggestion?: string;
+  /** Spec / docs links the AI agent can follow for more context */
+  relatedDocs?: string[];
 }
 
 // ── Base error ────────────────────────────────────────


### PR DESCRIPTION
## Summary
Adds optional structured `context` field to `LinchKitError` so AI agents (MCP / AI actors) get diagnostic data they can act on, while human callers in production still see clean envelopes.

### `ErrorContext` shape
- `entity` / `action` / `field` — what was involved
- `constraint` — which check failed (`required`, `enum`, `min`, `format`, …)
- `expected` / `actual` — typed as `unknown` (call site redacts secrets)
- `suggestion` — short remediation hint
- `relatedDocs` — spec / doc URLs

### Visibility gating
- `isAiAgentCaller(actor)` — true for `actor.type === "ai"` OR `actor.metadata.channel === "mcp" | "ai"`. Forward-compat check for literal `"mcp"` type when `ActorType` is widened (TODO documented).
- `shouldIncludeErrorContext(actor)` — true in dev or when actor is an AI agent.
- `LinchKitError.toResponse({ includeContext })` + 5 subclass overrides — context only on the wire when allowed.

### Engine sites populated
- **action-engine**: 8 sites (action-not-found, exposure, input-validation, lock-preflight-fetch-failure, lock-violation, pre-validation, state-transition-from-mismatch, state-machine-blocked).
- **state-machine**: 2 sites in `transition()`.
- **rule-engine**: block + warn effects push contexts via `output.contexts[]`.
- `validation-engine` intentionally untouched — its `ValidationError[]` shape belongs to the proposal pipeline, not LinchKitError.

### Deferrals
- `ActorType` widening to include literal `"mcp"`: cross-cutting; TODO at `errors.ts` documents the planned change. Metadata-channel fallback covers MCP today.

## Test plan
- [x] 19 new tests in `error-context.test.ts` (extended fields, includeContext gating, isAiAgentCaller, shouldIncludeErrorContext, integration on ConflictError + BusinessRuleError)
- [x] Full `packages/core/` suite — 3181/3181 pass
- [x] `bun test` — 4730 pass / 0 fail (1 unrelated `linch install` network flake, issue #221)
- [x] `bun run typecheck` / `bun run check` — clean

## Refs
- Spec 60 (`docs/specs/60_ai_workspace.md`)
- Closes the Phase 5 deliverable on tracking issue #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI agent caller detection with intelligent error context inclusion
  * Enhanced error responses include related documentation and structured validation context
  * Environment-aware error detail visibility (development, production, and test modes)

* **Improvements**
  * Error messages now provide richer context (expected/actual values, resource details, business rules, version conflicts)
  * Configurable error response detail levels based on caller type and environment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->