### PR TITLE
feat(demo): cap-life-demo — Spec 55 Sense → Memory pipeline skeleton

### DIFF
--- a/addons/demo/cap-life-demo/README.md
+++ b/addons/demo/cap-life-demo/README.md
@@ -1,0 +1,43 @@
+# cap-life-demo
+
+A minimal end-to-end skeleton proving the Spec 55 life-system pipeline runs
+through the lifecycle abstractions added in PR #255 — `LifecycleSensor`,
+`LifecycleSignal`, `LifecycleMemoryStore`, `LifecycleBaseline`. The demo
+intentionally skips databases, HTTP, and AI providers: the Sense -> Memory
+flow stays in-process so future capabilities have a copy-pasteable wiring
+example.
+
+## Wiring
+
+```ts
+import {
+  CountingBaseline,
+  InMemoryLifecycleStore,
+  PollSensor,
+  run,
+} from "@linchkit/cap-life-demo";
+
+const sensor = new PollSensor({
+  id: "my-cap.heartbeat",
+  intervalMs: 250,
+  produce: () => ({ value: Math.random() }),
+});
+const store = new InMemoryLifecycleStore();
+const baseline = new CountingBaseline({ id: "my-cap.heartbeat.value" });
+
+const controller = run({
+  sensor,
+  store,
+  baseline,
+  anomalyThreshold: 0.5,
+  onAnomaly: (signal, score) => console.log("spike", signal, score),
+});
+
+// later: controller.stop();
+```
+
+The pipeline subscribes to the sensor, writes every signal under
+`signals/${sensorId}/${timestamp}` in the memory store, and asks the
+baseline to score the new value before updating it.
+
+See `docs/specs/55_evolution_system.md` for the five-layer life-system model.

--- a/addons/demo/cap-life-demo/__tests__/pipeline.test.ts
+++ b/addons/demo/cap-life-demo/__tests__/pipeline.test.ts
@@ -39,12 +39,22 @@ function makePipeline(values: number[]) {
     anomalyThreshold: 0.5,
     onAnomaly: (signal, score) => anomalies.push({ signal, score }),
   });
+  // Register into the global sensor-registry so afterEach cleanup is effective
+  // even if a test throws before reaching `controller.stop()`. The
+  // sensor-registry helper test has its own dedicated registration and is
+  // tolerant of double-register via try/catch.
+  try {
+    registerSensor(sensor);
+  } catch {
+    // Already registered (e.g. by a test that re-registers explicitly) — ignore.
+  }
   return { sensor, store, baseline, controller, anomalies };
 }
 
 afterEach(async () => {
-  // The demo only registers a single sensor under SENSOR_ID per test;
-  // unregisterSensor handles its own stop()+remove cleanup.
+  // The demo only registers a single sensor under SENSOR_ID per test (now
+  // happens inside makePipeline). unregisterSensor handles its own
+  // stop()+remove cleanup, so a failing test still releases the polling timer.
   await unregisterSensor(SENSOR_ID);
 });
 

--- a/addons/demo/cap-life-demo/__tests__/pipeline.test.ts
+++ b/addons/demo/cap-life-demo/__tests__/pipeline.test.ts
@@ -1,0 +1,147 @@
+/**
+ * End-to-end tests for the Spec 55 life-system demo skeleton.
+ *
+ * Each test drives the pipeline through `controller.tick()` so we never
+ * have to wait on real timers. The polling timer is exercised separately
+ * in the cleanup test, where we verify `stop()` actually clears it and
+ * unsubscribes from the sensor.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import type { LifecycleSignal } from "@linchkit/core";
+import { findSensor, getSensors, registerSensor, unregisterSensor } from "@linchkit/core";
+import { CountingBaseline } from "../src/counting-baseline";
+import { InMemoryLifecycleStore } from "../src/in-memory-store";
+import { run } from "../src/pipeline";
+import { PollSensor } from "../src/poll-sensor";
+
+const SENSOR_ID = "life-demo.tick";
+
+function makePipeline(values: number[]) {
+  let cursor = 0;
+  let clock = 1_000;
+  const sensor = new PollSensor({
+    id: SENSOR_ID,
+    intervalMs: 250,
+    produce: () => ({ value: values[Math.min(cursor++, values.length - 1)] ?? 0 }),
+    now: () => {
+      clock += 1;
+      return clock;
+    },
+  });
+  const store = new InMemoryLifecycleStore();
+  const baseline = new CountingBaseline({ id: "life-demo.tick.value", warmup: 2 });
+  const anomalies: Array<{ signal: LifecycleSignal; score: number }> = [];
+  const controller = run({
+    sensor,
+    store,
+    baseline,
+    anomalyThreshold: 0.5,
+    onAnomaly: (signal, score) => anomalies.push({ signal, score }),
+  });
+  return { sensor, store, baseline, controller, anomalies };
+}
+
+afterEach(async () => {
+  // The demo only registers a single sensor under SENSOR_ID per test;
+  // unregisterSensor handles its own stop()+remove cleanup.
+  await unregisterSensor(SENSOR_ID);
+});
+
+describe("life-system demo pipeline", () => {
+  test("normal flow: every signal lands in the memory store", async () => {
+    const { store, controller } = makePipeline([1, 2, 3, 4]);
+    try {
+      await controller.tick();
+      await controller.tick();
+      await controller.tick();
+      const page = await store.list(`signals/${SENSOR_ID}/`);
+      expect(page.keys.length).toBe(3);
+      expect(store.size()).toBe(3);
+    } finally {
+      controller.stop();
+    }
+  });
+
+  test("spike detection: anomaly callback fires exactly once for the outlier", async () => {
+    // Three small values establish a low baseline (mean ~ 1), then a big
+    // spike (1000) crosses the spikeMultiplier (default 5) threshold.
+    const { controller, anomalies } = makePipeline([1, 1, 1, 1000, 1]);
+    try {
+      await controller.tick(); // value=1, warmup
+      await controller.tick(); // value=1
+      await controller.tick(); // value=1, baseline now warm
+      await controller.tick(); // value=1000 — should trip
+      await controller.tick(); // value=1 — back to normal
+
+      expect(anomalies.length).toBe(1);
+      expect((anomalies[0]?.signal.data as { value: number }).value).toBe(1000);
+      expect(anomalies[0]?.score).toBeGreaterThan(0.5);
+    } finally {
+      controller.stop();
+    }
+  });
+
+  test("baseline observes every value, including the spike", async () => {
+    const { controller, baseline } = makePipeline([2, 4, 6, 100]);
+    try {
+      await controller.tick();
+      await controller.tick();
+      await controller.tick();
+      await controller.tick();
+      const snap = baseline.snapshot() as { count: number; max: number };
+      expect(snap.count).toBe(4);
+      expect(snap.max).toBe(100);
+    } finally {
+      controller.stop();
+    }
+  });
+
+  test("cleanup: stop() unsubscribes and halts the polling timer", async () => {
+    const { sensor, controller } = makePipeline([1, 2, 3]);
+    expect(sensor.isRunning()).toBe(true);
+    expect(sensor.subscriberCount()).toBe(1);
+
+    controller.stop();
+
+    expect(sensor.isRunning()).toBe(false);
+    expect(sensor.subscriberCount()).toBe(0);
+    expect(controller.isRunning()).toBe(false);
+
+    // Idempotent — a second stop() must not throw.
+    controller.stop();
+  });
+
+  test("sensor-registry helpers: register, find, getSensors, unregister", async () => {
+    const sensor = new PollSensor({
+      id: "life-demo.registry-roundtrip",
+      intervalMs: 250,
+      produce: () => ({ value: 0 }),
+    });
+
+    expect(getSensors()).toHaveLength(0);
+    registerSensor(sensor);
+    expect(getSensors()).toHaveLength(1);
+    expect(findSensor(sensor.id)).toBe(sensor);
+
+    const removed = await unregisterSensor(sensor.id);
+    expect(removed).toBe(true);
+    expect(getSensors()).toHaveLength(0);
+    expect(findSensor(sensor.id)).toBeUndefined();
+  });
+
+  test("registry rejects duplicate sensor IDs", () => {
+    const a = new PollSensor({
+      id: "life-demo.duplicate",
+      intervalMs: 250,
+      produce: () => ({ value: 0 }),
+    });
+    const b = new PollSensor({
+      id: "life-demo.duplicate",
+      intervalMs: 250,
+      produce: () => ({ value: 0 }),
+    });
+    registerSensor(a);
+    expect(() => registerSensor(b)).toThrow(/already registered/);
+  });
+});

--- a/addons/demo/cap-life-demo/__tests__/pipeline.test.ts
+++ b/addons/demo/cap-life-demo/__tests__/pipeline.test.ts
@@ -140,7 +140,7 @@ describe("life-system demo pipeline", () => {
     expect(findSensor(sensor.id)).toBeUndefined();
   });
 
-  test("registry rejects duplicate sensor IDs", () => {
+  test("registry rejects duplicate sensor IDs", async () => {
     const a = new PollSensor({
       id: "life-demo.duplicate",
       intervalMs: 250,
@@ -151,7 +151,13 @@ describe("life-system demo pipeline", () => {
       intervalMs: 250,
       produce: () => ({ value: 0 }),
     });
-    registerSensor(a);
-    expect(() => registerSensor(b)).toThrow(/already registered/);
+    try {
+      registerSensor(a);
+      expect(() => registerSensor(b)).toThrow(/already registered/);
+    } finally {
+      // afterEach only cleans SENSOR_ID; this test uses a different id and
+      // must remove it itself or it leaks into later tests in this file.
+      await unregisterSensor("life-demo.duplicate");
+    }
   });
 });

--- a/addons/demo/cap-life-demo/package.json
+++ b/addons/demo/cap-life-demo/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@linchkit/cap-life-demo",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "peerDependencies": {
+    "@linchkit/core": "workspace:*"
+  }
+}

--- a/addons/demo/cap-life-demo/src/counting-baseline.ts
+++ b/addons/demo/cap-life-demo/src/counting-baseline.ts
@@ -1,0 +1,85 @@
+/**
+ * Tiny LifecycleBaseline that flags spikes in a stream of numeric values.
+ *
+ * Tracks the running mean and a moving max over the observations seen so
+ * far. `score()` returns 1.0 when an observation exceeds
+ * `mean * spikeMultiplier` (clamped to [0, 1]); otherwise the score
+ * scales linearly between 0 and 1 across the band.
+ *
+ * Synchronous on every method — there's no I/O. Production baselines
+ * (z-score, rolling EWMA, model-based) belong in their own capability;
+ * this one exists to keep the demo readable.
+ */
+
+import type { LifecycleBaseline } from "@linchkit/core";
+
+export interface CountingBaselineOptions {
+  /** Stable identifier — typically `<entity>.<metric>`. */
+  id: string;
+  /** Multiplier above the running mean that counts as a full spike (score=1). Default: 5. */
+  spikeMultiplier?: number;
+  /** Minimum number of observations before scoring returns > 0. Default: 3. */
+  warmup?: number;
+}
+
+interface Snapshot {
+  id: string;
+  count: number;
+  mean: number;
+  max: number;
+  spikeMultiplier: number;
+}
+
+export class CountingBaseline implements LifecycleBaseline {
+  readonly id: string;
+  private readonly spikeMultiplier: number;
+  private readonly warmup: number;
+  private count = 0;
+  private mean = 0;
+  private max = 0;
+
+  constructor(options: CountingBaselineOptions) {
+    this.id = options.id;
+    this.spikeMultiplier = options.spikeMultiplier ?? 5;
+    this.warmup = options.warmup ?? 3;
+  }
+
+  update(observation: unknown): void {
+    const value = this.toNumber(observation);
+    if (value === null) return;
+    this.count += 1;
+    // Running mean: mean_n = mean_{n-1} + (x - mean_{n-1}) / n
+    this.mean = this.mean + (value - this.mean) / this.count;
+    if (value > this.max) this.max = value;
+  }
+
+  score(observation: unknown): number {
+    const value = this.toNumber(observation);
+    if (value === null) return 0;
+    if (this.count < this.warmup) return 0;
+    if (this.mean <= 0) return value > 0 ? 1 : 0;
+    const ratio = value / (this.mean * this.spikeMultiplier);
+    if (ratio <= 0) return 0;
+    if (ratio >= 1) return 1;
+    return ratio;
+  }
+
+  snapshot(): Snapshot {
+    return {
+      id: this.id,
+      count: this.count,
+      mean: this.mean,
+      max: this.max,
+      spikeMultiplier: this.spikeMultiplier,
+    };
+  }
+
+  private toNumber(observation: unknown): number | null {
+    if (typeof observation === "number" && Number.isFinite(observation)) return observation;
+    if (typeof observation === "object" && observation !== null) {
+      const candidate = (observation as { value?: unknown }).value;
+      if (typeof candidate === "number" && Number.isFinite(candidate)) return candidate;
+    }
+    return null;
+  }
+}

--- a/addons/demo/cap-life-demo/src/in-memory-store.ts
+++ b/addons/demo/cap-life-demo/src/in-memory-store.ts
@@ -46,14 +46,21 @@ export class InMemoryLifecycleStore implements LifecycleMemoryStore {
   }
 
   async list(prefix?: string, options?: MemoryStoreListOptions): Promise<MemoryStoreListPage> {
-    // Drop expired entries lazily so list() never returns stale keys.
+    // Filter expired entries lazily WHILE walking — we no longer scan the
+    // whole map separately. For each candidate key we either drop it (expired)
+    // or include it. This is still O(N) on a single list call, but at least we
+    // walk the map exactly once. Production-grade stores should maintain a TTL
+    // index (sorted heap or per-bucket sweep) to avoid the linear scan
+    // entirely; out of scope for this demo store.
+    const allKeys: string[] = [];
     for (const [key, entry] of this.entries.entries()) {
-      if (this.isExpired(entry)) this.entries.delete(key);
+      if (this.isExpired(entry)) {
+        this.entries.delete(key);
+        continue;
+      }
+      if (!prefix || key.startsWith(prefix)) allKeys.push(key);
     }
-
-    const allKeys = Array.from(this.entries.keys())
-      .filter((k) => (prefix ? k.startsWith(prefix) : true))
-      .sort();
+    allKeys.sort();
 
     // Cursor is an opaque token — we encode it as the offset into `allKeys`.
     const offset = options?.cursor ? Number.parseInt(options.cursor, 10) : 0;

--- a/addons/demo/cap-life-demo/src/in-memory-store.ts
+++ b/addons/demo/cap-life-demo/src/in-memory-store.ts
@@ -1,0 +1,82 @@
+/**
+ * In-process LifecycleMemoryStore implementation for the life-system demo.
+ *
+ * Stores values in a plain Map keyed by string. Honours the `ttlMs` write
+ * option by stamping an `expiresAt` field; expired entries are filtered
+ * out of `read()` and `list()` lazily so we never need a sweeper timer.
+ *
+ * Intentionally tiny — production stores live in dedicated capabilities
+ * (e.g. cap-memory-drizzle). This implementation exists so the
+ * Sense -> Memory pipeline can run end-to-end without external deps.
+ */
+
+import type {
+  LifecycleMemoryStore,
+  MemoryStoreListOptions,
+  MemoryStoreListPage,
+  MemoryStoreWriteOptions,
+} from "@linchkit/core";
+
+interface Entry {
+  value: unknown;
+  expiresAt?: number;
+}
+
+export class InMemoryLifecycleStore implements LifecycleMemoryStore {
+  private readonly entries = new Map<string, Entry>();
+
+  async read(key: string): Promise<unknown | null> {
+    const entry = this.entries.get(key);
+    if (!entry) return null;
+    if (this.isExpired(entry)) {
+      this.entries.delete(key);
+      return null;
+    }
+    return entry.value;
+  }
+
+  async write(key: string, value: unknown, options?: MemoryStoreWriteOptions): Promise<void> {
+    const ttl = options?.ttlMs;
+    const expiresAt = typeof ttl === "number" ? Date.now() + ttl : undefined;
+    this.entries.set(key, { value, expiresAt });
+  }
+
+  async delete(key: string): Promise<void> {
+    this.entries.delete(key);
+  }
+
+  async list(prefix?: string, options?: MemoryStoreListOptions): Promise<MemoryStoreListPage> {
+    // Drop expired entries lazily so list() never returns stale keys.
+    for (const [key, entry] of this.entries.entries()) {
+      if (this.isExpired(entry)) this.entries.delete(key);
+    }
+
+    const allKeys = Array.from(this.entries.keys())
+      .filter((k) => (prefix ? k.startsWith(prefix) : true))
+      .sort();
+
+    // Cursor is an opaque token — we encode it as the offset into `allKeys`.
+    const offset = options?.cursor ? Number.parseInt(options.cursor, 10) : 0;
+    const limit = options?.limit ?? allKeys.length;
+    const slice = allKeys.slice(offset, offset + limit);
+    const nextOffset = offset + slice.length;
+    const hasMore = nextOffset < allKeys.length;
+
+    return {
+      keys: slice,
+      nextCursor: hasMore ? String(nextOffset) : undefined,
+    };
+  }
+
+  /** Test helper — total non-expired entry count. */
+  size(): number {
+    for (const [key, entry] of this.entries.entries()) {
+      if (this.isExpired(entry)) this.entries.delete(key);
+    }
+    return this.entries.size;
+  }
+
+  private isExpired(entry: Entry): boolean {
+    return typeof entry.expiresAt === "number" && entry.expiresAt <= Date.now();
+  }
+}

--- a/addons/demo/cap-life-demo/src/index.ts
+++ b/addons/demo/cap-life-demo/src/index.ts
@@ -1,0 +1,44 @@
+/**
+ * @linchkit/cap-life-demo — Spec 55 life-system end-to-end skeleton.
+ *
+ * Demonstrates the Sense -> Memory -> Awareness pipeline using only the
+ * lifecycle abstractions added in PR #255 (LifecycleSensor,
+ * LifecycleSignal, LifecycleBaseline, LifecycleMemoryStore).
+ *
+ * Intentionally tiny — no DB, no HTTP, no AI provider, no autoInstall.
+ * Future capabilities can copy this wiring to bootstrap their own
+ * lifecycle plumbing.
+ *
+ * @see ./pipeline.ts for the run() entry point.
+ * @see docs/specs/55_evolution_system.md
+ */
+
+import { defineCapability } from "@linchkit/core";
+
+export type { CountingBaselineOptions } from "./counting-baseline";
+export { CountingBaseline } from "./counting-baseline";
+export { InMemoryLifecycleStore } from "./in-memory-store";
+export type { PipelineController, RunPipelineOptions } from "./pipeline";
+export { run } from "./pipeline";
+export type { PollSensorOptions } from "./poll-sensor";
+export { PollSensor } from "./poll-sensor";
+
+/**
+ * Capability descriptor for the life-system skeleton demo.
+ *
+ * Empty by design — the demo is consumed via the `run()` API rather than
+ * via any meta-model surface (no entities, no actions, no views). The
+ * descriptor is published so the addon shows up in `linch validate` /
+ * AGENTS.md and so future revisions have a canonical place to hang
+ * sensors, automations, or views.
+ */
+export const capLifeDemo = defineCapability({
+  name: "cap-life-demo",
+  label: "Life-system Skeleton Demo",
+  description:
+    "Minimal Sense -> Memory pipeline skeleton wiring LifecycleSensor, " +
+    "LifecycleMemoryStore and LifecycleBaseline (Spec 55).",
+  type: "standard",
+  category: "system",
+  version: "0.0.1",
+});

--- a/addons/demo/cap-life-demo/src/pipeline.ts
+++ b/addons/demo/cap-life-demo/src/pipeline.ts
@@ -51,10 +51,14 @@ export interface PipelineController {
 export function run(options: RunPipelineOptions): PipelineController {
   const { sensor, store, baseline, anomalyThreshold = 0.5, onAnomaly } = options;
   let stopped = false;
+  // Monotonic counter so two ticks landing in the same millisecond (or any
+  // test using a fixed `now()`) produce distinct keys instead of silently
+  // overwriting each other.
+  let seq = 0;
 
   const handle = async (signal: LifecycleSignal) => {
     // Step 2: write the Signal to the Memory layer.
-    const key = `signals/${sensor.id}/${signal.timestamp}`;
+    const key = `signals/${sensor.id}/${signal.timestamp}/${++seq}`;
     await store.write(key, signal);
 
     // Step 3: score against the baseline; fire the anomaly hook if needed.

--- a/addons/demo/cap-life-demo/src/pipeline.ts
+++ b/addons/demo/cap-life-demo/src/pipeline.ts
@@ -1,0 +1,104 @@
+/**
+ * Sense -> Memory -> Awareness pipeline wiring for the life-system demo.
+ *
+ * End-to-end flow:
+ *
+ *   1. The {@link PollSensor} produces a Signal (`kind: "synthetic.tick"`,
+ *      `data: { value: number }`) on each polling tick.
+ *
+ *   2. The pipeline subscribes to the sensor and writes every Signal to
+ *      the {@link InMemoryLifecycleStore} under the key
+ *      `signals/${sensorId}/${timestamp}`. This is the Memory write.
+ *
+ *   3. The pipeline asks the {@link CountingBaseline} to score the new
+ *      observation. If the score exceeds `anomalyThreshold`, the
+ *      `onAnomaly` callback fires with the offending Signal.
+ *
+ *   4. The pipeline updates the baseline with the observation so future
+ *      ticks score against an up-to-date distribution.
+ *
+ * `run()` returns a controller exposing:
+ *   - `stop()` — unsubscribes from the sensor and stops its timer.
+ *   - `tick()` — synchronously drives one observation (test ergonomics).
+ *
+ * Everything stays in-process. No PostgreSQL, no HTTP, no AI provider.
+ */
+
+import type { LifecycleSignal } from "@linchkit/core";
+import type { CountingBaseline } from "./counting-baseline";
+import type { InMemoryLifecycleStore } from "./in-memory-store";
+import type { PollSensor } from "./poll-sensor";
+
+export interface RunPipelineOptions {
+  sensor: PollSensor;
+  store: InMemoryLifecycleStore;
+  baseline: CountingBaseline;
+  /** Score (0..1) above which a Signal is treated as anomalous. Default: 0.5. */
+  anomalyThreshold?: number;
+  /** Called once per Signal whose baseline score exceeds the threshold. */
+  onAnomaly?: (signal: LifecycleSignal, score: number) => void;
+}
+
+export interface PipelineController {
+  /** Stop the sensor and unsubscribe from its signal stream. Idempotent. */
+  stop(): void;
+  /** Drive one synchronous tick — emits a signal and processes it inline. */
+  tick(): Promise<void>;
+  /** Whether the pipeline is currently running. */
+  isRunning(): boolean;
+}
+
+export function run(options: RunPipelineOptions): PipelineController {
+  const { sensor, store, baseline, anomalyThreshold = 0.5, onAnomaly } = options;
+  let stopped = false;
+
+  const handle = async (signal: LifecycleSignal) => {
+    // Step 2: write the Signal to the Memory layer.
+    const key = `signals/${sensor.id}/${signal.timestamp}`;
+    await store.write(key, signal);
+
+    // Step 3: score against the baseline; fire the anomaly hook if needed.
+    const score = await Promise.resolve(baseline.score(signal.data));
+    if (onAnomaly && score > anomalyThreshold) {
+      onAnomaly(signal, score);
+    }
+
+    // Step 4: update the baseline with the new observation.
+    await Promise.resolve(baseline.update(signal.data));
+  };
+
+  // We capture the most recent in-flight handle promise so the
+  // synchronous `tick()` helper can await it deterministically. The
+  // `subscribe` callback intentionally has no async surface, so this
+  // shared reference is the only way to bridge it back out for tests.
+  let inflight: Promise<void> = Promise.resolve();
+
+  const unsubscribe = sensor.subscribe((signal) => {
+    // Errors from a single observation must not poison the stream.
+    inflight = handle(signal).catch(() => {
+      // Future revisions can route this into the Signal bus as a
+      // pipeline.error event; for the demo we swallow.
+    });
+  });
+
+  sensor.start();
+
+  return {
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      unsubscribe();
+      sensor.stop();
+    },
+    async tick() {
+      // Drive a single emit; the subscribe handler above starts the
+      // handle() promise and assigns it to `inflight`. Awaiting that
+      // promise lets tests observe the post-state synchronously.
+      sensor.emitOnce();
+      await inflight;
+    },
+    isRunning() {
+      return !stopped;
+    },
+  };
+}

--- a/addons/demo/cap-life-demo/src/poll-sensor.ts
+++ b/addons/demo/cap-life-demo/src/poll-sensor.ts
@@ -91,7 +91,11 @@ export class PollSensor implements LifecycleSensor {
       timestamp: this.now(),
       metadata: { sensorId: this.id },
     };
-    for (const handler of this.handlers) {
+    // Snapshot the handler set before iterating so a subscriber registered
+    // *during* delivery doesn't get the current signal — that contradicts the
+    // documented "subscribers added before start() see every signal" contract
+    // and creates surprising reentrant behavior.
+    for (const handler of [...this.handlers]) {
       // Each subscriber is isolated: a throw in one handler must not interrupt
       // delivery to the others or kill the polling loop. Errors get logged
       // (the demo uses console.error; a real impl would route to telemetry).

--- a/addons/demo/cap-life-demo/src/poll-sensor.ts
+++ b/addons/demo/cap-life-demo/src/poll-sensor.ts
@@ -1,0 +1,99 @@
+/**
+ * LifecycleSensor that emits a synthetic "tick" Signal on a fixed interval.
+ *
+ * Calls a caller-supplied `produce()` function each tick to pick the
+ * payload value. This lets tests inject deterministic sequences (normal
+ * values then a spike) without faking timers — the test simply provides
+ * a generator and steps the timer manually via the polling interval.
+ *
+ * `start()` / `stop()` are idempotent. Subscribers added before `start()`
+ * still receive every signal once the sensor is running.
+ */
+
+import type { LifecycleSensor, LifecycleSignal, Unsubscribe } from "@linchkit/core";
+
+export interface PollSensorOptions {
+  /** Stable sensor ID — conventionally `<capability>.<sensor_name>`. */
+  id: string;
+  /** Polling interval in milliseconds. */
+  intervalMs: number;
+  /** Producer for the next signal payload. Called once per tick. */
+  produce: () => { value: number };
+  /** Optional source channel; defaults to "synthetic". */
+  source?: string;
+  /** Optional kind discriminator; defaults to "synthetic.tick". */
+  kind?: string;
+  /** Optional clock — defaults to Date.now. Allows deterministic tests. */
+  now?: () => number;
+}
+
+export class PollSensor implements LifecycleSensor {
+  readonly id: string;
+  private readonly intervalMs: number;
+  private readonly produce: () => { value: number };
+  private readonly source: string;
+  private readonly kind: string;
+  private readonly now: () => number;
+  private readonly handlers = new Set<(signal: LifecycleSignal) => void>();
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(options: PollSensorOptions) {
+    this.id = options.id;
+    this.intervalMs = options.intervalMs;
+    this.produce = options.produce;
+    this.source = options.source ?? "synthetic";
+    this.kind = options.kind ?? "synthetic.tick";
+    this.now = options.now ?? Date.now;
+  }
+
+  start(): void {
+    if (this.timer !== null) return; // Idempotent.
+    this.timer = setInterval(() => this.tick(), this.intervalMs);
+  }
+
+  stop(): void {
+    if (this.timer === null) return; // Idempotent.
+    clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  subscribe(handler: (signal: LifecycleSignal) => void): Unsubscribe {
+    this.handlers.add(handler);
+    return () => {
+      this.handlers.delete(handler);
+    };
+  }
+
+  /**
+   * Emit a single signal immediately. Exposed so tests can drive the
+   * pipeline deterministically without waiting on real timers.
+   */
+  emitOnce(): LifecycleSignal {
+    return this.tick();
+  }
+
+  /** Test helper — number of currently registered subscribers. */
+  subscriberCount(): number {
+    return this.handlers.size;
+  }
+
+  /** Test helper — whether the polling timer is active. */
+  isRunning(): boolean {
+    return this.timer !== null;
+  }
+
+  private tick(): LifecycleSignal {
+    const payload = this.produce();
+    const signal: LifecycleSignal = {
+      source: this.source,
+      kind: this.kind,
+      data: payload,
+      timestamp: this.now(),
+      metadata: { sensorId: this.id },
+    };
+    for (const handler of this.handlers) {
+      handler(signal);
+    }
+    return signal;
+  }
+}

--- a/addons/demo/cap-life-demo/src/poll-sensor.ts
+++ b/addons/demo/cap-life-demo/src/poll-sensor.ts
@@ -92,7 +92,14 @@ export class PollSensor implements LifecycleSensor {
       metadata: { sensorId: this.id },
     };
     for (const handler of this.handlers) {
-      handler(signal);
+      // Each subscriber is isolated: a throw in one handler must not interrupt
+      // delivery to the others or kill the polling loop. Errors get logged
+      // (the demo uses console.error; a real impl would route to telemetry).
+      try {
+        handler(signal);
+      } catch (err) {
+        console.error(`[PollSensor] Handler error in sensor ${this.id}:`, err);
+      }
     }
     return signal;
   }

--- a/addons/demo/cap-life-demo/tsconfig.json
+++ b/addons/demo/cap-life-demo/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun-types"]
+  },
+  "include": ["src", "__tests__"]
+}

--- a/docs/specs/55_evolution_system.md
+++ b/docs/specs/55_evolution_system.md
@@ -13,6 +13,11 @@
 >
 > Execution source of truth: GitHub milestones and issues.
 
+> **Status (2026-05-07):** A minimal end-to-end skeleton lives in
+> `addons/demo/cap-life-demo/` proving the Sense → Memory pipeline runs
+> through the `LifecycleSensor` / `LifecycleMemoryStore` / `LifecycleBaseline`
+> abstractions added in PR #255.
+
 ## 1. 核心理念
 
 传统软件是**死的**——写好了就固定了，除非有人改它。

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -54,6 +54,7 @@
       "@linchkit/ui-kit/hooks": ["./addons/adapter-ui/cap-adapter-ui/ui-kit/src/hooks"],
       "@linchkit/ui-kit/lib/utils": ["./addons/adapter-ui/cap-adapter-ui/ui-kit/src/lib/utils"],
       "@linchkit/cap-purchase-demo": ["./addons/demo/cap-purchase-demo/src"],
+      "@linchkit/cap-life-demo": ["./addons/demo/cap-life-demo/src"],
       "@linchkit/cap-chatter-ui": ["./addons/chatter/cap-chatter-ui/src"],
       "@linchkit/cap-chatter": ["./addons/chatter/cap-chatter/src"],
       "@linchkit/cap-chatter/capability": ["./addons/chatter/cap-chatter/src/capability.ts"],


### PR DESCRIPTION
## Summary
Adds a **private demo capability** that proves the lifecycle abstractions added in PR #255 (`LifecycleSensor` / `LifecycleMemoryStore` / `LifecycleBaseline` / sensor-registry helpers) compose into a runnable Sense → Memory → Awareness pipeline. No new types in core; no databases, HTTP layers, or external deps.

## What it shows
The pipeline:
1. `PollSensor` produces a `Signal` (`kind: "synthetic.tick"`, `data: { value }`).
2. Subscriber writes the signal to the `InMemoryLifecycleStore` at key `signals/<sensorId>/<ts>`.
3. `CountingBaseline` scores the value; if `score > threshold`, calls `onAnomaly(signal)`.
4. Baseline updates its rolling statistics.

A future capability that wants its own life-system can copy this wiring almost verbatim.

## Files
- **`addons/demo/cap-life-demo/`** — new private capability (`private: true`, not published)
  - `src/poll-sensor.ts` / `in-memory-store.ts` / `counting-baseline.ts` / `pipeline.ts` / `index.ts`
  - `__tests__/pipeline.test.ts` — 6 deterministic tests; controller.tick() drives the loop, one cleanup test exercises the real timer
  - `README.md` — short pointer to Spec 55 + example usage
- `docs/specs/55_evolution_system.md` — pointer paragraph added
- `tsconfig.json` — path mapping for `@linchkit/cap-life-demo`

## Tests (6)
- normal flow: every signal lands in the store
- spike detection: anomaly callback fires exactly once for the outlier
- baseline observes every value, including the spike
- cleanup: `stop()` unsubscribes and halts the polling timer
- sensor-registry helpers: `register` / `find` / `getSensors` / `unregister`
- registry rejects duplicate sensor IDs

## Pre-PR fix
The first commit imported `clearSensors` from `@linchkit/core`'s root barrel — but PR #255 deliberately keeps `clearSensors` internal (only exposed via `@linchkit/core/life-system`). Test cleanup now uses the public `unregisterSensor(SENSOR_ID)` helper, which handles its own `stop()` + remove.

## Test plan
- [x] `bun test` — 4704 pass / 0 fail / 3 skip (Volcengine E2E)
- [x] `bun run check` — 0 errors (2 pre-existing infos unrelated)
- [x] `bun run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a demo addon for the Spec 55 life-system pipeline, including working examples of anomaly detection and lifecycle monitoring with comprehensive test coverage.

* **Documentation**
  * Added detailed documentation for the demo addon and updated the evolution system specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->