### PR TITLE
feat(cli): MCP generation tools — Spec 60 Phase 4 (refs #156)

### DIFF
--- a/packages/cli/__tests__/mcp-dev-generation.test.ts
+++ b/packages/cli/__tests__/mcp-dev-generation.test.ts
@@ -160,7 +160,10 @@ describe("MCP Dev Server — generation tools", () => {
       expect(data.validation.valid).toBe(true);
       expect(data.code).toContain("defineEntity(");
       expect(data.code).toContain('name: "invoice"');
-      expect(data.code).toContain('options: ["draft","sent","paid"]');
+      // EnumField.options shape (per packages/core/src/types/entity.ts) is
+      // Array<{ value: string }>, NOT string[]. The generator must render
+      // the wrapped object form so the resulting code passes core's typecheck.
+      expect(data.code).toContain('options: [{"value":"draft"},{"value":"sent"},{"value":"paid"}]');
       expect(data.path).toContain("addons/cap-billing/src/entities/invoice.ts");
       expect(data.written).toBe(false);
     });
@@ -206,6 +209,78 @@ describe("MCP Dev Server — generation tools", () => {
       const data = parseResult(result);
       expect(data.validation.valid).toBe(false);
       expect(data.validation.errors.some((e) => e.includes("snake_case"))).toBe(true);
+    });
+
+    test("rejects entity name that is a JavaScript reserved keyword", async () => {
+      const server = makeServer();
+      const result = await callTool(server, "linchkit_generate_entity", {
+        name: "export",
+        fields: { x: { type: "string" } },
+        targetPath: "x.ts",
+        dryRun: true,
+      });
+      expect(result.isError).toBe(true);
+      const data = parseResult(result);
+      expect(data.validation.valid).toBe(false);
+      expect(data.validation.errors.some((e) => e.includes("reserved"))).toBe(true);
+    });
+
+    test("renders immutable, machine, derived, pattern, and format on fields", async () => {
+      const server = makeServer();
+      const result = await callTool(server, "linchkit_generate_entity", {
+        name: "ledger_entry",
+        fields: {
+          ref: {
+            type: "string",
+            required: true,
+            immutable: true,
+            pattern: "^LE-",
+            format: "currency",
+          },
+          stage: { type: "state", machine: "ledger_state" },
+          total: {
+            type: "number",
+            derived: { type: "expression", strategy: "compute" },
+          },
+        },
+        targetPath: "addons/cap-ledger/src/entities/ledger_entry.ts",
+        dryRun: true,
+      });
+      expect(result.isError).toBeUndefined();
+      const data = parseResult(result);
+      expect(data.validation.valid).toBe(true);
+      expect(data.code).toContain("immutable: true");
+      expect(data.code).toContain('pattern: "^LE-"');
+      expect(data.code).toContain('format: "currency"');
+      expect(data.code).toContain('machine: "ledger_state"');
+      expect(data.code).toContain('derived: {"type":"expression","strategy":"compute"}');
+    });
+
+    test("generated enum + immutable code matches the EnumField shape (smoke)", async () => {
+      // Lightweight smoke test: assert the generated source contains the
+      // exact wrapped-options literal expected by EnumField (Array<{ value }>)
+      // and the immutable flag rendering. We avoid `new Function`/`eval`
+      // here on purpose (project rule: no dynamic code execution); see the
+      // earlier "generates a defineEntity() source file" test for the full
+      // string-shape assertions covered against real input.
+      const server = makeServer();
+      const result = await callTool(server, "linchkit_generate_entity", {
+        name: "smoke_entity",
+        label: "Smoke",
+        fields: {
+          status: { type: "enum", label: "Status", options: ["draft", "active"] },
+          name: { type: "string", required: true, immutable: true },
+        },
+        targetPath: "addons/cap-smoke/src/entities/smoke_entity.ts",
+        dryRun: true,
+      });
+      expect(result.isError).toBeUndefined();
+      const data = parseResult(result);
+      expect(data.validation.valid).toBe(true);
+      expect(data.code).toContain('options: [{"value":"draft"},{"value":"active"}]');
+      expect(data.code).toContain("immutable: true");
+      // Sanity check: must NOT contain the legacy string[] form.
+      expect(data.code).not.toContain('options: ["draft"');
     });
   });
 
@@ -257,6 +332,23 @@ describe("MCP Dev Server — generation tools", () => {
       const data = parseResult(result);
       expect(data.validation.errors.some((e) => e.includes("already exists"))).toBe(true);
     });
+
+    test("rejects action name that is a JavaScript reserved keyword", async () => {
+      const server = makeServer();
+      // 'delete' is in VERB_LIST but is also a JS reserved keyword. The
+      // reserved check must fire so a generated `export const delete = ...`
+      // never reaches disk.
+      const result = await callTool(server, "linchkit_generate_action", {
+        name: "delete",
+        entity: "purchase_request",
+        targetPath: "x.ts",
+        dryRun: true,
+      });
+      expect(result.isError).toBe(true);
+      const data = parseResult(result);
+      expect(data.validation.valid).toBe(false);
+      expect(data.validation.errors.some((e) => e.includes("reserved"))).toBe(true);
+    });
   });
 
   describe("linchkit_generate_capability", () => {
@@ -303,6 +395,24 @@ describe("MCP Dev Server — generation tools", () => {
       const data = parseResult(result);
       expect(data.validation.valid).toBe(false);
       expect(data.validation.errors.some((e) => e.includes("type"))).toBe(true);
+    });
+
+    test("rejects capability name whose domain is a JavaScript reserved keyword", async () => {
+      const server = makeServer();
+      // Domain segment after `cap-` collides with a reserved JS identifier
+      // (`class`). The generated `export const cap_class = ...` would still
+      // compile, but accepting reserved domain names is a foot-gun; reject.
+      const result = await callTool(server, "linchkit_generate_capability", {
+        name: "cap-class",
+        type: "standard",
+        category: "business",
+        rootPath: "addons/class/cap-class",
+        dryRun: true,
+      });
+      expect(result.isError).toBe(true);
+      const data = parseResult(result);
+      expect(data.validation.valid).toBe(false);
+      expect(data.validation.errors.some((e) => e.includes("reserved"))).toBe(true);
     });
   });
 

--- a/packages/cli/__tests__/mcp-dev-generation.test.ts
+++ b/packages/cli/__tests__/mcp-dev-generation.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Tests for MCP Dev Server generation tools (issue #156 Phase 4).
+ *
+ * Verifies linchkit_generate_entity / linchkit_generate_action /
+ * linchkit_generate_capability tools and the design_entity /
+ * design_capability / diagnose_error prompts.
+ *
+ * All tool calls use `dryRun: true` so nothing is written to disk.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { ActionDefinition, CapabilityDefinition, EntityDefinition } from "@linchkit/core";
+import type { CollectedDefinitions } from "../src/commands/startup/collect-capabilities";
+import { createMcpDevServer } from "../src/mcp-dev/server";
+
+// ── Mock data ───────────────────────────────────────────────────
+
+const mockEntity: EntityDefinition = {
+  name: "purchase_request",
+  label: "Purchase Request",
+  fields: {
+    title: { type: "string", label: "Title", required: true },
+    amount: { type: "number", label: "Amount", required: true },
+  },
+};
+
+const mockAction: ActionDefinition = {
+  name: "submit_request",
+  entity: "purchase_request",
+  label: "Submit Request",
+  policy: { requiresAuth: true },
+};
+
+const mockCapability: CapabilityDefinition = {
+  name: "cap-purchase",
+  label: "Purchase Management",
+  type: "standard",
+  category: "business",
+  version: "0.1.0",
+  entities: [mockEntity],
+  actions: [mockAction],
+};
+
+const mockDefinitions: CollectedDefinitions = {
+  interfaces: [],
+  entities: [mockEntity],
+  actions: [mockAction],
+  views: [],
+  states: [],
+  links: [],
+  rules: [],
+  eventHandlers: [],
+  middlewares: [],
+  transports: [],
+  graphqlExtensions: [],
+  commands: [],
+};
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+interface RegisteredTool {
+  handler: (
+    args: Record<string, unknown>,
+    extra: unknown,
+  ) => Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+  }>;
+}
+type ToolsMap = Record<string, RegisteredTool>;
+
+function getTools(server: ReturnType<typeof createMcpDevServer>): ToolsMap {
+  return (server as unknown as { _registeredTools: ToolsMap })._registeredTools;
+}
+
+async function callTool(
+  server: ReturnType<typeof createMcpDevServer>,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }> {
+  const tools = getTools(server);
+  const tool = tools[name];
+  if (!tool) {
+    throw new Error(`Tool '${name}' not registered. Available: ${Object.keys(tools).join(", ")}`);
+  }
+  return tool.handler(args, {});
+}
+
+function parseResult(result: { content: Array<{ type: string; text: string }> }): {
+  path?: string;
+  rootPath?: string;
+  code?: string;
+  files?: { path: string; content: string }[];
+  validation: { valid: boolean; errors: string[]; warnings: string[] };
+  written?: boolean;
+  error?: string;
+} {
+  const text = result.content[0]?.text;
+  if (text === undefined) throw new Error("Tool returned no text content");
+  return JSON.parse(text);
+}
+
+async function callPrompt(
+  server: ReturnType<typeof createMcpDevServer>,
+  name: string,
+  args: Record<string, string> = {},
+): Promise<{ messages: Array<{ role: string; content: { type: string; text: string } }> }> {
+  // biome-ignore lint/suspicious/noExplicitAny: accessing internal for testing
+  const prompts = (server as any)._registeredPrompts as Record<
+    string,
+    { callback: (...args: never[]) => unknown }
+  >;
+  const prompt = prompts[name];
+  if (!prompt) {
+    throw new Error(
+      `Prompt '${name}' not registered. Available: ${Object.keys(prompts).join(", ")}`,
+    );
+  }
+  return prompt.callback(args, {}) as ReturnType<typeof callPrompt>;
+}
+
+const PROJECT_ROOT = "/tmp/linchkit-mcp-gen-test";
+
+function makeServer(): ReturnType<typeof createMcpDevServer> {
+  return createMcpDevServer({
+    definitions: mockDefinitions,
+    capabilities: [mockCapability],
+    projectRoot: PROJECT_ROOT,
+  });
+}
+
+// ── Tests ───────────────────────────────────────────────────────
+
+describe("MCP Dev Server — generation tools", () => {
+  describe("linchkit_generate_entity", () => {
+    test("generates a defineEntity() source file (dry run)", async () => {
+      const server = makeServer();
+      const result = await callTool(server, "linchkit_generate_entity", {
+        name: "invoice",
+        label: "Invoice",
+        description: "A billing invoice",
+        fields: {
+          number: { type: "string", label: "Number", required: true, unique: true },
+          total: { type: "number", label: "Total", min: 0 },
+          status: {
+            type: "enum",
+            label: "Status",
+            options: ["draft", "sent", "paid"],
+          },
+        },
+        targetPath: "addons/cap-billing/src/entities/invoice.ts",
+        dryRun: true,
+      });
+
+      expect(result.isError).toBeUndefined();
+      const data = parseResult(result);
+      expect(data.validation.valid).toBe(true);
+      expect(data.code).toContain("defineEntity(");
+      expect(data.code).toContain('name: "invoice"');
+      expect(data.code).toContain('options: ["draft","sent","paid"]');
+      expect(data.path).toContain("addons/cap-billing/src/entities/invoice.ts");
+      expect(data.written).toBe(false);
+    });
+
+    test("rejects collision with existing entity", async () => {
+      const server = makeServer();
+      const result = await callTool(server, "linchkit_generate_entity", {
+        name: "purchase_request",
+        fields: { x: { type: "string" } },
+        targetPath: "x.ts",
+        dryRun: true,
+      });
+      expect(result.isError).toBe(true);
+      const data = parseResult(result);
+      expect(data.validation.valid).toBe(false);
+      expect(data.validation.errors.some((e) => e.includes("already exists"))).toBe(true);
+    });
+
+    test("rejects invalid extends target", async () => {
+      const server = makeServer();
+      const result = await callTool(server, "linchkit_generate_entity", {
+        name: "weird_request",
+        fields: { x: { type: "string" } },
+        extends: "nonexistent_entity",
+        targetPath: "x.ts",
+        dryRun: true,
+      });
+      expect(result.isError).toBe(true);
+      const data = parseResult(result);
+      expect(data.validation.valid).toBe(false);
+      expect(data.validation.errors.some((e) => e.includes("Cannot extend"))).toBe(true);
+    });
+
+    test("rejects non-snake_case name without throwing", async () => {
+      const server = makeServer();
+      const result = await callTool(server, "linchkit_generate_entity", {
+        name: "MyEntity",
+        fields: { x: { type: "string" } },
+        targetPath: "x.ts",
+        dryRun: true,
+      });
+      expect(result.isError).toBe(true);
+      const data = parseResult(result);
+      expect(data.validation.valid).toBe(false);
+      expect(data.validation.errors.some((e) => e.includes("snake_case"))).toBe(true);
+    });
+  });
+
+  describe("linchkit_generate_action", () => {
+    test("generates a defineAction() source file (dry run)", async () => {
+      const server = makeServer();
+      const result = await callTool(server, "linchkit_generate_action", {
+        name: "approve_request",
+        entity: "purchase_request",
+        label: "Approve Request",
+        input: { request_id: { type: "string", required: true } },
+        policy: { requiresAuth: true },
+        targetPath: "addons/cap-purchase/src/actions/approve-request.ts",
+        dryRun: true,
+      });
+
+      expect(result.isError).toBeUndefined();
+      const data = parseResult(result);
+      expect(data.validation.valid).toBe(true);
+      expect(data.code).toContain("defineAction(");
+      expect(data.code).toContain('name: "approve_request"');
+      expect(data.code).toContain('entity: "purchase_request"');
+      expect(data.code).toContain("handler:");
+    });
+
+    test("rejects action without verb_noun shape (no underscore)", async () => {
+      const server = makeServer();
+      const result = await callTool(server, "linchkit_generate_action", {
+        name: "approve",
+        entity: "purchase_request",
+        targetPath: "x.ts",
+        dryRun: true,
+      });
+      expect(result.isError).toBe(true);
+      const data = parseResult(result);
+      expect(data.validation.valid).toBe(false);
+      expect(data.validation.errors.some((e) => e.includes("verb_noun"))).toBe(true);
+    });
+
+    test("rejects action name colliding with existing action", async () => {
+      const server = makeServer();
+      const result = await callTool(server, "linchkit_generate_action", {
+        name: "submit_request",
+        entity: "purchase_request",
+        targetPath: "x.ts",
+        dryRun: true,
+      });
+      expect(result.isError).toBe(true);
+      const data = parseResult(result);
+      expect(data.validation.errors.some((e) => e.includes("already exists"))).toBe(true);
+    });
+  });
+
+  describe("linchkit_generate_capability", () => {
+    test("scaffolds package.json + src/index.ts + sub-folders (dry run)", async () => {
+      const server = makeServer();
+      const result = await callTool(server, "linchkit_generate_capability", {
+        name: "cap-inventory",
+        type: "standard",
+        category: "business",
+        label: "Inventory",
+        description: "Stock management",
+        rootPath: "addons/inventory/cap-inventory",
+        scaffoldFolders: true,
+        dryRun: true,
+      });
+
+      expect(result.isError).toBeUndefined();
+      const data = parseResult(result);
+      expect(data.validation.valid).toBe(true);
+      expect(data.rootPath).toContain("addons/inventory/cap-inventory");
+      expect(Array.isArray(data.files)).toBe(true);
+      const paths = (data.files ?? []).map((f) => f.path);
+      expect(paths.some((p) => p.endsWith("package.json"))).toBe(true);
+      expect(paths.some((p) => p.endsWith("src/index.ts"))).toBe(true);
+      expect(paths.some((p) => p.endsWith("src/entities/.gitkeep"))).toBe(true);
+      expect(paths.some((p) => p.endsWith("src/actions/.gitkeep"))).toBe(true);
+
+      const indexFile = (data.files ?? []).find((f) => f.path.endsWith("src/index.ts"));
+      expect(indexFile?.content).toContain("defineCapability(");
+      expect(indexFile?.content).toContain('name: "cap-inventory"');
+      expect(data.written).toBe(false);
+    });
+
+    test("rejects invalid capability type", async () => {
+      const server = makeServer();
+      const result = await callTool(server, "linchkit_generate_capability", {
+        name: "cap-foo",
+        type: "weird",
+        category: "business",
+        rootPath: "addons/foo/cap-foo",
+        dryRun: true,
+      });
+      expect(result.isError).toBe(true);
+      const data = parseResult(result);
+      expect(data.validation.valid).toBe(false);
+      expect(data.validation.errors.some((e) => e.includes("type"))).toBe(true);
+    });
+  });
+
+  describe("prompts (smoke)", () => {
+    test("design_entity returns guidance referencing the domain", async () => {
+      const server = makeServer();
+      const result = await callPrompt(server, "design_entity", { domain: "inventory" });
+      expect(result.messages.length).toBeGreaterThan(0);
+      const text = result.messages[0].content.text;
+      expect(text).toContain("inventory");
+      expect(text).toContain("snake_case");
+      expect(text).toContain("linchkit_generate_entity");
+    });
+
+    test("design_capability walks through scope question and naming", async () => {
+      const server = makeServer();
+      const result = await callPrompt(server, "design_capability", { domain: "billing" });
+      const text = result.messages[0].content.text;
+      expect(text).toContain("billing");
+      expect(text).toContain("zero-capability");
+      expect(text).toContain("linchkit_generate_capability");
+    });
+
+    test("diagnose_error parses LinchKitError context and shows the involved entity/action", async () => {
+      const server = makeServer();
+      const errorPayload = JSON.stringify({
+        message: "Budget exceeded",
+        code: "RULE_VIOLATION",
+        context: {
+          entity: "purchase_request",
+          action: "submit_request",
+          constraint: "budget_check",
+          expected: "amount <= 50000",
+          actual: "amount = 75000",
+          suggestion: "Reduce the amount or get override approval",
+        },
+      });
+      const result = await callPrompt(server, "diagnose_error", { error: errorPayload });
+      const text = result.messages[0].content.text;
+      expect(text).toContain("purchase_request");
+      expect(text).toContain("submit_request");
+      expect(text).toContain("budget_check");
+      expect(text).toContain("Proposal");
+      expect(text).toContain("[exists in catalog]");
+    });
+  });
+});

--- a/packages/cli/__tests__/mcp-dev-generation.test.ts
+++ b/packages/cli/__tests__/mcp-dev-generation.test.ts
@@ -8,7 +8,10 @@
  * All tool calls use `dryRun: true` so nothing is written to disk.
  */
 
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 import type { ActionDefinition, CapabilityDefinition, EntityDefinition } from "@linchkit/core";
 import type { CollectedDefinitions } from "../src/commands/startup/collect-capabilities";
 import { createMcpDevServer } from "../src/mcp-dev/server";
@@ -344,6 +347,194 @@ describe("MCP Dev Server — generation tools", () => {
       expect(text).toContain("budget_check");
       expect(text).toContain("Proposal");
       expect(text).toContain("[exists in catalog]");
+    });
+  });
+});
+
+// ── Filesystem-touching tests ───────────────────────────────────
+//
+// These tests use a real temp dir to verify path-traversal rejection,
+// overwrite protection, and dryRun semantics. The temp dir doubles as
+// the projectRoot so non-malicious targetPaths resolve inside it.
+
+describe("MCP Dev Server — filesystem safety", () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "mcp-gen-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  function makeServerWithRoot(root: string): ReturnType<typeof createMcpDevServer> {
+    return createMcpDevServer({
+      definitions: mockDefinitions,
+      capabilities: [mockCapability],
+      projectRoot: root,
+    });
+  }
+
+  describe("path traversal", () => {
+    test("entity tool rejects ../../ targetPath without writing", async () => {
+      const server = makeServerWithRoot(tmpRoot);
+      const result = await callTool(server, "linchkit_generate_entity", {
+        name: "invoice",
+        fields: { number: { type: "string" } },
+        targetPath: "../../../etc/passwd-test.ts",
+        dryRun: false,
+      });
+      expect(result.isError).toBe(true);
+      const data = parseResult(result);
+      expect(data.validation.valid).toBe(false);
+      expect(data.validation.errors.some((e) => e.includes("outside projectRoot"))).toBe(true);
+      // Sanity: nothing got written under tmpRoot's parent.
+      expect(existsSync(join(tmpRoot, "..", "..", "..", "etc", "passwd-test.ts"))).toBe(false);
+    });
+
+    test("action tool rejects ../../ targetPath without writing", async () => {
+      const server = makeServerWithRoot(tmpRoot);
+      const result = await callTool(server, "linchkit_generate_action", {
+        name: "approve_request",
+        entity: "purchase_request",
+        targetPath: "../../../etc/passwd-action.ts",
+        dryRun: false,
+      });
+      expect(result.isError).toBe(true);
+      const data = parseResult(result);
+      expect(data.validation.valid).toBe(false);
+      expect(data.validation.errors.some((e) => e.includes("outside projectRoot"))).toBe(true);
+      expect(existsSync(join(tmpRoot, "..", "..", "..", "etc", "passwd-action.ts"))).toBe(false);
+    });
+
+    test("capability tool rejects ../../ rootPath without writing", async () => {
+      const server = makeServerWithRoot(tmpRoot);
+      const result = await callTool(server, "linchkit_generate_capability", {
+        name: "cap-evil",
+        type: "standard",
+        category: "business",
+        rootPath: "../../../etc/cap-evil",
+        dryRun: false,
+      });
+      expect(result.isError).toBe(true);
+      const data = parseResult(result);
+      expect(data.validation.valid).toBe(false);
+      expect(data.validation.errors.some((e) => e.includes("outside projectRoot"))).toBe(true);
+      expect(existsSync(join(tmpRoot, "..", "..", "..", "etc", "cap-evil"))).toBe(false);
+    });
+  });
+
+  describe("overwrite protection", () => {
+    test("entity tool refuses to overwrite without force; succeeds with force", async () => {
+      const server = makeServerWithRoot(tmpRoot);
+      const targetRel = "addons/cap-billing/src/entities/invoice.ts";
+      const targetAbs = join(tmpRoot, targetRel);
+      mkdirSync(dirname(targetAbs), { recursive: true });
+      const fixture = "// pre-existing fixture content\n";
+      writeFileSync(targetAbs, fixture);
+
+      // Without force — must error and leave file untouched.
+      const blocked = await callTool(server, "linchkit_generate_entity", {
+        name: "invoice",
+        fields: { number: { type: "string", required: true } },
+        targetPath: targetRel,
+        dryRun: false,
+        force: false,
+      });
+      expect(blocked.isError).toBe(true);
+      const blockedData = parseResult(blocked);
+      expect(blockedData.validation.valid).toBe(false);
+      expect(blockedData.validation.errors.some((e) => e.includes("Refusing to overwrite"))).toBe(
+        true,
+      );
+      expect(readFileSync(targetAbs, "utf8")).toBe(fixture);
+
+      // With force — must succeed and overwrite.
+      const allowed = await callTool(server, "linchkit_generate_entity", {
+        name: "invoice",
+        fields: { number: { type: "string", required: true } },
+        targetPath: targetRel,
+        dryRun: false,
+        force: true,
+      });
+      expect(allowed.isError).toBeUndefined();
+      const allowedData = parseResult(allowed);
+      expect(allowedData.validation.valid).toBe(true);
+      expect(allowedData.written).toBe(true);
+      const written = readFileSync(targetAbs, "utf8");
+      expect(written).not.toBe(fixture);
+      expect(written).toContain("defineEntity(");
+    });
+  });
+
+  describe("dryRun does not touch fs", () => {
+    test("entity tool returns code without writing when dryRun=true", async () => {
+      const server = makeServerWithRoot(tmpRoot);
+      const targetRel = "addons/cap-billing/src/entities/invoice.ts";
+      const targetAbs = join(tmpRoot, targetRel);
+      const result = await callTool(server, "linchkit_generate_entity", {
+        name: "invoice",
+        fields: { number: { type: "string", required: true } },
+        targetPath: targetRel,
+        dryRun: true,
+      });
+      expect(result.isError).toBeUndefined();
+      const data = parseResult(result);
+      expect(data.validation.valid).toBe(true);
+      expect(data.path).toBe(targetAbs);
+      expect(data.code).toContain("defineEntity(");
+      expect(data.written).toBe(false);
+      expect(existsSync(targetAbs)).toBe(false);
+    });
+  });
+
+  describe("capability cap- prefix", () => {
+    test("rejects bare name without cap- prefix", async () => {
+      const server = makeServerWithRoot(tmpRoot);
+      const result = await callTool(server, "linchkit_generate_capability", {
+        name: "billing",
+        type: "standard",
+        category: "business",
+        rootPath: "addons/billing/cap-billing",
+        dryRun: true,
+      });
+      expect(result.isError).toBe(true);
+      const data = parseResult(result);
+      expect(data.validation.valid).toBe(false);
+      expect(data.validation.errors.some((e) => e.includes("cap-<domain>"))).toBe(true);
+    });
+
+    test("accepts cap-<domain> name", async () => {
+      const server = makeServerWithRoot(tmpRoot);
+      const result = await callTool(server, "linchkit_generate_capability", {
+        name: "cap-billing",
+        type: "standard",
+        category: "business",
+        rootPath: "addons/billing/cap-billing",
+        dryRun: true,
+      });
+      expect(result.isError).toBeUndefined();
+      const data = parseResult(result);
+      expect(data.validation.valid).toBe(true);
+    });
+  });
+
+  describe("entity field validation", () => {
+    test("rejects enum field with empty options[]", async () => {
+      const server = makeServerWithRoot(tmpRoot);
+      const result = await callTool(server, "linchkit_generate_entity", {
+        name: "invoice",
+        fields: {
+          status: { type: "enum", options: [] },
+        },
+        targetPath: "addons/cap-billing/src/entities/invoice.ts",
+        dryRun: true,
+      });
+      expect(result.isError).toBe(true);
+      const data = parseResult(result);
+      expect(data.validation.valid).toBe(false);
+      expect(data.validation.errors.some((e) => e.includes("non-empty options"))).toBe(true);
     });
   });
 });

--- a/packages/cli/src/mcp-dev/generation-tools.ts
+++ b/packages/cli/src/mcp-dev/generation-tools.ts
@@ -10,7 +10,7 @@
  */
 
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { dirname, resolve, sep } from "node:path";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import type { CapabilityDefinition } from "@linchkit/core";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CollectedDefinitions } from "../commands/startup/collect-capabilities";
@@ -66,16 +66,89 @@ interface ValidationResult {
   warnings: string[];
 }
 
+/**
+ * Reserved JavaScript identifiers (ES2022 reserved + future-reserved + strict-mode reserved).
+ * Used to reject entity / action / capability names that would generate
+ * uncompilable `export const <reserved> = ...` source.
+ */
+const JS_RESERVED = new Set([
+  "abstract",
+  "await",
+  "boolean",
+  "break",
+  "byte",
+  "case",
+  "catch",
+  "char",
+  "class",
+  "const",
+  "continue",
+  "debugger",
+  "default",
+  "delete",
+  "do",
+  "double",
+  "else",
+  "enum",
+  "export",
+  "extends",
+  "false",
+  "final",
+  "finally",
+  "float",
+  "for",
+  "function",
+  "goto",
+  "if",
+  "implements",
+  "import",
+  "in",
+  "instanceof",
+  "int",
+  "interface",
+  "let",
+  "long",
+  "native",
+  "new",
+  "null",
+  "package",
+  "private",
+  "protected",
+  "public",
+  "return",
+  "short",
+  "static",
+  "super",
+  "switch",
+  "synchronized",
+  "this",
+  "throw",
+  "throws",
+  "transient",
+  "true",
+  "try",
+  "typeof",
+  "var",
+  "void",
+  "volatile",
+  "while",
+  "with",
+  "yield",
+]);
+
 interface FieldSpec {
   type: string;
   label?: string;
   description?: string;
   required?: boolean;
   unique?: boolean;
+  immutable?: boolean;
   min?: number;
   max?: number;
   default?: unknown;
   options?: string[];
+  machine?: string;
+  derived?: Record<string, unknown>;
   pattern?: string;
   format?: string;
 }
@@ -116,13 +189,23 @@ function renderField(spec: FieldSpec): string {
     parts.push(`description: ${JSON.stringify(spec.description)}`);
   if (spec.required) parts.push(`required: true`);
   if (spec.unique) parts.push(`unique: true`);
+  if (spec.immutable) parts.push(`immutable: true`);
   if (spec.default !== undefined) parts.push(`default: ${JSON.stringify(spec.default)}`);
   if (spec.min !== undefined) parts.push(`min: ${spec.min}`);
   if (spec.max !== undefined) parts.push(`max: ${spec.max}`);
   if (spec.pattern !== undefined) parts.push(`pattern: ${JSON.stringify(spec.pattern)}`);
   if (spec.format !== undefined) parts.push(`format: ${JSON.stringify(spec.format)}`);
+  // EnumField.options shape is Array<{ value: string }> — see packages/core/src/types/entity.ts.
+  // Render the input string[] as objects so generated code passes core's typecheck.
   if (spec.type === "enum" && Array.isArray(spec.options)) {
-    parts.push(`options: ${JSON.stringify(spec.options)}`);
+    const options = spec.options.map((opt) => ({ value: opt }));
+    parts.push(`options: ${JSON.stringify(options)}`);
+  }
+  if (spec.type === "state" && spec.machine) {
+    parts.push(`machine: ${JSON.stringify(spec.machine)}`);
+  }
+  if (spec.derived) {
+    parts.push(`derived: ${JSON.stringify(spec.derived)}`);
   }
   return `{ ${parts.join(", ")} }`;
 }
@@ -257,6 +340,8 @@ function validateEntityInput(input: EntityGenInput, defs: CollectedDefinitions):
     errors.push("Entity name is required");
   } else if (!SNAKE_CASE_RE.test(input.name)) {
     errors.push(`Entity name '${input.name}' must be snake_case`);
+  } else if (JS_RESERVED.has(input.name)) {
+    errors.push(`Entity name '${input.name}' is a reserved JavaScript keyword`);
   }
 
   // Name collision against existing catalog
@@ -309,6 +394,8 @@ function validateActionInput(input: ActionGenInput, defs: CollectedDefinitions):
     errors.push("Action name is required");
   } else if (!SNAKE_CASE_RE.test(input.name)) {
     errors.push(`Action name '${input.name}' must be snake_case`);
+  } else if (JS_RESERVED.has(input.name)) {
+    errors.push(`Action name '${input.name}' is a reserved JavaScript keyword`);
   } else {
     // verb_noun: must contain underscore + first segment in verb list (warning if missing)
     const segments = input.name.split("_");
@@ -349,6 +436,14 @@ function validateCapabilityInput(
     errors.push(
       `Capability name '${input.name}' must match 'cap-<domain>' (lowercase letters/digits, hyphens or underscores)`,
     );
+  } else {
+    // Domain segment after cap- must not be a JS reserved keyword once the
+    // hyphen is normalised to underscore (since safeId strips hyphens).
+    const safeId = input.name.replace(/[^a-zA-Z0-9_]/g, "_");
+    const domain = input.name.slice("cap-".length);
+    if (JS_RESERVED.has(domain) || JS_RESERVED.has(safeId)) {
+      errors.push(`Capability name '${input.name}' is a reserved JavaScript keyword`);
+    }
   }
 
   if (input.name && capabilities.some((c) => c.name === input.name)) {
@@ -381,8 +476,13 @@ function validateCapabilityInput(
  * structured `validation` error in the tool result.
  */
 function ensureWithinProjectRoot(projectRoot: string, absPath: string): void {
-  const normalizedRoot = projectRoot.endsWith(sep) ? projectRoot : projectRoot + sep;
-  if (absPath !== projectRoot && !absPath.startsWith(normalizedRoot)) {
+  // Use path.relative for a cross-platform check. A path is "outside" the
+  // root iff the relative form starts with `..` or is itself absolute (which
+  // happens on Windows when projectRoot and absPath live on different drives).
+  // String prefix checks alone are fragile on Windows due to drive-letter
+  // case differences (e.g. C:\ vs c:\).
+  const rel = relative(projectRoot, absPath);
+  if (rel.startsWith(`..${sep}`) || rel === ".." || isAbsolute(rel)) {
     throw new Error(`targetPath '${absPath}' resolves outside projectRoot '${projectRoot}'`);
   }
 }
@@ -415,10 +515,13 @@ const generateEntityInputSchema = {
           description: z.string().optional(),
           required: z.boolean().optional(),
           unique: z.boolean().optional(),
+          immutable: z.boolean().optional(),
           min: z.number().optional(),
           max: z.number().optional(),
           default: z.unknown().optional(),
           options: z.array(z.string()).optional(),
+          machine: z.string().optional(),
+          derived: z.record(z.string(), z.unknown()).optional(),
           pattern: z.string().optional(),
           format: z.string().optional(),
         })

--- a/packages/cli/src/mcp-dev/generation-tools.ts
+++ b/packages/cli/src/mcp-dev/generation-tools.ts
@@ -1,0 +1,709 @@
+/**
+ * MCP Dev Server — Generation tools for scaffolding entities, actions, and capabilities.
+ *
+ * These tools allow AI agents (Claude Code, Cursor, etc.) to produce
+ * LinchKit-compatible source code through MCP. Each tool returns the
+ * generated source string and the target file path. Tools may either
+ * write to disk (default) or return code only (`dryRun: true`).
+ *
+ * Issue #156 Phase 4 (Spec 60 §3).
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import type { CapabilityDefinition } from "@linchkit/core";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CollectedDefinitions } from "../commands/startup/collect-capabilities";
+import { z } from "./schema";
+
+// ── Validation helpers ──────────────────────────────────────────
+
+const SNAKE_CASE_RE = /^[a-z][a-z0-9_]*$/;
+const VERB_LIST = [
+  "create",
+  "update",
+  "delete",
+  "submit",
+  "approve",
+  "reject",
+  "cancel",
+  "archive",
+  "restore",
+  "publish",
+  "unpublish",
+  "assign",
+  "unassign",
+  "send",
+  "receive",
+  "import",
+  "export",
+  "sync",
+  "validate",
+  "process",
+  "complete",
+  "start",
+  "stop",
+  "pause",
+  "resume",
+  "lock",
+  "unlock",
+  "duplicate",
+  "merge",
+  "split",
+  "reorder",
+  "schedule",
+  "notify",
+  "generate",
+  "register",
+  "deregister",
+  "subscribe",
+  "unsubscribe",
+];
+
+interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+interface FieldSpec {
+  type: string;
+  label?: string;
+  description?: string;
+  required?: boolean;
+  unique?: boolean;
+  min?: number;
+  max?: number;
+  default?: unknown;
+  options?: string[];
+  pattern?: string;
+  format?: string;
+}
+
+const VALID_FIELD_TYPES = [
+  "string",
+  "text",
+  "number",
+  "boolean",
+  "date",
+  "datetime",
+  "enum",
+  "json",
+  "state",
+  "computed",
+];
+
+const VALID_CAPABILITY_TYPES = ["standard", "adapter", "bridge"];
+
+const VALID_CAPABILITY_CATEGORIES = [
+  "business",
+  "system",
+  "infrastructure",
+  "integration",
+  "ui",
+  "utility",
+  "starter",
+];
+
+// ── Code-string builders ────────────────────────────────────────
+
+/** Render a field options object literal as a TS source string. */
+function renderField(spec: FieldSpec): string {
+  const parts: string[] = [];
+  parts.push(`type: ${JSON.stringify(spec.type)}`);
+  if (spec.label !== undefined) parts.push(`label: ${JSON.stringify(spec.label)}`);
+  if (spec.description !== undefined)
+    parts.push(`description: ${JSON.stringify(spec.description)}`);
+  if (spec.required) parts.push(`required: true`);
+  if (spec.unique) parts.push(`unique: true`);
+  if (spec.default !== undefined) parts.push(`default: ${JSON.stringify(spec.default)}`);
+  if (spec.min !== undefined) parts.push(`min: ${spec.min}`);
+  if (spec.max !== undefined) parts.push(`max: ${spec.max}`);
+  if (spec.pattern !== undefined) parts.push(`pattern: ${JSON.stringify(spec.pattern)}`);
+  if (spec.format !== undefined) parts.push(`format: ${JSON.stringify(spec.format)}`);
+  if (spec.type === "enum" && Array.isArray(spec.options)) {
+    parts.push(`options: ${JSON.stringify(spec.options)}`);
+  }
+  return `{ ${parts.join(", ")} }`;
+}
+
+/** Render a fields record as a multi-line TS object literal. */
+function renderFields(fields: Record<string, FieldSpec>): string {
+  const entries = Object.entries(fields);
+  if (entries.length === 0) return "{}";
+  const lines = entries.map(([name, spec]) => `    ${name}: ${renderField(spec)},`);
+  return `{\n${lines.join("\n")}\n  }`;
+}
+
+interface EntityGenInput {
+  name: string;
+  fields: Record<string, FieldSpec>;
+  label?: string;
+  description?: string;
+  extends?: string;
+  implements?: string[];
+}
+
+function buildEntitySource(input: EntityGenInput): string {
+  const parts: string[] = [];
+  parts.push(`  name: ${JSON.stringify(input.name)},`);
+  if (input.label !== undefined) parts.push(`  label: ${JSON.stringify(input.label)},`);
+  if (input.description !== undefined)
+    parts.push(`  description: ${JSON.stringify(input.description)},`);
+  if (input.extends !== undefined) parts.push(`  extends: ${JSON.stringify(input.extends)},`);
+  if (input.implements !== undefined && input.implements.length > 0)
+    parts.push(`  implements: ${JSON.stringify(input.implements)},`);
+  parts.push(`  fields: ${renderFields(input.fields)},`);
+
+  return `import { defineEntity } from "@linchkit/core";
+
+export const ${input.name} = defineEntity({
+${parts.join("\n")}
+});
+`;
+}
+
+interface ActionGenInput {
+  name: string;
+  entity: string;
+  label?: string;
+  description?: string;
+  input?: Record<string, FieldSpec>;
+  output?: Record<string, FieldSpec>;
+  policy?: Record<string, unknown>;
+  handlerStub?: string;
+}
+
+function buildActionSource(input: ActionGenInput): string {
+  const policy = input.policy ?? { requiresAuth: true };
+  const parts: string[] = [];
+  parts.push(`  name: ${JSON.stringify(input.name)},`);
+  parts.push(`  entity: ${JSON.stringify(input.entity)},`);
+  parts.push(`  label: ${JSON.stringify(input.label ?? input.name)},`);
+  if (input.description !== undefined)
+    parts.push(`  description: ${JSON.stringify(input.description)},`);
+  if (input.input !== undefined) parts.push(`  input: ${renderFields(input.input)},`);
+  if (input.output !== undefined) parts.push(`  output: ${renderFields(input.output)},`);
+  parts.push(`  policy: ${JSON.stringify(policy)},`);
+
+  const handler =
+    input.handlerStub ??
+    `async (ctx) => {
+    // TODO: implement ${input.name}
+    return ctx.input;
+  }`;
+  parts.push(`  handler: ${handler},`);
+
+  return `import { defineAction } from "@linchkit/core";
+
+export const ${input.name} = defineAction({
+${parts.join("\n")}
+});
+`;
+}
+
+interface CapabilityGenInput {
+  name: string;
+  type: string;
+  category: string;
+  label?: string;
+  description?: string;
+  /** Optionally seed empty entity / action / rule / view sub-folders. */
+  scaffoldFolders?: boolean;
+}
+
+function buildCapabilitySource(input: CapabilityGenInput): string {
+  const safeId = input.name.replace(/[^a-zA-Z0-9_]/g, "_");
+  return `import { defineCapability } from "@linchkit/core";
+
+export const ${safeId} = defineCapability({
+  name: ${JSON.stringify(input.name)},
+  label: ${JSON.stringify(input.label ?? input.name)},
+  type: ${JSON.stringify(input.type)},
+  category: ${JSON.stringify(input.category)},
+  version: "0.1.0",
+  description: ${JSON.stringify(input.description ?? "")},
+  entities: [],
+  actions: [],
+  rules: [],
+  views: [],
+});
+`;
+}
+
+function buildCapabilityPackageJson(input: CapabilityGenInput): string {
+  return `${JSON.stringify(
+    {
+      name: `@linchkit/${input.name}`,
+      version: "0.1.0",
+      type: "module",
+      main: "src/index.ts",
+      peerDependencies: {
+        "@linchkit/core": "workspace:*",
+      },
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+// ── Validation ──────────────────────────────────────────────────
+
+function validateEntityInput(input: EntityGenInput, defs: CollectedDefinitions): ValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  if (!input.name) {
+    errors.push("Entity name is required");
+  } else if (!SNAKE_CASE_RE.test(input.name)) {
+    errors.push(`Entity name '${input.name}' must be snake_case`);
+  }
+
+  // Name collision against existing catalog
+  if (input.name && defs.entities.some((e) => e.name === input.name)) {
+    errors.push(`Entity '${input.name}' already exists in the project catalog`);
+  }
+
+  // extends target must exist
+  if (input.extends && !defs.entities.some((e) => e.name === input.extends)) {
+    errors.push(`Cannot extend '${input.extends}' — entity not found in project catalog`);
+  }
+
+  // implements targets must exist
+  if (input.implements) {
+    for (const iface of input.implements) {
+      if (!defs.interfaces.some((i) => i.name === iface)) {
+        warnings.push(`Interface '${iface}' not found in project catalog`);
+      }
+    }
+  }
+
+  if (!input.fields || Object.keys(input.fields).length === 0) {
+    errors.push("Entity must have at least one field");
+  } else {
+    for (const [fieldName, spec] of Object.entries(input.fields)) {
+      if (!SNAKE_CASE_RE.test(fieldName)) {
+        errors.push(`Field '${fieldName}' must be snake_case`);
+      }
+      if (!spec.type) {
+        errors.push(`Field '${fieldName}' missing 'type'`);
+      } else if (!VALID_FIELD_TYPES.includes(spec.type)) {
+        errors.push(
+          `Field '${fieldName}' has invalid type '${spec.type}' (valid: ${VALID_FIELD_TYPES.join(", ")})`,
+        );
+      }
+      if (spec.type === "enum" && (!Array.isArray(spec.options) || spec.options.length === 0)) {
+        errors.push(`Enum field '${fieldName}' must have non-empty options[]`);
+      }
+    }
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}
+
+function validateActionInput(input: ActionGenInput, defs: CollectedDefinitions): ValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  if (!input.name) {
+    errors.push("Action name is required");
+  } else if (!SNAKE_CASE_RE.test(input.name)) {
+    errors.push(`Action name '${input.name}' must be snake_case`);
+  } else {
+    // verb_noun: must contain underscore + first segment in verb list (warning if missing)
+    const segments = input.name.split("_");
+    const verb = segments[0];
+    if (segments.length < 2 || !verb) {
+      errors.push(`Action name '${input.name}' must follow verb_noun (snake_case with underscore)`);
+    } else if (!VERB_LIST.includes(verb)) {
+      warnings.push(
+        `Action name '${input.name}' starts with '${verb}' which is not a recognised verb (e.g. ${VERB_LIST.slice(0, 6).join(", ")})`,
+      );
+    }
+  }
+
+  // name collision with existing actions
+  if (input.name && defs.actions.some((a) => a.name === input.name)) {
+    errors.push(`Action '${input.name}' already exists in the project catalog`);
+  }
+
+  if (!input.entity) {
+    errors.push("Action must reference an entity");
+  } else if (!defs.entities.some((e) => e.name === input.entity)) {
+    warnings.push(`Entity '${input.entity}' not found in project catalog`);
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}
+
+function validateCapabilityInput(
+  input: CapabilityGenInput,
+  capabilities: CapabilityDefinition[],
+): ValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  if (!input.name) {
+    errors.push("Capability name is required");
+  } else if (!/^[a-z][a-z0-9_-]*$/.test(input.name)) {
+    errors.push(`Capability name '${input.name}' must be lowercase letters/digits/-/_`);
+  }
+
+  if (input.name && capabilities.some((c) => c.name === input.name)) {
+    errors.push(`Capability '${input.name}' already exists`);
+  }
+
+  if (!VALID_CAPABILITY_TYPES.includes(input.type)) {
+    errors.push(
+      `Invalid capability type '${input.type}' (valid: ${VALID_CAPABILITY_TYPES.join(", ")})`,
+    );
+  }
+
+  if (!VALID_CAPABILITY_CATEGORIES.includes(input.category)) {
+    errors.push(
+      `Invalid capability category '${input.category}' (valid: ${VALID_CAPABILITY_CATEGORIES.join(", ")})`,
+    );
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}
+
+// ── File-write helper ───────────────────────────────────────────
+
+function maybeWriteFile(filePath: string, content: string, dryRun: boolean): void {
+  if (dryRun) return;
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  writeFileSync(filePath, content);
+}
+
+// ── Tool registration ───────────────────────────────────────────
+
+const generateEntityInputSchema = {
+  name: z.string().describe("Entity name in snake_case (e.g. purchase_request)"),
+  fields: z
+    .record(
+      z.string(),
+      z
+        .object({
+          type: z.string(),
+          label: z.string().optional(),
+          description: z.string().optional(),
+          required: z.boolean().optional(),
+          unique: z.boolean().optional(),
+          min: z.number().optional(),
+          max: z.number().optional(),
+          default: z.unknown().optional(),
+          options: z.array(z.string()).optional(),
+          pattern: z.string().optional(),
+          format: z.string().optional(),
+        })
+        .passthrough(),
+    )
+    .describe("Map of field-name → field spec"),
+  label: z.string().optional().describe("Human-readable entity label"),
+  description: z.string().optional().describe("Entity description"),
+  extends: z.string().optional().describe("Parent entity name to inherit from"),
+  implements: z.array(z.string()).optional().describe("Entity interfaces to implement"),
+  targetPath: z
+    .string()
+    .describe(
+      "Absolute or project-relative path of the file to create, e.g. addons/cap-foo/src/entities/foo.ts",
+    ),
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe("When true, do not write to disk; only return generated code"),
+};
+
+const generateActionInputSchema = {
+  name: z.string().describe("Action name in verb_noun snake_case"),
+  entity: z.string().describe("Target entity name"),
+  label: z.string().optional(),
+  description: z.string().optional(),
+  input: z.record(z.string(), z.object({ type: z.string() }).passthrough()).optional(),
+  output: z.record(z.string(), z.object({ type: z.string() }).passthrough()).optional(),
+  policy: z.record(z.string(), z.unknown()).optional(),
+  handlerStub: z.string().optional().describe("Optional handler body source string"),
+  targetPath: z.string().describe("Path to create, e.g. addons/cap-foo/src/actions/submit-foo.ts"),
+  dryRun: z.boolean().optional(),
+};
+
+const generateCapabilityInputSchema = {
+  name: z.string().describe("Capability name (e.g. cap-inventory)"),
+  type: z.string().describe("Capability type: standard | adapter | bridge"),
+  category: z.string().describe("Capability category"),
+  label: z.string().optional(),
+  description: z.string().optional(),
+  rootPath: z.string().describe("Absolute or project-relative root directory for the capability"),
+  scaffoldFolders: z
+    .boolean()
+    .optional()
+    .describe("When true, create empty entities/actions/rules/views sub-folders"),
+  dryRun: z.boolean().optional(),
+};
+
+/** Register all generation tools on the MCP server. */
+export function registerGenerationTools(
+  server: McpServer,
+  defs: CollectedDefinitions,
+  capabilities: CapabilityDefinition[],
+  projectRoot: string,
+): void {
+  // ── linchkit_generate_entity ────────────────────────────────
+  server.registerTool(
+    "linchkit_generate_entity",
+    {
+      description:
+        "Generate a defineEntity() source file. Validates against existing catalog (no name collision, valid extends target). Set dryRun=true to return code without writing.",
+      inputSchema: generateEntityInputSchema,
+    },
+    // biome-ignore lint/suspicious/noTsIgnore: TS2589 inconsistent across TS versions (MCP SDK #985)
+    // @ts-ignore — TS2589 deep type recursion
+    async (args: {
+      name: string;
+      fields: Record<string, FieldSpec>;
+      label?: string;
+      description?: string;
+      extends?: string;
+      implements?: string[];
+      targetPath: string;
+      dryRun?: boolean;
+    }) => {
+      const validation = validateEntityInput(
+        {
+          name: args.name,
+          fields: args.fields,
+          label: args.label,
+          description: args.description,
+          extends: args.extends,
+          implements: args.implements,
+        },
+        defs,
+      );
+
+      if (!validation.valid) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ error: "Validation failed", validation }, null, 2),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const code = buildEntitySource({
+        name: args.name,
+        fields: args.fields,
+        label: args.label,
+        description: args.description,
+        extends: args.extends,
+        implements: args.implements,
+      });
+
+      const absPath = resolve(projectRoot, args.targetPath);
+      maybeWriteFile(absPath, code, args.dryRun ?? false);
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              { path: absPath, code, validation, written: !(args.dryRun ?? false) },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    },
+  );
+
+  // ── linchkit_generate_action ────────────────────────────────
+  server.registerTool(
+    "linchkit_generate_action",
+    {
+      description:
+        "Generate a defineAction() source file. Validates verb_noun naming and entity reference. Set dryRun=true to return code without writing.",
+      inputSchema: generateActionInputSchema,
+    },
+    // biome-ignore lint/suspicious/noTsIgnore: TS2589 inconsistent across TS versions (MCP SDK #985)
+    // @ts-ignore — TS2589 deep type recursion
+    async (args: {
+      name: string;
+      entity: string;
+      label?: string;
+      description?: string;
+      input?: Record<string, FieldSpec>;
+      output?: Record<string, FieldSpec>;
+      policy?: Record<string, unknown>;
+      handlerStub?: string;
+      targetPath: string;
+      dryRun?: boolean;
+    }) => {
+      const validation = validateActionInput(
+        {
+          name: args.name,
+          entity: args.entity,
+          label: args.label,
+          description: args.description,
+          input: args.input,
+          output: args.output,
+          policy: args.policy,
+          handlerStub: args.handlerStub,
+        },
+        defs,
+      );
+
+      if (!validation.valid) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ error: "Validation failed", validation }, null, 2),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const code = buildActionSource({
+        name: args.name,
+        entity: args.entity,
+        label: args.label,
+        description: args.description,
+        input: args.input,
+        output: args.output,
+        policy: args.policy,
+        handlerStub: args.handlerStub,
+      });
+
+      const absPath = resolve(projectRoot, args.targetPath);
+      maybeWriteFile(absPath, code, args.dryRun ?? false);
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              { path: absPath, code, validation, written: !(args.dryRun ?? false) },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    },
+  );
+
+  // ── linchkit_generate_capability ────────────────────────────
+  server.registerTool(
+    "linchkit_generate_capability",
+    {
+      description:
+        "Scaffold a full capability skeleton: package.json, src/index.ts with defineCapability(), and optional entities/actions/rules/views sub-folders. Set dryRun=true to return file list without writing.",
+      inputSchema: generateCapabilityInputSchema,
+    },
+    // biome-ignore lint/suspicious/noTsIgnore: TS2589 inconsistent across TS versions (MCP SDK #985)
+    // @ts-ignore — TS2589 deep type recursion
+    async (args: {
+      name: string;
+      type: string;
+      category: string;
+      label?: string;
+      description?: string;
+      rootPath: string;
+      scaffoldFolders?: boolean;
+      dryRun?: boolean;
+    }) => {
+      const validation = validateCapabilityInput(
+        {
+          name: args.name,
+          type: args.type,
+          category: args.category,
+          label: args.label,
+          description: args.description,
+          scaffoldFolders: args.scaffoldFolders,
+        },
+        capabilities,
+      );
+
+      if (!validation.valid) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ error: "Validation failed", validation }, null, 2),
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const absRoot = resolve(projectRoot, args.rootPath);
+      const dryRun = args.dryRun ?? false;
+
+      const indexCode = buildCapabilitySource({
+        name: args.name,
+        type: args.type,
+        category: args.category,
+        label: args.label,
+        description: args.description,
+      });
+      const pkgJson = buildCapabilityPackageJson({
+        name: args.name,
+        type: args.type,
+        category: args.category,
+      });
+
+      const files: { path: string; content: string }[] = [
+        { path: resolve(absRoot, "package.json"), content: pkgJson },
+        { path: resolve(absRoot, "src/index.ts"), content: indexCode },
+      ];
+
+      if (args.scaffoldFolders ?? true) {
+        files.push(
+          {
+            path: resolve(absRoot, "src/entities/.gitkeep"),
+            content: "",
+          },
+          {
+            path: resolve(absRoot, "src/actions/.gitkeep"),
+            content: "",
+          },
+          {
+            path: resolve(absRoot, "src/rules/.gitkeep"),
+            content: "",
+          },
+          {
+            path: resolve(absRoot, "src/views/.gitkeep"),
+            content: "",
+          },
+        );
+      }
+
+      if (!dryRun) {
+        for (const f of files) {
+          maybeWriteFile(f.path, f.content, false);
+        }
+      }
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(
+              { rootPath: absRoot, files, validation, written: !dryRun },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    },
+  );
+}

--- a/packages/cli/src/mcp-dev/generation-tools.ts
+++ b/packages/cli/src/mcp-dev/generation-tools.ts
@@ -10,7 +10,7 @@
  */
 
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { dirname, resolve, sep } from "node:path";
 import type { CapabilityDefinition } from "@linchkit/core";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CollectedDefinitions } from "../commands/startup/collect-capabilities";
@@ -345,8 +345,10 @@ function validateCapabilityInput(
 
   if (!input.name) {
     errors.push("Capability name is required");
-  } else if (!/^[a-z][a-z0-9_-]*$/.test(input.name)) {
-    errors.push(`Capability name '${input.name}' must be lowercase letters/digits/-/_`);
+  } else if (!/^cap-[a-z][a-z0-9_-]*$/.test(input.name)) {
+    errors.push(
+      `Capability name '${input.name}' must match 'cap-<domain>' (lowercase letters/digits, hyphens or underscores)`,
+    );
   }
 
   if (input.name && capabilities.some((c) => c.name === input.name)) {
@@ -370,8 +372,28 @@ function validateCapabilityInput(
 
 // ── File-write helper ───────────────────────────────────────────
 
-function maybeWriteFile(filePath: string, content: string, dryRun: boolean): void {
+/**
+ * Ensure an absolute path resolves to a location at or beneath `projectRoot`.
+ *
+ * Guards against path-traversal payloads such as `../../etc/passwd` slipping
+ * through `resolve(projectRoot, args.targetPath)`. Throws on violation so the
+ * caller's outer try/catch (or explicit wrapper) can convert it into a
+ * structured `validation` error in the tool result.
+ */
+function ensureWithinProjectRoot(projectRoot: string, absPath: string): void {
+  const normalizedRoot = projectRoot.endsWith(sep) ? projectRoot : projectRoot + sep;
+  if (absPath !== projectRoot && !absPath.startsWith(normalizedRoot)) {
+    throw new Error(`targetPath '${absPath}' resolves outside projectRoot '${projectRoot}'`);
+  }
+}
+
+function maybeWriteFile(filePath: string, content: string, dryRun: boolean, force: boolean): void {
   if (dryRun) return;
+  if (!force && existsSync(filePath)) {
+    throw new Error(
+      `Refusing to overwrite existing file '${filePath}' — pass force: true to overwrite`,
+    );
+  }
   const dir = dirname(filePath);
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
@@ -416,6 +438,10 @@ const generateEntityInputSchema = {
     .boolean()
     .optional()
     .describe("When true, do not write to disk; only return generated code"),
+  force: z
+    .boolean()
+    .optional()
+    .describe("Overwrite existing files (default: false — refuses to clobber)"),
 };
 
 const generateActionInputSchema = {
@@ -429,6 +455,10 @@ const generateActionInputSchema = {
   handlerStub: z.string().optional().describe("Optional handler body source string"),
   targetPath: z.string().describe("Path to create, e.g. addons/cap-foo/src/actions/submit-foo.ts"),
   dryRun: z.boolean().optional(),
+  force: z
+    .boolean()
+    .optional()
+    .describe("Overwrite existing files (default: false — refuses to clobber)"),
 };
 
 const generateCapabilityInputSchema = {
@@ -443,6 +473,10 @@ const generateCapabilityInputSchema = {
     .optional()
     .describe("When true, create empty entities/actions/rules/views sub-folders"),
   dryRun: z.boolean().optional(),
+  force: z
+    .boolean()
+    .optional()
+    .describe("Overwrite existing files (default: false — refuses to clobber)"),
 };
 
 /** Register all generation tools on the MCP server. */
@@ -471,6 +505,7 @@ export function registerGenerationTools(
       implements?: string[];
       targetPath: string;
       dryRun?: boolean;
+      force?: boolean;
     }) => {
       const validation = validateEntityInput(
         {
@@ -496,30 +531,52 @@ export function registerGenerationTools(
         };
       }
 
-      const code = buildEntitySource({
-        name: args.name,
-        fields: args.fields,
-        label: args.label,
-        description: args.description,
-        extends: args.extends,
-        implements: args.implements,
-      });
+      try {
+        const code = buildEntitySource({
+          name: args.name,
+          fields: args.fields,
+          label: args.label,
+          description: args.description,
+          extends: args.extends,
+          implements: args.implements,
+        });
 
-      const absPath = resolve(projectRoot, args.targetPath);
-      maybeWriteFile(absPath, code, args.dryRun ?? false);
+        const absPath = resolve(projectRoot, args.targetPath);
+        ensureWithinProjectRoot(projectRoot, absPath);
+        const dryRun = args.dryRun ?? false;
+        maybeWriteFile(absPath, code, dryRun, args.force ?? false);
 
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify(
-              { path: absPath, code, validation, written: !(args.dryRun ?? false) },
-              null,
-              2,
-            ),
-          },
-        ],
-      };
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ path: absPath, code, validation, written: !dryRun }, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  error: "Validation failed",
+                  validation: {
+                    valid: false,
+                    errors: [message],
+                    warnings: validation.warnings,
+                  },
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+          isError: true,
+        };
+      }
     },
   );
 
@@ -544,6 +601,7 @@ export function registerGenerationTools(
       handlerStub?: string;
       targetPath: string;
       dryRun?: boolean;
+      force?: boolean;
     }) => {
       const validation = validateActionInput(
         {
@@ -571,32 +629,54 @@ export function registerGenerationTools(
         };
       }
 
-      const code = buildActionSource({
-        name: args.name,
-        entity: args.entity,
-        label: args.label,
-        description: args.description,
-        input: args.input,
-        output: args.output,
-        policy: args.policy,
-        handlerStub: args.handlerStub,
-      });
+      try {
+        const code = buildActionSource({
+          name: args.name,
+          entity: args.entity,
+          label: args.label,
+          description: args.description,
+          input: args.input,
+          output: args.output,
+          policy: args.policy,
+          handlerStub: args.handlerStub,
+        });
 
-      const absPath = resolve(projectRoot, args.targetPath);
-      maybeWriteFile(absPath, code, args.dryRun ?? false);
+        const absPath = resolve(projectRoot, args.targetPath);
+        ensureWithinProjectRoot(projectRoot, absPath);
+        const dryRun = args.dryRun ?? false;
+        maybeWriteFile(absPath, code, dryRun, args.force ?? false);
 
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify(
-              { path: absPath, code, validation, written: !(args.dryRun ?? false) },
-              null,
-              2,
-            ),
-          },
-        ],
-      };
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ path: absPath, code, validation, written: !dryRun }, null, 2),
+            },
+          ],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  error: "Validation failed",
+                  validation: {
+                    valid: false,
+                    errors: [message],
+                    warnings: validation.warnings,
+                  },
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+          isError: true,
+        };
+      }
     },
   );
 
@@ -619,6 +699,7 @@ export function registerGenerationTools(
       rootPath: string;
       scaffoldFolders?: boolean;
       dryRun?: boolean;
+      force?: boolean;
     }) => {
       const validation = validateCapabilityInput(
         {
@@ -644,66 +725,97 @@ export function registerGenerationTools(
         };
       }
 
-      const absRoot = resolve(projectRoot, args.rootPath);
-      const dryRun = args.dryRun ?? false;
+      try {
+        const absRoot = resolve(projectRoot, args.rootPath);
+        ensureWithinProjectRoot(projectRoot, absRoot);
+        const dryRun = args.dryRun ?? false;
+        const force = args.force ?? false;
 
-      const indexCode = buildCapabilitySource({
-        name: args.name,
-        type: args.type,
-        category: args.category,
-        label: args.label,
-        description: args.description,
-      });
-      const pkgJson = buildCapabilityPackageJson({
-        name: args.name,
-        type: args.type,
-        category: args.category,
-      });
+        const indexCode = buildCapabilitySource({
+          name: args.name,
+          type: args.type,
+          category: args.category,
+          label: args.label,
+          description: args.description,
+        });
+        const pkgJson = buildCapabilityPackageJson({
+          name: args.name,
+          type: args.type,
+          category: args.category,
+        });
 
-      const files: { path: string; content: string }[] = [
-        { path: resolve(absRoot, "package.json"), content: pkgJson },
-        { path: resolve(absRoot, "src/index.ts"), content: indexCode },
-      ];
+        const files: { path: string; content: string }[] = [
+          { path: resolve(absRoot, "package.json"), content: pkgJson },
+          { path: resolve(absRoot, "src/index.ts"), content: indexCode },
+        ];
 
-      if (args.scaffoldFolders ?? true) {
-        files.push(
-          {
-            path: resolve(absRoot, "src/entities/.gitkeep"),
-            content: "",
-          },
-          {
-            path: resolve(absRoot, "src/actions/.gitkeep"),
-            content: "",
-          },
-          {
-            path: resolve(absRoot, "src/rules/.gitkeep"),
-            content: "",
-          },
-          {
-            path: resolve(absRoot, "src/views/.gitkeep"),
-            content: "",
-          },
-        );
-      }
-
-      if (!dryRun) {
-        for (const f of files) {
-          maybeWriteFile(f.path, f.content, false);
+        if (args.scaffoldFolders ?? true) {
+          files.push(
+            {
+              path: resolve(absRoot, "src/entities/.gitkeep"),
+              content: "",
+            },
+            {
+              path: resolve(absRoot, "src/actions/.gitkeep"),
+              content: "",
+            },
+            {
+              path: resolve(absRoot, "src/rules/.gitkeep"),
+              content: "",
+            },
+            {
+              path: resolve(absRoot, "src/views/.gitkeep"),
+              content: "",
+            },
+          );
         }
-      }
 
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify(
-              { rootPath: absRoot, files, validation, written: !dryRun },
-              null,
-              2,
-            ),
-          },
-        ],
-      };
+        // Re-check every scaffolded path against the project root before writing.
+        for (const f of files) {
+          ensureWithinProjectRoot(projectRoot, f.path);
+        }
+
+        if (!dryRun) {
+          for (const f of files) {
+            maybeWriteFile(f.path, f.content, false, force);
+          }
+        }
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                { rootPath: absRoot, files, validation, written: !dryRun },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  error: "Validation failed",
+                  validation: {
+                    valid: false,
+                    errors: [message],
+                    warnings: validation.warnings,
+                  },
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+          isError: true,
+        };
+      }
     },
   );
 }

--- a/packages/cli/src/mcp-dev/index.ts
+++ b/packages/cli/src/mcp-dev/index.ts
@@ -1,0 +1,14 @@
+/**
+ * MCP Dev Server — public re-exports.
+ *
+ * Consumers should prefer this barrel for stable imports rather than
+ * referencing internal sub-modules directly.
+ */
+
+export { registerDiscoveryTools } from "./discovery-tools";
+export { registerGenerationTools } from "./generation-tools";
+export { registerPrompts } from "./prompts";
+export { registerResources } from "./resources";
+export { createMcpDevServer, type McpDevServerOptions } from "./server";
+export { registerUtilityTools } from "./utility-tools";
+export { registerValidationTools } from "./validation-tools";

--- a/packages/cli/src/mcp-dev/prompts.ts
+++ b/packages/cli/src/mcp-dev/prompts.ts
@@ -14,6 +14,10 @@ const fromToSchema = {
   from: z.string().describe("Source entity name"),
   to: z.string().describe("Target entity name"),
 };
+const domainSchema = { domain: z.string().describe("Business domain (e.g. inventory, billing)") };
+const errorSchema = {
+  error: z.string().describe("Stringified LinchKitError JSON, including the structured `context`"),
+};
 
 /** Register all prompts on the MCP server. */
 export function registerPrompts(
@@ -316,5 +320,245 @@ ${capabilities.map((c) => `- ${c.name} (${c.type}${c.category ? `, ${c.category}
         },
       ],
     }),
+  );
+
+  // design_entity — guided entity design (issue #156 Phase 4)
+  server.registerPrompt(
+    "design_entity",
+    {
+      description:
+        "Guide an AI agent through entity design — domain, name, fields, state, relations — and produce a defineEntity() ready for linchkit_generate_entity",
+      argsSchema: domainSchema,
+    },
+    async ({ domain }: { domain: string }) => ({
+      messages: [
+        {
+          role: "user" as const,
+          content: {
+            type: "text" as const,
+            text: `You are designing a LinchKit entity in the **${domain}** domain.
+
+Walk through these steps in order. At each step, state your decision clearly before moving on.
+
+## 1. Choose entity name
+- Use snake_case, singular noun (e.g. \`purchase_request\`, \`inventory_item\`).
+- Verify it does not collide with existing entities:
+  ${defs.entities.map((e) => `  - ${e.name}`).join("\n") || "  (no existing entities)"}
+
+## 2. Define fields
+For each field, decide:
+- **name** (snake_case)
+- **type** — one of: string, text, number, boolean, date, datetime, enum, json, state, computed
+- **required**, **unique**, **min/max**, **default**, **pattern**, **format**
+- **enum** fields MUST include \`options: [...]\`
+
+> **System fields are auto-managed — do NOT define**: id, tenant_id, created_at, updated_at, created_by, updated_by, _version
+
+## 3. Decide if a state machine is needed
+If this entity has a lifecycle (e.g. draft → submitted → approved):
+- Add a \`state\` field
+- Plan to call \`defineState()\` separately
+
+## 4. Decide on relations
+Identify foreign keys and many-to-many links. These are defined separately via \`defineRelation()\`.
+
+## 5. Decide on inheritance
+- \`extends\` — inherit from a parent entity (must already exist)
+- \`implements\` — adopt one or more entity-interface field contracts
+
+## 6. Output the call
+Once decided, invoke the \`linchkit_generate_entity\` tool with:
+\`\`\`json
+{
+  "name": "<snake_case_name>",
+  "label": "Human Label",
+  "description": "What this entity represents",
+  "fields": { /* spec map */ },
+  "extends": "<optional>",
+  "implements": ["<optional>"],
+  "targetPath": "addons/<capability>/src/entities/<name>.ts",
+  "dryRun": false
+}
+\`\`\`
+
+Existing entities in this project:
+${defs.entities.map((e) => `- ${e.name}${e.label ? ` (${e.label})` : ""}`).join("\n") || "(none)"}`,
+          },
+        },
+      ],
+    }),
+  );
+
+  // design_capability — guided full capability design (issue #156 Phase 4)
+  server.registerPrompt(
+    "design_capability",
+    {
+      description:
+        "Guide an AI agent through full capability design — scope, name, entities, actions, rules, views — culminating in linchkit_generate_capability",
+      argsSchema: domainSchema,
+    },
+    async ({ domain }: { domain: string }) => ({
+      messages: [
+        {
+          role: "user" as const,
+          content: {
+            type: "text" as const,
+            text: `You are designing a new LinchKit capability for the **${domain}** domain.
+
+Work through these decisions in order:
+
+## 1. Scope question — is this a capability?
+> "Without this, is a zero-capability LinchKit still AI-Native?"
+- **Yes** → it belongs in a capability (continue)
+- **No** → it belongs in core (stop and discuss)
+
+## 2. Capability name
+- Format: \`cap-<domain>\` (e.g. \`cap-inventory\`, \`cap-purchase\`)
+- Lowercase, hyphens allowed, must start with a letter
+
+## 3. Capability type and category
+- **type**: standard | adapter | bridge
+- **category**: business | system | infrastructure | integration | ui | utility | starter
+
+## 4. List entities
+For each entity, run the \`design_entity\` prompt or call \`linchkit_generate_entity\` directly.
+Suggested approach: 1-3 core entities, more can be added later.
+
+## 5. List actions
+For each entity, identify the verbs (verb_noun naming):
+- Lifecycle: create_*, update_*, delete_*
+- Domain-specific: submit_*, approve_*, archive_*, …
+Use \`linchkit_generate_action\` per action.
+
+## 6. Rules (optional)
+Declarative conditions + effects triggered by actions/events.
+Examples: budget_check, low_stock_alert.
+
+## 7. Views (optional)
+UI rendering config (list, form, kanban, calendar).
+
+## 8. Scaffold the capability
+Invoke \`linchkit_generate_capability\` with:
+\`\`\`json
+{
+  "name": "cap-<domain>",
+  "type": "standard",
+  "category": "business",
+  "label": "Human Label",
+  "description": "What this capability does",
+  "rootPath": "addons/<domain>/cap-<domain>",
+  "scaffoldFolders": true,
+  "dryRun": false
+}
+\`\`\`
+Then add entities and actions inside the generated \`src/entities\` and \`src/actions\` folders.
+
+Existing capabilities:
+${capabilities.map((c) => `- ${c.name} (${c.type}${c.category ? `, ${c.category}` : ""})`).join("\n") || "(none)"}`,
+          },
+        },
+      ],
+    }),
+  );
+
+  // diagnose_error — guided LinchKitError diagnosis (Spec 60 §3.3 Phase 5 context)
+  server.registerPrompt(
+    "diagnose_error",
+    {
+      description:
+        "Given a LinchKitError JSON (with structured `context`), guide the agent through diagnosis: identify entity/action/field, check spec, check overlay, propose fix as a Proposal",
+      argsSchema: errorSchema,
+    },
+    async ({ error }: { error: string }) => {
+      let parsed: {
+        message?: string;
+        code?: string;
+        context?: {
+          entity?: string;
+          action?: string;
+          field?: string;
+          constraint?: string;
+          expected?: string;
+          actual?: string;
+          suggestion?: string;
+        };
+      } = {};
+      try {
+        parsed = JSON.parse(error);
+      } catch {
+        // leave parsed as empty object — we'll show the raw text below
+      }
+
+      const ctx = parsed.context ?? {};
+      const knownEntity = ctx.entity && defs.entities.find((e) => e.name === ctx.entity);
+      const knownAction = ctx.action && defs.actions.find((a) => a.name === ctx.action);
+
+      return {
+        messages: [
+          {
+            role: "user" as const,
+            content: {
+              type: "text" as const,
+              text: `You are diagnosing a LinchKitError. Follow this checklist.
+
+## Raw error
+\`\`\`json
+${JSON.stringify(parsed, null, 2) || error}
+\`\`\`
+
+## Step 1 — Identify what's involved
+- **Entity**: ${ctx.entity ?? "(not specified)"} ${knownEntity ? "[exists in catalog]" : ctx.entity ? "[NOT in catalog]" : ""}
+- **Action**: ${ctx.action ?? "(not specified)"} ${knownAction ? "[exists in catalog]" : ctx.action ? "[NOT in catalog]" : ""}
+- **Field**: ${ctx.field ?? "(not specified)"}
+- **Constraint that failed**: ${ctx.constraint ?? "(not specified)"}
+- **Expected**: ${ctx.expected ?? "(not specified)"}
+- **Actual**: ${ctx.actual ?? "(not specified)"}
+- **Hint**: ${ctx.suggestion ?? "(none)"}
+
+## Step 2 — Check the relevant spec
+Look up the related spec in \`docs/specs/\`:
+- Entity / field issues → Spec 02 (entities), Spec 33 (errors)
+- Action / state issues → Spec 03 (actions), Spec 04 (state machines)
+- Permission / auth → Spec 09 (permission), Spec 10 (auth)
+- Validation / rules → Spec 06 (rules)
+- AI-context errors → Spec 60 §3.3
+
+## Step 3 — Inspect overlay state
+Run \`linch overlay status\` (or read \`linchkit/overlay.json\`) to see if a recent overlay change introduced the failing constraint.
+
+## Step 4 — Inspect the involved definitions
+${
+  knownEntity
+    ? `Use \`linchkit_describe_entity\` with name=${knownEntity.name}.`
+    : ctx.entity
+      ? `Entity \`${ctx.entity}\` is referenced but not in the project catalog — check that the relevant capability is loaded.`
+      : ""
+}
+${
+  knownAction
+    ? `Use \`linchkit_describe_action\` with name=${knownAction.name}.`
+    : ctx.action
+      ? `Action \`${ctx.action}\` is referenced but not in the project catalog.`
+      : ""
+}
+
+## Step 5 — Propose a fix
+**AI never modifies production directly.** Wrap the fix as a **Proposal** (Spec 55):
+1. Describe the change in plain language.
+2. Identify whether it's a code change (overlay or source), a data change (migration), or a config change.
+3. Submit via the proposal flow — do not edit production tables or core code without approval.
+
+Possible fix categories:
+- **Definition mismatch** — update the entity/action/rule definition (overlay)
+- **Data violation** — propose a migration / cleanup action
+- **Logic bug** — open an issue and write a failing test first
+- **Permission gap** — adjust the RBAC permission via cap-permission
+
+End your response with the proposal payload as JSON.`,
+            },
+          },
+        ],
+      };
+    },
   );
 }

--- a/packages/cli/src/mcp-dev/prompts.ts
+++ b/packages/cli/src/mcp-dev/prompts.ts
@@ -96,6 +96,8 @@ Naming conventions:
 | datetime | Date and time | min, max |
 | enum | Fixed set of values | options (required) |
 | json | Arbitrary JSON | — |
+| state | Finite state machine value (enum-like, governed by defineState) | — |
+| computed | Derived field per Spec 48 (config in \`derived\`) | — |
 
 > **Relationships** between entities are defined using \`defineRelation()\`, not field types. See Spec 46/61.
 

--- a/packages/cli/src/mcp-dev/server.ts
+++ b/packages/cli/src/mcp-dev/server.ts
@@ -12,6 +12,7 @@ import type { CapabilityDefinition } from "@linchkit/core";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CollectedDefinitions } from "../commands/startup/collect-capabilities";
 import { registerDiscoveryTools } from "./discovery-tools";
+import { registerGenerationTools } from "./generation-tools";
 import { registerPrompts } from "./prompts";
 import { registerResources } from "./resources";
 import { registerUtilityTools } from "./utility-tools";
@@ -54,6 +55,7 @@ export function createMcpDevServer(options: McpDevServerOptions): McpServer {
   registerDiscoveryTools(server, definitions, capabilities);
   registerValidationTools(server, definitions);
   registerUtilityTools(server, definitions, capabilities, projectRoot);
+  registerGenerationTools(server, definitions, capabilities, projectRoot);
   registerResources(server, definitions);
   registerPrompts(server, definitions, capabilities);
 


### PR DESCRIPTION
## Summary
Spec 60 Phase 4 — adds dev-time MCP **generation tools** + **design prompts** so AI agents can scaffold LinchKit artifacts through the dev MCP server.

## Tools (in `packages/cli/src/mcp-dev/generation-tools.ts`)
- **`linchkit_generate_entity`** — produces `defineEntity({ ... })` source + writes to `<capability>/src/entities/<entity-name>.ts`. Validates name (snake_case singular), extends/implements targets, field types.
- **`linchkit_generate_action`** — produces `defineAction({ ... })` source + writes to `<capability>/src/actions/<action-name>.ts`. Strict on `verb_noun` underscore form (refuses obviously-malformed names); unknown verb is a warning, not a hard error.
- **`linchkit_generate_capability`** — scaffolds `package.json` + `src/index.ts` with `defineCapability()`, plus optional sub-folders for `entities/` `actions/` `rules/` `views/` (default scaffolded).

All tools accept absolute or project-relative paths (resolved against `projectRoot`) and these flags:
- `dryRun: true` — return `{ path, content }` without filesystem writes
- `force: true` — overwrite an existing file (refuses by default)

Validation is structured (no throws): every error is a stable code in the `ValidationResult` payload. Filesystem-safety errors (path traversal, overwrite without force) are caught and reported the same way.

## Prompts (extending `packages/cli/src/mcp-dev/prompts.ts`)
- **`design_entity`** — guides Claude through entity design ending in a `linchkit_generate_entity` call.
- **`design_capability`** — guides Claude through full capability design ending in `linchkit_generate_capability`.
- **`diagnose_error`** — parses a `LinchKitError`'s structured `context` (Spec 60 §3.3) and walks the agent through entity / action / spec / overlay diagnosis, ending in a Proposal.

## Wiring
- `packages/cli/src/mcp-dev/server.ts` registers the new tools and prompts.
- `packages/cli/src/mcp-dev/index.ts` (new) re-exports all `register*` helpers + `McpDevServerOptions`.

## Codex review iteration (this PR's two commits)

The first commit had two MAJOR issues caught in cross-model review:
1. **Path traversal allowed** — `resolve(projectRoot, '../../etc/passwd')` collapsed outside `projectRoot`. Fixed with `ensureWithinProjectRoot()` guard called after every `resolve()` in all three tools.
2. **Silent overwrite** — `maybeWriteFile` clobbered existing user code. Fixed with explicit `force` flag (default false) and a refusal error wrapped into the `validation` result.

Plus two MINOR mismatches (capability name `cap-` prefix; `state`/`computed` types missing from the prompt's field-types table).

## Tests (20 in `packages/cli/__tests__/mcp-dev-generation.test.ts`)
- 12 baseline: happy paths + name-collision / invalid-extends / invalid-action-naming / invalid-type rejections + prompt smoke tests.
- 8 added in second commit (filesystem safety): path-traversal rejection × 3 tools, overwrite-without-force refused / with-force succeeds, dryRun-doesn't-touch-fs, capability `cap-` prefix enforcement, empty-enum-options rejection.

## Test plan
- [x] `bun test` — 4721 pass / 0 fail / 3 skip
- [x] `bun run check` — clean
- [x] `bun run typecheck` — clean
- [x] Cross-model review — MAJOR/MINOR findings addressed in second commit

Refs #156 (closes Phase 4 only — Phase 3 MCP dev server is largely Done; Phase 6 runtime MCP enhancement remaining)

🤖 Generated with [Claude Code](https://claude.com/claude-code)