### PR TITLE
feat(core): transaction-aware OverlayAwareDataProvider (closes overlay write-path)

### DIFF
--- a/docs/specs/59_runtime_overlay.md
+++ b/docs/specs/59_runtime_overlay.md
@@ -294,6 +294,8 @@ WHERE (_extensions->>'score')::numeric > 80;
 
 The DataProvider query builder adds JSONB filter support when it detects the target field is an overlay field.
 
+**Transactional path:** `OverlayAwareDataProvider` implements `withConnection(client)`, returning a fresh wrapper around the inner provider's transaction-scoped copy and sharing the same `OverlayRegistry` instance. When `DrizzleTransactionManager` opens a transaction it applies an opt-in `wrapForTx` callback (configured by the dev-wiring) so the action handler receives the wrapper — not the bare `DrizzleDataProvider`. Overlay-managed field values therefore fold into `_extensions` end-to-end whether or not a transaction is in flight (issue #156).
+
 ### 8.2 GraphQL
 
 GraphQL schema is rebuilt dynamically when overlays change. `graphql-yoga` supports runtime schema replacement via `yoga.replaceSchema()`.

--- a/packages/cli/__tests__/dev-wiring-overlay.test.ts
+++ b/packages/cli/__tests__/dev-wiring-overlay.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for dev-wiring overlay registry construction (Spec 60 §6, issue #156).
+ * Tests for dev-wiring overlay registry construction (Spec 59 §8.1, issue #156).
  *
  * Verifies that wireDevEngines:
  *   1. Constructs an OverlayRegistry exactly once and assigns it to
@@ -8,11 +8,11 @@
  *   2. Falls back to InMemoryOverlayStore when no DB instance is provided.
  *   3. Surfaces overlays added at runtime via `overlayRegistry.register()` —
  *      no restart required for the discovery loop to see them.
- *
- * Out of scope here: wrapping the DataProvider with OverlayAwareDataProvider
- * for write-side handling of overlay field VALUES. That wrap leaks past the
- * transactional execution path (DrizzleTransactionManager unwraps to a bare
- * DrizzleDataProvider) and needs a separate fix tracked under #156.
+ *   4. Wraps the runtime DataProvider with OverlayAwareDataProvider so action
+ *      writes that include overlay-managed fields fold their values into
+ *      `_extensions` (issue #156). The transactional path is preserved by
+ *      `OverlayAwareDataProvider.withConnection` and the
+ *      `DrizzleTransactionManager.wrapForTx` callback.
  *
  * These tests bypass the full CLI subprocess path (covered by `info.test.ts`
  * / `exec.test.ts`) and exercise the wiring function directly with
@@ -80,7 +80,7 @@ function buildInput(opts: { dataProvider?: InMemoryStore } = {}) {
   } as const;
 }
 
-describe("wireDevEngines — overlay registry wiring (Spec 60 §6)", () => {
+describe("wireDevEngines — overlay registry wiring (Spec 59 §8.1)", () => {
   test("assigns an OverlayRegistry to TransportContext (in-memory fallback)", async () => {
     const { transportCtx } = await wireDevEngines(buildInput());
 
@@ -114,5 +114,41 @@ describe("wireDevEngines — overlay registry wiring (Spec 60 §6)", () => {
     expect(overlays).toHaveLength(1);
     expect(overlays[0]?.fieldName).toBe("color");
     expect(overlays[0]?.fieldType).toBe("enum");
+  });
+
+  test("transportCtx.dataProvider is overlay-aware — writes fold into _extensions (issue #156)", async () => {
+    const inner = new InMemoryStore();
+    const { transportCtx } = await wireDevEngines(buildInput({ dataProvider: inner }));
+    const reg = transportCtx.overlayRegistry;
+    if (!reg) throw new Error("overlayRegistry undefined");
+
+    // Register an overlay AFTER wiring to confirm the registry handed to the
+    // wrapper is the same instance the transport context exposes — i.e. the
+    // wrapper sees overlay registrations made through the public API.
+    await reg.register({
+      entityName: "order",
+      fieldName: "color",
+      fieldType: "string",
+      config: {},
+      status: "active",
+    });
+
+    const created = await transportCtx.dataProvider.create("order", {
+      customer_name: "Alice",
+      color: "red",
+    });
+
+    // From the wrapper's POV the overlay field is at the row root (spread
+    // back from `_extensions` on the way out).
+    expect(created.color).toBe("red");
+    expect(created.customer_name).toBe("Alice");
+    expect(created._extensions).toBeUndefined();
+
+    // The underlying InMemoryStore stores the value in `_extensions`, NOT
+    // as a top-level column. This is the bug class #156 fixes — without
+    // the wrap a Drizzle column write would have failed.
+    const raw = await inner.get("order", created.id as string);
+    expect(raw._extensions).toEqual({ color: "red" });
+    expect(raw.color).toBeUndefined();
   });
 });

--- a/packages/cli/src/commands/dev-wiring.ts
+++ b/packages/cli/src/commands/dev-wiring.ts
@@ -72,6 +72,7 @@ import {
   InMemoryOverlayStore,
   livenessCheck,
   type OutboxWorker,
+  OverlayAwareDataProvider,
   type OverlayRegistry,
   type PermissionRegistry,
 } from "@linchkit/core/server";
@@ -142,24 +143,21 @@ export async function wireDevEngines(input: WireDevEnginesInput): Promise<WireDe
     dataProvider,
   } = input;
 
-  // ── Overlay registry — Spec 60 §6 ────────────────────────────────────
+  // ── Overlay registry — Spec 59 §8.1 ──────────────────────────────────
   // Constructed exactly once per dev session and assigned to
   // transportCtx.overlayRegistry so cap-adapter-mcp, the REST overlay
   // routes, and the GraphQL overlay-aware schema builder all read from the
   // same instance. An overlay registered via the API is therefore visible
   // through MCP introspection without a server restart.
   //
-  // NOTE: This PR intentionally does NOT wrap `dataProvider` with
-  // `OverlayAwareDataProvider`. That wrap is needed for action writes to
-  // fold overlay field VALUES into the `_extensions` column, but the
-  // wrap leaks past the transactional execution path: ActionEngine
-  // resolves a transaction-scoped DataProvider via
-  // `DrizzleTransactionManager.runInTransaction`, which produces a bare
-  // `DrizzleDataProvider` — bypassing the wrapper and writing overlay
-  // fields straight to non-existent columns. Wiring the wrap correctly
-  // requires either making `DrizzleTransactionManager` aware of the
-  // wrapper or implementing a transaction-aware `withConnection`. Out
-  // of scope here; tracked as a follow-up to issue #156.
+  // The runtime DataProvider is wrapped with `OverlayAwareDataProvider`
+  // below (after the registry initializes) so action writes that include
+  // overlay-managed fields fold their values into the `_extensions` JSONB
+  // column instead of hitting non-existent code-defined columns. The
+  // wrapper survives the transactional path: `OverlayAwareDataProvider`
+  // implements `withConnection`, and `DrizzleTransactionManager` accepts
+  // a `wrapForTx` callback so the same wrapper class re-wraps the
+  // tx-scoped Drizzle provider before the handler runs (issue #156).
   const overlayStore = dbInstance
     ? new DrizzleOverlayStore(dbInstance)
     : new InMemoryOverlayStore();
@@ -183,6 +181,13 @@ export async function wireDevEngines(input: WireDevEnginesInput): Promise<WireDe
     dbInstance ? "Overlay registry: drizzle" : "Overlay registry: in-memory (no DB)",
   );
 
+  // Wrap the runtime DataProvider with `OverlayAwareDataProvider` so action
+  // writes split overlay-managed fields into `_extensions` and reads spread
+  // them back. The transactional path is preserved by the wrapper's own
+  // `withConnection` implementation (used when no transaction manager is in
+  // play) and by the `wrapForTx` callback below (used when one is).
+  const overlayAwareDataProvider = new OverlayAwareDataProvider(dataProvider, overlayRegistry);
+
   // Create execution logger — Drizzle-backed when DB is available
   const executionLogger = dbInstance
     ? new DrizzleExecutionLogger(dbInstance)
@@ -195,10 +200,15 @@ export async function wireDevEngines(input: WireDevEnginesInput): Promise<WireDe
     : new InMemoryApprovalStore();
   consoleLogger.info(`Using ${dbInstance ? "DrizzleApprovalStore" : "InMemoryApprovalStore"}`);
 
-  // Create transaction manager when DB is available (Transactional Outbox pattern)
+  // Create transaction manager when DB is available (Transactional Outbox pattern).
+  // The `wrapForTx` callback re-applies the OverlayAwareDataProvider wrapper to
+  // the transaction-scoped DrizzleDataProvider so overlay field writes inside an
+  // open tx still fold into `_extensions` (issue #156).
   const transactionManager =
     dbInstance && input.dataProvider instanceof DrizzleDataProvider
-      ? new DrizzleTransactionManager(dbInstance, input.dataProvider as DrizzleDataProvider)
+      ? new DrizzleTransactionManager(dbInstance, input.dataProvider as DrizzleDataProvider, {
+          wrapForTx: (txProvider) => new OverlayAwareDataProvider(txProvider, overlayRegistry),
+        })
       : undefined;
   if (transactionManager) {
     consoleLogger.info("Using DrizzleTransactionManager (Transactional Outbox)");
@@ -214,7 +224,7 @@ export async function wireDevEngines(input: WireDevEnginesInput): Promise<WireDe
   const capabilityNames = new Set(capabilities.map((c) => c.name));
 
   const executor = createActionExecutor({
-    dataProvider,
+    dataProvider: overlayAwareDataProvider,
     transactionManager,
     executionLogger,
     configRegistry: registry,
@@ -478,7 +488,7 @@ export async function wireDevEngines(input: WireDevEnginesInput): Promise<WireDe
   // silently see zero rows in both PostgreSQL and in-memory dev modes.
   const evolutionRuntime = createEvolutionRuntime({
     sensors,
-    query: createDispatchQuery({ dataProvider, executionLogger }),
+    query: createDispatchQuery({ dataProvider: overlayAwareDataProvider, executionLogger }),
   });
   consoleLogger.info(
     `Evolution runtime ready: ${evolutionRuntime.signalBus.listSensors().length} sensor(s) registered`,
@@ -496,7 +506,7 @@ export async function wireDevEngines(input: WireDevEnginesInput): Promise<WireDe
     relationRegistry,
     middlewares,
     config: registry,
-    dataProvider,
+    dataProvider: overlayAwareDataProvider,
     eventBus,
     executionLogger,
     approvalEngine,

--- a/packages/core/__tests__/overlay-data-provider.test.ts
+++ b/packages/core/__tests__/overlay-data-provider.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { beforeEach, describe, expect, test } from "bun:test";
+import type { DataProvider, DataQueryOptions } from "../src/engine/action-engine";
 import { DefaultOverlayRegistry } from "../src/overlay/overlay-registry";
 import { InMemoryOverlayStore } from "../src/persistence/in-memory-overlay-store";
 import { InMemoryStore } from "../src/persistence/in-memory-store";
@@ -398,5 +399,221 @@ describe("OverlayAwareDataProvider", () => {
     expect(raw.custom_color).toBe("red");
     // Only active overlay (priority_score) should be in _extensions
     expect(raw._extensions).toEqual({ priority_score: 50 });
+  });
+});
+
+// ── withConnection (transaction-scoped wrapper) ─────────────────
+//
+// Issue #156: `OverlayAwareDataProvider` must survive the transactional
+// path so `DrizzleTransactionManager` can keep the wrapper in flight when
+// it spawns a tx-scoped DataProvider via `withConnection(tx)`.
+
+/**
+ * Inner DataProvider that records every operation against a per-instance
+ * transcript and exposes a `withConnection(client)` factory which produces
+ * a sibling instance sharing nothing but its parent's transcript root.
+ * Lets us assert that the wrapper's `withConnection` returns a NEW wrapper
+ * that delegates to the inner provider's tx-scoped copy.
+ */
+class TrackingProvider implements DataProvider {
+  readonly id: string;
+  readonly receivedClients: unknown[] = [];
+  readonly children: TrackingProvider[] = [];
+  readonly inner: InMemoryStore;
+
+  constructor(id: string, inner: InMemoryStore = new InMemoryStore()) {
+    this.id = id;
+    this.inner = inner;
+  }
+
+  withConnection(client: unknown): TrackingProvider {
+    this.receivedClients.push(client);
+    // Share the same backing InMemoryStore so the parent and tx copy see
+    // the same data — mirrors how `DrizzleDataProvider.withConnection`
+    // returns a sibling provider that talks to the same tables.
+    const child = new TrackingProvider(`${this.id}#tx${this.children.length}`, this.inner);
+    this.children.push(child);
+    return child;
+  }
+
+  get = (schema: string, id: string, options?: DataQueryOptions) =>
+    this.inner.get(schema, id, options);
+  query = (schema: string, filter: Record<string, unknown>, options?: DataQueryOptions) =>
+    this.inner.query(schema, filter, options);
+  create = (schema: string, data: Record<string, unknown>) => this.inner.create(schema, data);
+  update = (
+    schema: string,
+    id: string,
+    data: Record<string, unknown>,
+    options?: DataQueryOptions,
+  ) => this.inner.update(schema, id, data, options);
+  delete = (schema: string, id: string, options?: DataQueryOptions) =>
+    this.inner.delete(schema, id, options);
+  count = (schema: string, filter?: Record<string, unknown>, options?: DataQueryOptions) =>
+    this.inner.count(schema, filter, options);
+}
+
+describe("OverlayAwareDataProvider.withConnection (issue #156)", () => {
+  let overlayStore: InMemoryOverlayStore;
+  let registry: DefaultOverlayRegistry;
+  let tracking: TrackingProvider;
+  let wrapper: OverlayAwareDataProvider;
+
+  beforeEach(async () => {
+    overlayStore = new InMemoryOverlayStore();
+    registry = new DefaultOverlayRegistry(overlayStore);
+    await registry.register({
+      entityName: "order",
+      fieldName: "custom_color",
+      fieldType: "string",
+      config: {},
+      status: "active",
+    });
+    tracking = new TrackingProvider("root");
+    wrapper = new OverlayAwareDataProvider(tracking, registry);
+  });
+
+  test("withConnection returns a new wrapper that delegates to the inner's tx-scoped provider", () => {
+    const fakeClient = { __tx: true };
+    const txWrapper = wrapper.withConnection(fakeClient);
+
+    // A NEW wrapper instance — not `this`.
+    expect(txWrapper).toBeInstanceOf(OverlayAwareDataProvider);
+    expect(txWrapper).not.toBe(wrapper);
+
+    // The inner was asked to spawn a tx-scoped copy with our client.
+    expect(tracking.receivedClients).toEqual([fakeClient]);
+    expect(tracking.children).toHaveLength(1);
+  });
+
+  test("writes through the tx-scoped wrapper still split overlay fields into _extensions", async () => {
+    const fakeClient = { __tx: true };
+    const txWrapper = wrapper.withConnection(fakeClient);
+
+    const created = await txWrapper.create("order", {
+      title: "Tx Order",
+      custom_color: "red",
+    });
+
+    expect(created.custom_color).toBe("red");
+    expect(created._extensions).toBeUndefined();
+
+    // Inspect raw storage on the SHARED InMemoryStore to confirm the
+    // overlay field landed in `_extensions`, not as a top-level column.
+    const child = tracking.children[0];
+    if (!child) throw new Error("expected a tx child");
+    const raw = await child.inner.get("order", created.id as string);
+    expect(raw._extensions).toEqual({ custom_color: "red" });
+    expect(raw.custom_color).toBeUndefined();
+  });
+
+  test("reads through the tx-scoped wrapper spread _extensions onto the row root", async () => {
+    const fakeClient = { __tx: true };
+    const txWrapper = wrapper.withConnection(fakeClient);
+    const child = tracking.children[0];
+    if (!child) throw new Error("expected a tx child");
+
+    // Seed the underlying store directly so we test the read path in
+    // isolation (write path tested separately).
+    child.inner.seed("order", [
+      {
+        id: "tx-1",
+        title: "Seeded",
+        _extensions: { custom_color: "blue" },
+      },
+    ]);
+
+    const fetched = await txWrapper.get("order", "tx-1");
+    expect(fetched.title).toBe("Seeded");
+    expect(fetched.custom_color).toBe("blue");
+    expect(fetched._extensions).toBeUndefined();
+  });
+
+  test("parent and tx-scoped wrapper share the SAME OverlayRegistry instance", async () => {
+    const txWrapper = wrapper.withConnection({ __tx: true });
+
+    // Register a NEW overlay AFTER spawning the tx wrapper. Because both
+    // wrappers reference the same registry, the tx wrapper sees the
+    // mutation immediately — no re-initialization needed.
+    await registry.register({
+      entityName: "order",
+      fieldName: "priority_score",
+      fieldType: "number",
+      config: {},
+      status: "active",
+    });
+
+    const child = tracking.children[0];
+    if (!child) throw new Error("expected a tx child");
+
+    const created = await txWrapper.create("order", {
+      title: "Late Overlay",
+      custom_color: "green",
+      priority_score: 7,
+    });
+
+    const raw = await child.inner.get("order", created.id as string);
+    expect(raw._extensions).toEqual({ custom_color: "green", priority_score: 7 });
+  });
+
+  test("withConnection is a no-op for inner providers that don't implement it", async () => {
+    // InMemoryStore directly — no `withConnection`. The wrapper must still
+    // return a usable wrapper around the SAME inner so test wiring (and the
+    // exec.ts non-Drizzle path) keeps working.
+    const plainStore = new InMemoryStore();
+    const plainWrapper = new OverlayAwareDataProvider(plainStore, registry);
+    const txWrapper = plainWrapper.withConnection({ __tx: true });
+    expect(txWrapper).toBeInstanceOf(OverlayAwareDataProvider);
+    expect(txWrapper).not.toBe(plainWrapper);
+
+    const created = await txWrapper.create("order", {
+      title: "No-Conn",
+      custom_color: "yellow",
+    });
+    const raw = await plainStore.get("order", created.id as string);
+    expect(raw._extensions).toEqual({ custom_color: "yellow" });
+  });
+});
+
+describe("DrizzleTransactionManager.wrapForTx integration (issue #156)", () => {
+  // We can't construct a real DrizzleTransactionManager without a Postgres
+  // client, but we can simulate the same control flow with a fake
+  // TransactionManager + the wrapper, which is what dev-wiring relies on.
+  // This proves the structural plumbing the dev-wiring depends on.
+
+  test("wrapForTx callback re-applies OverlayAwareDataProvider inside runInTransaction", async () => {
+    const overlayStore = new InMemoryOverlayStore();
+    const registry = new DefaultOverlayRegistry(overlayStore);
+    await registry.register({
+      entityName: "order",
+      fieldName: "custom_color",
+      fieldType: "string",
+      config: {},
+      status: "active",
+    });
+
+    const innerStore = new InMemoryStore();
+    const tracking = new TrackingProvider("root", innerStore);
+
+    // Simulate what dev-wiring does: the executor sees the wrapper, the
+    // transaction manager applies wrapForTx after `withConnection(tx)`.
+    const wrapForTx = (txInner: DataProvider): DataProvider =>
+      new OverlayAwareDataProvider(txInner, registry);
+
+    // "tx" path: take the bare provider's tx copy, apply wrapForTx, run a
+    // write through it, observe the split.
+    const fakeTx = { __tx: true };
+    const bareTx = tracking.withConnection(fakeTx);
+    const wrappedTx = wrapForTx(bareTx);
+
+    const created = await wrappedTx.create("order", {
+      title: "Wrapped Tx",
+      custom_color: "purple",
+    });
+
+    expect(created.custom_color).toBe("purple");
+    const raw = await innerStore.get("order", created.id as string);
+    expect(raw._extensions).toEqual({ custom_color: "purple" });
+    expect(raw.custom_color).toBeUndefined();
   });
 });

--- a/packages/core/src/persistence/drizzle-transaction-manager.ts
+++ b/packages/core/src/persistence/drizzle-transaction-manager.ts
@@ -18,11 +18,39 @@ import type { DataProvider, PendingEvent, TransactionManager } from "../engine/a
 import type { DrizzleDataProvider } from "./drizzle-data-provider";
 import { eventsTable } from "./system-tables";
 
+/**
+ * Optional callback that wraps the bare transactional `DrizzleDataProvider`
+ * before it is handed to the action handler. Used by the dev-wiring to
+ * keep an `OverlayAwareDataProvider` in the transactional path so overlay
+ * field values fold into `_extensions` end-to-end (issue #156). Default is
+ * the identity function — no wrapper applied.
+ */
+export type WrapForTxFn = (txProvider: DrizzleDataProvider) => DataProvider;
+
+export interface DrizzleTransactionManagerOptions {
+  /**
+   * Apply a wrapper (e.g. `OverlayAwareDataProvider`) around the
+   * transaction-scoped data provider before passing it to the handler.
+   * Defaults to identity. The wrapper itself must NOT call
+   * `withConnection` again — the manager has already opened the tx.
+   */
+  wrapForTx?: WrapForTxFn;
+}
+
 export class DrizzleTransactionManager implements TransactionManager {
+  private readonly db: PostgresJsDatabase;
+  private readonly dataProvider: DrizzleDataProvider;
+  private readonly wrapForTx: WrapForTxFn;
+
   constructor(
-    private readonly db: PostgresJsDatabase,
-    private readonly dataProvider: DrizzleDataProvider,
-  ) {}
+    db: PostgresJsDatabase,
+    dataProvider: DrizzleDataProvider,
+    options?: DrizzleTransactionManagerOptions,
+  ) {
+    this.db = db;
+    this.dataProvider = dataProvider;
+    this.wrapForTx = options?.wrapForTx ?? ((p) => p);
+  }
 
   async runInTransaction<T>(
     fn: (txDataProvider: DataProvider) => Promise<T>,
@@ -31,7 +59,11 @@ export class DrizzleTransactionManager implements TransactionManager {
     return this.db.transaction(async (tx) => {
       // Create a transactional copy of the data provider
       const txDb = tx as unknown as PostgresJsDatabase;
-      const txProvider = this.dataProvider.withConnection(txDb);
+      const bareTxProvider = this.dataProvider.withConnection(txDb);
+      // Apply the optional wrap (identity by default). Used by dev-wiring
+      // to keep `OverlayAwareDataProvider` in the transactional path so
+      // overlay field values fold into `_extensions` end-to-end.
+      const txProvider = this.wrapForTx(bareTxProvider);
 
       // Execute the handler with the transactional provider
       const result = await fn(txProvider);

--- a/packages/core/src/persistence/overlay-aware-data-provider.ts
+++ b/packages/core/src/persistence/overlay-aware-data-provider.ts
@@ -188,4 +188,32 @@ export class OverlayAwareDataProvider implements DataProvider {
   ): Promise<number> {
     return this.inner.count(schema, filter, options);
   }
+
+  /**
+   * Produce a transaction-scoped wrapper backed by `client`.
+   *
+   * `DrizzleTransactionManager.runInTransaction` calls
+   * `dataProvider.withConnection(txDb)` to bind data ops to an open
+   * transaction. When the dev-wiring registers an `OverlayAwareDataProvider`
+   * as the executor's data provider, that wrapper must also be tx-aware —
+   * otherwise overlay-aware writes silently fall back to a bare
+   * `DrizzleDataProvider` inside the transaction and overlay fields hit
+   * non-existent columns.
+   *
+   * The returned wrapper shares the SAME `OverlayRegistry` instance, so
+   * overlay registrations made on the parent are visible inside the
+   * transactional copy without re-initialization.
+   *
+   * Inner providers that don't implement `withConnection` (e.g. the
+   * `InMemoryStore` used in tests) are returned as-is — there is no
+   * transactional boundary to honour.
+   */
+  withConnection(client: unknown): OverlayAwareDataProvider {
+    const inner = this.inner as DataProvider & {
+      withConnection?: (client: unknown) => DataProvider;
+    };
+    const innerWithConn =
+      typeof inner.withConnection === "function" ? inner.withConnection(client) : this.inner;
+    return new OverlayAwareDataProvider(innerWithConn, this.overlayRegistry);
+  }
 }


### PR DESCRIPTION
## Summary

Closes the overlay write-path that PR #268 deferred. After this PR, runtime overlay fields fold into `_extensions` JSONB end-to-end on writes, including writes that happen inside an open `DrizzleTransactionManager` transaction (the previous bypass).

Tracks the open follow-up under #156.

## Two-layer fix

### 1. `OverlayAwareDataProvider.withConnection`

The wrapper now implements `withConnection(client)` — delegates to the inner provider, returns a NEW wrapper around the tx-scoped inner, sharing the same `OverlayRegistry` instance. Both parent and tx-scoped wrappers see the same registry mutations.

Falls back to a no-op fresh wrapper when the inner lacks `withConnection` (e.g. `InMemoryStore`), preserving non-Drizzle test paths.

### 2. `DrizzleTransactionManager.wrapForTx`

Added optional `wrapForTx` callback in the constructor options. Default: identity. The dev wiring passes `(txProvider) => new OverlayAwareDataProvider(txProvider, registry)` so the overlay-fold logic reaches the action handler inside the transaction.

Backward-compatible — existing positional ctor sites (`packages/cli/src/commands/exec.ts`) keep working unchanged.

### 3. Re-add wrap in `dev-wiring.ts`

The `OverlayAwareDataProvider` wrap that PR #268 had to drop is back, now safe because both layers above propagate it through the tx layer. The `instanceof DrizzleDataProvider` gate stays on `input.dataProvider` (unwrapped) so the manager keeps its strong type.

## Why two layers

`wrapForTx` keeps the manager's ctor concrete (still receives a real `DrizzleDataProvider` for `.withConnection(txDb)` and any future Drizzle-specific calls) — the structural-check alternative would have leaked Drizzle internals into the wrapper.

`OverlayAwareDataProvider.withConnection` makes the wrapper a true transparent decorator, so any future caller that composes the wrapper without going through `DrizzleTransactionManager` (e.g. a direct `provider.withConnection(client)` call from a custom transport) still gets the wrap to survive.

## Cross-model review

Gemini cross-review attempted but the rate-limit quota (`gemini-3-flash-preview`) was exhausted on this turn. Self-reviewed against the agent's detailed report and the diff. The two-layer composition is the cleanest path that PR #268's gemini review explicitly recommended (it was the reviewer that caught the bypass).

## Test plan

- [x] `bun test packages/core` — 3023 pass / 0 fail.
- [x] `bun test packages/cli` — 241 pass / 0 fail (was 240).
- [x] `bun test addons/adapter-mcp/cap-adapter-mcp` — 198 pass / 0 fail.
- [x] `bun test addons/adapter-server/cap-adapter-server` — 603 pass / 0 fail.
- [x] `bun test` (full repo) — 4743 pass / 0 fail.
- [x] `bun run typecheck` — clean.
- [x] `bun run check` — clean for changed files.

7 new tests cover: `withConnection` returns fresh wrapper, tx-scoped writes split overlay fields into `_extensions`, tx-scoped reads spread keys back, parent + tx wrappers share one registry, inner without `withConnection` falls back gracefully, simulated `wrapForTx` integration mirroring dev-wiring control flow, and `wireDevEngines` end-to-end producing an overlay-aware `transportCtx.dataProvider`.

## Out of scope (follow-ups)

- `linch exec` (`packages/cli/src/commands/exec.ts`) does not yet wrap its DataProvider — overlay writes via `linch exec` still bypass. Mechanical mirror of `dev-wiring.ts`; separate PR if needed.
- GraphQL schema rebuild on overlay registration during a transaction (registry is shared so it should already work; no test coverage yet).

Refs Spec 59 §8.1, Spec 60 §6. Refs #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)