### PR TITLE
refactor(core): Detector/Watcher abstractions + impl move (Spec 56 Phase 2 Step 2c)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/package.json
+++ b/addons/adapter-server/cap-adapter-server/package.json
@@ -25,9 +25,11 @@
     "dataloader": "^2.2.3"
   },
   "peerDependencies": {
+    "@linchkit/cap-ai-provider": "^1.0.0",
     "@linchkit/core": "^0.2.0"
   },
   "devDependencies": {
+    "@linchkit/cap-ai-provider": "workspace:*",
     "@linchkit/core": "workspace:*",
     "typescript": "^6.0.2"
   },

--- a/addons/adapter-server/cap-adapter-server/src/proposal-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/proposal-api.ts
@@ -6,9 +6,9 @@
  * execution logs to generate insights on demand (cached with short TTL).
  */
 
+import { PatternDetector, type PatternInsight } from "@linchkit/cap-ai-provider";
 import type { ExecutionLogger, ProposalDefinition } from "@linchkit/core";
-import type { PatternInsight } from "@linchkit/core/server";
-import { createProposalEngine, PatternDetector } from "@linchkit/core/server";
+import { createProposalEngine } from "@linchkit/core/server";
 
 // ── Types ─────────────────────────────────────────────────
 

--- a/addons/ai-provider/cap-ai-provider/__tests__/anomaly-detector.test.ts
+++ b/addons/ai-provider/cap-ai-provider/__tests__/anomaly-detector.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, mock } from "bun:test";
-import type { AnomalyDetection, UsageEvent } from "../src/ai/anomaly-detector";
-import { AnomalyDetector } from "../src/ai/anomaly-detector";
+import type { AnomalyDetection, UsageEvent } from "../src/anomaly-detector";
+import { AnomalyDetector } from "../src/anomaly-detector";
 
 // ── Helpers ────────────────────────────────────────────────────
 

--- a/addons/ai-provider/cap-ai-provider/__tests__/pattern-detector-integration.test.ts
+++ b/addons/ai-provider/cap-ai-provider/__tests__/pattern-detector-integration.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { PatternDetector } from "../src/ai/pattern-detector";
-import { InMemoryExecutionLogger } from "../src/observability/execution-logger";
-import type { ExecutionLogEntry } from "../src/types/execution-log";
+import type { ExecutionLogEntry } from "@linchkit/core";
+import { InMemoryExecutionLogger } from "@linchkit/core/server";
+import { PatternDetector } from "../src/pattern-detector";
 
 // ── Test helpers ──────────────────────────────────────────
 

--- a/addons/ai-provider/cap-ai-provider/__tests__/pattern-detector.test.ts
+++ b/addons/ai-provider/cap-ai-provider/__tests__/pattern-detector.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from "bun:test";
-import { PatternDetector } from "../src/ai/pattern-detector";
-import { InMemoryExecutionLogger } from "../src/observability/execution-logger";
-import type { ExecutionLogEntry } from "../src/types/execution-log";
+import type { ExecutionLogEntry } from "@linchkit/core";
+import { InMemoryExecutionLogger } from "@linchkit/core/server";
+import { PatternDetector } from "../src/pattern-detector";
 
 // ── Test helpers ──────────────────────────────────────────
 

--- a/addons/ai-provider/cap-ai-provider/__tests__/watcher-engine.test.ts
+++ b/addons/ai-provider/cap-ai-provider/__tests__/watcher-engine.test.ts
@@ -1,15 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import {
+  defineWatcher,
+  type EventBusLike,
+  type EventRecord,
+  type WatcherDefinition,
+} from "@linchkit/core";
+import { createWatcherRegistry, type WatcherRegistry } from "@linchkit/core/server";
+import {
   createWatcherEngine,
   evaluateComparison,
   parseDuration,
   type WatcherActionExecutor,
   type WatcherEngine,
-} from "../src/automation";
-import { createWatcherRegistry, type WatcherRegistry } from "../src/automation/watcher-registry";
-import { defineWatcher } from "../src/define";
-import type { EventBusLike, EventRecord } from "../src/types/event";
-import type { WatcherDefinition } from "../src/types/watcher";
+} from "../src/watcher-engine";
 
 // ── Mock factories ──────────────────────────────────────
 

--- a/addons/ai-provider/cap-ai-provider/src/anomaly-detector.ts
+++ b/addons/ai-provider/cap-ai-provider/src/anomaly-detector.ts
@@ -5,6 +5,10 @@
  * compromise, abuse, or malfunction. Operates on sliding time windows
  * of usage data.
  *
+ * Implements the abstract `Detector` contract from `@linchkit/core` (Spec 56
+ * Phase 2 Step 2c). The concrete impl was moved out of core into this
+ * capability so core retains only the interface.
+ *
  * See spec 27_ai_security.md §1.5 (Rate Abuse) and M2 requirements
  * (anomalous behavior detection).
  *
@@ -15,6 +19,8 @@
  * 4. Off-hours activity — AI calls outside normal business hours
  * 5. Diverse action anomaly — sudden use of many different actions
  */
+
+import type { Detector } from "@linchkit/core";
 
 // ── Types ─────────────────────────────────────────────────────
 
@@ -116,6 +122,9 @@ export interface AnomalyDetectorConfig {
 
   /** Callback when an anomaly is detected */
   onAnomaly?: (anomaly: AnomalyDetection) => void;
+
+  /** Optional override for the detector's stable id (default: "ai.anomaly_detector"). */
+  id?: string;
 }
 
 // ── Anomaly Detector ───────────────────────────────────────────
@@ -126,8 +135,16 @@ export interface AnomalyDetectorConfig {
  * Feed usage events via `recordEvent()` and call `detect()` to check
  * for anomalies. The detector maintains a bounded event buffer and
  * computes statistics over configurable time windows.
+ *
+ * Implements the abstract `Detector<DetectOptions, AnomalyDetection[]>`
+ * contract from `@linchkit/core`. The legacy `detect(options?)` signature
+ * is preserved (optional argument) so existing callers keep working;
+ * passing `undefined` matches the abstract contract's `TInput`.
  */
-export class AnomalyDetector {
+export class AnomalyDetector
+  implements Detector<AnomalyDetectorDetectOptions | undefined, AnomalyDetection[]>
+{
+  readonly id: string;
   private readonly events: UsageEvent[] = [];
   private readonly config: Required<
     Pick<
@@ -159,6 +176,7 @@ export class AnomalyDetector {
   private static readonly EMA_ALPHA = 0.3;
 
   constructor(config?: AnomalyDetectorConfig) {
+    this.id = config?.id ?? "ai.anomaly_detector";
     this.config = {
       spikeMultiplier: config?.spikeMultiplier ?? 3.0,
       errorRateThreshold: config?.errorRateThreshold ?? 0.5,
@@ -190,7 +208,7 @@ export class AnomalyDetector {
    * Returns all detected anomalies. Also fires onAnomaly callback
    * for each detection.
    */
-  detect(options?: { tenantId?: string; actorId?: string; now?: Date }): AnomalyDetection[] {
+  detect(options?: AnomalyDetectorDetectOptions): AnomalyDetection[] {
     const now = options?.now ?? new Date();
     const windowStart = new Date(now.getTime() - this.config.windowSizeMs);
     const anomalies: AnomalyDetection[] = [];
@@ -452,4 +470,11 @@ export class AnomalyDetector {
         (1 - AnomalyDetector.EMA_ALPHA) * this.baselineRate;
     }
   }
+}
+
+/** Options accepted by {@link AnomalyDetector.detect}. */
+export interface AnomalyDetectorDetectOptions {
+  tenantId?: string;
+  actorId?: string;
+  now?: Date;
 }

--- a/addons/ai-provider/cap-ai-provider/src/index.ts
+++ b/addons/ai-provider/cap-ai-provider/src/index.ts
@@ -27,9 +27,40 @@ export {
   resolveTenantConfig,
 } from "./ai-service";
 
+// Anomaly Detector (moved from @linchkit/core, Spec 56 Phase 2 Step 2c)
+export type {
+  AnomalyDetection,
+  AnomalyDetectorConfig,
+  AnomalyDetectorDetectOptions,
+  AnomalySeverity,
+  AnomalyType,
+  UsageEvent,
+} from "./anomaly-detector";
+export { AnomalyDetector } from "./anomaly-detector";
+
 // Cost Estimator
 export type { ModelPricing } from "./cost-estimator";
 export { CostEstimator, defaultCostEstimator } from "./cost-estimator";
 
+// Pattern Detector (moved from @linchkit/core, Spec 56 Phase 2 Step 2c)
+export type {
+  PatternDetectorConfig,
+  PatternEvidence,
+  PatternInsight,
+  PatternType,
+} from "./pattern-detector";
+export { PatternDetector } from "./pattern-detector";
+
 // Response Cache
 export { AIResponseCache } from "./response-cache";
+
+// Watcher Engine (moved from @linchkit/core, Spec 56 Phase 2 Step 2c)
+export {
+  createWatcherEngine,
+  evaluateComparison,
+  parseDuration,
+  type WatcherActionExecutor,
+  type WatcherDataQuerier,
+  type WatcherEngine,
+  type WatcherEngineOptions,
+} from "./watcher-engine";

--- a/addons/ai-provider/cap-ai-provider/src/index.ts
+++ b/addons/ai-provider/cap-ai-provider/src/index.ts
@@ -3,14 +3,22 @@
  *
  * AI Provider capability — Vercel AI SDK implementations for LinchKit.
  *
- * Provides the concrete AI service implementation with:
- * - Anthropic (Claude) provider support
- * - OpenAI and OpenAI-compatible provider support
+ * Provides:
+ * - Concrete AIService impl: Anthropic (Claude), OpenAI, OpenAI-compatible
  * - Cost estimation, response caching, fallback chains, model routing
+ * - PatternDetector and AnomalyDetector (Spec 55 Sense layer impls)
+ * - WatcherEngine (Spec 45 reactive automation) — see note below
  *
  * Core (@linchkit/core) retains:
  * - AIService interface and createNoopAIService()
  * - Security layer: AIBoundary, PromptSanitizer, OutputValidator
+ * - Detector / Watcher abstract interfaces (Spec 56 Phase 2 Step 2c)
+ *
+ * **WatcherEngine note**: this engine is conceptually generic data-condition
+ * automation, not AI-specific. It is parked here for now (Spec 56 Phase 2
+ * Step 2c) since cap-ai-provider was the closest existing capability. If
+ * non-AI watcher kinds proliferate, a future PR should split it into a
+ * dedicated `cap-watcher` addon.
  *
  * Usage:
  *   import { createAIService } from "@linchkit/cap-ai-provider";

--- a/addons/ai-provider/cap-ai-provider/src/pattern-detector.ts
+++ b/addons/ai-provider/cap-ai-provider/src/pattern-detector.ts
@@ -12,48 +12,19 @@
  * - state_flow: common paths through state machines
  * - timing: actions performed at specific times of day/week
  *
+ * Implements the abstract `Detector` contract from `@linchkit/core` (Spec 56
+ * Phase 2 Step 2c). The concrete impl was moved out of core into this
+ * capability so core retains only the interface.
+ *
  * See spec 22_ai_rule_boundary.md §7 (Evolution Cycle).
  */
 
-import type { ExecutionLogEntry, ExecutionLogger } from "../types/execution-log";
-import type { ProposalDraft } from "./proposal-engine";
+import type { Detector, ExecutionLogEntry, ExecutionLogger } from "@linchkit/core";
+import type { PatternEvidence, PatternInsight, PatternType } from "@linchkit/core/ai";
 
-// ── Pattern insight types ────────────────────────────────
-
-export type PatternType =
-  | "repetitive_action"
-  | "default_value"
-  | "validation_pattern"
-  | "state_flow"
-  | "timing";
-
-/** Evidence supporting a detected pattern */
-export interface PatternEvidence {
-  /** Number of occurrences observed */
-  count: number;
-  /** Human-readable timespan (e.g. "7 days", "30 days") */
-  timespan: string;
-  /** Sample data points illustrating the pattern */
-  examples: unknown[];
-}
-
-/** A detected pattern insight ready for proposal generation */
-export interface PatternInsight {
-  /** Unique insight identifier */
-  id: string;
-  /** Type of pattern detected */
-  type: PatternType;
-  /** Entity name this pattern relates to */
-  entity: string;
-  /** Human-readable description of the pattern */
-  description: string;
-  /** Confidence score 0-1 */
-  confidence: number;
-  /** Supporting evidence */
-  evidence: PatternEvidence;
-  /** Suggested change based on this pattern */
-  suggestedAction: ProposalDraft;
-}
+// Re-export the shared insight contract so existing callers of
+// `@linchkit/cap-ai-provider` keep importing these names from here.
+export type { PatternEvidence, PatternInsight, PatternType };
 
 // ── Detector configuration ───────────────────────────────
 
@@ -68,11 +39,13 @@ export interface PatternDetectorConfig {
   maxExamples?: number;
   /** Pattern types to detect (default: all) */
   enabledPatterns?: PatternType[];
+  /** Optional override for the detector's stable id (default: "ai.pattern_detector"). */
+  id?: string;
 }
 
 // ── Default configuration ────────────────────────────────
 
-const DEFAULT_CONFIG: Required<PatternDetectorConfig> = {
+const DEFAULT_CONFIG: Required<Omit<PatternDetectorConfig, "id">> = {
   minOccurrences: 5,
   minConfidence: 0.7,
   lookbackDays: 30,
@@ -88,12 +61,28 @@ const DEFAULT_CONFIG: Required<PatternDetectorConfig> = {
 
 // ── Pattern Detector ─────────────────────────────────────
 
-export class PatternDetector {
-  private readonly config: Required<PatternDetectorConfig>;
+export class PatternDetector implements Detector<ExecutionLogger, PatternInsight[]> {
+  readonly id: string;
+  private readonly config: Required<Omit<PatternDetectorConfig, "id">>;
   private idCounter = 0;
 
   constructor(config?: PatternDetectorConfig) {
-    this.config = { ...DEFAULT_CONFIG, ...config };
+    const { id, ...rest } = config ?? {};
+    this.id = id ?? "ai.pattern_detector";
+    this.config = { ...DEFAULT_CONFIG, ...rest };
+  }
+
+  /**
+   * Detect patterns in the supplied execution logger.
+   *
+   * Implements `Detector<ExecutionLogger, PatternInsight[]>`. Returns
+   * `null` when the logger has no entries in the lookback window so the
+   * caller can short-circuit; otherwise returns insights sorted by
+   * confidence (highest first).
+   */
+  async detect(input: ExecutionLogger): Promise<PatternInsight[] | null> {
+    const insights = await this.analyze(input);
+    return insights.length > 0 ? insights : null;
   }
 
   /**

--- a/addons/ai-provider/cap-ai-provider/src/watcher-engine.ts
+++ b/addons/ai-provider/cap-ai-provider/src/watcher-engine.ts
@@ -7,19 +7,25 @@
  * - Timer-based (polling): staleness watchers evaluated on interval
  *
  * Watcher effects execute through normal action pipeline (CommandLayer).
+ *
+ * Implements the abstract `Watcher` lifecycle contract from `@linchkit/core`
+ * (Spec 56 Phase 2 Step 2c). The concrete impl was moved out of core into
+ * this capability so core retains only the interface.
  */
 
-import { type ConditionContext, evaluateCondition } from "../engine/condition-evaluator";
-import type { EventBusLike, EventRecord } from "../types/event";
-import type { Logger } from "../types/logger";
 import type {
+  EventBusLike,
+  EventRecord,
+  Logger,
+  Watcher,
   WatcherComparisonCondition,
   WatcherContext,
   WatcherDefinition,
   WatcherEvaluationResult,
   WatcherStateEntry,
-} from "../types/watcher";
-import type { WatcherRegistry } from "./watcher-registry";
+} from "@linchkit/core";
+import { type ConditionContext, evaluateCondition } from "@linchkit/core";
+import type { WatcherRegistry } from "@linchkit/core/server";
 
 // ── Action executor interface (shared with watcher effects) ──
 
@@ -40,13 +46,14 @@ export interface WatcherDataQuerier {
 
 // ── Watcher Engine interface ──────────────────────────────
 
-export interface WatcherEngine {
-  /** Start listening for mutation events and schedule staleness checks */
-  start(): void;
-
-  /** Stop all listeners and timers */
-  stop(): void;
-
+/**
+ * WatcherEngine extends the abstract `Watcher` lifecycle contract with the
+ * data-condition-specific evaluation API needed by the action pipeline.
+ *
+ * `start()` / `stop()` come from `Watcher`; the additional methods cover the
+ * post-mutation reactive path and debounce-state inspection.
+ */
+export interface WatcherEngine extends Watcher {
   /**
    * Evaluate watchers for a specific schema after a mutation.
    * Called by the mutation pipeline (post-action).
@@ -77,6 +84,8 @@ export interface WatcherEngineOptions {
   dataQuerier?: WatcherDataQuerier;
   /** Staleness check interval in ms (default: 60_000 = 1 minute) */
   stalenessIntervalMs?: number;
+  /** Optional override for the watcher's stable id (default: "automation.watcher_engine"). */
+  id?: string;
   logger?: Logger;
 }
 
@@ -123,6 +132,7 @@ export function evaluateComparison(value: number, condition: WatcherComparisonCo
 // ── Implementation ────────────────────────────────────────
 
 class WatcherEngineImpl implements WatcherEngine {
+  readonly id: string;
   private registry: WatcherRegistry;
   private eventBus?: EventBusLike;
   private actionExecutor?: WatcherActionExecutor;
@@ -138,6 +148,7 @@ class WatcherEngineImpl implements WatcherEngine {
   private stateMap = new Map<string, WatcherStateEntry>();
 
   constructor(options: WatcherEngineOptions) {
+    this.id = options.id ?? "automation.watcher_engine";
     this.registry = options.registry;
     this.eventBus = options.eventBus;
     this.actionExecutor = options.actionExecutor;

--- a/docs/specs/56_core_slimming.md
+++ b/docs/specs/56_core_slimming.md
@@ -148,6 +148,59 @@ follows in subsequent PRs (Step 2b).
   migration (PatternDetector / AnomalyDetector / WatcherEngine) deferred
   pending the `Detector` / `Watcher` interface design.
 
+**Step 2c — Detector / Watcher abstractions land + concrete impls move out**
+
+- 2026-05-07: Phase 2 Step 2c executed.
+  - **New core abstractions** (additive, type-only):
+    - `Detector<TInput, TOutput>` — minimal Awareness-layer contract
+      (`{ id; detect(input): TOutput | null | Promise<...> }`) at
+      `packages/core/src/life-system/detector.ts`.
+    - `Watcher` — minimal Sense-layer lifecycle contract
+      (`{ id; start(); stop() }`) at
+      `packages/core/src/life-system/watcher.ts`.
+    - Both are re-exported via `@linchkit/core` (root barrel) and
+      `packages/core/src/life-system/index.ts`. The pre-existing stub
+      `Detector` interface in `packages/core/src/types/life-system.ts`
+      was removed (no in-tree consumers).
+  - **Concrete impls moved** out of core, alongside their tests, into
+    `@linchkit/cap-ai-provider`:
+    - `packages/core/src/ai/pattern-detector.ts` →
+      `addons/ai-provider/cap-ai-provider/src/pattern-detector.ts`
+    - `packages/core/src/ai/anomaly-detector.ts` →
+      `addons/ai-provider/cap-ai-provider/src/anomaly-detector.ts`
+    - `packages/core/src/automation/watcher-engine.ts` →
+      `addons/ai-provider/cap-ai-provider/src/watcher-engine.ts`
+    - Each class now declares an `id` and `implements` its core
+      interface (`PatternDetector`/`AnomalyDetector` implement
+      `Detector`; `WatcherEngine` extends a domain-specific interface
+      that itself extends the abstract `Watcher`).
+  - **Core retains** the `WatcherRegistry` (action pipeline consumes
+    `WatcherDefinition` records directly) and a small
+    `PatternInsight` data contract at
+    `packages/core/src/ai/pattern-insight.ts` so
+    `ProposalEngine.createFromInsight()` keeps its existing API
+    without depending on `cap-ai-provider`.
+  - **Out-of-tree consumer migrated**:
+    `addons/adapter-server/cap-adapter-server/src/proposal-api.ts` now
+    imports `PatternDetector` / `PatternInsight` from
+    `@linchkit/cap-ai-provider`; `cap-adapter-server`'s `package.json`
+    gained a `peerDependencies`/`devDependencies` entry for it.
+  - **Path mapping**: root `tsconfig.json` gained
+    `"@linchkit/cap-ai-provider": ["./addons/ai-provider/cap-ai-provider/src"]`.
+  - **Tests moved** into `addons/ai-provider/cap-ai-provider/__tests__/`
+    (`pattern-detector.test.ts`, `pattern-detector-integration.test.ts`,
+    `anomaly-detector.test.ts`, `watcher-engine.test.ts`); their
+    imports were rewritten to use `@linchkit/core` / `@linchkit/core/server`.
+  - Follow-ups:
+    - `cap-ai-provider` is currently the only home for `WatcherEngine`.
+      A dedicated `cap-watcher` (or generic automation capability) may
+      be split out later if non-AI watchers proliferate; tracked as a
+      separate issue.
+    - Several lifecycle-style abstractions
+      (`LifecycleSensor`/`LifecycleSignal`/...) and the new minimal
+      `Detector`/`Watcher` interfaces still co-exist; consolidating
+      them is out of scope for Step 2c.
+
 ### 不移出（三方一致同意留核心）
 
 | 组件 | 原因 |

--- a/packages/core/src/ai/index.ts
+++ b/packages/core/src/ai/index.ts
@@ -32,15 +32,7 @@ export type {
 } from "./ai-rate-limiter";
 export { AIRateLimiter } from "./ai-rate-limiter";
 export { createNoopAIService } from "./ai-service";
-// Anomaly Detector
-export type {
-  AnomalyDetection,
-  AnomalyDetectorConfig,
-  AnomalySeverity,
-  AnomalyType,
-  UsageEvent,
-} from "./anomaly-detector";
-export { AnomalyDetector } from "./anomaly-detector";
+// Anomaly Detector — moved to @linchkit/cap-ai-provider (Spec 56 Phase 2 Step 2c).
 // Context Masker
 export type {
   ContextMaskerConfig,
@@ -69,14 +61,9 @@ export type {
   OutputViolationType,
 } from "./output-validator";
 export { sanitizeAIOutput, validateAIOutput } from "./output-validator";
-// Pattern Detector
-export type {
-  PatternDetectorConfig,
-  PatternEvidence,
-  PatternInsight,
-  PatternType,
-} from "./pattern-detector";
-export { PatternDetector } from "./pattern-detector";
+// Pattern Detector — moved to @linchkit/cap-ai-provider (Spec 56 Phase 2 Step 2c).
+// Core retains only the data contract consumed by ProposalEngine.
+export type { PatternEvidence, PatternInsight, PatternType } from "./pattern-insight";
 // Prompt Sanitizer
 export type {
   InjectionDetectionConfig,

--- a/packages/core/src/ai/pattern-insight.ts
+++ b/packages/core/src/ai/pattern-insight.ts
@@ -1,0 +1,55 @@
+/**
+ * PatternInsight contract — shared between core's ProposalEngine and the
+ * concrete pattern-detection implementation in `@linchkit/cap-ai-provider`.
+ *
+ * The detection algorithm itself lives in `cap-ai-provider`
+ * (Spec 56 Phase 2 Step 2c — `PatternDetector` was moved out of core), but
+ * `ProposalEngine.createFromInsight()` still has to accept the resulting
+ * shape. Putting the data contract in core keeps the engine API intact
+ * without forcing core to depend on the capability.
+ */
+
+import type { ProposalDraft } from "./proposal-engine";
+
+/** Categories of pattern that an Awareness-layer detector may surface. */
+export type PatternType =
+  | "repetitive_action"
+  | "default_value"
+  | "validation_pattern"
+  | "state_flow"
+  | "timing";
+
+/** Evidence supporting a detected pattern. */
+export interface PatternEvidence {
+  /** Number of occurrences observed. */
+  count: number;
+  /** Human-readable timespan (e.g. "7 days", "30 days"). */
+  timespan: string;
+  /** Sample data points illustrating the pattern. */
+  examples: unknown[];
+}
+
+/**
+ * A detected pattern insight ready for proposal generation.
+ *
+ * Concrete pattern detectors (e.g. cap-ai-provider's `PatternDetector`)
+ * produce values matching this shape; `ProposalEngine.createFromInsight()`
+ * consumes them. Capabilities are free to extend the shape — only the
+ * fields below are part of the contract with core.
+ */
+export interface PatternInsight {
+  /** Unique insight identifier. */
+  id: string;
+  /** Type of pattern detected. */
+  type: PatternType;
+  /** Entity name this pattern relates to. */
+  entity: string;
+  /** Human-readable description of the pattern. */
+  description: string;
+  /** Confidence score, 0–1. */
+  confidence: number;
+  /** Supporting evidence. */
+  evidence: PatternEvidence;
+  /** Suggested change based on this pattern. */
+  suggestedAction: ProposalDraft;
+}

--- a/packages/core/src/ai/proposal-engine.ts
+++ b/packages/core/src/ai/proposal-engine.ts
@@ -12,7 +12,7 @@
 
 import type { EventHandlerDefinition } from "../types/event";
 import type { RuleDefinition } from "../types/rule";
-import type { PatternInsight } from "./pattern-detector";
+import type { PatternInsight } from "./pattern-insight";
 import type {
   ProposalValidatorConfig,
   ProposalChange as SecurityProposalChange,

--- a/packages/core/src/automation/index.ts
+++ b/packages/core/src/automation/index.ts
@@ -1,12 +1,7 @@
-export {
-  createWatcherEngine,
-  evaluateComparison,
-  parseDuration,
-  type WatcherActionExecutor,
-  type WatcherDataQuerier,
-  type WatcherEngine,
-  type WatcherEngineOptions,
-} from "./watcher-engine";
+// WatcherEngine concrete impl moved to @linchkit/cap-ai-provider
+// (Spec 56 Phase 2 Step 2c). Core retains the abstract `Watcher` interface
+// (see `../life-system/watcher.ts`) plus the WatcherRegistry — definition
+// storage stays in core because it is consumed by the action pipeline.
 export {
   createWatcherRegistry,
   type WatcherRegistry,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,10 +23,10 @@ export type {
   AIUsageRecord,
 } from "./ai";
 // AI Boundary — runtime classes exported from server-entry.ts only
-export type {
-  WatcherEngine,
-  WatcherRegistry,
-} from "./automation";
+// WatcherEngine concrete impl moved to @linchkit/cap-ai-provider
+// (Spec 56 Phase 2 Step 2c); core retains the abstract `Watcher` interface
+// (see `./life-system/watcher.ts`) and the WatcherRegistry.
+export type { WatcherRegistry } from "./automation";
 // Cache — type exports (browser-safe)
 export type {
   CacheEntry,
@@ -263,6 +263,7 @@ export type {
   CreateImpactAnalyzerOptions,
   CreatePreAnalysisPipelineOptions,
   DedupResult,
+  Detector,
   EvolutionRuntime,
   EvolutionRuntimeOptions,
   ImpactDataProvider,
@@ -286,6 +287,7 @@ export type {
   SignalBusOptions,
   SignalHandler,
   Unsubscribe,
+  Watcher,
 } from "./life-system";
 // Life-system — Sense layer (Spec 55) + Proposal pre-analysis (Spec 55 §7.3)
 // Spec 56 Phase 2 Step 2a adds lifecycle-style Sensor/Signal/Baseline/MemoryStore

--- a/packages/core/src/life-system/abstractions.ts
+++ b/packages/core/src/life-system/abstractions.ts
@@ -5,9 +5,12 @@
  *   Sense → Memory → Awareness → Insight → Proposal
  *
  * These interfaces are intentionally minimal and additive. Concrete
- * implementations (PatternDetector, AnomalyDetector, WatcherEngine,
- * persistent stores, ...) continue to live where they are today; this
- * module only declares the public contracts that capabilities can target.
+ * implementations live in capabilities — `PatternDetector`,
+ * `AnomalyDetector`, and `WatcherEngine` were moved out of core into
+ * `@linchkit/cap-ai-provider` in Spec 56 Phase 2 Step 2c. This module
+ * declares only the public contracts that capabilities can target. The
+ * minimal abstract `Detector` and `Watcher` contracts live alongside in
+ * `./detector.ts` and `./watcher.ts`.
  *
  * NOTE: A pre-existing detection-style `Sensor` interface (with `name` /
  * `source` / `detect()`) lives in `../types/life-system.ts` and powers

--- a/packages/core/src/life-system/detector.ts
+++ b/packages/core/src/life-system/detector.ts
@@ -1,0 +1,39 @@
+/**
+ * Detector — abstract Awareness-layer contract (Spec 55 / Spec 56 Phase 2 Step 2c).
+ *
+ * A Detector consumes some input (logs, events, usage records, ...) and returns
+ * a domain-specific output, or `null` when nothing is detected. Concrete
+ * detection algorithms — pattern detection, anomaly detection, drift
+ * detection, ... — live in capabilities (e.g. `cap-ai-provider`). Core only
+ * keeps this minimal interface so engines and capabilities can wire detectors
+ * through DI without coupling to specific implementations.
+ *
+ * Both sync and async implementations are supported: the return type is
+ * `TOutput | null | Promise<TOutput | null>`. Implementations may throw on
+ * malformed input but should prefer returning `null` for a "no signal"
+ * outcome rather than treating it as an error.
+ *
+ * @typeParam TInput  Shape of data fed to the detector. Defaults to `unknown`
+ *                    so the interface stays open.
+ * @typeParam TOutput Shape of the detector's positive output. Defaults to
+ *                    `unknown`. Detectors that emit arrays of findings can
+ *                    parameterise `TOutput` with the array type.
+ *
+ * @see docs/specs/55_evolution_system.md (Awareness layer)
+ * @see docs/specs/56_core_slimming.md (Phase 2 Step 2c)
+ */
+export interface Detector<TInput = unknown, TOutput = unknown> {
+  /**
+   * Stable identifier for this detector instance. Conventionally
+   * `<capability>.<detector_name>` (e.g. `ai.pattern_detector`). Used by
+   * registries / DI containers as a lookup key.
+   */
+  readonly id: string;
+
+  /**
+   * Run detection over `input`. Return the detector's positive output, or
+   * `null` when nothing was detected. May return a Promise so detectors
+   * needing I/O (DB lookups, model inference) do not have to block.
+   */
+  detect(input: TInput): Promise<TOutput | null> | TOutput | null;
+}

--- a/packages/core/src/life-system/index.ts
+++ b/packages/core/src/life-system/index.ts
@@ -27,6 +27,9 @@ export type { AwarenessEngineOptions } from "./awareness-engine";
 export { createAwarenessEngine } from "./awareness-engine";
 export type { SensorDefinitionConfig } from "./define-sensor";
 export { defineSensor } from "./define-sensor";
+// Spec 56 Phase 2 Step 2c — abstract Detector contract.
+// Concrete implementations live in capabilities (cap-ai-provider).
+export type { Detector } from "./detector";
 export type { CreateDispatchQueryOptions } from "./dispatch-query";
 export { createDispatchQuery } from "./dispatch-query";
 export type { EvolutionCycleOptions } from "./evolution-cycle";
@@ -72,3 +75,4 @@ export {
 export type { SignalBus, SignalBusOptions, SignalHandler } from "./signal-bus";
 export { createSignalBus } from "./signal-bus";
 export { createUsageImportanceGraph } from "./usage-graph";
+export type { Watcher } from "./watcher";

--- a/packages/core/src/life-system/watcher.ts
+++ b/packages/core/src/life-system/watcher.ts
@@ -1,0 +1,43 @@
+/**
+ * Watcher — abstract Sense-layer contract (Spec 55 / Spec 56 Phase 2 Step 2c).
+ *
+ * A Watcher is a long-lived component that observes some condition (data,
+ * timers, external streams, ...) and fires effects when the condition is
+ * met. Concrete watcher engines — the data-condition WatcherEngine
+ * (Spec 45), schedule-based watchers, external-source watchers, ... — live
+ * in capabilities (e.g. `cap-ai-provider`). Core keeps this minimal
+ * interface so capabilities can register watchers, and runtimes can manage
+ * their lifecycle, without coupling to a specific implementation.
+ *
+ * NOTE: This is distinct from the `WatcherDefinition` declarative shape in
+ * `../types/watcher.ts`, which describes a *single* declarative watcher (its
+ * trigger, watch target, and effect). `Watcher` here is the lifecycle
+ * contract for an *engine* (or other agent) that owns one or more such
+ * declarative watchers and manages their start/stop lifetime.
+ *
+ * @see docs/specs/55_evolution_system.md (Sense layer)
+ * @see docs/specs/56_core_slimming.md (Phase 2 Step 2c)
+ */
+export interface Watcher {
+  /**
+   * Stable identifier for this watcher instance. Conventionally
+   * `<capability>.<watcher_name>` (e.g. `ai.watcher_engine`). Used by
+   * registries / DI containers as a lookup key.
+   */
+  readonly id: string;
+
+  /**
+   * Begin watching. Called once during system startup. Implementations may
+   * subscribe to event buses, schedule timers, or open external streams.
+   * Should be idempotent — calling `start()` on an already-started watcher
+   * is a no-op.
+   */
+  start(): Promise<void> | void;
+
+  /**
+   * Stop watching and release any resources acquired by {@link Watcher.start}.
+   * Called once during shutdown. Should be idempotent so the runtime can
+   * safely call it on an already-stopped watcher.
+   */
+  stop(): Promise<void> | void;
+}

--- a/packages/core/src/server-entry.ts
+++ b/packages/core/src/server-entry.ts
@@ -7,18 +7,12 @@
  * Usage: import { createActionExecutor, EntityRegistry } from "@linchkit/core/server"
  */
 
-// === Watcher engine (data-condition automation, spec 45) ===
-
-export {
-  createWatcherEngine,
-  createWatcherRegistry,
-  evaluateComparison,
-  parseDuration,
-  type WatcherDataQuerier,
-  type WatcherEngine,
-  type WatcherEngineOptions,
-  type WatcherRegistry,
-} from "./automation";
+// === Watcher registry (data-condition automation, spec 45) ===
+// WatcherEngine concrete impl moved to @linchkit/cap-ai-provider
+// (Spec 56 Phase 2 Step 2c) — the abstract `Watcher` lifecycle interface
+// lives in `./life-system/watcher.ts`; the registry stays in core because
+// the action pipeline consumes WatcherDefinition records directly.
+export { createWatcherRegistry, type WatcherRegistry } from "./automation";
 
 // === Engine: action, command, approval, state, rule, validation, permission, proposal ===
 
@@ -206,13 +200,13 @@ export {
 export { createNoopAIService } from "./ai/ai-service";
 
 // === AI Boundary (server-only — heavyweight runtime classes) ===
+// AI Pattern Detection: concrete `PatternDetector` moved to
+// @linchkit/cap-ai-provider (Spec 56 Phase 2 Step 2c). Core re-exports
+// only the shared `PatternInsight` contract that
+// ProposalEngine.createFromInsight() consumes.
 
+export type { PatternEvidence, PatternInsight, PatternType } from "./ai";
 export { AIBoundary, AIBoundaryError } from "./ai";
-
-// === AI Pattern Detection (server-only — analysis engine) ===
-
-export type { PatternDetectorConfig, PatternEvidence, PatternInsight, PatternType } from "./ai";
-export { PatternDetector } from "./ai";
 
 // === AI Audit (server-only — compliance audit trail) ===
 
@@ -270,16 +264,8 @@ export {
   validateProposal as validateAIProposal,
 } from "./ai";
 
-// === AI Anomaly Detector (server-only — behavioral anomaly detection) ===
-
-export {
-  type AnomalyDetection,
-  AnomalyDetector,
-  type AnomalyDetectorConfig,
-  type AnomalySeverity,
-  type AnomalyType,
-  type UsageEvent,
-} from "./ai";
+// === AI Anomaly Detector ===
+// Moved to @linchkit/cap-ai-provider (Spec 56 Phase 2 Step 2c).
 
 // === Security: data masking (server-only — uses node:crypto) ===
 

--- a/packages/core/src/types/life-system.ts
+++ b/packages/core/src/types/life-system.ts
@@ -108,16 +108,9 @@ export interface MemoryStore {
 
 // ── Awareness layer ─────────────────────────────────────────
 
-/**
- * Abstract Detector interface — retained in core as an Awareness-layer contract.
- *
- * Concrete implementations (PatternDetector, AnomalyDetector) may live in
- * capabilities. Core keeps this interface so engines can depend on the abstraction
- * without coupling to specific detection algorithms.
- */
-export interface Detector<TEvent = unknown, TResult = unknown> {
-  detect(events: TEvent[]): Promise<TResult[]>;
-}
+// NOTE: The abstract `Detector` Awareness-layer contract now lives in
+// `../life-system/detector.ts` (Spec 56 Phase 2 Step 2c) so it sits next
+// to the other lifecycle abstractions. Import it via `@linchkit/core`.
 
 // -- SignalBus --
 export interface SignalBus {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -45,6 +45,7 @@
         "./addons/adapter-ui/cap-adapter-ui/src/hooks/use-subscription.ts"
       ],
       "@linchkit/cap-adapter-ui/lib/api": ["./addons/adapter-ui/cap-adapter-ui/src/lib/api.ts"],
+      "@linchkit/cap-ai-provider": ["./addons/ai-provider/cap-ai-provider/src"],
       "@linchkit/cap-adapter-mcp": ["./addons/adapter-mcp/cap-adapter-mcp/src"],
       "@linchkit/cap-auth": ["./addons/auth/cap-auth/src"],
       "@linchkit/cap-auth/ui": ["./addons/auth/cap-auth/ui/index.ts"],


### PR DESCRIPTION
## Summary
Spec 56 Phase 2 Step 2c. Slims `@linchkit/core` further by extracting AI-specific concrete impls of `PatternDetector` / `AnomalyDetector` / `WatcherEngine` into `cap-ai-provider`, leaving abstract `Detector<TInput, TOutput>` and `Watcher` contracts in core.

## Changes

**Core (added)**
- `packages/core/src/life-system/detector.ts` — `Detector<TInput, TOutput>` interface
- `packages/core/src/life-system/watcher.ts` — `Watcher` lifecycle interface (start / stop)
- `packages/core/src/ai/pattern-insight.ts` — `PatternInsight` data contract retained in core (consumed by `ProposalEngine.createFromInsight()`)

**Core (removed — moved to cap-ai-provider)**
- `packages/core/src/ai/pattern-detector.ts`
- `packages/core/src/ai/anomaly-detector.ts`
- `packages/core/src/automation/watcher-engine.ts`
- + 4 corresponding test files

**cap-ai-provider (added)**
- `addons/ai-provider/cap-ai-provider/src/{pattern-detector,anomaly-detector,watcher-engine}.ts`
- `addons/ai-provider/cap-ai-provider/__tests__/*` (relocated)
- Each moved class now implements its respective core interface (`PatternDetector implements Detector<...>`, `WatcherEngine extends Watcher`).

**Out-of-tree consumers updated**
- `cap-adapter-server/src/proposal-api.ts` imports `PatternDetector` / `PatternInsight` from `@linchkit/cap-ai-provider`
- `cap-adapter-server/package.json` declares `@linchkit/cap-ai-provider` as peer + dev dep
- `tsconfig.json` adds path mapping for `@linchkit/cap-ai-provider`

## Architectural notes
The only architectural challenge was `ProposalEngine.createFromInsight(insight: PatternInsight)`, which consumed `PatternInsight` from a file being moved out. To avoid making core depend on cap-ai-provider, the `PatternInsight` data contract (just the type, no algorithm) is extracted into `packages/core/src/ai/pattern-insight.ts` and re-exported from cap-ai-provider so external consumers see the unchanged shape.

## Cross-model review (no blockers)
- Architectural cleanliness — confirmed: `git grep "@linchkit/cap-ai-provider" packages/core/` returns zero source imports.
- PatternInsight extraction is pure data contract.
- Move completeness: old paths deleted, new paths in cap-ai-provider, imports rewritten.
- Interface design — `Detector` and `Watcher` actively constrain implementations, not merely conceptual.
- One MINOR addressed in second commit: package docstring now lists the new exports + flags WatcherEngine's parked status with a follow-up pointer.

## Follow-ups (not in this PR)
- WatcherEngine is conceptually generic data-condition automation, not AI-specific. Track moving it to a dedicated `cap-watcher` if non-AI watcher kinds proliferate.
- Older detection-style `Sensor`/`Signal`/`Baseline`/`MemoryStore` types in `core/src/types/life-system.ts` co-exist with the lifecycle abstractions from PR #255 + the new minimal `Detector`/`Watcher` here. A future spec pass should rationalize these.

## Test plan
- [x] `bun test` — 4698 pass / 0 fail / 3 skip
- [x] `bun run check` — clean (only the 2 pre-existing infos unrelated)
- [x] `bun run typecheck` — clean
- [x] Cross-model review — no blockers; MINOR doc addressed

Refs #155 (closes Phase 2 Step 2c)

🤖 Generated with [Claude Code](https://claude.com/claude-code)