### PR TITLE
feat(flow-restate): Saga compensation (Spec 26 §1.2/§4, part of #123)

### DIFF
--- a/addons/flow-restate/cap-flow-restate/__tests__/saga-compensation.test.ts
+++ b/addons/flow-restate/cap-flow-restate/__tests__/saga-compensation.test.ts
@@ -1,0 +1,462 @@
+/**
+ * Saga compensation tests for the Restate flow runtime.
+ *
+ * The compiled run handler is exercised directly with a stub WorkflowContext
+ * — no real Restate server is required. The stub mirrors the small surface
+ * (`ctx.key`, `ctx.run`, `ctx.set`) the compensation orchestration relies on,
+ * matching the pattern used by other in-memory flow tests in this repo.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { FlowDefinition } from "@linchkit/core";
+import type { FlowExecuteActionOptions, FlowStepContext } from "@linchkit/core/server";
+import { buildFlowRunHandler } from "../src/flow-compiler";
+
+// ── Stub WorkflowContext ─────────────────────────────────
+
+interface ActionInvocation {
+  actionName: string;
+  input: Record<string, unknown>;
+  options?: FlowExecuteActionOptions;
+}
+
+interface StubContext {
+  key: string;
+  state: Map<string, unknown>;
+  runCalls: string[];
+  set: (key: string, value: unknown) => void;
+  run: <T>(name: string, fn: () => Promise<T>) => Promise<T>;
+}
+
+/**
+ * Build a stub Restate WorkflowContext that records `set()` calls into a Map,
+ * delegates `run()` to the inner function (no durability), and exposes `key`
+ * as the flow instance ID.
+ */
+function createStubContext(key: string): StubContext {
+  const state = new Map<string, unknown>();
+  const runCalls: string[] = [];
+
+  return {
+    key,
+    state,
+    runCalls,
+    set(k, v) {
+      state.set(k, v);
+    },
+    async run(name, fn) {
+      runCalls.push(name);
+      return fn();
+    },
+  };
+}
+
+/**
+ * Build a stub FlowStepContext that records every executeAction invocation
+ * (including options) and dispatches to the supplied action handlers.
+ */
+function createStubStepContext(
+  handlers: Record<
+    string,
+    (input: Record<string, unknown>) => Record<string, unknown> | Promise<Record<string, unknown>>
+  >,
+  invocations: ActionInvocation[],
+): FlowStepContext {
+  return {
+    flowContext: {},
+    async executeAction(actionName, input, options) {
+      invocations.push({ actionName, input, options });
+      const handler = handlers[actionName];
+      if (!handler) {
+        return { ok: true, actionName };
+      }
+      return handler(input);
+    },
+    async callAI() {
+      return { response: "stub", tokensUsed: 0 };
+    },
+    evaluateCondition() {
+      return false;
+    },
+  };
+}
+
+/**
+ * Build the stepIndex map the way `compileFlow` would.
+ */
+function buildStepIndex(definition: FlowDefinition): Map<string, number> {
+  const map = new Map<string, number>();
+  for (let i = 0; i < definition.steps.length; i++) {
+    const step = definition.steps[i];
+    if (step) map.set(step.id, i);
+  }
+  return map;
+}
+
+// ── Tests ────────────────────────────────────────────────
+
+describe("Restate Saga compensation", () => {
+  it("runs compensations in reverse order when a step fails (failurePolicy: 'compensate')", async () => {
+    const invocations: ActionInvocation[] = [];
+    const stepCtx = createStubStepContext(
+      {
+        create_inbound: (input) => ({ inboundId: "ib-1", ...input }),
+        reserve_warehouse: (input) => ({ slotId: "slot-7", ...input }),
+        create_payment: () => {
+          throw new Error("Payment gateway timeout");
+        },
+        cancel_inbound: () => ({ cancelled: "ib-1" }),
+        release_warehouse: () => ({ released: "slot-7" }),
+      },
+      invocations,
+    );
+
+    const flow: FlowDefinition = {
+      name: "purchase_to_payment",
+      trigger: { type: "manual" },
+      failurePolicy: "compensate",
+      steps: [
+        {
+          id: "step_inbound",
+          name: "Create Inbound",
+          type: "action",
+          actionName: "create_inbound",
+          compensation: "cancel_inbound",
+        },
+        {
+          id: "step_warehouse",
+          name: "Reserve Warehouse",
+          type: "action",
+          actionName: "reserve_warehouse",
+          compensation: "release_warehouse",
+        },
+        {
+          id: "step_payment",
+          name: "Create Payment",
+          type: "action",
+          actionName: "create_payment",
+        },
+      ],
+    };
+
+    const ctx = createStubContext("flow-instance-001");
+    const run = buildFlowRunHandler(flow, flow.steps, buildStepIndex(flow), stepCtx);
+
+    await expect(run(ctx as never, {})).rejects.toThrow("Payment gateway timeout");
+
+    // Three forward calls + two compensations (step 3 had no compensation to run).
+    const order = invocations.map((i) => i.actionName);
+    expect(order).toEqual([
+      "create_inbound",
+      "reserve_warehouse",
+      "create_payment",
+      "release_warehouse",
+      "cancel_inbound",
+    ]);
+
+    // Compensation log was published into workflow state in reverse order.
+    const log = ctx.state.get("compensation_log") as Array<{ stepId: string; status: string }>;
+    expect(log).toHaveLength(2);
+    expect(log[0]?.stepId).toBe("step_warehouse");
+    expect(log[1]?.stepId).toBe("step_inbound");
+    expect(log.every((entry) => entry.status === "succeeded")).toBe(true);
+
+    expect(ctx.state.get("status")).toBe("compensated");
+  });
+
+  it("skips steps without a compensation declaration", async () => {
+    const invocations: ActionInvocation[] = [];
+    const stepCtx = createStubStepContext(
+      {
+        prepare: () => ({ prepared: true }),
+        finalize: () => ({ finalized: true }),
+        crash: () => {
+          throw new Error("oops");
+        },
+        undo_finalize: () => ({ undone: true }),
+      },
+      invocations,
+    );
+
+    const flow: FlowDefinition = {
+      name: "partial-compensation",
+      trigger: { type: "manual" },
+      failurePolicy: "compensate",
+      steps: [
+        // No compensation declared on this step — it must be skipped during rollback.
+        { id: "s1", name: "Prepare", type: "action", actionName: "prepare" },
+        {
+          id: "s2",
+          name: "Finalize",
+          type: "action",
+          actionName: "finalize",
+          compensation: "undo_finalize",
+        },
+        { id: "s3", name: "Crash", type: "action", actionName: "crash" },
+      ],
+    };
+
+    const ctx = createStubContext("flow-002");
+    const run = buildFlowRunHandler(flow, flow.steps, buildStepIndex(flow), stepCtx);
+
+    await expect(run(ctx as never, {})).rejects.toThrow("oops");
+
+    expect(invocations.map((i) => i.actionName)).toEqual([
+      "prepare",
+      "finalize",
+      "crash",
+      "undo_finalize", // only step with a compensation runs
+    ]);
+
+    const log = ctx.state.get("compensation_log") as Array<{ stepId: string }>;
+    expect(log).toHaveLength(1);
+    expect(log[0]?.stepId).toBe("s2");
+  });
+
+  it("continues compensating when one compensation throws and surfaces both errors", async () => {
+    const invocations: ActionInvocation[] = [];
+    const stepCtx = createStubStepContext(
+      {
+        do_a: () => ({ a: 1 }),
+        do_b: () => ({ b: 2 }),
+        boom: () => {
+          throw new Error("primary failure");
+        },
+        undo_a: () => ({ undone: "a" }),
+        undo_b: () => {
+          throw new Error("undo_b failed");
+        },
+      },
+      invocations,
+    );
+
+    const flow: FlowDefinition = {
+      name: "best-effort-compensation",
+      trigger: { type: "manual" },
+      failurePolicy: "compensate",
+      steps: [
+        { id: "a", name: "A", type: "action", actionName: "do_a", compensation: "undo_a" },
+        { id: "b", name: "B", type: "action", actionName: "do_b", compensation: "undo_b" },
+        { id: "c", name: "C", type: "action", actionName: "boom" },
+      ],
+    };
+
+    const ctx = createStubContext("flow-003");
+    const run = buildFlowRunHandler(flow, flow.steps, buildStepIndex(flow), stepCtx);
+
+    let captured: Error | undefined;
+    try {
+      await run(ctx as never, {});
+    } catch (err) {
+      captured = err as Error;
+    }
+
+    expect(captured).toBeDefined();
+    // Original error survives; the compensation failure is wrapped into context.
+    expect(captured?.message).toContain("primary failure");
+    expect(captured?.message).toContain("compensation failures");
+    expect(captured?.message).toContain("b->undo_b");
+
+    // Both compensations ran in reverse order even though undo_b threw.
+    expect(invocations.map((i) => i.actionName)).toEqual([
+      "do_a",
+      "do_b",
+      "boom",
+      "undo_b",
+      "undo_a",
+    ]);
+
+    const log = ctx.state.get("compensation_log") as Array<{
+      stepId: string;
+      status: string;
+      error?: string;
+    }>;
+    expect(log).toHaveLength(2);
+    expect(log[0]?.stepId).toBe("b");
+    expect(log[0]?.status).toBe("failed");
+    expect(log[0]?.error).toBe("undo_b failed");
+    expect(log[1]?.stepId).toBe("a");
+    expect(log[1]?.status).toBe("succeeded");
+  });
+
+  it("does not compensate when failurePolicy is 'fail_fast' (or unset)", async () => {
+    for (const policyVariant of [{ failurePolicy: "fail_fast" as const }, {}]) {
+      const invocations: ActionInvocation[] = [];
+      const stepCtx = createStubStepContext(
+        {
+          step_one: () => ({ ok: true }),
+          step_two: () => {
+            throw new Error("step_two failed");
+          },
+          undo_one: () => ({ undone: true }),
+        },
+        invocations,
+      );
+
+      const flow: FlowDefinition = {
+        name: "fail-fast-flow",
+        trigger: { type: "manual" },
+        ...policyVariant,
+        steps: [
+          {
+            id: "s1",
+            name: "Step One",
+            type: "action",
+            actionName: "step_one",
+            compensation: "undo_one",
+          },
+          { id: "s2", name: "Step Two", type: "action", actionName: "step_two" },
+        ],
+      };
+
+      const ctx = createStubContext("flow-fail-fast");
+      const run = buildFlowRunHandler(flow, flow.steps, buildStepIndex(flow), stepCtx);
+
+      await expect(run(ctx as never, {})).rejects.toThrow("step_two failed");
+
+      // No compensation was attempted — only the two forward steps ran.
+      expect(invocations.map((i) => i.actionName)).toEqual(["step_one", "step_two"]);
+      expect(ctx.state.get("compensation_log")).toBeUndefined();
+      expect(ctx.state.get("status")).not.toBe("compensated");
+    }
+  });
+
+  it("forwards a deterministic idempotency key for each compensation invocation", async () => {
+    const invocations: ActionInvocation[] = [];
+    const stepCtx = createStubStepContext(
+      {
+        do_a: () => ({}),
+        do_b: () => ({}),
+        crash: () => {
+          throw new Error("boom");
+        },
+        undo_a: () => ({}),
+        undo_b: () => ({}),
+      },
+      invocations,
+    );
+
+    const flow: FlowDefinition = {
+      name: "idem-flow",
+      trigger: { type: "manual" },
+      failurePolicy: "compensate",
+      steps: [
+        { id: "a", name: "A", type: "action", actionName: "do_a", compensation: "undo_a" },
+        { id: "b", name: "B", type: "action", actionName: "do_b", compensation: "undo_b" },
+        { id: "c", name: "C", type: "action", actionName: "crash" },
+      ],
+    };
+
+    const ctx = createStubContext("flow-idem-XYZ");
+    const run = buildFlowRunHandler(flow, flow.steps, buildStepIndex(flow), stepCtx);
+
+    await expect(run(ctx as never, {})).rejects.toThrow("boom");
+
+    // Forward steps must NOT carry an idempotency key.
+    const forward = invocations.filter((i) => ["do_a", "do_b", "crash"].includes(i.actionName));
+    for (const call of forward) {
+      expect(call.options?.idempotencyKey).toBeUndefined();
+    }
+
+    const undoB = invocations.find((i) => i.actionName === "undo_b");
+    const undoA = invocations.find((i) => i.actionName === "undo_a");
+    // Key shape: `${ctx.key}:${completionIndex}:${stepId}:compensate`.
+    // The completion index disambiguates compensations for steps that ran
+    // multiple times in a loop — see the "loop" regression test below.
+    expect(undoB?.options?.idempotencyKey).toBe("flow-idem-XYZ:1:b:compensate");
+    expect(undoA?.options?.idempotencyKey).toBe("flow-idem-XYZ:0:a:compensate");
+  });
+
+  it("treats legacy onError === 'compensate' as a compensation trigger", async () => {
+    const invocations: ActionInvocation[] = [];
+    const stepCtx = createStubStepContext(
+      {
+        do_a: () => ({ a: 1 }),
+        crash: () => {
+          throw new Error("legacy boom");
+        },
+        undo_a: () => ({ undone: true }),
+      },
+      invocations,
+    );
+
+    const flow: FlowDefinition = {
+      name: "legacy-onerror-flow",
+      trigger: { type: "manual" },
+      // Note: failurePolicy unset; fall back to legacy onError contract.
+      onError: "compensate",
+      steps: [
+        { id: "a", name: "A", type: "action", actionName: "do_a", compensation: "undo_a" },
+        { id: "b", name: "B", type: "action", actionName: "crash" },
+      ],
+    };
+
+    const ctx = createStubContext("flow-legacy");
+    const run = buildFlowRunHandler(flow, flow.steps, buildStepIndex(flow), stepCtx);
+
+    await expect(run(ctx as never, {})).rejects.toThrow("legacy boom");
+    expect(invocations.map((i) => i.actionName)).toEqual(["do_a", "crash", "undo_a"]);
+  });
+
+  it("disambiguates compensation keys for steps that ran multiple times in a loop", async () => {
+    // Regression test for the loop key-collision: when a single action step
+    // executes more than once via __jump, each completion must get its own
+    // idempotency key + ctx.run name. Otherwise Restate's ctx.run cache and
+    // the ActionEngine's idempotency dedupe would collapse all compensations
+    // into a single call — the second debit would never be credited back.
+    const invocations: ActionInvocation[] = [];
+    let bodyRunCount = 0;
+    let checkRunCount = 0;
+    const stepCtx = createStubStepContext(
+      {
+        body: () => {
+          bodyRunCount++;
+          return { iter: bodyRunCount };
+        },
+        check: () => {
+          checkRunCount++;
+          // First time: jump back to body so it runs a second time.
+          // Second time: fall through to crash.
+          return checkRunCount === 1 ? { __jump: "body" } : { ok: true };
+        },
+        crash: () => {
+          throw new Error("after loop boom");
+        },
+        undo_body: () => ({ undone: true }),
+      },
+      invocations,
+    );
+
+    const flow: FlowDefinition = {
+      name: "loop-flow",
+      trigger: { type: "manual" },
+      failurePolicy: "compensate",
+      steps: [
+        { id: "body", name: "Body", type: "action", actionName: "body", compensation: "undo_body" },
+        { id: "check", name: "Check", type: "action", actionName: "check" },
+        { id: "after", name: "After", type: "action", actionName: "crash" },
+      ],
+    };
+
+    const ctx = createStubContext("flow-loop-1");
+    const run = buildFlowRunHandler(flow, flow.steps, buildStepIndex(flow), stepCtx);
+
+    await expect(run(ctx as never, {})).rejects.toThrow("after loop boom");
+
+    // body should have executed twice and undo_body should have been called
+    // twice — once per completion.
+    expect(bodyRunCount).toBe(2);
+    const undoCalls = invocations.filter((i) => i.actionName === "undo_body");
+    expect(undoCalls).toHaveLength(2);
+
+    // The two undo invocations must carry DISTINCT idempotency keys, with
+    // the completion index baked in (1 first, then 0 — reverse order).
+    expect(undoCalls[0]?.options?.idempotencyKey).toBe("flow-loop-1:1:body:compensate");
+    expect(undoCalls[1]?.options?.idempotencyKey).toBe("flow-loop-1:0:body:compensate");
+
+    // The two ctx.run names must also be distinct, so Restate's per-step
+    // result cache cannot dedupe them into a single execution.
+    const compensateRuns = ctx.runCalls.filter((n) => n.startsWith("compensate_"));
+    expect(compensateRuns).toEqual(["compensate_1_body", "compensate_0_body"]);
+  });
+});

--- a/addons/flow-restate/cap-flow-restate/src/flow-compiler.ts
+++ b/addons/flow-restate/cap-flow-restate/src/flow-compiler.ts
@@ -158,53 +158,71 @@ interface FlowRunResult {
   output?: unknown;
 }
 
-// ── Compiler ─────────────────────────────────────────────
+// ── Saga helpers ─────────────────────────────────────────
 
 /**
- * Compile a FlowDefinition into a Restate workflow service.
+ * Decide whether a flow's failure should trigger Saga compensation.
  *
- * The compiled workflow has:
- * - A `run` handler that executes steps sequentially with branching
- * - Signal handlers for each approval step (named `approve_{stepId}`)
- * - A `status` handler for querying current state
- * - A `signal` handler for sending arbitrary signals (for WaitFlowStep.signal)
+ * Spec 26 §1.2 introduces `failurePolicy` as the explicit opt-in field:
+ *   - `'compensate'` — run reverse compensations on failure.
+ *   - `'fail_fast'` — propagate the original error without compensation.
+ *
+ * The legacy `onError === 'compensate'` value remains a compensation trigger
+ * for backward compatibility, unless `failurePolicy === 'fail_fast'`
+ * explicitly overrides it.
  */
-export function compileFlow(
+function shouldCompensate(definition: FlowDefinition): boolean {
+  if (definition.failurePolicy === "compensate") return true;
+  if (definition.failurePolicy === "fail_fast") return false;
+  return definition.onError === "compensate";
+}
+
+/**
+ * Wrap the original failure with information about any failed compensations.
+ *
+ * Per the task spec: the original error is what the flow ultimately throws;
+ * if any compensation failed we extend the message so observers (Restate logs,
+ * downstream callers) see both the root cause AND the cleanup gaps.
+ *
+ * The returned error is always a TerminalError so Restate marks the workflow
+ * as failed without further retries (compensation has already run; retrying
+ * the whole workflow would re-execute every step).
+ */
+function wrapWithCompensationFailures(
+  originalError: unknown,
+  compensationLog: CompensationLogEntry[],
+): Error {
+  const originalMessage =
+    originalError instanceof Error ? originalError.message : String(originalError);
+  const failed = compensationLog.filter((entry) => entry.status === "failed");
+
+  if (failed.length === 0) {
+    // All compensations succeeded — surface the original error verbatim.
+    return new restate.TerminalError(originalMessage);
+  }
+
+  const failedSummary = failed
+    .map((entry) => `${entry.stepId}->${entry.compensationAction}: ${entry.error ?? "unknown"}`)
+    .join("; ");
+  return new restate.TerminalError(`${originalMessage} (compensation failures: ${failedSummary})`);
+}
+
+// ── Run-handler builder (extracted for testability) ──────
+
+/**
+ * Build the `run` handler for a flow's Restate workflow service.
+ *
+ * Exported so unit tests can drive it with a stub `WorkflowContext` instead
+ * of standing up a real Restate server. The handler shape is identical to
+ * what `compileFlow` would attach to its `restate.workflow({...})` service.
+ */
+export function buildFlowRunHandler(
   definition: FlowDefinition,
+  steps: FlowStep[],
+  stepIndex: Map<string, number>,
   stepContext: FlowStepContext,
-): CompiledFlow {
-  const { steps } = definition;
-
-  // Build step index for O(1) lookups by step ID
-  const stepIndex = new Map<string, number>();
-  for (let i = 0; i < steps.length; i++) {
-    const step = steps[i];
-    if (step) stepIndex.set(step.id, i);
-  }
-
-  // Collect approval steps and wait-signal steps for handler generation
-  const approvalSteps = steps.filter((s): s is ApprovalFlowStep => s.type === "approval");
-  const signalHandlerNames = approvalSteps.map((s) => `approve_${s.id}`);
-
-  // Check if any wait steps use signals — if so, we need a generic signal handler
-  const hasSignalWaits = steps.some((s) => s.type === "wait" && (s as WaitFlowStep).signal);
-  if (hasSignalWaits) {
-    signalHandlerNames.push("signal");
-  }
-
-  // Always include status handler
-  signalHandlerNames.push("status");
-
-  // ── Build handlers object ──────────────────────────────
-
-  // biome-ignore lint: Dynamic handler map — typed as any to support heterogeneous Restate handler signatures
-  const handlers: Record<string, any> = {};
-
-  // Main run handler
-  handlers.run = async (
-    ctx: restate.WorkflowContext,
-    input: Record<string, unknown>,
-  ): Promise<FlowRunResult> => {
+): (ctx: restate.WorkflowContext, input: Record<string, unknown>) => Promise<FlowRunResult> {
+  return async (ctx, input) => {
     const flowCtx: FlowExecutionContext = {
       input,
       instanceId: ctx.key,
@@ -281,12 +299,15 @@ export function compileFlow(
         pointer++;
       }
     } catch (err) {
-      // Run Saga compensations if onError === 'compensate'
-      if (definition.onError === "compensate" && completedActionSteps.length > 0) {
+      // Run Saga compensations when the flow opted in via failurePolicy
+      // (Spec 26 §1.2) or the legacy onError === 'compensate' value.
+      if (shouldCompensate(definition) && completedActionSteps.length > 0) {
         ctx.set("status", "compensating");
         const compensationLog: CompensationLogEntry[] = [];
 
-        // Run compensations in reverse order (durable via ctx.run)
+        // Run compensations in reverse order (durable via ctx.run).
+        // A compensation failure is recorded but does NOT abort the
+        // remaining compensations — Spec 26 §4 mandates best-effort cleanup.
         for (let i = completedActionSteps.length - 1; i >= 0; i--) {
           const record = completedActionSteps[i];
           if (!record) continue;
@@ -306,8 +327,19 @@ export function compileFlow(
           };
 
           try {
-            await ctx.run(`compensate_${record.stepId}`, () =>
-              stepContext.executeAction(record.compensationAction, resolvedInput),
+            // Idempotency key (Spec 26 §3.2): identical across re-runs of the
+            // same flow instance + step + 'compensate' phase, so retried Restate
+            // invocations of the same compensation are deduplicated by the
+            // ActionEngine instead of double-applying the undo. The completion
+            // index `i` is included so a step that ran multiple times in a
+            // loop gets distinct keys per execution — without it, only the
+            // first compensation would actually run (the rest would dedupe
+            // both at Restate's `ctx.run` cache and at the ActionEngine).
+            const idempotencyKey = `${ctx.key}:${i}:${record.stepId}:compensate`;
+            await ctx.run(`compensate_${i}_${record.stepId}`, () =>
+              stepContext.executeAction(record.compensationAction, resolvedInput, {
+                idempotencyKey,
+              }),
             );
           } catch (compErr) {
             entry.status = "failed";
@@ -319,13 +351,15 @@ export function compileFlow(
 
         ctx.set("compensation_log", compensationLog);
         ctx.set("status", "compensated");
-        return {
-          status: "completed",
-          output: { compensated: true, compensationLog },
-        };
+
+        // Re-throw the ORIGINAL error so the flow surfaces as failed; if any
+        // compensation also failed, wrap the original error message with the
+        // failed entries so the error context carries both signals.
+        throw wrapWithCompensationFailures(err, compensationLog);
       }
 
-      // Re-throw to let Restate handle retries / terminal error propagation
+      // No compensation policy in effect — propagate the original error so
+      // Restate can retry / mark the workflow failed.
       throw err;
     }
 
@@ -335,6 +369,53 @@ export function compileFlow(
       output: flowCtx.prev?.output,
     };
   };
+}
+
+// ── Compiler ─────────────────────────────────────────────
+
+/**
+ * Compile a FlowDefinition into a Restate workflow service.
+ *
+ * The compiled workflow has:
+ * - A `run` handler that executes steps sequentially with branching
+ * - Signal handlers for each approval step (named `approve_{stepId}`)
+ * - A `status` handler for querying current state
+ * - A `signal` handler for sending arbitrary signals (for WaitFlowStep.signal)
+ */
+export function compileFlow(
+  definition: FlowDefinition,
+  stepContext: FlowStepContext,
+): CompiledFlow {
+  const { steps } = definition;
+
+  // Build step index for O(1) lookups by step ID
+  const stepIndex = new Map<string, number>();
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i];
+    if (step) stepIndex.set(step.id, i);
+  }
+
+  // Collect approval steps and wait-signal steps for handler generation
+  const approvalSteps = steps.filter((s): s is ApprovalFlowStep => s.type === "approval");
+  const signalHandlerNames = approvalSteps.map((s) => `approve_${s.id}`);
+
+  // Check if any wait steps use signals — if so, we need a generic signal handler
+  const hasSignalWaits = steps.some((s) => s.type === "wait" && (s as WaitFlowStep).signal);
+  if (hasSignalWaits) {
+    signalHandlerNames.push("signal");
+  }
+
+  // Always include status handler
+  signalHandlerNames.push("status");
+
+  // ── Build handlers object ──────────────────────────────
+
+  // biome-ignore lint: Dynamic handler map — typed as any to support heterogeneous Restate handler signatures
+  const handlers: Record<string, any> = {};
+
+  // Main run handler — built as a standalone function so the same logic can
+  // be unit tested with a mocked WorkflowContext (see __tests__/saga-compensation.test.ts).
+  handlers.run = buildFlowRunHandler(definition, steps, stepIndex, stepContext);
 
   // Status query handler
   handlers.status = async (ctx: restate.WorkflowSharedContext): Promise<string> => {

--- a/addons/flow-restate/cap-flow-restate/src/index.ts
+++ b/addons/flow-restate/cap-flow-restate/src/index.ts
@@ -5,7 +5,7 @@
  * Includes: flow compiler, Restate flow engine, endpoint management, health checks.
  */
 
-export { compileFlow } from "./flow-compiler";
+export { buildFlowRunHandler, compileFlow } from "./flow-compiler";
 export {
   checkRestateHealth,
   createRestateEndpoint,

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@modelcontextprotocol/sdk": "1.29.0",
-        "@restatedev/restate-sdk": "1.11.1",
+        "@restatedev/restate-sdk": "1.13.0",
         "@tanstack/react-table": "^8.21.3",
         "ai": "^6.0.134",
         "dataloader": "^2.2.3",
@@ -67,11 +67,13 @@
         "graphql-yoga": "^5.18.1",
       },
       "devDependencies": {
+        "@linchkit/cap-ai-provider": "workspace:*",
         "@linchkit/core": "workspace:*",
         "typescript": "^6.0.2",
       },
       "peerDependencies": {
-        "@linchkit/core": "^0.1.0",
+        "@linchkit/cap-ai-provider": "^1.0.0",
+        "@linchkit/core": "^0.2.0",
       },
     },
     "addons/adapter-ui/cap-adapter-ui": {
@@ -97,7 +99,7 @@
         "cmdk": "^1.1.1",
         "dagre": "^0.8.5",
         "date-fns": "^4.1.0",
-        "i18next": "^25.10.4",
+        "i18next": "^26.0.6",
         "lucide-react": "^1.7.0",
         "mermaid": "^11.6.0",
         "next-themes": "^0.4.6",
@@ -122,7 +124,7 @@
         "vite": "^8.0.1",
       },
       "peerDependencies": {
-        "@linchkit/core": "^0.1.0",
+        "@linchkit/core": "^0.2.0",
       },
     },
     "addons/adapter-ui/cap-adapter-ui/ui-kit": {
@@ -158,7 +160,7 @@
         "typescript": "^6.0.2",
       },
       "peerDependencies": {
-        "@linchkit/core": "^0.1.0",
+        "@linchkit/core": "^0.2.0",
       },
     },
     "addons/auth/cap-auth": {
@@ -226,6 +228,13 @@
         "react": "^19.0.0",
       },
     },
+    "addons/demo/cap-life-demo": {
+      "name": "@linchkit/cap-life-demo",
+      "version": "0.0.1",
+      "peerDependencies": {
+        "@linchkit/core": "workspace:*",
+      },
+    },
     "addons/demo/cap-purchase-demo": {
       "name": "@linchkit/cap-purchase-demo",
       "version": "0.0.1",
@@ -248,14 +257,14 @@
       "name": "@linchkit/cap-flow-restate",
       "version": "1.0.0",
       "dependencies": {
-        "@restatedev/restate-sdk": "1.11.1",
+        "@restatedev/restate-sdk": "1.13.0",
       },
       "devDependencies": {
         "@linchkit/core": "workspace:*",
         "typescript": "^6.0.2",
       },
       "peerDependencies": {
-        "@linchkit/core": "^0.1.0",
+        "@linchkit/core": "^0.2.0",
       },
     },
     "addons/migration/cap-migration": {
@@ -640,6 +649,8 @@
 
     "@linchkit/cap-flow-restate": ["@linchkit/cap-flow-restate@workspace:addons/flow-restate/cap-flow-restate"],
 
+    "@linchkit/cap-life-demo": ["@linchkit/cap-life-demo@workspace:addons/demo/cap-life-demo"],
+
     "@linchkit/cap-mcp-ui": ["@linchkit/cap-mcp-ui@workspace:addons/adapter-mcp/cap-mcp-ui"],
 
     "@linchkit/cap-migration": ["@linchkit/cap-migration@workspace:addons/migration/cap-migration"],
@@ -822,9 +833,9 @@
 
     "@repeaterjs/repeater": ["@repeaterjs/repeater@3.0.6", "https://registry.npmmirror.com/@repeaterjs/repeater/-/repeater-3.0.6.tgz", {}, "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA=="],
 
-    "@restatedev/restate-sdk": ["@restatedev/restate-sdk@1.11.1", "", { "dependencies": { "@restatedev/restate-sdk-core": "1.11.1" } }, "sha512-qJNpA5POJOOTx4piMNp3zwMbyS6SPn9DWpFYmWXV9zCdX1nl/mflUrSOMIdAp97xSJUo3D4thRKRuRTyv4SSzg=="],
+    "@restatedev/restate-sdk": ["@restatedev/restate-sdk@1.13.0", "", { "dependencies": { "@restatedev/restate-sdk-core": "1.13.0" } }, "sha512-SAqes+qbpMn1HCRn/275FuNkyhvYsNwoe9BJwT0OjV1ocKC27SR4UGp/d2vO9mV6804VlSapybpGs4H7SM3HMA=="],
 
-    "@restatedev/restate-sdk-core": ["@restatedev/restate-sdk-core@1.11.1", "", {}, "sha512-noGcYm6WePsCNLH2becGARKnfMXxDccvVn8UyOEv1Nzxix/8S25nbnYEpRylxCPlcHdgfyvDlIQF0sW5Clk2iQ=="],
+    "@restatedev/restate-sdk-core": ["@restatedev/restate-sdk-core@1.13.0", "", {}, "sha512-DVmlI3rI8coA0Hcpxd2cLaK5DKUCwKDyXWXqjMorhqd4HBqdJBWtgrS0y0ZGUW+vuzJMeFpFvq3nhQJIvn6U9Q=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.10", "https://registry.npmmirror.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.10.tgz", { "os": "android", "cpu": "arm64" }, "sha512-jOHxwXhxmFKuXztiu1ORieJeTbx5vrTkcOkkkn2d35726+iwhrY1w/+nYY/AGgF12thg33qC3R1LMBF5tHTZHg=="],
 
@@ -1584,7 +1595,7 @@
 
     "human-signals": ["human-signals@8.0.1", "https://registry.npmmirror.com/human-signals/-/human-signals-8.0.1.tgz", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
 
-    "i18next": ["i18next@25.10.4", "https://registry.npmmirror.com/i18next/-/i18next-25.10.4.tgz", { "dependencies": { "@babel/runtime": "^7.29.2" }, "peerDependencies": { "typescript": "^5" }, "optionalPeers": ["typescript"] }, "sha512-XsE/6eawy090meuFU0BTY9BtmWr1m9NSwLr0NK7/A04LA58wdAvDsi9WNOJ40Qb1E9NIPbvnVLZEN2fWDd3/3Q=="],
+    "i18next": ["i18next@26.0.10", "", { "peerDependencies": { "typescript": "^5 || ^6" }, "optionalPeers": ["typescript"] }, "sha512-k3yGPAlWR2RdMYoVXJoDZDT87qeHIWKH7gVksdZMpRty7QX/D9QZeYGvN08KGbKHke9wn01eYT+EEsrqX/YTlw=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.7.2.tgz", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
@@ -2308,8 +2319,6 @@
 
     "@linchkit/cap-ai-provider/ai": ["ai@6.0.138", "", { "dependencies": { "@ai-sdk/gateway": "3.0.80", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-49OfPe0f5uxJ6jUdA5BBXjIinP6+ZdYfAtpF2aEH64GA5wPcxH2rf/TBUQQ0bbamBz/D+TLMV18xilZqOC+zaA=="],
 
-    "@linchkit/core/i18next": ["i18next@26.0.3", "", { "dependencies": { "@babel/runtime": "^7.29.2" }, "peerDependencies": { "typescript": "^5 || ^6" }, "optionalPeers": ["typescript"] }, "sha512-1571kXINxHKY7LksWp8wP+zP0YqHSSpl/OW0Y0owFEf2H3s8gCAffWaZivcz14rMkOvn3R/psiQxVsR9t2Nafg=="],
-
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
     "@manypkg/find-root/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
@@ -2354,8 +2363,6 @@
 
     "express/cookie": ["cookie@0.7.2", "https://registry.npmmirror.com/cookie/-/cookie-0.7.2.tgz", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
-    "i18next/typescript": ["typescript@5.9.3", "https://registry.npmmirror.com/typescript/-/typescript-5.9.3.tgz", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
-
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "https://registry.npmmirror.com/resolve-from/-/resolve-from-4.0.0.tgz", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
@@ -2371,8 +2378,6 @@
     "prompts/kleur": ["kleur@3.0.3", "https://registry.npmmirror.com/kleur/-/kleur-3.0.3.tgz", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
     "react-grid-layout/fast-equals": ["fast-equals@4.0.3", "", {}, "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg=="],
-
-    "react-i18next/i18next": ["i18next@26.0.3", "", { "dependencies": { "@babel/runtime": "^7.29.2" }, "peerDependencies": { "typescript": "^5 || ^6" }, "optionalPeers": ["typescript"] }, "sha512-1571kXINxHKY7LksWp8wP+zP0YqHSSpl/OW0Y0owFEf2H3s8gCAffWaZivcz14rMkOvn3R/psiQxVsR9t2Nafg=="],
 
     "read-yaml-file/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 

--- a/docs/specs/26_transaction_model.md
+++ b/docs/specs/26_transaction_model.md
@@ -157,7 +157,7 @@ await executeAction('submit_request', { id: 'pr_001' }, {
 - 基础幂等
 
 ### M1
-- Saga 补偿（Restate Flow）
+- Saga 补偿（Restate Flow） — Implemented (issue #123). `FlowDefinition.failurePolicy: 'compensate'` runs each completed step's `compensation` Action in reverse order; per-step idempotency key (`{flow_run_id}:{step_id}:compensate`) prevents double compensation on retry. Best-effort cleanup: a single failed compensation does not abort the others, the original error is what the flow ultimately throws, with failed compensations wrapped into the error context.
 - 变更事务（蓝绿部署原子性）
 - 幂等键管理
 

--- a/packages/core/__tests__/sync-flow-engine.test.ts
+++ b/packages/core/__tests__/sync-flow-engine.test.ts
@@ -496,5 +496,98 @@ describe("SyncFlowEngine", () => {
 
       expect(compensationCallInput).toEqual({ reason: "rollback" });
     });
+
+    it("disambiguates compensation idempotency keys when a step runs multiple times in a loop", async () => {
+      // Regression for the loop-collision bug: when a single action step
+      // executes more than once via a condition jump, each completion must
+      // get its own idempotency key. Without the completion index `i` baked
+      // into the key, the ActionEngine would dedupe all but the first
+      // compensation — the second debit would never be credited back.
+      const compensationKeys: Array<string | undefined> = [];
+
+      const ctx: FlowStepContext = {
+        flowContext: {},
+        async executeAction(actionName, _input, options) {
+          if (actionName === "undo_body") {
+            compensationKeys.push(options?.idempotencyKey);
+            return { undone: true };
+          }
+          if (actionName === "crash") {
+            throw new Error("after-loop boom");
+          }
+          if (actionName === "body") {
+            return { iter: 1 };
+          }
+          return { ok: true };
+        },
+        async callAI() {
+          return { response: "stub", tokensUsed: 0 };
+        },
+        evaluateCondition() {
+          return false;
+        },
+      };
+
+      // Sync engine stores each step's output at $steps.<id>.output (overwriting
+      // on each visit). Body returns `iter: 1` every call; the condition compares
+      // a counter we maintain via the action handler's call number.
+      let bodyCalls = 0;
+      const wrapped: FlowStepContext = {
+        ...ctx,
+        async executeAction(actionName, input, options) {
+          if (actionName === "body") {
+            bodyCalls++;
+            return { iter: bodyCalls };
+          }
+          return ctx.executeAction(actionName, input, options);
+        },
+      };
+
+      const flow: FlowDefinition = {
+        name: "loop-saga",
+        trigger: { type: "manual" },
+        failurePolicy: "compensate",
+        steps: [
+          {
+            id: "body",
+            name: "Body",
+            type: "action",
+            actionName: "body",
+            compensation: "undo_body",
+          },
+          {
+            id: "check",
+            name: "Check",
+            type: "condition",
+            expression: "$steps.body.output.iter < 2",
+            // biome-ignore lint/suspicious/noThenProperty: flow condition step definition
+            then: "body",
+            else: "after",
+          },
+          {
+            id: "after",
+            name: "After",
+            type: "action",
+            actionName: "crash",
+          },
+        ],
+      };
+
+      const engine = createSyncFlowEngine(wrapped);
+      engine.registerFlow(flow);
+
+      const instance = await engine.startFlow("loop-saga", {}, { instanceId: "loop-instance-1" });
+
+      // body should have run twice (iter=1 then iter=2), then crash.
+      expect(bodyCalls).toBe(2);
+      expect(instance.status).toBe("compensated");
+
+      // Two undo_body invocations, with DISTINCT keys carrying the
+      // completion index. Reverse order: i=1 first, then i=0.
+      expect(compensationKeys).toEqual([
+        "loop-instance-1:1:body:compensate",
+        "loop-instance-1:0:body:compensate",
+      ]);
+    });
   });
 });

--- a/packages/core/src/flow/flow-step-context.ts
+++ b/packages/core/src/flow/flow-step-context.ts
@@ -22,6 +22,8 @@ export interface FlowStepContextDeps {
       options?: {
         actor?: Actor;
         tenantId?: string;
+        /** Optional idempotency key (Spec 26 §3.2) — forwarded by Saga compensation */
+        idempotencyKey?: string;
       },
       // biome-ignore lint/suspicious/noExplicitAny: ActionExecutor returns ActionResult<T> with varying T
     ) => Promise<any>;
@@ -193,7 +195,7 @@ export function createFlowStepContext(deps: FlowStepContextDeps): FlowStepContex
       };
     },
 
-    async executeAction(actionName, input) {
+    async executeAction(actionName, input, options) {
       // Use the flow's actor/tenant when available, fall back to system actor
       const actor = this.actor ?? {
         type: "system",
@@ -204,6 +206,7 @@ export function createFlowStepContext(deps: FlowStepContextDeps): FlowStepContex
       const result = await actionEngine.execute(actionName, input, {
         actor,
         tenantId: this.tenantId,
+        ...(options?.idempotencyKey ? { idempotencyKey: options.idempotencyKey } : {}),
       });
       // ActionExecutor returns ActionResult with { success, data, executionId }
       if (typeof result === "object" && result !== null && "success" in result) {

--- a/packages/core/src/flow/index.ts
+++ b/packages/core/src/flow/index.ts
@@ -16,6 +16,7 @@ export type { EventBusLike, TriggerBinding } from "./trigger-binding";
 export { createTriggerBinding } from "./trigger-binding";
 export type {
   FlowEngine,
+  FlowExecuteActionOptions,
   FlowRegistry,
   FlowStepContext,
 } from "./types";

--- a/packages/core/src/flow/sync-engine.ts
+++ b/packages/core/src/flow/sync-engine.ts
@@ -318,8 +318,12 @@ async function runCompensations(
 
     try {
       // Idempotency key (Spec 26 §3.2): identical across re-runs of the same
-      // flow instance + step so the compensating action is applied at most once.
-      const idempotencyKey = `${flowRunId}:${record.stepId}:compensate`;
+      // flow instance + step + completion-index so the compensating action is
+      // applied at most once per completion. The completion index `i` is
+      // essential — without it, a step that ran multiple times in a loop
+      // (via condition jumps) would collide on the same key and the
+      // ActionEngine would dedupe all but the first compensation.
+      const idempotencyKey = `${flowRunId}:${i}:${record.stepId}:compensate`;
       await runCtx.executeAction(record.compensationAction, resolvedInput, {
         idempotencyKey,
       });

--- a/packages/core/src/flow/sync-engine.ts
+++ b/packages/core/src/flow/sync-engine.ts
@@ -296,6 +296,7 @@ async function runCompensations(
   completed: CompletedActionRecord[],
   runCtx: FlowStepContext,
   flowContext: Record<string, unknown>,
+  flowRunId: string,
 ): Promise<CompensationLogEntry[]> {
   const log: CompensationLogEntry[] = [];
 
@@ -316,7 +317,12 @@ async function runCompensations(
     };
 
     try {
-      await runCtx.executeAction(record.compensationAction, resolvedInput);
+      // Idempotency key (Spec 26 §3.2): identical across re-runs of the same
+      // flow instance + step so the compensating action is applied at most once.
+      const idempotencyKey = `${flowRunId}:${record.stepId}:compensate`;
+      await runCtx.executeAction(record.compensationAction, resolvedInput, {
+        idempotencyKey,
+      });
     } catch (err) {
       entry.status = "failed";
       entry.error = err instanceof Error ? err.message : String(err);
@@ -326,6 +332,20 @@ async function runCompensations(
   }
 
   return log;
+}
+
+/**
+ * Decide whether a flow's failure should trigger Saga compensation.
+ *
+ * `failurePolicy` (Spec 26 §1.2) is the new opt-in field; the legacy
+ * `onError === 'compensate'` value continues to trigger compensation for
+ * back-compat. When `failurePolicy === 'fail_fast'` it explicitly disables
+ * compensation even if `onError` is `'compensate'`.
+ */
+function shouldCompensate(definition: FlowDefinition): boolean {
+  if (definition.failurePolicy === "compensate") return true;
+  if (definition.failurePolicy === "fail_fast") return false;
+  return definition.onError === "compensate";
 }
 
 // ── SyncFlowEngine ──────────────────────────────────────
@@ -529,10 +549,17 @@ export function createSyncFlowEngine(
         message: err instanceof Error ? err.message : String(err),
       };
 
-      // Run Saga compensations if onError === 'compensate' and there are steps to undo
-      if (definition.onError === "compensate" && completedActionSteps.length > 0) {
+      // Run Saga compensations when the flow opted in via failurePolicy
+      // (or the legacy onError === 'compensate') and at least one step
+      // with a declared compensation action has already completed.
+      if (shouldCompensate(definition) && completedActionSteps.length > 0) {
         instance.status = "compensating";
-        const compensationLog = await runCompensations(completedActionSteps, runCtx, flowContext);
+        const compensationLog = await runCompensations(
+          completedActionSteps,
+          runCtx,
+          flowContext,
+          instanceId,
+        );
         instance.compensationLog = compensationLog;
         instance.status = "compensated";
       }

--- a/packages/core/src/flow/types.ts
+++ b/packages/core/src/flow/types.ts
@@ -41,12 +41,30 @@ export interface FlowEngine {
 
 // ── Flow Runtime Context ────────────────────────────────
 
+/** Optional execution hints passed to {@link FlowStepContext.executeAction}. */
+export interface FlowExecuteActionOptions {
+  /**
+   * Idempotency key forwarded to the underlying ActionEngine. Used by Flow
+   * Saga compensation (Spec 26 §3.2) so a re-run of the same flow step does
+   * not double-apply a compensating action.
+   */
+  idempotencyKey?: string;
+}
+
 /** Context available to flow steps during execution */
 export interface FlowStepContext {
-  /** Execute a LinchKit action */
+  /**
+   * Execute a LinchKit action.
+   *
+   * The optional `options` argument lets the Flow runtime forward an
+   * idempotency key for Saga compensation re-runs. Implementations MUST treat
+   * a missing `options` as identical to a prior 2-argument call, so existing
+   * mocks and adapters keep working.
+   */
   executeAction(
     actionName: string,
     input: Record<string, unknown>,
+    options?: FlowExecuteActionOptions,
   ): Promise<Record<string, unknown>>;
 
   /** Call AI service */

--- a/packages/core/src/server-entry.ts
+++ b/packages/core/src/server-entry.ts
@@ -286,6 +286,7 @@ export {
   createSyncFlowEngine,
   createTriggerBinding,
   type FlowEngine,
+  type FlowExecuteActionOptions,
   type FlowRegistry,
   FlowRegistryImpl,
   type FlowStepContext,

--- a/packages/core/src/types/flow.ts
+++ b/packages/core/src/types/flow.ts
@@ -153,6 +153,19 @@ export interface FlowDefinition {
 
   /** Error handling strategy for the entire flow */
   onError?: "abort" | "retry" | "compensate";
+  /**
+   * Saga failure policy (Spec 26 §1.2).
+   *
+   * - `compensate` — when a step fails, run the compensating Action of each
+   *   previously-completed step in reverse order (Saga pattern).
+   * - `fail_fast` — propagate the original error without compensation
+   *   (current default behaviour for backward compatibility).
+   *
+   * Optional. When set, takes precedence over the legacy `onError`
+   * value for compensation decisions; otherwise `onError === "compensate"`
+   * still triggers Saga rollback so existing flows keep working.
+   */
+  failurePolicy?: "compensate" | "fail_fast";
   /** Maximum retry attempts (applies when onError is "retry") */
   maxRetries?: number;
   /** Timeout for the entire flow in milliseconds */


### PR DESCRIPTION
## Summary

Implements **cross-action Saga compensation** for Restate Flows per Spec 26 §1.2 / §4. When a step fails after earlier steps have already committed, the runtime invokes each completed step's `compensation` Action in reverse order.

Closes the **Saga compensation** portion of #123 (P1: High). Nested-action transactions remain in scope of the same issue, deferred to a follow-up.

## Type extensions (`@linchkit/core`)

- `FlowDefinition.failurePolicy?: 'compensate' | 'fail_fast'` — opt-in; defaults to legacy `onError === 'compensate'` behavior so existing flows are unaffected. `failurePolicy: 'fail_fast'` explicitly disables compensation even if `onError === 'compensate'`.
- `FlowExecuteActionOptions { idempotencyKey? }` and `FlowStepContext.executeAction` gains an optional 3rd `options` argument so the runtime can pass an idempotency key down to the ActionEngine.
- `ActionFlowStep.compensation` was already defined; left as-is.

## Restate orchestration (`cap-flow-restate`)

- `buildFlowRunHandler()` extracted from the inline run handler so the compensation path can be unit-tested with a stub `WorkflowContext`.
- On step failure with `shouldCompensate(definition)` true:
  1. Set `status: "compensating"`.
  2. Iterate `completedActionSteps` in **reverse**, invoking each step's compensation Action via `ctx.run()` for durability.
  3. Idempotency key shape: `${ctx.key}:${i}:${stepId}:compensate` — the completion index `i` disambiguates compensations for steps that ran multiple times in a loop.
  4. A failing compensation is logged but does not abort the rest (Spec 26 §4 — best-effort cleanup).
  5. Persist `compensation_log` to workflow state, set `status: "compensated"`, re-throw the original error wrapped with any compensation-failure summary as a `restate.TerminalError`.

## Cross-model review

Gemini flagged a CRITICAL: loop steps would collide on a single idempotency key (`${ctx.key}:${stepId}:compensate`) → only the first compensation would actually run. **Fixed in the same commit by including the completion index `i`** + a regression test ("disambiguates compensation keys for steps that ran multiple times in a loop") that pins both the key and the `ctx.run` name.

Two SHOULD-FIX items deferred:
- TerminalError stack-trace preservation (broader Restate-runtime concern, not Saga-specific)
- `compensationInput` string-expression resolution (pre-existing limitation, not introduced here)

## Out of scope

- Nested action transactions (separate behavior tracked in same #123 issue)
- TerminalError stack-trace preservation across Restate runtime
- `compensationInput` string-expression resolution

## Test plan

- [x] `bun test addons/flow-restate` — 7/7 pass (6 spec cases + 1 loop regression)
- [x] `bun test packages/core` — 3023/3023 pass
- [x] `bun test` (full repo) — 4708 pass / 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean for changed files

Refs Spec 26 §1.2, §4. Part of #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)