### PR TITLE
feat(adapter-ui): proposal pre-analysis impact preview UI (closes #166)

### DIFF
--- a/addons/adapter-ui/cap-adapter-ui/__tests__/proposal-impact-preview.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/proposal-impact-preview.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Tests for ProposalImpactPreview helpers (Spec 55 §7.3).
+ *
+ * The component itself is JSX-only — we test the pure data-shaping helpers
+ * since the existing test setup is logic-only (no happy-dom / jsdom). The
+ * helpers cover every branch the component renders:
+ *   - tone derivation per stage status / conflict kind
+ *   - conflict grouping by `kind`
+ *   - summarizing a full / partial / null pipeline result
+ */
+
+import { describe, expect, test } from "bun:test";
+import type {
+  ConflictFinding,
+  ProposalDefinition,
+  ProposalPreAnalysisResult,
+} from "@linchkit/core";
+import {
+  groupConflicts,
+  STAGE_ORDER,
+  summarizePreAnalysis,
+  toneForConflict,
+  toneForStatus,
+} from "../src/components/proposal-impact-preview-helpers";
+
+// ── Fixtures ────────────────────────────────────────────────
+
+const NOW = new Date("2026-05-06T00:00:00Z");
+
+function makeProposal(id: string): ProposalDefinition {
+  return {
+    id,
+    title: `Proposal ${id}`,
+    description: "fixture",
+    author: { type: "ai", id: "ai", name: "AI" },
+    capability: "demo",
+    changeType: "minor",
+    changes: [],
+    impact: {
+      schemasAffected: [],
+      actionsAffected: [],
+      rulesAffected: [],
+      dependentsAffected: [],
+      migrationRequired: false,
+    },
+    status: "draft",
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+}
+
+const findings: ConflictFinding[] = [
+  { kind: "rule", targetId: "rule.a", message: "rule a" },
+  { kind: "state_transition", targetId: "state.b", message: "state b" },
+  { kind: "proposal", targetId: "prop.c", message: "prop c" },
+  { kind: "other", targetId: "x", message: "other x" },
+  { kind: "rule", targetId: "rule.d", message: "rule d" },
+];
+
+// ── Stage order ────────────────────────────────────────────
+
+describe("STAGE_ORDER", () => {
+  test("matches Spec 55 §7.3 canonical order", () => {
+    expect(STAGE_ORDER).toEqual(["dedup", "conflict", "impact", "backtest"]);
+  });
+});
+
+// ── toneForStatus ──────────────────────────────────────────
+
+describe("toneForStatus", () => {
+  test("ok → success", () => {
+    expect(toneForStatus("ok")).toBe("success");
+  });
+
+  test("error → error", () => {
+    expect(toneForStatus("error")).toBe("error");
+  });
+
+  test("skipped → muted", () => {
+    expect(toneForStatus("skipped")).toBe("muted");
+  });
+
+  test("undefined → muted (defensive default)", () => {
+    expect(toneForStatus(undefined)).toBe("muted");
+  });
+});
+
+// ── toneForConflict ────────────────────────────────────────
+
+describe("toneForConflict", () => {
+  test("rule kind escalates to error", () => {
+    expect(toneForConflict({ kind: "rule", targetId: "r", message: "" })).toBe("error");
+  });
+
+  test("state_transition stays warning", () => {
+    expect(toneForConflict({ kind: "state_transition", targetId: "s", message: "" })).toBe(
+      "warning",
+    );
+  });
+
+  test("proposal stays warning", () => {
+    expect(toneForConflict({ kind: "proposal", targetId: "p", message: "" })).toBe("warning");
+  });
+
+  test("other stays warning", () => {
+    expect(toneForConflict({ kind: "other", targetId: "x", message: "" })).toBe("warning");
+  });
+});
+
+// ── groupConflicts ─────────────────────────────────────────
+
+describe("groupConflicts", () => {
+  test("groups by kind preserving input order within each group", () => {
+    const grouped = groupConflicts(findings);
+    expect(grouped.rule.map((f) => f.targetId)).toEqual(["rule.a", "rule.d"]);
+    expect(grouped.state_transition.map((f) => f.targetId)).toEqual(["state.b"]);
+    expect(grouped.proposal.map((f) => f.targetId)).toEqual(["prop.c"]);
+    expect(grouped.other.map((f) => f.targetId)).toEqual(["x"]);
+  });
+
+  test("empty input yields empty groups", () => {
+    const grouped = groupConflicts([]);
+    expect(grouped.rule).toEqual([]);
+    expect(grouped.state_transition).toEqual([]);
+    expect(grouped.proposal).toEqual([]);
+    expect(grouped.other).toEqual([]);
+  });
+});
+
+// ── summarizePreAnalysis ───────────────────────────────────
+
+describe("summarizePreAnalysis", () => {
+  test("null result → empty summary (defensive)", () => {
+    expect(summarizePreAnalysis(null)).toEqual({
+      hasData: false,
+      ranCount: 0,
+      errorCount: 0,
+      skippedCount: 0,
+      totalFindings: 0,
+    });
+  });
+
+  test("undefined result → empty summary (defensive)", () => {
+    expect(summarizePreAnalysis(undefined)).toEqual({
+      hasData: false,
+      ranCount: 0,
+      errorCount: 0,
+      skippedCount: 0,
+      totalFindings: 0,
+    });
+  });
+
+  test("counts errors, skipped, and total findings across stages", () => {
+    const result: ProposalPreAnalysisResult = {
+      proposalId: "p1",
+      analyzedAt: NOW,
+      totalDurationMs: 50,
+      allStagesSucceeded: false,
+      stages: {
+        dedup: {
+          stage: "dedup",
+          status: "ok",
+          durationMs: 10,
+          data: {
+            payloadHash: "h",
+            exactMatch: null,
+            similar: [makeProposal("a"), makeProposal("b")],
+          },
+        },
+        conflict: {
+          stage: "conflict",
+          status: "ok",
+          durationMs: 10,
+          data: {
+            conflicts: [
+              { kind: "rule", targetId: "r", message: "" },
+              { kind: "proposal", targetId: "p", message: "" },
+            ],
+          },
+        },
+        impact: {
+          stage: "impact",
+          status: "error",
+          durationMs: 5,
+          error: { code: "X", message: "boom" },
+        },
+        backtest: { stage: "backtest", status: "skipped", durationMs: 0 },
+      },
+    };
+    const summary = summarizePreAnalysis(result);
+    expect(summary).toEqual({
+      hasData: true,
+      ranCount: 4,
+      errorCount: 1,
+      skippedCount: 1,
+      totalFindings: 4, // 2 dedup + 2 conflict
+    });
+  });
+
+  test("missing stages are not counted as ran", () => {
+    const result: ProposalPreAnalysisResult = {
+      proposalId: "p2",
+      analyzedAt: NOW,
+      totalDurationMs: 5,
+      allStagesSucceeded: true,
+      stages: {
+        dedup: {
+          stage: "dedup",
+          status: "ok",
+          durationMs: 5,
+          data: { payloadHash: "h", exactMatch: null, similar: [] },
+        },
+      },
+    };
+    const summary = summarizePreAnalysis(result);
+    expect(summary.ranCount).toBe(1);
+    expect(summary.errorCount).toBe(0);
+    expect(summary.skippedCount).toBe(0);
+    expect(summary.totalFindings).toBe(0);
+    expect(summary.hasData).toBe(true);
+  });
+
+  test("skipped/error stages contribute zero findings even with no data", () => {
+    const result: ProposalPreAnalysisResult = {
+      proposalId: "p3",
+      analyzedAt: NOW,
+      totalDurationMs: 0,
+      allStagesSucceeded: false,
+      stages: {
+        dedup: { stage: "dedup", status: "skipped", durationMs: 0 },
+        conflict: {
+          stage: "conflict",
+          status: "error",
+          durationMs: 0,
+          error: { code: "E", message: "bad" },
+        },
+      },
+    };
+    const summary = summarizePreAnalysis(result);
+    expect(summary.totalFindings).toBe(0);
+    expect(summary.errorCount).toBe(1);
+    expect(summary.skippedCount).toBe(1);
+  });
+
+  test("ok stage with missing data is tolerated (no crash)", () => {
+    // Defensive: an analyzer reporting status=ok but no data field shouldn't
+    // explode the summarizer. The shape stays valid because the helper guards
+    // on `stage.data` truthiness before reading shape-specific arrays.
+    const result: ProposalPreAnalysisResult = {
+      proposalId: "p4",
+      analyzedAt: NOW,
+      totalDurationMs: 0,
+      allStagesSucceeded: true,
+      stages: {
+        dedup: { stage: "dedup", status: "ok", durationMs: 0 },
+      },
+    };
+    const summary = summarizePreAnalysis(result);
+    expect(summary.totalFindings).toBe(0);
+    expect(summary.ranCount).toBe(1);
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/src/app.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/app.tsx
@@ -32,6 +32,7 @@ import { EntityListPage } from "./pages/entity-list";
 import { EvolutionPage } from "./pages/evolution";
 import { FlowDetailPage } from "./pages/flow-detail";
 import { MetricsDashboardPage } from "./pages/metrics-dashboard";
+import { ProposalReviewDemoPage } from "./pages/proposal-review-demo";
 import { RelationGraphPage } from "./pages/relation-graph";
 import { RuleDetailPage } from "./pages/rule-detail";
 import { StateMachineDetailPage } from "./pages/state-machines";
@@ -221,6 +222,15 @@ function buildRouter(appConfig: AppConfig) {
     beforeLoad: buildPageBeforeLoad("required", "/login", authEnabled),
   });
 
+  // Spec 55 §7.3 — pre-analysis review panel demo. Renders mock fixtures so the
+  // panel is reviewable end-to-end before a real proposal review page lands.
+  const proposalReviewDemoRoute = createRoute({
+    getParentRoute: () => shellRoute,
+    path: "/admin/proposals/preview-demo",
+    component: ProposalReviewDemoPage,
+    beforeLoad: buildPageBeforeLoad("required", "/login", authEnabled),
+  });
+
   // Build capability page routes from server response
   const pageRegistrations = capabilityPages as PageRegistration[];
 
@@ -238,6 +248,7 @@ function buildRouter(appConfig: AppConfig) {
       configCenterRoute,
       relationGraphRoute,
       metricsDashboardRoute,
+      proposalReviewDemoRoute,
       ...pageRegistrations
         .filter((page) => page.layout === "shell")
         .map((p) => createCapabilityPageRoute(p, authEnabled)),

--- a/addons/adapter-ui/cap-adapter-ui/src/components/proposal-impact-preview-helpers.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/proposal-impact-preview-helpers.ts
@@ -7,6 +7,8 @@
 
 import type {
   ConflictFinding,
+  ConflictResult,
+  DedupResult,
   PreAnalysisStage,
   PreAnalysisStageResult,
   ProposalPreAnalysisResult,
@@ -123,10 +125,10 @@ export function summarizePreAnalysis(
     if (stage.status === "skipped") skippedCount += 1;
     if (stage.status === "ok" && stage.data) {
       if (stageKey === "dedup") {
-        const dedup = stage.data as { similar?: unknown[] };
+        const dedup = stage.data as DedupResult;
         totalFindings += dedup.similar?.length ?? 0;
       } else if (stageKey === "conflict") {
-        const conflict = stage.data as { conflicts?: unknown[] };
+        const conflict = stage.data as ConflictResult;
         totalFindings += conflict.conflicts?.length ?? 0;
       }
     }

--- a/addons/adapter-ui/cap-adapter-ui/src/components/proposal-impact-preview-helpers.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/proposal-impact-preview-helpers.ts
@@ -1,0 +1,142 @@
+/**
+ * Helpers for ProposalImpactPreview (Spec 55 §7.3).
+ *
+ * Kept separate from the JSX component so the data-shaping logic can be
+ * unit-tested without a DOM. The component file imports from here.
+ */
+
+import type {
+  ConflictFinding,
+  PreAnalysisStage,
+  PreAnalysisStageResult,
+  ProposalPreAnalysisResult,
+} from "@linchkit/core";
+
+// ── Tone / severity ─────────────────────────────────────────
+
+/**
+ * Visual tone for a stage outcome or a finding.
+ *
+ * Spec 55 §7.3 talks about Error/Warning/Info severities but the current
+ * envelope types don't carry an explicit `severity` field — so we derive a
+ * tone from what's available (status, conflict kind, etc).
+ */
+export type Tone = "error" | "warning" | "success" | "info" | "muted";
+
+/** Tone for the whole stage envelope based on its status. */
+export function toneForStatus(status: PreAnalysisStageResult["status"] | undefined): Tone {
+  switch (status) {
+    case "ok":
+      return "success";
+    case "error":
+      return "error";
+    case "skipped":
+      return "muted";
+    default:
+      return "muted";
+  }
+}
+
+/**
+ * Tone for a single conflict finding. Rule conflicts are treated as errors;
+ * everything else is a warning. This matches Spec 55 §7.3's intent that an
+ * active rule clash blocks the proposal while softer conflicts only warn.
+ */
+export function toneForConflict(finding: ConflictFinding): Tone {
+  return finding.kind === "rule" ? "error" : "warning";
+}
+
+// ── Stage ordering ─────────────────────────────────────────
+
+/** Canonical render order for the four stages from Spec 55 §7.3. */
+export const STAGE_ORDER: readonly PreAnalysisStage[] = [
+  "dedup",
+  "conflict",
+  "impact",
+  "backtest",
+] as const;
+
+// ── Conflict grouping ──────────────────────────────────────
+
+/** Conflict findings grouped by kind, preserving original order within each group. */
+export interface GroupedConflicts {
+  rule: ConflictFinding[];
+  state_transition: ConflictFinding[];
+  proposal: ConflictFinding[];
+  other: ConflictFinding[];
+}
+
+/** Group conflict findings by `kind` for sectioned rendering. */
+export function groupConflicts(findings: readonly ConflictFinding[]): GroupedConflicts {
+  const grouped: GroupedConflicts = {
+    rule: [],
+    state_transition: [],
+    proposal: [],
+    other: [],
+  };
+  for (const f of findings) {
+    grouped[f.kind].push(f);
+  }
+  return grouped;
+}
+
+// ── Stage status summary ───────────────────────────────────
+
+/** Compact summary of a pipeline result for header / banner rendering. */
+export interface PreAnalysisSummary {
+  /** True if the result was produced (non-null) and at least one stage ran. */
+  hasData: boolean;
+  /** Number of stages that ran (any status). */
+  ranCount: number;
+  /** Number of stages with status === "error". */
+  errorCount: number;
+  /** Number of stages with status === "skipped". */
+  skippedCount: number;
+  /** Total findings across all stages that report them (dedup similar + conflict). */
+  totalFindings: number;
+}
+
+/** Build a defensive summary from a possibly-null pipeline result. */
+export function summarizePreAnalysis(
+  result: ProposalPreAnalysisResult | null | undefined,
+): PreAnalysisSummary {
+  if (!result) {
+    return {
+      hasData: false,
+      ranCount: 0,
+      errorCount: 0,
+      skippedCount: 0,
+      totalFindings: 0,
+    };
+  }
+
+  let ranCount = 0;
+  let errorCount = 0;
+  let skippedCount = 0;
+  let totalFindings = 0;
+
+  for (const stageKey of STAGE_ORDER) {
+    const stage = result.stages[stageKey];
+    if (!stage) continue;
+    ranCount += 1;
+    if (stage.status === "error") errorCount += 1;
+    if (stage.status === "skipped") skippedCount += 1;
+    if (stage.status === "ok" && stage.data) {
+      if (stageKey === "dedup") {
+        const dedup = stage.data as { similar?: unknown[] };
+        totalFindings += dedup.similar?.length ?? 0;
+      } else if (stageKey === "conflict") {
+        const conflict = stage.data as { conflicts?: unknown[] };
+        totalFindings += conflict.conflicts?.length ?? 0;
+      }
+    }
+  }
+
+  return {
+    hasData: ranCount > 0,
+    ranCount,
+    errorCount,
+    skippedCount,
+    totalFindings,
+  };
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/components/proposal-impact-preview-stages.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/proposal-impact-preview-stages.tsx
@@ -1,0 +1,270 @@
+/**
+ * Per-stage subviews for ProposalImpactPreview (Spec 55 §7.3).
+ *
+ * Pulled out of the main component file to keep each module under the
+ * 300-line cap. The shared tone → tailwind class maps live alongside the
+ * helpers; everything here is pure JSX that renders one stage's payload.
+ */
+
+import type {
+  BacktestResult,
+  ConflictFinding,
+  ConflictResult,
+  DedupResult,
+  ImpactResult,
+  PreAnalysisStageResult,
+} from "@linchkit/core";
+import { Badge } from "@linchkit/ui-kit/components";
+import {
+  AlertTriangleIcon,
+  CheckCircle2Icon,
+  MinusCircleIcon,
+  ShieldAlertIcon,
+  XCircleIcon,
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { groupConflicts, toneForConflict } from "./proposal-impact-preview-helpers";
+
+// ── Tone → border class (also used by the parent for stage borders) ─────
+
+export const TONE_BORDER_CLASS = {
+  error: "border-l-destructive",
+  warning: "border-l-amber-500",
+  success: "border-l-emerald-500",
+  info: "border-l-blue-500",
+  muted: "border-l-muted-foreground/40",
+} as const;
+
+// ── Placeholder + error blocks ─────────────────────────────
+
+export function MutedPlaceholder({ messageKey }: { messageKey: string }) {
+  const { t } = useTranslation();
+  return (
+    <div className="flex items-center gap-2 text-xs text-muted-foreground">
+      <MinusCircleIcon className="h-3.5 w-3.5" />
+      <span>{t(messageKey)}</span>
+    </div>
+  );
+}
+
+export function ErrorBlock({ envelope }: { envelope: PreAnalysisStageResult }) {
+  const { t } = useTranslation();
+  const code = envelope.error?.code ?? "UNKNOWN";
+  const message = envelope.error?.message ?? t("proposals.preanalysis.unknownError");
+  return (
+    <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3">
+      <div className="flex items-start gap-2">
+        <XCircleIcon className="h-4 w-4 text-destructive shrink-0 mt-0.5" />
+        <div className="text-xs">
+          <div className="font-mono text-destructive">{code}</div>
+          <div className="mt-1 text-foreground">{message}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Dedup view ─────────────────────────────────────────────
+
+export function DedupView({ data }: { data: DedupResult }) {
+  const { t } = useTranslation();
+  const hasExact = data.exactMatch !== null;
+  const similarCount = data.similar.length;
+
+  if (!hasExact && similarCount === 0) {
+    return (
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <CheckCircle2Icon className="h-3.5 w-3.5 text-emerald-500" />
+        <span>{t("proposals.preanalysis.stages.dedup.empty")}</span>
+        <span className="ml-auto font-mono text-[10px]">{data.payloadHash}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {hasExact && data.exactMatch && (
+        <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3">
+          <div className="flex items-start gap-2">
+            <ShieldAlertIcon className="h-4 w-4 text-destructive shrink-0 mt-0.5" />
+            <div className="text-xs">
+              <div className="font-medium text-destructive">
+                {t("proposals.preanalysis.stages.dedup.exactMatchBanner")}
+              </div>
+              <div className="mt-1 text-foreground">
+                <span className="font-mono">{data.exactMatch.id}</span>
+                {" — "}
+                {data.exactMatch.title}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+      {similarCount > 0 && (
+        <div className="space-y-2">
+          <div className="text-xs font-medium text-muted-foreground">
+            {t("proposals.preanalysis.stages.dedup.similarHeader", { count: similarCount })}
+          </div>
+          <ul className="space-y-1">
+            {data.similar.map((p) => (
+              <li
+                key={p.id}
+                className="flex items-center gap-2 rounded border bg-muted/30 px-2 py-1.5 text-xs"
+              >
+                <span className="font-mono text-muted-foreground">{p.id}</span>
+                <span className="truncate">{p.title}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <div className="text-[10px] text-muted-foreground font-mono">
+        {t("proposals.preanalysis.stages.dedup.payloadHash")}: {data.payloadHash}
+      </div>
+    </div>
+  );
+}
+
+// ── Conflict view ──────────────────────────────────────────
+
+function ConflictGroup({
+  kind,
+  findings,
+}: {
+  kind: ConflictFinding["kind"];
+  findings: ConflictFinding[];
+}) {
+  const { t } = useTranslation();
+  if (findings.length === 0) return null;
+  return (
+    <div className="space-y-1.5">
+      <div className="text-xs font-medium text-muted-foreground">
+        {t(`proposals.preanalysis.stages.conflict.kinds.${kind}`)} · {findings.length}
+      </div>
+      <ul className="space-y-1">
+        {findings.map((f, idx) => {
+          const tone = toneForConflict(f);
+          return (
+            <li
+              // biome-ignore lint/suspicious/noArrayIndexKey: findings have no stable id
+              key={`${f.kind}-${f.targetId}-${idx}`}
+              className={`flex items-start gap-2 rounded border-l-2 ${TONE_BORDER_CLASS[tone]} bg-muted/30 px-2 py-1.5 text-xs`}
+            >
+              <AlertTriangleIcon
+                className={`h-3.5 w-3.5 shrink-0 mt-0.5 ${
+                  tone === "error" ? "text-destructive" : "text-amber-500"
+                }`}
+              />
+              <div className="min-w-0 flex-1">
+                <div className="font-mono text-muted-foreground">{f.targetId}</div>
+                <div className="text-foreground">{f.message}</div>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+export function ConflictView({ data }: { data: ConflictResult }) {
+  const { t } = useTranslation();
+  if (data.conflicts.length === 0) {
+    return (
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <CheckCircle2Icon className="h-3.5 w-3.5 text-emerald-500" />
+        <span>{t("proposals.preanalysis.stages.conflict.empty")}</span>
+        {data.notes && <span className="ml-auto italic">{data.notes}</span>}
+      </div>
+    );
+  }
+  const grouped = groupConflicts(data.conflicts);
+  return (
+    <div className="space-y-3">
+      <ConflictGroup kind="rule" findings={grouped.rule} />
+      <ConflictGroup kind="state_transition" findings={grouped.state_transition} />
+      <ConflictGroup kind="proposal" findings={grouped.proposal} />
+      <ConflictGroup kind="other" findings={grouped.other} />
+      {data.notes && <div className="text-[10px] italic text-muted-foreground">{data.notes}</div>}
+    </div>
+  );
+}
+
+// ── Impact view ────────────────────────────────────────────
+
+export function ImpactView({ data }: { data: ImpactResult }) {
+  const { t } = useTranslation();
+  return (
+    <div className="space-y-3">
+      <div className="flex items-baseline gap-2">
+        <span className="text-2xl font-semibold tabular-nums">{data.affectedRecordCount}</span>
+        <span className="text-xs text-muted-foreground">
+          {t("proposals.preanalysis.stages.impact.recordsAffected")}
+        </span>
+      </div>
+
+      {data.reason && (
+        <div className="rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
+          {data.reason}
+        </div>
+      )}
+
+      {data.probedEntities.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-xs text-muted-foreground">
+            {t("proposals.preanalysis.stages.impact.probedEntities")}:
+          </span>
+          {data.probedEntities.map((entity) => (
+            <Badge key={entity} variant="outline" className="text-[10px] font-mono">
+              {entity}
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      {data.sampleRecordIds.length > 0 && (
+        <div className="space-y-1.5">
+          <div className="text-xs font-medium text-muted-foreground">
+            {t("proposals.preanalysis.stages.impact.sample", {
+              count: data.sampleRecordIds.length,
+            })}
+          </div>
+          <ul className="flex flex-wrap gap-1">
+            {data.sampleRecordIds.map((id) => (
+              <li key={id} className="rounded border bg-muted/30 px-2 py-0.5 text-[11px] font-mono">
+                {id}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Backtest view ──────────────────────────────────────────
+
+export function BacktestView({ data }: { data: BacktestResult }) {
+  const { t } = useTranslation();
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-2 gap-3">
+        <div className="rounded-md border bg-muted/30 p-3">
+          <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+            {t("proposals.preanalysis.stages.backtest.windowDays")}
+          </div>
+          <div className="mt-1 text-xl font-semibold tabular-nums">{data.windowDays}</div>
+        </div>
+        <div className="rounded-md border bg-muted/30 p-3">
+          <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+            {t("proposals.preanalysis.stages.backtest.triggers")}
+          </div>
+          <div className="mt-1 text-xl font-semibold tabular-nums">
+            {data.hypotheticalTriggerCount}
+          </div>
+        </div>
+      </div>
+      {data.summary && <div className="rounded-md bg-muted/40 p-3 text-xs">{data.summary}</div>}
+    </div>
+  );
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/components/proposal-impact-preview.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/proposal-impact-preview.tsx
@@ -1,0 +1,223 @@
+/**
+ * ProposalImpactPreview — Spec 55 §7.3 review panel.
+ *
+ * Renders the four pre-analysis stages (dedup, conflict, impact, backtest)
+ * for a Proposal that has been run through the pre-analysis pipeline.
+ *
+ * Each stage is a collapsible Card section. Stages with status === "skipped"
+ * or no data render a muted placeholder. Stages with errors surface the
+ * error code + message. The component is purely presentational — it never
+ * invokes the analyzer pipeline itself.
+ *
+ * Closes the last open deliverable on Spec 55 §7.3.
+ */
+
+import type {
+  BacktestResult,
+  ConflictResult,
+  DedupResult,
+  ImpactResult,
+  PreAnalysisStage,
+  PreAnalysisStageResult,
+  ProposalPreAnalysisResult,
+} from "@linchkit/core";
+import {
+  Badge,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@linchkit/ui-kit/components";
+import {
+  ChevronDownIcon,
+  ChevronRightIcon,
+  CopyIcon,
+  DatabaseIcon,
+  GitMergeIcon,
+  HistoryIcon,
+} from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { STAGE_ORDER, type Tone, toneForStatus } from "./proposal-impact-preview-helpers";
+import {
+  BacktestView,
+  ConflictView,
+  DedupView,
+  ErrorBlock,
+  ImpactView,
+  MutedPlaceholder,
+  TONE_BORDER_CLASS,
+} from "./proposal-impact-preview-stages";
+
+// ── Component props ────────────────────────────────────────
+
+export interface ProposalImpactPreviewProps {
+  /** Pre-analysis result. Pass null/undefined to render an empty placeholder. */
+  result: ProposalPreAnalysisResult | null | undefined;
+  /** Optional className for outer wrapper. */
+  className?: string;
+}
+
+// ── Tone → badge class (status pill colours) ───────────────
+
+const TONE_BADGE_CLASS: Record<Tone, string> = {
+  error: "bg-destructive/10 text-destructive border-destructive/30",
+  warning: "bg-amber-500/10 text-amber-700 dark:text-amber-400 border-amber-500/30",
+  success: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 border-emerald-500/30",
+  info: "bg-blue-500/10 text-blue-700 dark:text-blue-400 border-blue-500/30",
+  muted: "bg-muted text-muted-foreground border-border",
+};
+
+// ── Stage icons ────────────────────────────────────────────
+
+const STAGE_ICON: Record<PreAnalysisStage, typeof CopyIcon> = {
+  dedup: CopyIcon,
+  conflict: GitMergeIcon,
+  impact: DatabaseIcon,
+  backtest: HistoryIcon,
+};
+
+// ── Status badge ───────────────────────────────────────────
+
+function StatusBadge({ status }: { status: PreAnalysisStageResult["status"] | undefined }) {
+  const { t } = useTranslation();
+  const tone = toneForStatus(status);
+  const labelKey =
+    status === "ok"
+      ? "proposals.preanalysis.status.ok"
+      : status === "error"
+        ? "proposals.preanalysis.status.error"
+        : status === "skipped"
+          ? "proposals.preanalysis.status.skipped"
+          : "proposals.preanalysis.status.notRun";
+  return (
+    <Badge variant="outline" className={`text-[10px] ${TONE_BADGE_CLASS[tone]}`}>
+      {t(labelKey)}
+    </Badge>
+  );
+}
+
+// ── Stage shell (collapsible card around each stage) ───────
+
+function StageShell({
+  stage,
+  envelope,
+  children,
+}: {
+  stage: PreAnalysisStage;
+  envelope: PreAnalysisStageResult | undefined;
+  children: React.ReactNode;
+}) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(true);
+  const Icon = STAGE_ICON[stage];
+  const tone = toneForStatus(envelope?.status);
+  const titleKey = `proposals.preanalysis.stages.${stage}.title`;
+
+  return (
+    <Card className={`border-l-4 ${TONE_BORDER_CLASS[tone]}`}>
+      <Collapsible open={open} onOpenChange={setOpen}>
+        <CollapsibleTrigger asChild>
+          <CardHeader className="cursor-pointer pb-3 hover:bg-muted/30 transition-colors">
+            <div className="flex items-center justify-between gap-2">
+              <CardTitle className="flex items-center gap-2 text-sm font-medium">
+                {open ? (
+                  <ChevronDownIcon className="h-3.5 w-3.5 text-muted-foreground" />
+                ) : (
+                  <ChevronRightIcon className="h-3.5 w-3.5 text-muted-foreground" />
+                )}
+                <Icon className="h-4 w-4 text-muted-foreground" />
+                {t(titleKey)}
+              </CardTitle>
+              <div className="flex items-center gap-2">
+                <StatusBadge status={envelope?.status} />
+                {envelope?.durationMs !== undefined && (
+                  <span className="text-[10px] text-muted-foreground">
+                    {Math.round(envelope.durationMs)}ms
+                  </span>
+                )}
+              </div>
+            </div>
+          </CardHeader>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <CardContent className="pt-0 text-sm">{children}</CardContent>
+        </CollapsibleContent>
+      </Collapsible>
+    </Card>
+  );
+}
+
+// ── Stage render dispatcher ────────────────────────────────
+
+function StageBody({
+  stage,
+  envelope,
+}: {
+  stage: PreAnalysisStage;
+  envelope: PreAnalysisStageResult | undefined;
+}) {
+  if (!envelope) {
+    return <MutedPlaceholder messageKey={`proposals.preanalysis.stages.${stage}.notRun`} />;
+  }
+  if (envelope.status === "skipped") {
+    return <MutedPlaceholder messageKey={`proposals.preanalysis.stages.${stage}.skipped`} />;
+  }
+  if (envelope.status === "error") {
+    return <ErrorBlock envelope={envelope} />;
+  }
+  if (!envelope.data) {
+    return <MutedPlaceholder messageKey={`proposals.preanalysis.stages.${stage}.noData`} />;
+  }
+
+  switch (stage) {
+    case "dedup":
+      return <DedupView data={envelope.data as DedupResult} />;
+    case "conflict":
+      return <ConflictView data={envelope.data as ConflictResult} />;
+    case "impact":
+      return <ImpactView data={envelope.data as ImpactResult} />;
+    case "backtest":
+      return <BacktestView data={envelope.data as BacktestResult} />;
+    default:
+      return null;
+  }
+}
+
+// ── Main component ─────────────────────────────────────────
+
+export function ProposalImpactPreview({ result, className }: ProposalImpactPreviewProps) {
+  const { t } = useTranslation();
+
+  if (!result) {
+    return (
+      <Card className={className}>
+        <CardContent className="py-8 text-center text-sm text-muted-foreground">
+          {t("proposals.preanalysis.empty")}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className={`space-y-3 ${className ?? ""}`}>
+      <div className="flex flex-wrap items-center gap-2">
+        <h3 className="text-sm font-semibold">{t("proposals.preanalysis.heading")}</h3>
+        <span className="text-[11px] text-muted-foreground">
+          {new Date(result.analyzedAt).toLocaleString()}
+        </span>
+        <span className="ml-auto text-[11px] text-muted-foreground">
+          {Math.round(result.totalDurationMs)}ms
+        </span>
+      </div>
+      {STAGE_ORDER.map((stage) => (
+        <StageShell key={stage} stage={stage} envelope={result.stages[stage]}>
+          <StageBody stage={stage} envelope={result.stages[stage]} />
+        </StageShell>
+      ))}
+    </div>
+  );
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
@@ -744,7 +744,72 @@
     "phase": "Phase {{phase}}: {{status}}",
     "phaseErrors": "{{count}} error",
     "phaseErrors_other": "{{count}} errors",
-    "defaultRejectReason": "Rejected by user"
+    "defaultRejectReason": "Rejected by user",
+    "preanalysis": {
+      "heading": "Pre-Analysis",
+      "empty": "No pre-analysis result available for this proposal.",
+      "unknownError": "Analyzer failed without an error message.",
+      "status": {
+        "ok": "OK",
+        "error": "Error",
+        "skipped": "Skipped",
+        "notRun": "Not run"
+      },
+      "stages": {
+        "dedup": {
+          "title": "Deduplication",
+          "empty": "No similar pending proposals.",
+          "exactMatchBanner": "Exact match against an existing pending proposal",
+          "similarHeader": "{{count}} similar proposal",
+          "similarHeader_other": "{{count}} similar proposals",
+          "payloadHash": "Payload hash",
+          "skipped": "Deduplication was skipped.",
+          "notRun": "Deduplication did not run for this proposal.",
+          "noData": "Deduplication completed without producing data."
+        },
+        "conflict": {
+          "title": "Conflict Detection",
+          "empty": "No conflicts detected.",
+          "kinds": {
+            "rule": "Rule conflicts",
+            "state_transition": "State transition conflicts",
+            "proposal": "Pending proposal conflicts",
+            "other": "Other conflicts"
+          },
+          "skipped": "Conflict detection was skipped.",
+          "notRun": "Conflict detection did not run for this proposal.",
+          "noData": "Conflict analyzer completed without producing data."
+        },
+        "impact": {
+          "title": "Impact Estimation",
+          "recordsAffected": "records affected",
+          "probedEntities": "Probed entities",
+          "sample": "Sample of {{count}} record",
+          "sample_other": "Sample of {{count}} records",
+          "skipped": "Impact estimation was skipped.",
+          "notRun": "Impact estimation did not run for this proposal.",
+          "noData": "Impact analyzer completed without producing data."
+        },
+        "backtest": {
+          "title": "Backtest",
+          "windowDays": "Window (days)",
+          "triggers": "Hypothetical triggers",
+          "skipped": "Backtest was skipped.",
+          "notRun": "Backtest did not run for this proposal.",
+          "noData": "Backtest analyzer completed without producing data."
+        }
+      },
+      "demo": {
+        "title": "Proposal Pre-Analysis Preview",
+        "subtitle": "Demo fixtures for the four-stage review panel (Spec 55 §7.3).",
+        "fixtures": {
+          "full": "All four stages",
+          "error": "Error + skipped",
+          "partial": "Partial (dedup only)",
+          "empty": "Empty / null"
+        }
+      }
+    }
   },
   "evolution": {
     "title": "Evolution History",

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
@@ -744,7 +744,72 @@
     "phase": "阶段 {{phase}}：{{status}}",
     "phaseErrors": "{{count}} 个错误",
     "phaseErrors_other": "{{count}} 个错误",
-    "defaultRejectReason": "用户拒绝"
+    "defaultRejectReason": "用户拒绝",
+    "preanalysis": {
+      "heading": "预分析结果",
+      "empty": "该提案暂无预分析结果。",
+      "unknownError": "分析器失败但未提供错误信息。",
+      "status": {
+        "ok": "正常",
+        "error": "错误",
+        "skipped": "已跳过",
+        "notRun": "未执行"
+      },
+      "stages": {
+        "dedup": {
+          "title": "去重检查",
+          "empty": "未发现相似的待审提案。",
+          "exactMatchBanner": "与现有待审提案完全重复",
+          "similarHeader": "{{count}} 个相似提案",
+          "similarHeader_other": "{{count}} 个相似提案",
+          "payloadHash": "负载哈希",
+          "skipped": "去重检查已跳过。",
+          "notRun": "该提案未执行去重检查。",
+          "noData": "去重检查未返回数据。"
+        },
+        "conflict": {
+          "title": "冲突检测",
+          "empty": "未检测到冲突。",
+          "kinds": {
+            "rule": "规则冲突",
+            "state_transition": "状态迁移冲突",
+            "proposal": "待审提案冲突",
+            "other": "其他冲突"
+          },
+          "skipped": "冲突检测已跳过。",
+          "notRun": "该提案未执行冲突检测。",
+          "noData": "冲突分析器未返回数据。"
+        },
+        "impact": {
+          "title": "影响评估",
+          "recordsAffected": "条记录将受影响",
+          "probedEntities": "已探测的实体",
+          "sample": "样本 {{count}} 条",
+          "sample_other": "样本 {{count}} 条",
+          "skipped": "影响评估已跳过。",
+          "notRun": "该提案未执行影响评估。",
+          "noData": "影响评估未返回数据。"
+        },
+        "backtest": {
+          "title": "回测",
+          "windowDays": "窗口（天）",
+          "triggers": "假设触发次数",
+          "skipped": "回测已跳过。",
+          "notRun": "该提案未执行回测。",
+          "noData": "回测分析器未返回数据。"
+        }
+      },
+      "demo": {
+        "title": "提案预分析预览",
+        "subtitle": "Spec 55 §7.3 四阶段审查面板的演示数据。",
+        "fixtures": {
+          "full": "完整四阶段",
+          "error": "错误 + 已跳过",
+          "partial": "部分（仅去重）",
+          "empty": "空 / null"
+        }
+      }
+    }
   },
   "evolution": {
     "title": "进化历史",

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/proposal-review-demo.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/proposal-review-demo.tsx
@@ -1,0 +1,240 @@
+/**
+ * ProposalReviewDemoPage — `/admin/proposals/preview-demo`.
+ *
+ * Demo route for ProposalImpactPreview (Spec 55 §7.3). Renders the panel
+ * against several mock ProposalPreAnalysisResult fixtures so reviewers can
+ * see every render branch (full data, errors, skipped, partial, empty).
+ *
+ * This page is intentionally a fixture playground — when a real Proposal
+ * review page lands, the panel is dropped in by importing the component.
+ */
+
+import type { ProposalPreAnalysisResult } from "@linchkit/core";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@linchkit/ui-kit/components";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ProposalImpactPreview } from "@/components/proposal-impact-preview";
+
+// ── Mock fixtures ──────────────────────────────────────────
+
+interface Fixture {
+  id: string;
+  labelKey: string;
+  result: ProposalPreAnalysisResult | null;
+}
+
+const NOW = new Date("2026-05-06T10:00:00Z");
+
+const fullFixture: ProposalPreAnalysisResult = {
+  proposalId: "prop_full_001",
+  analyzedAt: NOW,
+  totalDurationMs: 184,
+  allStagesSucceeded: true,
+  stages: {
+    dedup: {
+      stage: "dedup",
+      status: "ok",
+      durationMs: 22,
+      data: {
+        payloadHash: "sha256:9a3f…b21",
+        exactMatch: null,
+        similar: [
+          {
+            id: "prop_2025_0042",
+            title: "Add priority field to task entity",
+            description: "",
+            author: { type: "ai", id: "ai-claude", name: "Claude" },
+            capability: "demo",
+            changeType: "minor",
+            changes: [],
+            impact: {
+              schemasAffected: [],
+              actionsAffected: [],
+              rulesAffected: [],
+              dependentsAffected: [],
+              migrationRequired: false,
+            },
+            status: "draft",
+            createdAt: NOW,
+            updatedAt: NOW,
+          },
+        ],
+      },
+    },
+    conflict: {
+      stage: "conflict",
+      status: "ok",
+      durationMs: 31,
+      data: {
+        notes: "Checked 12 active rules and 3 state machines.",
+        conflicts: [
+          {
+            kind: "rule",
+            targetId: "task.priority_required",
+            message: "New default priority value contradicts active 'priority_required' rule.",
+          },
+          {
+            kind: "state_transition",
+            targetId: "task.in_progress→done",
+            message: "Proposed transition guard already validates priority elsewhere.",
+          },
+          {
+            kind: "proposal",
+            targetId: "prop_2025_0042",
+            message: "Pending proposal also touches task.priority — review both together.",
+          },
+        ],
+      },
+    },
+    impact: {
+      stage: "impact",
+      status: "ok",
+      durationMs: 91,
+      data: {
+        affectedRecordCount: 14_237,
+        sampleRecordIds: [
+          "task_a1b2",
+          "task_c3d4",
+          "task_e5f6",
+          "task_0001",
+          "task_0002",
+          "task_0003",
+        ],
+        probedEntities: ["task", "task_audit"],
+        reason: undefined,
+      },
+    },
+    backtest: {
+      stage: "backtest",
+      status: "ok",
+      durationMs: 40,
+      data: {
+        windowDays: 30,
+        hypotheticalTriggerCount: 412,
+        summary: "187 of 412 hypothetical triggers matched recently rejected outcomes.",
+      },
+    },
+  },
+};
+
+const errorFixture: ProposalPreAnalysisResult = {
+  proposalId: "prop_err_002",
+  analyzedAt: NOW,
+  totalDurationMs: 19,
+  allStagesSucceeded: false,
+  stages: {
+    dedup: {
+      stage: "dedup",
+      status: "error",
+      durationMs: 9,
+      error: { code: "STORE_UNAVAILABLE", message: "PendingProposalStore did not respond." },
+    },
+    conflict: {
+      stage: "conflict",
+      status: "skipped",
+      durationMs: 0,
+    },
+    impact: {
+      stage: "impact",
+      status: "ok",
+      durationMs: 10,
+      data: {
+        affectedRecordCount: 0,
+        sampleRecordIds: [],
+        probedEntities: [],
+        reason: "not-a-data-change",
+      },
+    },
+    backtest: {
+      stage: "backtest",
+      status: "skipped",
+      durationMs: 0,
+    },
+  },
+};
+
+const partialFixture: ProposalPreAnalysisResult = {
+  proposalId: "prop_partial_003",
+  analyzedAt: NOW,
+  totalDurationMs: 11,
+  allStagesSucceeded: true,
+  stages: {
+    dedup: {
+      stage: "dedup",
+      status: "ok",
+      durationMs: 11,
+      data: {
+        payloadHash: "sha256:0000…0001",
+        exactMatch: null,
+        similar: [],
+      },
+    },
+    // conflict / impact / backtest deliberately omitted to exercise the
+    // "stage missing entirely" branch.
+  },
+};
+
+const fixtures: Fixture[] = [
+  {
+    id: "full",
+    labelKey: "proposals.preanalysis.demo.fixtures.full",
+    result: fullFixture,
+  },
+  {
+    id: "error",
+    labelKey: "proposals.preanalysis.demo.fixtures.error",
+    result: errorFixture,
+  },
+  {
+    id: "partial",
+    labelKey: "proposals.preanalysis.demo.fixtures.partial",
+    result: partialFixture,
+  },
+  {
+    id: "empty",
+    labelKey: "proposals.preanalysis.demo.fixtures.empty",
+    result: null,
+  },
+];
+
+// ── Page ───────────────────────────────────────────────────
+
+export function ProposalReviewDemoPage() {
+  const { t } = useTranslation();
+  const [activeId, setActiveId] = useState<string>(fixtures[0]?.id ?? "full");
+  const active = fixtures.find((f) => f.id === activeId) ?? fixtures[0];
+
+  return (
+    <div className="p-4 space-y-4 max-w-4xl mx-auto">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">{t("proposals.preanalysis.demo.title")}</CardTitle>
+          <CardDescription>{t("proposals.preanalysis.demo.subtitle")}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-wrap gap-2">
+            {fixtures.map((f) => (
+              <Button
+                key={f.id}
+                size="sm"
+                variant={f.id === activeId ? "default" : "outline"}
+                onClick={() => setActiveId(f.id)}
+              >
+                {t(f.labelKey)}
+              </Button>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
+      <ProposalImpactPreview result={active?.result} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
The four pre-analysis stages (dedup, conflict, impact, backtest) all shipped to core in #240/#241/#190. This PR lands the last open Spec 55 §7.3 deliverable — a UI that visualizes those analyzer results for human reviewers.

`ProposalImpactPreview` accepts a `ProposalPreAnalysisResult` and renders four collapsible Cards in canonical Spec 55 order. Each Card shows status badge + duration. Stage-specific subviews:

- **Dedup** — exact-match banner, similar-proposal list, payload hash
- **Conflict** — findings grouped by kind, severity-toned (rule = error, others = warning)
- **Impact** — count headline, sample record IDs, probedEntities, reason
- **Backtest** — windowDays + hypotheticalTriggerCount + summary

Skipped / missing stages render muted placeholders; errored stages surface error code + message. Every visible string routes through useTranslation.

### Mounting
No existing proposal-review page exists yet. The panel is mounted on a demo route at /admin/proposals/preview-demo with four mock fixtures (full / error / partial / empty). When a real proposal review surface lands, integration is just import the component and pass the pipeline result.

## Test plan
- [x] 17 new helper tests
- [x] Full cap-adapter-ui suite — 300/300 pass
- [x] bun test — 4729 pass / 0 fail
- [x] typecheck / check — clean

Closes the final §7.3 deliverable on tracking issue #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)
