### PR TITLE
ci: Review Gate /check-reviews posts check-run on PR head SHA (closes #266)

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -19,6 +19,30 @@ on:
 # thread resolution, but caused a workflow registration parse failure on
 # GitHub Actions (synthetic "push" failure with no logs). Reverted to the
 # `/check-reviews` manual escape hatch until that's understood.
+#
+# How `/check-reviews` actually unblocks the PR:
+#   `issue_comment` events run on the default branch's HEAD SHA, NOT the PR
+#   head SHA. Previously the workflow relied on `core.setFailed()` to mark
+#   the run, which let GitHub auto-create a check-run on the workflow's run
+#   SHA (= main's HEAD). The PR head SHA therefore kept its stale FAILURE
+#   from the most recent `pull_request: synchronize` run, and contributors
+#   had to push an empty commit to force a fresh check on the PR head.
+#
+#   The fix below is to call `octokit.rest.checks.create()` ourselves with
+#   an explicit `head_sha` resolved from the PR (via GraphQL `headRefOid`).
+#   That writes the new SUCCESS / FAILURE conclusion directly onto the PR
+#   head SHA, which is what branch protection evaluates. For `issue_comment`
+#   events the workflow itself always succeeds — the gate verdict is carried
+#   by the check-run, so a green Actions run for `/check-reviews` is correct
+#   even when the gate concludes FAILURE. For `pull_request` events we keep
+#   `core.setFailed()` so the workflow's own conclusion mirrors the gate
+#   (matches today's UX in the PR's "Checks" tab).
+
+permissions:
+  pull-requests: read
+  checks: write
+  contents: read
+
 jobs:
   review-threads:
     name: Review Threads
@@ -42,14 +66,26 @@ jobs:
         uses: actions/github-script@v7
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
+          EVENT_NAME: ${{ github.event_name }}
         with:
           script: |
             const prNumber = Number(process.env.PR_NUMBER);
+            const eventName = process.env.EVENT_NAME;
+
+            // Fetch review threads + the PR head SHA. We need `headRefOid`
+            // because for `issue_comment` events the workflow runs against
+            // the default branch's HEAD, not the PR head — so we must post
+            // the resulting check-run onto the PR head SHA explicitly,
+            // otherwise branch protection keeps evaluating the stale
+            // FAILURE check from the previous `pull_request: synchronize`
+            // run and the PR remains BLOCKED.
             const { repository } = await github.graphql(`
               query($owner: String!, $repo: String!, $number: Int!) {
                 repository(owner: $owner, name: $repo) {
                   pullRequest(number: $number) {
+                    headRefOid
                     reviewThreads(first: 100) {
+                      totalCount
                       nodes {
                         isResolved
                         comments(first: 1) {
@@ -69,20 +105,95 @@ jobs:
               number: prNumber,
             });
 
-            const threads = repository.pullRequest.reviewThreads.nodes;
+            // Defensive null check: a deleted/merged PR would leave repository.pullRequest null.
+            if (!repository || !repository.pullRequest) {
+              core.setFailed(`Pull request #${prNumber} not found.`);
+              return;
+            }
+
+            const pr = repository.pullRequest;
+            const prHeadSha = pr.headRefOid;
+            const threads = pr.reviewThreads.nodes;
+            const totalCount = pr.reviewThreads.totalCount;
+
+            // We only fetched the first 100 threads. If there are more, refuse
+            // to render a verdict — silently passing on the assumption that
+            // threads 101+ are resolved would be incorrect, and silently
+            // failing would be opaque. Loud failure surfaces the limitation
+            // so a follow-up adds pagination if a real PR ever hits it.
+            if (totalCount > threads.length) {
+              core.setFailed(
+                `PR has ${totalCount} review threads but the gate only fetched ${threads.length}. ` +
+                  'Pagination is not yet implemented — file a workflow follow-up.',
+              );
+              return;
+            }
             const unresolved = threads.filter(t => !t.isResolved);
             const total = threads.length;
 
+            // Build human-readable output for the check-run.
+            let title;
+            let summary;
             if (unresolved.length > 0) {
-              core.info(`${unresolved.length}/${total} review thread(s) unresolved:`);
+              title = `${unresolved.length} unresolved review thread(s)`;
+              const lines = [
+                `${unresolved.length} of ${total} review thread(s) are still unresolved.`,
+                '',
+                'Resolve every thread (or post `/check-reviews` after resolving) before merging.',
+                '',
+                '### Unresolved threads',
+                '',
+              ];
               for (const t of unresolved) {
                 const c = t.comments.nodes[0];
-                const snippet = (c.body || '').substring(0, 100).replace(/\n/g, ' ');
-                core.info(`  - [${c.author.login}] ${snippet}...`);
+                const author = c && c.author ? c.author.login : 'unknown';
+                const snippet = ((c && c.body) || '')
+                  .substring(0, 200)
+                  .replace(/\r?\n/g, ' ');
+                lines.push(`- **@${author}**: ${snippet}`);
+                core.info(`  - [${author}] ${snippet}`);
               }
-              core.setFailed(`${unresolved.length} unresolved review thread(s). Resolve all before merging.`);
+              summary = lines.join('\n');
+              core.info(`${unresolved.length}/${total} review thread(s) unresolved.`);
             } else if (total === 0) {
-              core.info('No review threads — gate passes.');
+              title = 'No review threads';
+              summary = 'No review threads on this PR — gate passes.';
+              core.info(summary);
             } else {
-              core.info(`All ${total} review thread(s) resolved.`);
+              title = `All ${total} review thread(s) resolved.`;
+              summary = `All ${total} review thread(s) resolved — gate passes.`;
+              core.info(summary);
+            }
+
+            const conclusion = unresolved.length > 0 ? 'failure' : 'success';
+
+            // Explicitly create a check-run on the PR head SHA. This is the
+            // SHA branch protection evaluates, so writing here updates the
+            // PR's required-check status without needing an empty commit.
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'Review Threads',
+              head_sha: prHeadSha,
+              status: 'completed',
+              conclusion,
+              output: {
+                title,
+                summary,
+              },
+            });
+
+            core.info(`Posted Review Threads check-run (${conclusion}) on ${prHeadSha}.`);
+
+            // For `pull_request` events the workflow's own conclusion has
+            // historically mirrored the gate verdict (the check shown in
+            // the PR's Checks tab matches the workflow's run status). Keep
+            // that behavior. For `issue_comment` events the workflow's job
+            // is just to post the check-run on the PR head — the verdict
+            // is carried by that check-run, so the workflow itself always
+            // succeeds. Otherwise contributors would see a red Actions run
+            // for a `/check-reviews` comment even when the gate flipped to
+            // SUCCESS on the PR head.
+            if (eventName === 'pull_request' && unresolved.length > 0) {
+              core.setFailed(`${unresolved.length} unresolved review thread(s). Resolve all before merging.`);
             }

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -170,30 +170,60 @@ jobs:
             // Explicitly create a check-run on the PR head SHA. This is the
             // SHA branch protection evaluates, so writing here updates the
             // PR's required-check status without needing an empty commit.
-            await github.rest.checks.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'Review Threads',
-              head_sha: prHeadSha,
-              status: 'completed',
-              conclusion,
-              output: {
-                title,
-                summary,
-              },
-            });
-
-            core.info(`Posted Review Threads check-run (${conclusion}) on ${prHeadSha}.`);
+            //
+            // Fork-PR caveat: GitHub downgrades GITHUB_TOKEN to read-only for
+            // `pull_request` events whose head ref lives on a fork, regardless
+            // of the workflow-level `permissions:` block. `checks.create()`
+            // therefore 403s for those runs. Catch the failure and fall back
+            // to the workflow's own status — `core.setFailed` below still
+            // marks the workflow run, and GitHub auto-attaches a check-run
+            // with that status to the head SHA, matching today's behavior.
+            // For `issue_comment` events the token is the base repo's, so
+            // the call always succeeds.
+            let checkRunPosted = false;
+            try {
+              await github.rest.checks.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'Review Threads',
+                head_sha: prHeadSha,
+                status: 'completed',
+                conclusion,
+                output: {
+                  title,
+                  summary,
+                },
+              });
+              checkRunPosted = true;
+              core.info(`Posted Review Threads check-run (${conclusion}) on ${prHeadSha}.`);
+            } catch (err) {
+              const message = err instanceof Error ? err.message : String(err);
+              core.warning(
+                `Could not post Review Threads check-run on ${prHeadSha} (${message}). ` +
+                  'This is expected for pull_request events from forked repositories — ' +
+                  'GitHub downgrades GITHUB_TOKEN to read-only in that case. The workflow ' +
+                  "run status itself will still convey the gate verdict.",
+              );
+            }
 
             // For `pull_request` events the workflow's own conclusion has
             // historically mirrored the gate verdict (the check shown in
             // the PR's Checks tab matches the workflow's run status). Keep
-            // that behavior. For `issue_comment` events the workflow's job
-            // is just to post the check-run on the PR head — the verdict
-            // is carried by that check-run, so the workflow itself always
-            // succeeds. Otherwise contributors would see a red Actions run
-            // for a `/check-reviews` comment even when the gate flipped to
-            // SUCCESS on the PR head.
-            if (eventName === 'pull_request' && unresolved.length > 0) {
+            // that behavior — and on fork PRs where `checks.create()` was
+            // refused, this is the ONLY signal the gate ran at all.
+            //
+            // For `issue_comment` events the verdict is carried by the
+            // explicit check-run on the PR head — so when posting succeeded
+            // the workflow always succeeds. If the post FAILED (rare, but
+            // possible if base-repo token rotation hit the API), surface the
+            // failure on the workflow itself so contributors see something
+            // went wrong.
+            const isPullRequest = eventName === 'pull_request';
+            if (isPullRequest && unresolved.length > 0) {
               core.setFailed(`${unresolved.length} unresolved review thread(s). Resolve all before merging.`);
+            } else if (!isPullRequest && !checkRunPosted) {
+              core.setFailed(
+                'Failed to post Review Threads check-run on the PR head. ' +
+                  'See warning above for details.',
+              );
             }


### PR DESCRIPTION
## Summary

Fixes #266 — `/check-reviews` now actually unblocks a PR. Previously, posting the comment ran the workflow against `main`'s HEAD SHA, so GitHub auto-created the check-run on `main` instead of the PR head. The PR head's required `Review Threads` check stayed stuck on the stale FAILURE from the previous `pull_request: synchronize` run, forcing contributors to push an empty commit.

The workflow now explicitly calls `octokit.rest.checks.create({ ..., head_sha: prHeadSha })` with the PR head SHA fetched via GraphQL (`pullRequest.headRefOid`). Branch protection re-evaluates against that SHA so the gate flips green directly.

## Behavior matrix

| Event | Workflow run conclusion | Check-run on PR head |
|---|---|---|
| `pull_request: synchronize` (etc.) | mirrors gate verdict via `core.setFailed()` | written via explicit `checks.create` |
| `issue_comment: /check-reviews` | always SUCCESS (verdict carried by check-run) | written via explicit `checks.create` |

The `/check-reviews` workflow no longer surfaces as a red Actions run when the gate concludes SUCCESS on the PR head — that was a confusing UX before.

## Cross-model review (gemini)

Verdict: solid. Two SHOULD-FIX hardenings applied in the same commit:

- **Pagination loud-fail**: GraphQL fetches `reviewThreads(first: 100)`. Now reads `totalCount`; if it exceeds 100 the gate explicitly fails with a clear message, instead of silently passing on the assumption that threads 101+ are resolved. Real pagination is a follow-up if any PR ever hits the limit.
- **Null-defensive PR lookup**: `if (!repository || !repository.pullRequest)` so a deleted/merged PR can't crash the script.

## Permissions

Added a `permissions:` block (workflow had none before):

```yaml
permissions:
  pull-requests: read
  checks: write
  contents: read
```

`checks: write` is required by `octokit.rest.checks.create`; the others are minimum standard.

## Triggers — unchanged

Per the workflow header comment, the trigger set stays:
- `pull_request: [opened, synchronize, reopened, ready_for_review]`
- `issue_comment: [created]`

`pull_request_review: submitted` and `pull_request_review_thread: resolved` are NOT added back. Both regressions documented in the file's header comment (PR #250 / #254 history).

## Manual test plan

- [ ] Draft PR with 1 resolved + 1 unresolved review thread → Review Threads check FAILURE on PR head (existing behavior, regression check).
- [ ] Resolve the remaining thread, post `/check-reviews` → within ~30s the PR head's Review Threads check flips to SUCCESS (NEW behavior).
- [ ] `gh pr view --json mergeStateStatus` shows `BLOCKED → CLEAN`.
- [ ] The `/check-reviews` Actions run shows SUCCESS even when the gate ran (NEW behavior — workflow no longer calls `setFailed` for `issue_comment` events).
- [ ] Push a fresh commit → `pull_request: synchronize` still posts the gate as before (regression check).

Closes #266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Pull request review gate evaluation is now significantly more accurate and reliable with better status reporting
  * Check run reports now include comprehensive details about code review discussions and their resolution status
  * Improved edge case handling ensures consistent and dependable review gate behavior across all pull request scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->