### PR TITLE
fix(core): interface lock metadata propagates transitively through extends

### DIFF
--- a/packages/core/__tests__/entity-registry-resolve-merge.test.ts
+++ b/packages/core/__tests__/entity-registry-resolve-merge.test.ts
@@ -780,6 +780,46 @@ describe("EntityRegistry.resolve() — inherited constraint merge (issue #202)",
       expect(def?.label).toBe("B Code");
     });
 
+    it("conflicting interfaces across the chain: leaf-side interface wins over root-side interface (codex review followup)", () => {
+      // A implements I1 declaring `code: { immutable: true }`.
+      // B extends A and implements I2 declaring `code: { immutable: false }`.
+      // Closer-to-leaf interface (I2 from B) must win — leaf-side semantics
+      // mirror the standard child-wins precedence used everywhere else in
+      // resolve(). Without the resolution-order fix, the root-side I1 would
+      // overwrite I2 because ancestor seeding ran AFTER self-implements.
+      const interfaces = createInterfaceRegistry();
+      interfaces.register({
+        name: "imm_true_iface",
+        label: "Imm True",
+        fields: { code: { type: "string", immutable: true } },
+      });
+      interfaces.register({
+        name: "imm_false_iface",
+        label: "Imm False",
+        fields: { code: { type: "string", immutable: false } },
+      });
+
+      const registry = createEntityRegistry();
+      registry.setInterfaceRegistry(interfaces);
+
+      registry.register({
+        name: "iface_conflict_a",
+        implements: ["imm_true_iface"],
+        fields: { code: { type: "string", label: "A Code" } },
+      });
+      registry.register({
+        name: "iface_conflict_b",
+        extends: "iface_conflict_a",
+        implements: ["imm_false_iface"],
+        fields: { code: { type: "string", label: "B Code" } },
+      });
+
+      const def = registry.resolve("iface_conflict_b").fields.code?.definition;
+      // Leaf-side interface (I2: immutable: false) wins over root-side (I1: true).
+      expect(def?.immutable).toBe(false);
+      expect(def?.label).toBe("B Code");
+    });
+
     it("entity explicitly clearing interface-provided lockWhen via undefined wins", () => {
       const interfaces = createInterfaceRegistry();
       interfaces.register({

--- a/packages/core/__tests__/entity-registry-resolve-merge.test.ts
+++ b/packages/core/__tests__/entity-registry-resolve-merge.test.ts
@@ -584,17 +584,14 @@ describe("EntityRegistry.resolve() — inherited constraint merge (issue #202)",
   });
 
   describe("interface + extends combined chain (codex follow-up)", () => {
-    it("documents current limitation: interface metadata does NOT transitively propagate through extends", () => {
-      // KNOWN LIMITATION (separate from #202 scope): when entity A implements
-      // an interface that contributes `immutable: true` on field X, and entity
-      // B extends A, B does NOT inherit X.immutable from the interface unless B
-      // also implements the same interface. This is because the inheritance
-      // walk uses ancestor.fields (raw) — interface seeding only happens for
-      // the entity's own `implements`, not transitively up the chain.
-      //
-      // Tracked in a follow-up issue for the EntityRegistry.resolve()
-      // semantics. This test pins the current behavior so the limitation is
-      // visible and any future fix flips it intentionally.
+    it("interface metadata propagates transitively through extends", () => {
+      // Issue #253: when entity A implements an interface that contributes
+      // `immutable: true` on field X, and entity B extends A, B inherits
+      // X.immutable from the interface even if B does not list `implements`
+      // itself. The inheritance walk seeds each ancestor's `implements`
+      // interface fields before its own fields, mirroring the self-implements
+      // seed used for the most-derived entity. This keeps interface lock
+      // metadata (Spec 63) flowing through `extends` transitively.
       const interfaces = createInterfaceRegistry();
       interfaces.register({
         name: "code_holder",
@@ -623,11 +620,10 @@ describe("EntityRegistry.resolve() — inherited constraint merge (issue #202)",
       const indirectDef = registry.resolve("audited_doc_with_code").fields.code?.definition;
       // Direct implementor: interface seeding works — immutable preserved
       expect(directDef?.immutable).toBe(true);
-      // Grandchild via `extends` only: interface metadata is NOT inherited
-      // (current behavior). Workaround: have audited_doc_with_code also list
-      // `implements: ["code_holder"]`, or restate `immutable: true` on its own
-      // field redeclaration.
-      expect(indirectDef?.immutable).toBeUndefined();
+      // Grandchild via `extends` only: interface metadata IS inherited
+      // transitively now (issue #253 fix). The grandchild's redeclared label
+      // still wins for visual properties.
+      expect(indirectDef?.immutable).toBe(true);
       expect(indirectDef?.label).toBe("Audit Code");
     });
 
@@ -656,6 +652,132 @@ describe("EntityRegistry.resolve() — inherited constraint merge (issue #202)",
       const def = registry.resolve("audited_doc_with_code_2").fields.code?.definition;
       expect(def?.immutable).toBe(true);
       expect(def?.label).toBe("Audit Code");
+    });
+
+    it("multi-interface composition across extends chain combines contributions on shared field set", () => {
+      // A implements I1 (code: immutable), B extends A implements I2 (name: readonly).
+      // Resolved B must carry BOTH constraints because:
+      //   - I1 propagates transitively via A's `implements`
+      //   - I2 is seeded from B's own `implements`
+      const interfaces = createInterfaceRegistry();
+      interfaces.register({
+        name: "code_iface",
+        label: "Code Iface",
+        fields: { code: { type: "string", immutable: true } },
+      });
+      interfaces.register({
+        name: "name_iface",
+        label: "Name Iface",
+        fields: { name: { type: "string", readonly: true } },
+      });
+
+      const registry = createEntityRegistry();
+      registry.setInterfaceRegistry(interfaces);
+
+      registry.register({
+        name: "multi_iface_a",
+        implements: ["code_iface"],
+        fields: {
+          code: { type: "string", label: "A Code" },
+          name: { type: "string", label: "A Name" },
+        },
+      });
+      registry.register({
+        name: "multi_iface_b",
+        extends: "multi_iface_a",
+        implements: ["name_iface"],
+        fields: {
+          // B does not restate either constraint key — both must inherit.
+          code: { type: "string", label: "B Code" },
+          name: { type: "string", label: "B Name" },
+        },
+      });
+
+      const resolved = registry.resolve("multi_iface_b");
+      const codeDef = resolved.fields.code?.definition;
+      const nameDef = resolved.fields.name?.definition;
+
+      expect(codeDef?.immutable).toBe(true); // from I1 via ancestor
+      expect(codeDef?.label).toBe("B Code");
+      expect(nameDef?.readonly).toBe(true); // from I2 directly
+      expect(nameDef?.label).toBe("B Name");
+    });
+
+    it("three-level chain with mid-level interface: grandchild inherits interface metadata", () => {
+      // G (no interfaces) → P (implements I) → C (extends P, no interfaces).
+      // C must inherit I's `immutable: true` on `code`.
+      const interfaces = createInterfaceRegistry();
+      interfaces.register({
+        name: "mid_iface",
+        label: "Mid Iface",
+        fields: { code: { type: "string", immutable: true } },
+      });
+
+      const registry = createEntityRegistry();
+      registry.setInterfaceRegistry(interfaces);
+
+      registry.register({
+        name: "g_root",
+        abstract: true,
+        fields: {
+          code: { type: "string", label: "G Code" },
+        },
+      });
+      registry.register({
+        name: "p_mid",
+        extends: "g_root",
+        implements: ["mid_iface"],
+        fields: {
+          code: { type: "string", label: "P Code" },
+        },
+      });
+      registry.register({
+        name: "c_leaf",
+        extends: "p_mid",
+        fields: {
+          code: { type: "string", label: "C Code" },
+        },
+      });
+
+      const def = registry.resolve("c_leaf").fields.code?.definition;
+      expect(def?.immutable).toBe(true); // contributed by I via P
+      expect(def?.label).toBe("C Code");
+    });
+
+    it("override negation through transitive seed: child explicit `immutable: false` wins over interface", () => {
+      // A implements I (code: immutable: true). B extends A and redeclares
+      // `code: { immutable: false }`. The transitive seed contributes
+      // immutable: true from I, but the child's explicit negation must win.
+      const interfaces = createInterfaceRegistry();
+      interfaces.register({
+        name: "lock_iface",
+        label: "Lock Iface",
+        fields: { code: { type: "string", immutable: true } },
+      });
+
+      const registry = createEntityRegistry();
+      registry.setInterfaceRegistry(interfaces);
+
+      registry.register({
+        name: "negate_a",
+        implements: ["lock_iface"],
+        fields: {
+          code: { type: "string", label: "A Code" },
+        },
+      });
+      registry.register({
+        name: "negate_b",
+        extends: "negate_a",
+        fields: {
+          // Explicit negation: B wants the field mutable even though the
+          // interface (via A) declared it immutable.
+          code: { type: "string", immutable: false, label: "B Code" },
+        },
+      });
+
+      const def = registry.resolve("negate_b").fields.code?.definition;
+      expect(def?.immutable).toBe(false);
+      expect(def?.label).toBe("B Code");
     });
 
     it("entity explicitly clearing interface-provided lockWhen via undefined wins", () => {

--- a/packages/core/src/entity/entity-registry.ts
+++ b/packages/core/src/entity/entity-registry.ts
@@ -407,39 +407,24 @@ export class EntityRegistry {
       }
     }
 
-    // Inject interface fields (before inherited + own fields, so they can be overridden).
-    // We seed all interface fields — including ones the entity itself redeclares — so
-    // that lock metadata (Spec 63 `immutable`/`readonly`/`lockWhen`) and other
-    // constraints declared on the interface are preserved through the merge unless the
-    // entity explicitly restates them. Interface field validation (type/enum/required)
-    // is handled separately in InterfaceRegistry.validateImplementation.
-    if (schema.implements && schema.implements.length > 0 && this._interfaceRegistry) {
-      for (const ifaceName of schema.implements) {
-        const iface = this._interfaceRegistry.get(ifaceName);
-        if (!iface) continue;
-        for (const [fname, fdef] of Object.entries(iface.fields)) {
-          upsertField(fname, fdef);
-        }
-      }
-    }
-
-    // Merge inherited fields (from root ancestor down to parent)
+    // Resolution order for interface + inheritance precedence (root → leaf):
+    //
+    //   1. ancestor's interfaces, then ancestor's own fields  (root → parent)
+    //   2. self's own interfaces                              (current entity)
+    //   3. self's own fields                                  (current entity)
+    //   4. extensions, then overrides                         (later sections)
+    //
+    // Why interfaces are seeded WITHIN the chain walk before self-implements:
+    // closer-to-leaf interfaces must win over root-side interfaces when both
+    // contribute the same field. If self-implements were seeded first, a
+    // subsequent ancestor-implements pass would overwrite it (since
+    // upsertField treats each new layer as the merge "child"). Process root →
+    // leaf so leaf-side interfaces are the last to merge and win on
+    // explicit conflicts. mergeFieldDefinition's explicit-presence detection
+    // still preserves an ancestor's untouched constraints.
     if (schema.extends) {
       const chain = this.getInheritanceChain(name);
       // Apply fields from each ancestor (excluding self, which is last in chain).
-      // upsertField merges so multi-level inheritance composes constraints
-      // additively (grandparent → parent → child each contribute, most-derived
-      // explicit value wins).
-      //
-      // For each ancestor we ALSO seed its `implements` interface fields
-      // before its own fields, mirroring the self-implements seed above.
-      // This ensures interface lock metadata (Spec 63
-      // `immutable`/`readonly`/`lockWhen`) flows through `extends`
-      // transitively — exactly as if the most-derived entity had restated
-      // each ancestor's `implements`. Multi-interface composition across
-      // the chain is naturally additive thanks to upsertField's merge
-      // semantics: child explicit values still win, but unspecified
-      // constraints inherit from any ancestor's interface.
       for (let i = 0; i < chain.length - 1; i++) {
         // biome-ignore lint/style/noNonNullAssertion: index is within bounds
         const ancestor = this.entities.get(chain[i]!);
@@ -454,6 +439,19 @@ export class EntityRegistry {
           }
         }
         for (const [fname, fdef] of Object.entries(ancestor.fields)) {
+          upsertField(fname, fdef);
+        }
+      }
+    }
+
+    // Self's own interfaces — seeded AFTER the ancestor chain so leaf-side
+    // interface contributions win on conflicting keys, and BEFORE self's own
+    // fields so an entity's field declaration still wins over its interface.
+    if (schema.implements && schema.implements.length > 0 && this._interfaceRegistry) {
+      for (const ifaceName of schema.implements) {
+        const iface = this._interfaceRegistry.get(ifaceName);
+        if (!iface) continue;
+        for (const [fname, fdef] of Object.entries(iface.fields)) {
           upsertField(fname, fdef);
         }
       }

--- a/packages/core/src/entity/entity-registry.ts
+++ b/packages/core/src/entity/entity-registry.ts
@@ -294,17 +294,37 @@ export class EntityRegistry {
    * {@link mergeFieldDefinition} so inherited Spec 63 lock metadata
    * (`immutable`, `readonly`, `lockWhen`) and other constraints are preserved
    * unless the child explicitly restates them.
+   *
+   * For each entity in the chain we ALSO seed its `implements` interface
+   * fields before its own fields. This keeps `collectInheritedFields()`
+   * consistent with `resolve()` so CLI validation and runtime field merging
+   * agree on transitively-propagated interface constraints (issue #253).
    */
   private collectInheritedFields(name: string): Record<string, FieldDefinition> {
     const fields: Record<string, FieldDefinition> = {};
     const chain = this.getInheritanceChain(name);
+    const merge = (fname: string, fdef: FieldDefinition) => {
+      const existing = fields[fname];
+      fields[fname] = existing ? mergeFieldDefinition(existing, fdef) : fdef;
+    };
     // chain includes `name` itself as last element; iterate all
     for (const entityName of chain) {
       const schema = this.entities.get(entityName);
       if (!schema) continue;
+      // Seed interface contributions for this ancestor first so the
+      // ancestor's own fields (and any further descendants) can override
+      // them, matching resolve() semantics.
+      if (schema.implements && this._interfaceRegistry) {
+        for (const ifaceName of schema.implements) {
+          const iface = this._interfaceRegistry.get(ifaceName);
+          if (!iface) continue;
+          for (const [fname, fdef] of Object.entries(iface.fields)) {
+            merge(fname, fdef);
+          }
+        }
+      }
       for (const [fname, fdef] of Object.entries(schema.fields)) {
-        const existing = fields[fname];
-        fields[fname] = existing ? mergeFieldDefinition(existing, fdef) : fdef;
+        merge(fname, fdef);
       }
     }
     return fields;
@@ -410,13 +430,31 @@ export class EntityRegistry {
       // upsertField merges so multi-level inheritance composes constraints
       // additively (grandparent → parent → child each contribute, most-derived
       // explicit value wins).
+      //
+      // For each ancestor we ALSO seed its `implements` interface fields
+      // before its own fields, mirroring the self-implements seed above.
+      // This ensures interface lock metadata (Spec 63
+      // `immutable`/`readonly`/`lockWhen`) flows through `extends`
+      // transitively — exactly as if the most-derived entity had restated
+      // each ancestor's `implements`. Multi-interface composition across
+      // the chain is naturally additive thanks to upsertField's merge
+      // semantics: child explicit values still win, but unspecified
+      // constraints inherit from any ancestor's interface.
       for (let i = 0; i < chain.length - 1; i++) {
         // biome-ignore lint/style/noNonNullAssertion: index is within bounds
         const ancestor = this.entities.get(chain[i]!);
-        if (ancestor) {
-          for (const [fname, fdef] of Object.entries(ancestor.fields)) {
-            upsertField(fname, fdef);
+        if (!ancestor) continue;
+        if (ancestor.implements && this._interfaceRegistry) {
+          for (const ifaceName of ancestor.implements) {
+            const iface = this._interfaceRegistry.get(ifaceName);
+            if (!iface) continue;
+            for (const [fname, fdef] of Object.entries(iface.fields)) {
+              upsertField(fname, fdef);
+            }
           }
+        }
+        for (const [fname, fdef] of Object.entries(ancestor.fields)) {
+          upsertField(fname, fdef);
         }
       }
     }


### PR DESCRIPTION
## Summary
Closes #253 (follow-up to #202 / PR #252).

When entity `A implements I` and `B extends A`, `B` now inherits `I`'s lock metadata for shared fields without needing to redeclare `implements: [\"I\"]` itself. Multi-interface composition across the chain works additively, with leaf-side interfaces winning on conflicting keys.

## Resolution order in `EntityRegistry.resolve()`

```
1. system fields
2. ancestor chain (root → parent):
     ancestor's `implements` interfaces → ancestor's own fields
3. self's `implements` interfaces           ← seeded AFTER chain
4. self's own fields
5. extensions
6. overrides
```

`mergeFieldDefinition` treats each new layer as the merge "child"; the LAST layer to touch a key wins. Putting self-implements after the chain walk means leaf-side interfaces beat root-side interfaces on conflicts. `collectInheritedFields()` (used by `validateImplementation` callers) mirrors the same transitive seed.

## Codex review iteration

First commit had self-implements before the chain walk — codex flagged a real ordering bug where root-side ancestor's interface overwrote leaf-side interface on conflicts. Second commit reordered.

## Tests (+5)
- Flipped: `interface metadata propagates transitively through extends` (was a pinned limitation).
- multi-interface composition across the chain (additive on disjoint fields).
- three-level chain with mid-level interface (G → P implements I → C extends P).
- explicit child negation through transitive seed (`immutable: false` on grandchild wins).
- (codex fix) conflicting interfaces across the chain (leaf-side I2's `immutable: false` wins over root-side I1's `immutable: true`).

## Test plan
- [x] `bun test` — 4702 pass / 0 fail / 3 skip
- [x] `bun run check` / `typecheck` — clean
- [x] Cross-model review — MAJOR ordering bug fixed in second commit

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed interface field constraint propagation through multi-level inheritance chains to ensure correct precedence and conflict resolution across extends relationships.

* **Tests**
  * Expanded regression coverage for inherited and merged field constraints in interface composition scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->