### PR TITLE
feat(adapter-mcp): expose runtime overlay fields via MCP introspection (Spec 60 §6, refs #156)

### DIFF
--- a/addons/adapter-mcp/cap-adapter-mcp/__tests__/mcp-server.test.ts
+++ b/addons/adapter-mcp/cap-adapter-mcp/__tests__/mcp-server.test.ts
@@ -1320,26 +1320,32 @@ describe("createMcpAdapter — overlay-field discovery (Spec 60 §6)", () => {
     const result = await tools.get_entity?.handler({ name: "order" }, {});
 
     expect(result.isError).toBeUndefined();
-    const parsed = JSON.parse(result.content[0]?.text);
+    const parsed = JSON.parse(result.content[0]?.text) as {
+      fields: { properties: Record<string, unknown> };
+      overlayFields: Array<{
+        source: string;
+        name: string;
+        fieldType: string;
+        config: Record<string, unknown>;
+      }>;
+    };
 
     // Static fields still present.
     expect(parsed.fields.properties).toHaveProperty("customer_name");
 
     // Overlay fields surfaced with the documented shape.
     expect(parsed.overlayFields).toHaveLength(2);
-    const byName = new Map<string, Record<string, unknown>>(
-      (parsed.overlayFields as Array<{ name: string }>).map((f) => [f.name, f]),
-    );
+    const byName = new Map(parsed.overlayFields.map((f) => [f.name, f]));
     const color = byName.get("color");
     expect(color).toBeDefined();
     expect(color?.source).toBe("overlay");
     expect(color?.fieldType).toBe("enum");
-    expect((color?.config as Record<string, unknown>).enumValues).toEqual(["red", "green", "blue"]);
+    expect(color?.config.enumValues).toEqual(["red", "green", "blue"]);
 
     const warranty = byName.get("warranty_months");
     expect(warranty?.source).toBe("overlay");
     expect(warranty?.fieldType).toBe("number");
-    expect((warranty?.config as Record<string, unknown>).defaultValue).toBe(12);
+    expect(warranty?.config.defaultValue).toBe(12);
   });
 
   test("describe_entity (get_entity) returns empty overlayFields when none exist", async () => {

--- a/addons/adapter-mcp/cap-adapter-mcp/__tests__/mcp-server.test.ts
+++ b/addons/adapter-mcp/cap-adapter-mcp/__tests__/mcp-server.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { ActionResult, CommandLayer } from "@linchkit/core";
 import { defineAction, defineEntity, defineRule, defineState } from "@linchkit/core";
-import { ActionRegistry, createEntityRegistry } from "@linchkit/core/server";
+import {
+  ActionRegistry,
+  createEntityRegistry,
+  DefaultOverlayRegistry,
+  InMemoryOverlayStore,
+} from "@linchkit/core/server";
 import { createMcpAdapter } from "../src/mcp-server";
 
 const testEntity = defineEntity({
@@ -1248,5 +1253,257 @@ describe("createMcpAdapter — ExecutionMeta injection (Spec 65 §3.3)", () => {
     if (systemMeta !== undefined) {
       expect(systemMeta._mcp_client_id).toBeUndefined();
     }
+  });
+});
+
+// ── Overlay-field discovery (Spec 60 §6, issue #156) ───────────────────
+
+/** Helper: build an OverlayRegistry seeded with the given overlay definitions. */
+async function buildOverlayRegistry(
+  overlays: Array<{
+    entityName: string;
+    fieldName: string;
+    fieldType: "string" | "number" | "boolean" | "date" | "enum" | "json";
+    config: Record<string, unknown>;
+  }>,
+): Promise<DefaultOverlayRegistry> {
+  const store = new InMemoryOverlayStore();
+  for (const o of overlays) {
+    await store.addOverlay({
+      entityName: o.entityName,
+      fieldName: o.fieldName,
+      fieldType: o.fieldType,
+      config: o.config,
+      status: "active",
+    });
+  }
+  const registry = new DefaultOverlayRegistry(store);
+  await registry.initialize();
+  return registry;
+}
+
+describe("createMcpAdapter — overlay-field discovery (Spec 60 §6)", () => {
+  test("describe_entity (get_entity) returns overlay fields when registry has them", async () => {
+    const entityRegistry = createEntityRegistry();
+    entityRegistry.register(testEntity);
+
+    const actionRegistry = new ActionRegistry();
+    const commandLayer = createMockCommandLayer();
+
+    const overlayRegistry = await buildOverlayRegistry([
+      {
+        entityName: "order",
+        fieldName: "color",
+        fieldType: "enum",
+        config: {
+          label: { en: "Color", "zh-CN": "颜色" },
+          required: false,
+          enumValues: ["red", "green", "blue"],
+        },
+      },
+      {
+        entityName: "order",
+        fieldName: "warranty_months",
+        fieldType: "number",
+        config: { required: true, defaultValue: 12, min: 0, max: 60 },
+      },
+    ]);
+
+    const { server } = await createMcpAdapter({
+      commandLayer,
+      entityRegistry,
+      actionRegistry,
+      overlayRegistry,
+    });
+
+    const tools = getTools(server);
+    const result = await tools.get_entity?.handler({ name: "order" }, {});
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content[0]?.text);
+
+    // Static fields still present.
+    expect(parsed.fields.properties).toHaveProperty("customer_name");
+
+    // Overlay fields surfaced with the documented shape.
+    expect(parsed.overlayFields).toHaveLength(2);
+    const byName = new Map<string, Record<string, unknown>>(
+      (parsed.overlayFields as Array<{ name: string }>).map((f) => [f.name, f]),
+    );
+    const color = byName.get("color");
+    expect(color).toBeDefined();
+    expect(color?.source).toBe("overlay");
+    expect(color?.fieldType).toBe("enum");
+    expect((color?.config as Record<string, unknown>).enumValues).toEqual(["red", "green", "blue"]);
+
+    const warranty = byName.get("warranty_months");
+    expect(warranty?.source).toBe("overlay");
+    expect(warranty?.fieldType).toBe("number");
+    expect((warranty?.config as Record<string, unknown>).defaultValue).toBe(12);
+  });
+
+  test("describe_entity (get_entity) returns empty overlayFields when none exist", async () => {
+    const entityRegistry = createEntityRegistry();
+    entityRegistry.register(testEntity);
+
+    const actionRegistry = new ActionRegistry();
+    const commandLayer = createMockCommandLayer();
+
+    // Registry exists but has no overlays for this entity.
+    const overlayRegistry = await buildOverlayRegistry([]);
+
+    const { server } = await createMcpAdapter({
+      commandLayer,
+      entityRegistry,
+      actionRegistry,
+      overlayRegistry,
+    });
+
+    const tools = getTools(server);
+    const result = await tools.get_entity?.handler({ name: "order" }, {});
+
+    const parsed = JSON.parse(result.content[0]?.text);
+    expect(parsed.overlayFields).toEqual([]);
+  });
+
+  test("describe_entity (get_entity) returns empty overlayFields when no registry is wired", async () => {
+    const entityRegistry = createEntityRegistry();
+    entityRegistry.register(testEntity);
+
+    const actionRegistry = new ActionRegistry();
+    const commandLayer = createMockCommandLayer();
+
+    const { server } = await createMcpAdapter({
+      commandLayer,
+      entityRegistry,
+      actionRegistry,
+      // No overlayRegistry passed — must not throw.
+    });
+
+    const tools = getTools(server);
+    const result = await tools.get_entity?.handler({ name: "order" }, {});
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content[0]?.text);
+    expect(parsed.overlayFields).toEqual([]);
+  });
+
+  test("list_entities includes overlay fields for each entity", async () => {
+    const entityRegistry = createEntityRegistry();
+    entityRegistry.register(testEntity);
+    entityRegistry.register(productEntity);
+
+    const actionRegistry = new ActionRegistry();
+    const commandLayer = createMockCommandLayer();
+
+    const overlayRegistry = await buildOverlayRegistry([
+      {
+        entityName: "order",
+        fieldName: "color",
+        fieldType: "string",
+        config: { required: false, maxLength: 32 },
+      },
+      {
+        entityName: "product",
+        fieldName: "brand",
+        fieldType: "string",
+        config: { required: true },
+      },
+      {
+        entityName: "product",
+        fieldName: "in_stock",
+        fieldType: "boolean",
+        config: { defaultValue: true },
+      },
+    ]);
+
+    const { server } = await createMcpAdapter({
+      commandLayer,
+      entityRegistry,
+      actionRegistry,
+      overlayRegistry,
+    });
+
+    const tools = getTools(server);
+    const result = await tools.list_entities?.handler({}, {});
+
+    const parsed = JSON.parse(result.content[0]?.text) as Array<{
+      name: string;
+      fields: string[];
+      overlayFields: Array<{ source: string; name: string; fieldType: string }>;
+    }>;
+
+    expect(parsed).toHaveLength(2);
+    const order = parsed.find((e) => e.name === "order");
+    const product = parsed.find((e) => e.name === "product");
+    expect(order?.overlayFields).toHaveLength(1);
+    expect(order?.overlayFields[0]?.name).toBe("color");
+    expect(order?.overlayFields[0]?.source).toBe("overlay");
+    expect(product?.overlayFields).toHaveLength(2);
+    expect(product?.overlayFields.map((f) => f.name).sort()).toEqual(["brand", "in_stock"]);
+  });
+
+  test("list_entities returns empty overlayFields when no registry is wired", async () => {
+    const entityRegistry = createEntityRegistry();
+    entityRegistry.register(testEntity);
+
+    const actionRegistry = new ActionRegistry();
+    const commandLayer = createMockCommandLayer();
+
+    const { server } = await createMcpAdapter({
+      commandLayer,
+      entityRegistry,
+      actionRegistry,
+      // No overlayRegistry — must not throw and default to [].
+    });
+
+    const tools = getTools(server);
+    const result = await tools.list_entities?.handler({}, {});
+
+    const parsed = JSON.parse(result.content[0]?.text) as Array<{
+      overlayFields: unknown[];
+    }>;
+    expect(parsed[0]?.overlayFields).toEqual([]);
+  });
+
+  test("overlay-field lookup is scoped to the requested entity (no cross-entity leakage)", async () => {
+    // OverlayRegistry today is keyed by entity name (no tenant scoping in the
+    // store interface). This test pins the scoping contract we DO have:
+    // `overlaysFor("order")` must not return overlays defined for "product".
+    // When per-tenant scoping lands in OverlayRegistry, an additional test
+    // should assert the same isolation across tenant boundaries.
+    const entityRegistry = createEntityRegistry();
+    entityRegistry.register(testEntity);
+    entityRegistry.register(productEntity);
+
+    const actionRegistry = new ActionRegistry();
+    const commandLayer = createMockCommandLayer();
+
+    const overlayRegistry = await buildOverlayRegistry([
+      {
+        entityName: "product",
+        fieldName: "secret_only_for_product",
+        fieldType: "string",
+        config: {},
+      },
+    ]);
+
+    const { server } = await createMcpAdapter({
+      commandLayer,
+      entityRegistry,
+      actionRegistry,
+      overlayRegistry,
+    });
+
+    const tools = getTools(server);
+    const orderResult = await tools.get_entity?.handler({ name: "order" }, {});
+    const productResult = await tools.get_entity?.handler({ name: "product" }, {});
+
+    const orderParsed = JSON.parse(orderResult.content[0]?.text);
+    const productParsed = JSON.parse(productResult.content[0]?.text);
+
+    expect(orderParsed.overlayFields).toEqual([]);
+    expect(productParsed.overlayFields).toHaveLength(1);
+    expect(productParsed.overlayFields[0].name).toBe("secret_only_for_product");
   });
 });

--- a/addons/adapter-mcp/cap-adapter-mcp/src/factory.ts
+++ b/addons/adapter-mcp/cap-adapter-mcp/src/factory.ts
@@ -85,6 +85,9 @@ export function createCapAdapterMcp(options?: CapAdapterMcpOptions): CapabilityD
         // EvolutionRuntime is optional on TransportContext; when present we
         // expose its InsightEngine so MCP clients can call list_insights.
         insightEngine: ctx.evolutionRuntime?.insightEngine,
+        // Spec 60 §6 — when the runtime exposes overlay fields, surface them
+        // via list_entities / get_entity so AI agents see admin-added fields.
+        overlayRegistry: ctx.overlayRegistry,
       });
 
       if (transportMode === "stdio") {
@@ -131,6 +134,8 @@ export function createCapAdapterMcp(options?: CapAdapterMcpOptions): CapabilityD
         graphqlEndpoint,
         executionLogger: ctx.executionLogger,
         insightEngine: ctx.evolutionRuntime?.insightEngine,
+        // Spec 60 §6 — propagate overlay registry to per-session McpServers.
+        overlayRegistry: ctx.overlayRegistry,
       };
 
       const {

--- a/addons/adapter-mcp/cap-adapter-mcp/src/mcp-server.ts
+++ b/addons/adapter-mcp/cap-adapter-mcp/src/mcp-server.ts
@@ -19,11 +19,12 @@ import type {
   Actor,
   CommandLayer,
   EntityRegistry,
+  FieldOverlayRecord,
   OntologyRegistry,
   RuleDefinition,
   StateDefinition,
 } from "@linchkit/core";
-import type { ProposalEngine } from "@linchkit/core/server";
+import type { OverlayRegistry, ProposalEngine } from "@linchkit/core/server";
 import type { ExecutionLogger, InsightEngine } from "@linchkit/core/types";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
@@ -88,6 +89,14 @@ export interface McpAdapterOptions {
    * promoted insights (anomalies, friction, patterns, structural, positive).
    */
   insightEngine?: InsightEngine;
+  /**
+   * Overlay registry — exposes runtime overlay fields per entity (Spec 60 §6).
+   * When provided, the introspection tools (`list_entities`, `get_entity`)
+   * include any overlay fields in their responses so AI agents can see and
+   * reason about admin-added dynamic fields. When omitted, the responses
+   * fall back to an empty `overlayFields: []` array — never throw.
+   */
+  overlayRegistry?: OverlayRegistry;
 }
 
 /**
@@ -139,6 +148,7 @@ export async function createMcpAdapter(options: McpAdapterOptions): Promise<McpA
     proposalEngine,
     executionLogger,
     insightEngine,
+    overlayRegistry,
   } = options;
 
   const server = new McpServer({ name, version });
@@ -292,6 +302,7 @@ export async function createMcpAdapter(options: McpAdapterOptions): Promise<McpA
     graphqlEndpoint,
     bearerToken,
     tenantId,
+    overlayRegistry,
   );
 
   allToolNames.push(
@@ -438,6 +449,27 @@ function buildZodShape(
   return shape;
 }
 
+/**
+ * Serialize a FieldOverlayRecord to the shape returned by `list_entities`
+ * and `get_entity`. Picks only fields that are useful to an AI agent for
+ * reasoning about and acting on the field — internal IDs and audit timestamps
+ * are intentionally omitted to keep the payload focused. The `source: "overlay"`
+ * tag distinguishes these from static fields baked into `defineEntity()`.
+ */
+function serializeOverlayField(record: FieldOverlayRecord): {
+  source: "overlay";
+  name: string;
+  fieldType: FieldOverlayRecord["fieldType"];
+  config: FieldOverlayRecord["config"];
+} {
+  return {
+    source: "overlay",
+    name: record.fieldName,
+    fieldType: record.fieldType,
+    config: record.config,
+  };
+}
+
 /** Serialize a RuleDefinition to a JSON-safe object (strip code conditions) */
 function serializeRule(rule: RuleDefinition): Record<string, unknown> {
   const serialized: Record<string, unknown> = {
@@ -507,18 +539,26 @@ function registerBuiltinTools(
   graphqlEndpoint?: string,
   bearerToken?: string,
   tenantId?: string,
+  overlayRegistry?: OverlayRegistry,
 ): void {
-  // list_entities — returns entity summaries with field names
+  // list_entities — returns entity summaries with field names + overlay-field counts
   server.tool(
     "list_entities",
-    "List all available entities with their names, labels, descriptions, and field names",
+    "List all available entities with their names, labels, descriptions, static field names, and any runtime overlay fields (Spec 60 §6).",
     async () => {
-      const entities = entityRegistry.getAll().map((s) => ({
-        name: s.name,
-        label: s.label,
-        description: s.description,
-        fields: Object.keys(s.fields),
-      }));
+      const entities = entityRegistry.getAll().map((s) => {
+        // Spec 60 §6 — surface admin-added overlay fields so AI agents see the
+        // full live shape of each entity. Falls back to [] when no registry is
+        // wired in (test setups, stdio-only builds) — never throws.
+        const overlays = overlayRegistry?.overlaysFor(s.name) ?? [];
+        return {
+          name: s.name,
+          label: s.label,
+          description: s.description,
+          fields: Object.keys(s.fields),
+          overlayFields: overlays.map(serializeOverlayField),
+        };
+      });
 
       return {
         content: [{ type: "text" as const, text: JSON.stringify(entities, null, 2) }],
@@ -526,11 +566,11 @@ function registerBuiltinTools(
     },
   );
 
-  // get_entity — full entity definition with field types and constraints
+  // get_entity — full entity definition with field types, constraints, and overlay fields
   const getEntityShape = { name: z.string().describe("Entity name") };
   server.tool(
     "get_entity",
-    "Get the full definition of an entity by name, including all fields with types and constraints",
+    "Get the full definition of an entity by name, including all static fields with types and constraints plus any runtime overlay fields (Spec 60 §6).",
     // biome-ignore lint/suspicious/noExplicitAny: zod v4 vs SDK bundled zod type mismatch
     getEntityShape as any,
     async (args: { name: string }) => {
@@ -547,13 +587,18 @@ function registerBuiltinTools(
         };
       }
 
-      // Convert to a serializable representation with field JSON schemas
+      // Convert to a serializable representation with field JSON schemas.
+      // Overlay fields ride alongside the static field schema in their own
+      // array (richer shape than JSON Schema) so AI agents can distinguish
+      // baseline vs admin-added fields by `source: "overlay"`.
       const fieldSchemas = fieldsToJsonSchema(entity.fields);
+      const overlays = overlayRegistry?.overlaysFor(entity.name) ?? [];
       const result = {
         name: entity.name,
         label: entity.label,
         description: entity.description,
         fields: fieldSchemas,
+        overlayFields: overlays.map(serializeOverlayField),
       };
 
       return {

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@modelcontextprotocol/sdk": "1.29.0",
-        "@restatedev/restate-sdk": "1.11.1",
+        "@restatedev/restate-sdk": "1.13.0",
         "@tanstack/react-table": "^8.21.3",
         "ai": "^6.0.134",
         "dataloader": "^2.2.3",
@@ -67,11 +67,13 @@
         "graphql-yoga": "^5.18.1",
       },
       "devDependencies": {
+        "@linchkit/cap-ai-provider": "workspace:*",
         "@linchkit/core": "workspace:*",
         "typescript": "^6.0.2",
       },
       "peerDependencies": {
-        "@linchkit/core": "^0.1.0",
+        "@linchkit/cap-ai-provider": "^1.0.0",
+        "@linchkit/core": "^0.2.0",
       },
     },
     "addons/adapter-ui/cap-adapter-ui": {
@@ -97,7 +99,7 @@
         "cmdk": "^1.1.1",
         "dagre": "^0.8.5",
         "date-fns": "^4.1.0",
-        "i18next": "^25.10.4",
+        "i18next": "^26.0.6",
         "lucide-react": "^1.7.0",
         "mermaid": "^11.6.0",
         "next-themes": "^0.4.6",
@@ -122,7 +124,7 @@
         "vite": "^8.0.1",
       },
       "peerDependencies": {
-        "@linchkit/core": "^0.1.0",
+        "@linchkit/core": "^0.2.0",
       },
     },
     "addons/adapter-ui/cap-adapter-ui/ui-kit": {
@@ -158,7 +160,7 @@
         "typescript": "^6.0.2",
       },
       "peerDependencies": {
-        "@linchkit/core": "^0.1.0",
+        "@linchkit/core": "^0.2.0",
       },
     },
     "addons/auth/cap-auth": {
@@ -226,6 +228,13 @@
         "react": "^19.0.0",
       },
     },
+    "addons/demo/cap-life-demo": {
+      "name": "@linchkit/cap-life-demo",
+      "version": "0.0.1",
+      "peerDependencies": {
+        "@linchkit/core": "workspace:*",
+      },
+    },
     "addons/demo/cap-purchase-demo": {
       "name": "@linchkit/cap-purchase-demo",
       "version": "0.0.1",
@@ -248,14 +257,14 @@
       "name": "@linchkit/cap-flow-restate",
       "version": "1.0.0",
       "dependencies": {
-        "@restatedev/restate-sdk": "1.11.1",
+        "@restatedev/restate-sdk": "1.13.0",
       },
       "devDependencies": {
         "@linchkit/core": "workspace:*",
         "typescript": "^6.0.2",
       },
       "peerDependencies": {
-        "@linchkit/core": "^0.1.0",
+        "@linchkit/core": "^0.2.0",
       },
     },
     "addons/migration/cap-migration": {
@@ -640,6 +649,8 @@
 
     "@linchkit/cap-flow-restate": ["@linchkit/cap-flow-restate@workspace:addons/flow-restate/cap-flow-restate"],
 
+    "@linchkit/cap-life-demo": ["@linchkit/cap-life-demo@workspace:addons/demo/cap-life-demo"],
+
     "@linchkit/cap-mcp-ui": ["@linchkit/cap-mcp-ui@workspace:addons/adapter-mcp/cap-mcp-ui"],
 
     "@linchkit/cap-migration": ["@linchkit/cap-migration@workspace:addons/migration/cap-migration"],
@@ -822,9 +833,9 @@
 
     "@repeaterjs/repeater": ["@repeaterjs/repeater@3.0.6", "https://registry.npmmirror.com/@repeaterjs/repeater/-/repeater-3.0.6.tgz", {}, "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA=="],
 
-    "@restatedev/restate-sdk": ["@restatedev/restate-sdk@1.11.1", "", { "dependencies": { "@restatedev/restate-sdk-core": "1.11.1" } }, "sha512-qJNpA5POJOOTx4piMNp3zwMbyS6SPn9DWpFYmWXV9zCdX1nl/mflUrSOMIdAp97xSJUo3D4thRKRuRTyv4SSzg=="],
+    "@restatedev/restate-sdk": ["@restatedev/restate-sdk@1.13.0", "", { "dependencies": { "@restatedev/restate-sdk-core": "1.13.0" } }, "sha512-SAqes+qbpMn1HCRn/275FuNkyhvYsNwoe9BJwT0OjV1ocKC27SR4UGp/d2vO9mV6804VlSapybpGs4H7SM3HMA=="],
 
-    "@restatedev/restate-sdk-core": ["@restatedev/restate-sdk-core@1.11.1", "", {}, "sha512-noGcYm6WePsCNLH2becGARKnfMXxDccvVn8UyOEv1Nzxix/8S25nbnYEpRylxCPlcHdgfyvDlIQF0sW5Clk2iQ=="],
+    "@restatedev/restate-sdk-core": ["@restatedev/restate-sdk-core@1.13.0", "", {}, "sha512-DVmlI3rI8coA0Hcpxd2cLaK5DKUCwKDyXWXqjMorhqd4HBqdJBWtgrS0y0ZGUW+vuzJMeFpFvq3nhQJIvn6U9Q=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.10", "https://registry.npmmirror.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.10.tgz", { "os": "android", "cpu": "arm64" }, "sha512-jOHxwXhxmFKuXztiu1ORieJeTbx5vrTkcOkkkn2d35726+iwhrY1w/+nYY/AGgF12thg33qC3R1LMBF5tHTZHg=="],
 
@@ -1584,7 +1595,7 @@
 
     "human-signals": ["human-signals@8.0.1", "https://registry.npmmirror.com/human-signals/-/human-signals-8.0.1.tgz", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
 
-    "i18next": ["i18next@25.10.4", "https://registry.npmmirror.com/i18next/-/i18next-25.10.4.tgz", { "dependencies": { "@babel/runtime": "^7.29.2" }, "peerDependencies": { "typescript": "^5" }, "optionalPeers": ["typescript"] }, "sha512-XsE/6eawy090meuFU0BTY9BtmWr1m9NSwLr0NK7/A04LA58wdAvDsi9WNOJ40Qb1E9NIPbvnVLZEN2fWDd3/3Q=="],
+    "i18next": ["i18next@26.0.10", "", { "peerDependencies": { "typescript": "^5 || ^6" }, "optionalPeers": ["typescript"] }, "sha512-k3yGPAlWR2RdMYoVXJoDZDT87qeHIWKH7gVksdZMpRty7QX/D9QZeYGvN08KGbKHke9wn01eYT+EEsrqX/YTlw=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.7.2.tgz", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
@@ -2308,8 +2319,6 @@
 
     "@linchkit/cap-ai-provider/ai": ["ai@6.0.138", "", { "dependencies": { "@ai-sdk/gateway": "3.0.80", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-49OfPe0f5uxJ6jUdA5BBXjIinP6+ZdYfAtpF2aEH64GA5wPcxH2rf/TBUQQ0bbamBz/D+TLMV18xilZqOC+zaA=="],
 
-    "@linchkit/core/i18next": ["i18next@26.0.3", "", { "dependencies": { "@babel/runtime": "^7.29.2" }, "peerDependencies": { "typescript": "^5 || ^6" }, "optionalPeers": ["typescript"] }, "sha512-1571kXINxHKY7LksWp8wP+zP0YqHSSpl/OW0Y0owFEf2H3s8gCAffWaZivcz14rMkOvn3R/psiQxVsR9t2Nafg=="],
-
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
     "@manypkg/find-root/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
@@ -2354,8 +2363,6 @@
 
     "express/cookie": ["cookie@0.7.2", "https://registry.npmmirror.com/cookie/-/cookie-0.7.2.tgz", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
-    "i18next/typescript": ["typescript@5.9.3", "https://registry.npmmirror.com/typescript/-/typescript-5.9.3.tgz", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
-
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "https://registry.npmmirror.com/resolve-from/-/resolve-from-4.0.0.tgz", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
@@ -2371,8 +2378,6 @@
     "prompts/kleur": ["kleur@3.0.3", "https://registry.npmmirror.com/kleur/-/kleur-3.0.3.tgz", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
     "react-grid-layout/fast-equals": ["fast-equals@4.0.3", "", {}, "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg=="],
-
-    "react-i18next/i18next": ["i18next@26.0.3", "", { "dependencies": { "@babel/runtime": "^7.29.2" }, "peerDependencies": { "typescript": "^5 || ^6" }, "optionalPeers": ["typescript"] }, "sha512-1571kXINxHKY7LksWp8wP+zP0YqHSSpl/OW0Y0owFEf2H3s8gCAffWaZivcz14rMkOvn3R/psiQxVsR9t2Nafg=="],
 
     "read-yaml-file/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 

--- a/packages/core/src/types/transport.ts
+++ b/packages/core/src/types/transport.ts
@@ -23,6 +23,7 @@ import type { EventBus } from "../event/event-bus";
 import type { FlowEngine, FlowRegistry } from "../flow/types";
 import type { EvolutionRuntime } from "../life-system/runtime";
 import type { OntologyRegistry } from "../ontology";
+import type { OverlayRegistry } from "../overlay/overlay-registry";
 import type { ActionDefinition } from "./action";
 import type { AIService, AIServiceConfig } from "./ai";
 import type { CapabilityDefinition } from "./capability";
@@ -66,6 +67,12 @@ export interface TransportContext {
   flowEngine?: FlowEngine;
   /** Ontology registry — unified semantic facade over all registries */
   ontologyRegistry?: OntologyRegistry;
+  /**
+   * Overlay registry — exposes runtime-added overlay fields per entity.
+   * When provided, transports (GraphQL, REST, MCP) can include overlay
+   * fields in their entity discovery / introspection responses.
+   */
+  overlayRegistry?: OverlayRegistry;
   /** Cache manager — multi-layer cache with event-driven invalidation */
   cacheManager?: CacheManager;
   /** Health check registry — liveness and readiness probes */


### PR DESCRIPTION
## Summary

When AI agents call the runtime MCP introspection tools `list_entities` and `get_entity`, the response now includes any **overlay fields** added at runtime through `OverlayRegistry`. Without this, AI agents see only the static schema baked into `defineEntity()` and silently miss admin-added dynamic fields — making them unable to reason about or act on them.

Implements Spec 60 §6's overlay-field discovery enhancement. Part of #156.

## Wiring

- `TransportContext.overlayRegistry?: OverlayRegistry` (optional) — mirrors how `ontologyRegistry` / `evolutionRuntime` are exposed to transports.
- `cap-adapter-mcp`'s factory threads the registry from `ctx.overlayRegistry` into `createMcpAdapter()` for both stdio and SSE transports.
- When omitted (test setups, stdio-only minimal builds), tools return an empty `overlayFields: []` array — never throw.

## Response shape

Both tools gain a top-level `overlayFields` array. Entries are `{ source: "overlay", name, fieldType, config }` — internal IDs and audit timestamps are stripped to keep the AI-facing payload focused. The `source: "overlay"` discriminator distinguishes overlay-added fields from baseline static fields so AI agents can reason about provenance.

A separate array (rather than mixing into the existing `fields` JSON schema) was chosen because:
- `get_entity.fields` is JSON Schema; overlay metadata (label, enumValues, defaultValue) doesn't map cleanly without losing fidelity.
- `list_entities.fields` is `string[]` — even more lossy.
- Existing consumers stay backward-compatible.

## Cross-model review

Gemini findings evaluated:
- **CRITICAL "missing tenant isolation" — invalid**. `OverlayRegistry.overlaysFor(name)` has no `tenantId` parameter today (overlays are global per entity in the current core API). When overlays gain tenant scoping, the registry signature changes first, then this MCP layer can pass it through.
- 3 SHOULD-FIX items (additional `EntitySummary` fields, `execute_action` enhancements, GraphQL mutation safety) all belong to other Phase 6 sub-items, not the overlay-discovery scope of this PR.

## Out of scope (future Phase 6 work, refs #156)

- CLI dev wiring to construct an `OverlayRegistry` and put it on `TransportContext` (this PR exposes the type surface; runtime wiring closes the loop end-to-end).
- Per-tenant overlay scoping (requires `OverlayRegistry` API change first).
- `EntitySummary` enrichment with `fieldCount`/`actionCount`/`relationCount`.
- `execute_action` returning full execution context.
- Other Phase 6 runtime MCP tools.

## Test plan

- [x] `bun test addons/adapter-mcp/cap-adapter-mcp` — 198/198 pass (192 baseline + 6 new overlay tests)
- [x] `bun test` (full repo) — 4707 pass / 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean for changed files

Refs Spec 60 §6. Refs #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)