### PR TITLE
feat: Spec 52 polish — N-best alternatives + intent_resolution audit kind (refs #262)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/ai-resolve-intent.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/ai-resolve-intent.test.ts
@@ -211,11 +211,11 @@ describe("POST /api/ai/resolve-intent — happy path", () => {
     expect(body.proposal.missingFields).toEqual([]);
     expect(body.proposal.explanation.length).toBeGreaterThan(0);
 
-    // Audit entry: exactly one, matched=true
+    // Audit entry: exactly one, matched=true, eventType='intent_resolution'
     const entries = auditLogger.query();
     expect(entries.length).toBe(1);
+    expect(entries[0]?.eventType).toBe("intent_resolution");
     const meta = entries[0]?.metadata as Record<string, unknown> | undefined;
-    expect(meta?.kind).toBe("intent_resolution");
     expect((meta?.result as { matched: boolean }).matched).toBe(true);
     expect((meta?.result as { action: string | null }).action).toBe("create_purchase_request");
     expect((meta?.result as { confidence: number | null }).confidence).toBeCloseTo(0.92, 5);
@@ -265,6 +265,7 @@ describe("POST /api/ai/resolve-intent — AI cannot match", () => {
 
     const entries = auditLogger.query();
     expect(entries.length).toBe(1);
+    expect(entries[0]?.eventType).toBe("intent_resolution");
     const meta = entries[0]?.metadata as Record<string, unknown> | undefined;
     expect((meta?.result as { matched: boolean }).matched).toBe(false);
     expect((meta?.result as { action: string | null }).action).toBeNull();
@@ -360,6 +361,7 @@ describe("POST /api/ai/resolve-intent — AI unavailable", () => {
       // Audit entry still emitted so volume is observable.
       const entries = auditLogger2.query();
       expect(entries.length).toBe(1);
+      expect(entries[0]?.eventType).toBe("intent_resolution");
       const meta = entries[0]?.metadata as Record<string, unknown> | undefined;
       expect(meta?.serviceUnavailable).toBe(true);
     } finally {
@@ -491,12 +493,12 @@ describe("POST /api/ai/resolve-intent — audit entry shape", () => {
     // Top-level AIAuditEntry shape (from packages/core/src/ai/ai-audit.ts).
     expect(typeof entry.id).toBe("string");
     expect(typeof entry.timestamp).toBe("string");
-    expect(entry.eventType).toBe("ai_recommendation");
+    // Canonical Spec 52 §8.1.4 event type — no longer co-opting ai_recommendation.
+    expect(entry.eventType).toBe("intent_resolution");
     expect(entry.actorId).toBe("test-anon");
     expect(entry.actionName).toBe("create_purchase_request");
     // Spec 52 §8.1.4-shaped payload lives under `metadata`.
     const meta = entry.metadata as Record<string, unknown>;
-    expect(meta.kind).toBe("intent_resolution");
     expect(meta.prompt).toBe("create a purchase for 100 Eng");
     const result = meta.result as { matched: boolean; action: string | null; confidence: number };
     expect(result.matched).toBe(true);

--- a/addons/adapter-server/cap-adapter-server/src/routes/ai-resolve-intent.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/ai-resolve-intent.ts
@@ -10,21 +10,15 @@
  *    current user can see").
  *  - Returns `{ proposal: ActionProposal | null }` (200 either way — a null
  *    proposal is a normal "no usable match" outcome, not an error).
- *  - Emits one AI audit entry per call (success, no-match, or failure) so the
- *    full intent-resolution traffic is auditable per Spec 52 §8.1.4.
+ *  - Emits one AI audit entry per call (success, no-match, or failure) using
+ *    the canonical `logIntentResolution()` helper so the full intent-resolution
+ *    traffic is auditable per Spec 52 §8.1.4.
  *
  * Hard rules (Spec 52 §1.1):
  *  - This route NEVER executes the proposed action. The user confirms via
  *    the existing `POST /api/actions/:name` endpoint after reviewing the card.
  *  - When the resolver/AI is unavailable the endpoint degrades gracefully —
  *    503 with a structured envelope so the UI can show "AI unavailable" UX.
- *
- * Audit-log mapping (Spec 52 §8.1.4 vs runtime AIAuditLogger):
- *   The runtime `AIAuditLogger` does NOT yet declare an `intent_resolution`
- *   event type — see ai-audit.ts. We pick the closest existing kind
- *   (`ai_recommendation`) and stash the canonical type plus the per-call
- *   result payload under `metadata` so future migrations can rename the
- *   event type without re-mapping fields.
  */
 
 import { type ActionProposal, resolveIntent } from "@linchkit/cap-ai-provider";
@@ -122,16 +116,11 @@ function buildPermissionScopedOntology(opts: {
 // ── Audit emission helper ───────────────────────────────────
 
 /**
- * Emit one AI audit entry per resolve-intent call.
+ * Emit one AI audit entry per resolve-intent call (Spec 52 §8.1.4).
  *
- * Spec 52 §8.1.4 defines `AIAuditEntry.type === 'intent_resolution'` but the
- * runtime `AIAuditLogger` (packages/core/src/ai/ai-audit.ts) hasn't grown
- * that event type yet. We use the closest registered kind
- * (`ai_recommendation`) via `logRecommendation()` and stash the canonical
- * type + structured result under `metadata`.
- *
- * Follow-up tracked: extend AIAuditEventType to include 'intent_resolution'
- * and switch this caller to a dedicated `logIntentResolution()` helper.
+ * Thin wrapper around the canonical `AIAuditLogger.logIntentResolution()`
+ * helper — kept as a function in this module so future call sites (e.g. an
+ * MCP transport) don't need to know the actor-id derivation.
  */
 function emitIntentResolutionAudit(opts: {
   logger: AIAuditLogger;
@@ -146,31 +135,17 @@ function emitIntentResolutionAudit(opts: {
   scoped: boolean;
   serviceUnavailable: boolean;
 }): void {
-  const recommendation = opts.matched
-    ? `Resolved → ${opts.action ?? "(unknown)"}`
-    : opts.serviceUnavailable
-      ? "AI service unavailable"
-      : "No matching action proposal";
-
-  opts.logger.logRecommendation({
+  opts.logger.logIntentResolution({
     actorId: opts.actor.id,
     tenantId: opts.tenantId,
-    actionName: opts.action ?? "(none)",
-    recommendation,
-    riskLevel: "low",
-    metadata: {
-      kind: "intent_resolution",
-      prompt: opts.prompt,
-      result: {
-        matched: opts.matched,
-        action: opts.action,
-        confidence: opts.confidence,
-      },
-      durationMs: opts.durationMs,
-      catalogSize: opts.catalogSize,
-      scoped: opts.scoped,
-      serviceUnavailable: opts.serviceUnavailable,
-    },
+    prompt: opts.prompt,
+    matched: opts.matched,
+    action: opts.action,
+    confidence: opts.confidence,
+    durationMs: opts.durationMs,
+    catalogSize: opts.catalogSize,
+    scoped: opts.scoped,
+    serviceUnavailable: opts.serviceUnavailable,
   });
 }
 

--- a/addons/ai-provider/cap-ai-provider/__tests__/intent-resolver.test.ts
+++ b/addons/ai-provider/cap-ai-provider/__tests__/intent-resolver.test.ts
@@ -25,7 +25,13 @@ import type {
   AICompletionResult,
   AIService,
 } from "@linchkit/core";
-import { MIN_CONFIDENCE, type OntologyRegistryLike, resolveIntent } from "../src/intent-resolver";
+import {
+  ALTERNATIVES_CONFIDENCE_THRESHOLD,
+  MAX_ALTERNATIVES,
+  MIN_CONFIDENCE,
+  type OntologyRegistryLike,
+  resolveIntent,
+} from "../src/intent-resolver";
 
 // ── Fixture actions ─────────────────────────────────────────
 
@@ -541,5 +547,300 @@ describe("resolveIntent — scope filtering", () => {
       expect(content).not.toMatch(/[\x00\x07\x1B]/);
       expect(content).toContain("Normal labelwith NUL and BEL[31m");
     });
+  });
+});
+
+describe("resolveIntent — N-best alternatives (Spec 52 §2.2 step 4)", () => {
+  it("omits alternatives when primary confidence is at/above the threshold", async () => {
+    // AI returns a high-confidence primary plus alternatives — they must
+    // be dropped because the primary is confident enough on its own.
+    const ai = makeFakeAi(
+      JSON.stringify({
+        action: "create_purchase_request",
+        input: { amount: 5000, department: "IT" },
+        confidence: ALTERNATIVES_CONFIDENCE_THRESHOLD,
+        explanation: "High-confidence primary",
+        alternatives: [
+          {
+            action: "submit_purchase_request",
+            input: { id: "pr-123" },
+            confidence: 0.5,
+            explanation: "Maybe the user meant submit",
+          },
+        ],
+      }),
+    );
+
+    const proposal = await resolveIntent(
+      { prompt: "Create a 5000 purchase request for IT" },
+      { ai: ai.service, ontology: makeOntology() },
+    );
+
+    expect(proposal).not.toBeNull();
+    expect(proposal?.alternatives).toBeUndefined();
+  });
+
+  it("returns alternatives sorted by confidence desc when primary is uncertain", async () => {
+    const lowConfidence = ALTERNATIVES_CONFIDENCE_THRESHOLD - 0.2;
+    const ai = makeFakeAi(
+      JSON.stringify({
+        action: "create_purchase_request",
+        input: { amount: 5000, department: "IT" },
+        confidence: lowConfidence,
+        explanation: "Uncertain primary",
+        alternatives: [
+          {
+            action: "submit_purchase_request",
+            input: { id: "pr-123" },
+            confidence: 0.4,
+            explanation: "Maybe submit",
+          },
+          {
+            action: "create_vendor",
+            input: { name: "Acme" },
+            confidence: 0.6,
+            explanation: "Maybe create vendor",
+          },
+        ],
+      }),
+    );
+
+    const proposal = await resolveIntent(
+      { prompt: "do something purchase-y" },
+      { ai: ai.service, ontology: makeOntology() },
+    );
+
+    expect(proposal).not.toBeNull();
+    expect(proposal?.alternatives).toBeDefined();
+    expect(proposal?.alternatives?.length).toBe(2);
+    // Sorted by confidence desc: create_vendor (0.6) first, then submit (0.4).
+    expect(proposal?.alternatives?.[0]?.action).toBe("create_vendor");
+    expect(proposal?.alternatives?.[0]?.confidence).toBe(0.6);
+    expect(proposal?.alternatives?.[1]?.action).toBe("submit_purchase_request");
+    expect(proposal?.alternatives?.[1]?.confidence).toBe(0.4);
+  });
+
+  it("caps alternatives at MAX_ALTERNATIVES when AI returns more", async () => {
+    expect(MAX_ALTERNATIVES).toBe(3);
+
+    // AI returns 5 alternatives, all in scope. We expect only the top 3
+    // by confidence to survive.
+    // To have 5 unique in-scope candidates besides the primary, expand
+    // the ontology with extra actions only for this test.
+    const extra1: ActionDefinition = {
+      name: "extra_action_1",
+      entity: "purchase_request",
+      label: "Extra 1",
+      input: {},
+      policy: { mode: "sync", transaction: true },
+    };
+    const extra2: ActionDefinition = {
+      name: "extra_action_2",
+      entity: "purchase_request",
+      label: "Extra 2",
+      input: {},
+      policy: { mode: "sync", transaction: true },
+    };
+    const extra3: ActionDefinition = {
+      name: "extra_action_3",
+      entity: "purchase_request",
+      label: "Extra 3",
+      input: {},
+      policy: { mode: "sync", transaction: true },
+    };
+    const ontology: OntologyRegistryLike = {
+      listEntities: () => ["purchase_request", "vendor"],
+      actionsFor: (entity) =>
+        entity === "purchase_request"
+          ? [createPurchaseRequest, submitPurchaseRequest, extra1, extra2, extra3]
+          : entity === "vendor"
+            ? [createVendor]
+            : [],
+    };
+
+    const ai = makeFakeAi(
+      JSON.stringify({
+        action: "create_purchase_request",
+        input: { amount: 1, department: "IT" },
+        confidence: 0.5,
+        explanation: "Uncertain primary",
+        alternatives: [
+          { action: "submit_purchase_request", input: {}, confidence: 0.65, explanation: "" },
+          { action: "create_vendor", input: {}, confidence: 0.55, explanation: "" },
+          { action: "extra_action_1", input: {}, confidence: 0.45, explanation: "" },
+          { action: "extra_action_2", input: {}, confidence: 0.35, explanation: "" },
+          { action: "extra_action_3", input: {}, confidence: 0.25, explanation: "" },
+        ],
+      }),
+    );
+
+    const proposal = await resolveIntent(
+      { prompt: "ambiguous request" },
+      { ai: ai.service, ontology },
+    );
+
+    expect(proposal).not.toBeNull();
+    expect(proposal?.alternatives?.length).toBe(MAX_ALTERNATIVES);
+    // Confirm we kept the highest three.
+    expect(proposal?.alternatives?.map((a) => a.action)).toEqual([
+      "submit_purchase_request",
+      "create_vendor",
+      "extra_action_1",
+    ]);
+  });
+
+  it("drops alternatives whose action is not in the (scoped) catalog", async () => {
+    // entityFilter scopes the catalog to vendor only. The primary
+    // (create_vendor) is in scope, but the AI alternatives reference
+    // purchase_request actions that are filtered out.
+    const ai = makeFakeAi(
+      JSON.stringify({
+        action: "create_vendor",
+        input: { name: "Acme" },
+        confidence: 0.5,
+        explanation: "Uncertain vendor create",
+        alternatives: [
+          {
+            action: "submit_purchase_request",
+            input: { id: "pr-123" },
+            confidence: 0.4,
+            explanation: "out of scope",
+          },
+          {
+            action: "create_purchase_request",
+            input: { amount: 1, department: "IT" },
+            confidence: 0.45,
+            explanation: "out of scope",
+          },
+        ],
+      }),
+    );
+
+    const proposal = await resolveIntent(
+      { prompt: "something vendor-related", scope: { entityFilter: ["vendor"] } },
+      { ai: ai.service, ontology: makeOntology() },
+    );
+
+    expect(proposal).not.toBeNull();
+    // No in-scope alternatives → undefined (not empty array).
+    expect(proposal?.alternatives).toBeUndefined();
+  });
+
+  it("silently drops malformed alternative entries without affecting the primary", async () => {
+    const ai = makeFakeAi(
+      JSON.stringify({
+        action: "create_purchase_request",
+        input: { amount: 5000, department: "IT" },
+        confidence: 0.5,
+        explanation: "Uncertain primary",
+        alternatives: [
+          // Missing `action` field — malformed.
+          { input: {}, confidence: 0.4, explanation: "broken" },
+          // Wrong type for confidence — malformed.
+          { action: "create_vendor", input: { name: "Acme" }, confidence: "high", explanation: "" },
+          // Valid entry — survives.
+          {
+            action: "submit_purchase_request",
+            input: { id: "pr-1" },
+            confidence: 0.45,
+            explanation: "ok",
+          },
+        ],
+      }),
+    );
+
+    const proposal = await resolveIntent(
+      { prompt: "ambiguous" },
+      { ai: ai.service, ontology: makeOntology() },
+    );
+
+    // Primary survives untouched.
+    expect(proposal?.action).toBe("create_purchase_request");
+    expect(proposal?.confidence).toBe(0.5);
+    // Only the valid alternative remains.
+    expect(proposal?.alternatives?.length).toBe(1);
+    expect(proposal?.alternatives?.[0]?.action).toBe("submit_purchase_request");
+  });
+
+  it("returns undefined alternatives when the AI returns an empty array", async () => {
+    const ai = makeFakeAi(
+      JSON.stringify({
+        action: "create_purchase_request",
+        input: { amount: 5000, department: "IT" },
+        confidence: 0.5,
+        explanation: "Uncertain",
+        alternatives: [],
+      }),
+    );
+
+    const proposal = await resolveIntent(
+      { prompt: "ambiguous" },
+      { ai: ai.service, ontology: makeOntology() },
+    );
+
+    expect(proposal?.alternatives).toBeUndefined();
+  });
+
+  it("reconciles alternative input fields the same way as the primary", async () => {
+    // Alternative includes a bogus field that must be stripped, and is
+    // missing a required field that must surface in missingFields.
+    const ai = makeFakeAi(
+      JSON.stringify({
+        action: "create_vendor",
+        input: { name: "Acme" },
+        confidence: 0.5,
+        explanation: "Uncertain primary",
+        alternatives: [
+          {
+            action: "create_purchase_request",
+            input: { amount: 100, bogus: "x" },
+            confidence: 0.4,
+            explanation: "alt",
+          },
+        ],
+      }),
+    );
+
+    const proposal = await resolveIntent(
+      { prompt: "ambiguous" },
+      { ai: ai.service, ontology: makeOntology() },
+    );
+
+    expect(proposal?.alternatives?.length).toBe(1);
+    const alt = proposal?.alternatives?.[0];
+    expect(alt?.input).toEqual({ amount: 100 });
+    expect(alt?.missingFields).toEqual(["department"]);
+  });
+
+  it("never recurses — alternatives never carry their own alternatives", async () => {
+    const ai = makeFakeAi(
+      JSON.stringify({
+        action: "create_purchase_request",
+        input: { amount: 5000, department: "IT" },
+        confidence: 0.5,
+        explanation: "Uncertain",
+        alternatives: [
+          {
+            action: "create_vendor",
+            input: { name: "Acme" },
+            confidence: 0.4,
+            explanation: "alt",
+            // Even if the AI tries to nest, we ignore it.
+            alternatives: [
+              { action: "submit_purchase_request", input: {}, confidence: 0.3, explanation: "" },
+            ],
+          },
+        ],
+      }),
+    );
+
+    const proposal = await resolveIntent(
+      { prompt: "ambiguous" },
+      { ai: ai.service, ontology: makeOntology() },
+    );
+
+    expect(proposal?.alternatives?.length).toBe(1);
+    // The alternative itself has no nested alternatives.
+    expect(proposal?.alternatives?.[0]?.alternatives).toBeUndefined();
   });
 });

--- a/addons/ai-provider/cap-ai-provider/__tests__/intent-resolver.test.ts
+++ b/addons/ai-provider/cap-ai-provider/__tests__/intent-resolver.test.ts
@@ -689,6 +689,48 @@ describe("resolveIntent — N-best alternatives (Spec 52 §2.2 step 4)", () => {
     ]);
   });
 
+  it("drops alternatives whose confidence is below MIN_CONFIDENCE", async () => {
+    // gemini-code-assist on PR #272: alternatives below 0.4 should not
+    // surface in the UI (they would be low-quality "Did you mean..." chips).
+    // Mirrors the Spec 52 §2.2 step 5 floor applied to the primary.
+    const ai = makeFakeAi(
+      JSON.stringify({
+        action: "create_purchase_request",
+        input: { amount: 5000, department: "IT" },
+        confidence: 0.5,
+        explanation: "Maybe a PR",
+        alternatives: [
+          {
+            action: "create_vendor",
+            input: { name: "Acme" },
+            confidence: 0.55, // above MIN_CONFIDENCE — survives
+            explanation: "kept",
+          },
+          {
+            action: "submit_purchase_request",
+            input: { id: "pr-1" },
+            confidence: 0.3, // below MIN_CONFIDENCE — dropped
+            explanation: "dropped — too low",
+          },
+          {
+            action: "submit_purchase_request",
+            input: { id: "pr-2" },
+            confidence: 0.39, // just below — also dropped
+            explanation: "dropped — boundary",
+          },
+        ],
+      }),
+    );
+
+    const proposal = await resolveIntent(
+      { prompt: "something" },
+      { ai: ai.service, ontology: makeOntology() },
+    );
+
+    expect(proposal?.alternatives).toHaveLength(1);
+    expect(proposal?.alternatives?.[0]?.action).toBe("create_vendor");
+  });
+
   it("drops alternatives whose action is not in the (scoped) catalog", async () => {
     // entityFilter scopes the catalog to vendor only. The primary
     // (create_vendor) is in scope, but the AI alternatives reference

--- a/addons/ai-provider/cap-ai-provider/src/intent-prompt.ts
+++ b/addons/ai-provider/cap-ai-provider/src/intent-prompt.ts
@@ -48,7 +48,22 @@ export interface ActionCatalogEntry {
  * `catalog` (intent-resolver.ts), and unknown input fields are stripped
  * before reaching the user's confirmation card.
  */
-export function buildIntentSystemPrompt(catalog: ActionCatalogEntry[]): string {
+export interface BuildIntentSystemPromptOptions {
+  /**
+   * Threshold below which the AI is invited to surface alternatives.
+   * Mirrors `ALTERNATIVES_CONFIDENCE_THRESHOLD` from intent-resolver so the
+   * prompt and the resolver's runtime filter stay in lockstep when the
+   * threshold is tuned.
+   */
+  alternativesConfidenceThreshold: number;
+  /** Cap on the number of alternatives the AI is asked to emit. */
+  maxAlternatives: number;
+}
+
+export function buildIntentSystemPrompt(
+  catalog: ActionCatalogEntry[],
+  opts: BuildIntentSystemPromptOptions,
+): string {
   // Sanitize each user-controlled string before serialization. JSON.stringify
   // already escapes quotes/backslashes/newlines; we additionally strip ASCII
   // control characters (other than tab) so a label can't smuggle a literal
@@ -89,7 +104,7 @@ Rules:
 4. Use only field names that appear in the chosen action's "inputFields" list. Drop anything else.
 5. Provide a confidence score in [0, 1] reflecting how confident you are that this is the user's intent.
 6. Provide a one-sentence English explanation suitable for showing to the user inside a confirmation card.
-7. If the primary "confidence" is below 0.7, OPTIONALLY include an "alternatives" array with up to 3 other plausible matches, each with the same JSON shape as the primary (action, input, confidence, explanation). Each alternative's "action" MUST also appear in the JSON array above; do not invent. Sort alternatives by confidence descending. Omit "alternatives" entirely (or use an empty array) when confidence is high or when no other reasonable match exists.
+7. If the primary "confidence" is below ${opts.alternativesConfidenceThreshold}, OPTIONALLY include an "alternatives" array with up to ${opts.maxAlternatives} other plausible matches, each with the same JSON shape as the primary (action, input, confidence, explanation). Each alternative's "action" MUST also appear in the JSON array above; do not invent. Sort alternatives by confidence descending. Omit "alternatives" entirely (or use an empty array) when confidence is high or when no other reasonable match exists.
 8. Return STRICT JSON only — no prose, no Markdown fences. The JSON shape MUST be:
    {
      "action": "<action_name or null>",

--- a/addons/ai-provider/cap-ai-provider/src/intent-prompt.ts
+++ b/addons/ai-provider/cap-ai-provider/src/intent-prompt.ts
@@ -83,18 +83,27 @@ Available actions (JSON):
 ${catalogJson}
 
 Rules:
-1. Pick at most ONE action whose "name" appears in the JSON array above. NEVER invent an action that is not listed.
+1. Pick at most ONE primary action whose "name" appears in the JSON array above. NEVER invent an action that is not listed.
 2. If no listed action is a reasonable fit, set "action" to null and explain in plain English what was unclear.
 3. Extract input parameters that the user explicitly stated. Do NOT guess or hallucinate values.
 4. Use only field names that appear in the chosen action's "inputFields" list. Drop anything else.
 5. Provide a confidence score in [0, 1] reflecting how confident you are that this is the user's intent.
 6. Provide a one-sentence English explanation suitable for showing to the user inside a confirmation card.
-7. Return STRICT JSON only — no prose, no Markdown fences. The JSON shape MUST be:
+7. If the primary "confidence" is below 0.7, OPTIONALLY include an "alternatives" array with up to 3 other plausible matches, each with the same JSON shape as the primary (action, input, confidence, explanation). Each alternative's "action" MUST also appear in the JSON array above; do not invent. Sort alternatives by confidence descending. Omit "alternatives" entirely (or use an empty array) when confidence is high or when no other reasonable match exists.
+8. Return STRICT JSON only — no prose, no Markdown fences. The JSON shape MUST be:
    {
      "action": "<action_name or null>",
      "input": { "<field>": <value>, ... },
      "confidence": <number between 0 and 1>,
-     "explanation": "<short human-readable string>"
+     "explanation": "<short human-readable string>",
+     "alternatives": [
+       {
+         "action": "<action_name>",
+         "input": { "<field>": <value>, ... },
+         "confidence": <number between 0 and 1>,
+         "explanation": "<short human-readable string>"
+       }
+     ]
    }
 `;
 }

--- a/addons/ai-provider/cap-ai-provider/src/intent-resolver.ts
+++ b/addons/ai-provider/cap-ai-provider/src/intent-resolver.ts
@@ -164,7 +164,12 @@ export async function resolveIntent(
 
   // Call AI — text completion + manual JSON parsing keeps us compatible
   // with the simplest AiService shape (no JSON-mode dependency).
-  const systemPrompt = buildIntentSystemPrompt(catalog);
+  // Pass the threshold + cap as parameters so the prompt copy stays in
+  // lockstep with the constants enforced at runtime by reconcileAlternatives.
+  const systemPrompt = buildIntentSystemPrompt(catalog, {
+    alternativesConfidenceThreshold: ALTERNATIVES_CONFIDENCE_THRESHOLD,
+    maxAlternatives: MAX_ALTERNATIVES,
+  });
   let rawContent: string;
   try {
     const result = await deps.ai.complete({
@@ -412,13 +417,19 @@ function reconcileAlternatives(
     const catalogEntry = catalogIndex.get(alt.action);
     if (!catalogEntry) continue;
 
+    // Drop alternatives that themselves fall below MIN_CONFIDENCE — they
+    // would only show up in the UI's "Did you mean..." chips as low-quality
+    // noise. Mirrors the Spec 52 §2.2 step 5 floor applied to the primary.
+    const altConfidence = clampConfidence(alt.confidence);
+    if (altConfidence < MIN_CONFIDENCE) continue;
+
     const { input: cleanedInput, missingFields } = reconcileInput(catalogEntry, alt.input ?? {});
 
     seen.add(catalogEntry.name);
     reconciled.push({
       action: catalogEntry.name,
       input: cleanedInput,
-      confidence: clampConfidence(alt.confidence),
+      confidence: altConfidence,
       missingFields,
       explanation: alt.explanation || `Proposed action: ${catalogEntry.name}`,
     });

--- a/addons/ai-provider/cap-ai-provider/src/intent-resolver.ts
+++ b/addons/ai-provider/cap-ai-provider/src/intent-resolver.ts
@@ -91,16 +91,46 @@ export interface ResolveIntentDeps {
  */
 export const MIN_CONFIDENCE = 0.4;
 
+/**
+ * Confidence threshold below which the resolver surfaces N-best alternatives
+ * for the UI to render as "Did you mean..." chips (Spec 52 §2.2 step 4).
+ * At or above this threshold the primary match is confident enough that
+ * alternatives are not shown.
+ */
+export const ALTERNATIVES_CONFIDENCE_THRESHOLD = 0.7;
+
+/**
+ * Maximum number of alternatives surfaced alongside the primary proposal.
+ * Caps Spec 52 §2.2 step 4 "Did you mean..." UI chips at a sane number.
+ */
+export const MAX_ALTERNATIVES = 3;
+
 // ── AI response schema ───────────────────────────────────────
+
+/**
+ * One alternative match entry. Mirrors the primary fields exactly — no
+ * nested alternatives. Tolerated as `unknown` parsed into a flat shape,
+ * since downstream reconciliation re-validates against the catalog.
+ */
+const aiAlternativeSchema = z.object({
+  action: z.string(),
+  input: z.record(z.string(), z.unknown()).optional().default({}),
+  confidence: z.number(),
+  explanation: z.string().optional().default(""),
+});
 
 const aiResponseSchema = z.object({
   action: z.string().nullable(),
   input: z.record(z.string(), z.unknown()).optional().default({}),
   confidence: z.number(),
   explanation: z.string().optional().default(""),
+  // Alternatives are optional; each entry is independently validated and
+  // filtered by reconcileAlternatives() against the scoped catalog.
+  alternatives: z.array(z.unknown()).optional(),
 });
 
 type AiResponse = z.infer<typeof aiResponseSchema>;
+type AiAlternative = z.infer<typeof aiAlternativeSchema>;
 
 // ── Public API ───────────────────────────────────────────────
 
@@ -174,12 +204,21 @@ export async function resolveIntent(
 
   const { input: cleanedInput, missingFields } = reconcileInput(catalogEntry, parsed.input ?? {});
 
+  // Spec 52 §2.2 step 4 — surface N-best alternatives only when the
+  // primary match is uncertain. Above the threshold the AI is confident
+  // enough that "Did you mean..." UI chips would be noise.
+  const alternatives =
+    confidence < ALTERNATIVES_CONFIDENCE_THRESHOLD
+      ? reconcileAlternatives(parsed.alternatives, catalogIndex, catalogEntry.name)
+      : undefined;
+
   return {
     action: catalogEntry.name,
     input: cleanedInput,
     confidence,
     missingFields,
     explanation: parsed.explanation || `Proposed action: ${catalogEntry.name}`,
+    ...(alternatives && alternatives.length > 0 ? { alternatives } : {}),
   };
 }
 
@@ -335,4 +374,58 @@ function clampConfidence(value: number): number {
   if (value < 0) return 0;
   if (value > 1) return 1;
   return value;
+}
+
+// ── Alternatives reconciliation ─────────────────────────────
+
+/**
+ * Validate, allowlist, deduplicate, sort, and cap the AI-proposed
+ * alternatives list. Spec 52 §2.2 step 4.
+ *
+ * For each raw entry we:
+ *  - validate the shape via aiAlternativeSchema (drops anything malformed),
+ *  - require the action exists in the (scoped) catalog (drops out-of-scope),
+ *  - skip the primary action's own name to avoid duplication,
+ *  - reconcile its input against the action's catalog entry,
+ *  - clamp its confidence to [0, 1].
+ *
+ * Output is sorted by confidence descending and capped at MAX_ALTERNATIVES.
+ * Returns undefined when no usable alternatives remain so the caller can
+ * decide between "omit field" vs "empty array".
+ */
+function reconcileAlternatives(
+  rawAlternatives: unknown[] | undefined,
+  catalogIndex: Map<string, ActionCatalogEntry>,
+  primaryActionName: string,
+): ActionProposal[] | undefined {
+  if (!rawAlternatives || rawAlternatives.length === 0) return undefined;
+
+  const seen = new Set<string>([primaryActionName]);
+  const reconciled: ActionProposal[] = [];
+
+  for (const raw of rawAlternatives) {
+    const parsedAlt = aiAlternativeSchema.safeParse(raw);
+    if (!parsedAlt.success) continue;
+    const alt: AiAlternative = parsedAlt.data;
+
+    if (seen.has(alt.action)) continue;
+    const catalogEntry = catalogIndex.get(alt.action);
+    if (!catalogEntry) continue;
+
+    const { input: cleanedInput, missingFields } = reconcileInput(catalogEntry, alt.input ?? {});
+
+    seen.add(catalogEntry.name);
+    reconciled.push({
+      action: catalogEntry.name,
+      input: cleanedInput,
+      confidence: clampConfidence(alt.confidence),
+      missingFields,
+      explanation: alt.explanation || `Proposed action: ${catalogEntry.name}`,
+    });
+  }
+
+  if (reconciled.length === 0) return undefined;
+
+  reconciled.sort((a, b) => b.confidence - a.confidence);
+  return reconciled.slice(0, MAX_ALTERNATIVES);
 }

--- a/packages/core/__tests__/ai-security.test.ts
+++ b/packages/core/__tests__/ai-security.test.ts
@@ -385,6 +385,70 @@ describe("AIAuditLogger", () => {
     expect(entry.actionName).toBe("approve_purchase");
   });
 
+  it("should log intent resolution events with the canonical Spec 52 §8.1.4 shape", () => {
+    const audit = new AIAuditLogger();
+    const entry = audit.logIntentResolution({
+      actorId: "user-1",
+      tenantId: "tenant-a",
+      prompt: "Create a 5000 yuan purchase request for IT",
+      matched: true,
+      action: "create_purchase_request",
+      confidence: 0.85,
+      durationMs: 42,
+      catalogSize: 7,
+      scoped: true,
+      serviceUnavailable: false,
+    });
+
+    expect(entry.eventType).toBe("intent_resolution");
+    expect(entry.riskLevel).toBe("low");
+    expect(entry.actorId).toBe("user-1");
+    expect(entry.tenantId).toBe("tenant-a");
+    expect(entry.actionName).toBe("create_purchase_request");
+    expect(entry.recommendation).toBe("Resolved → create_purchase_request");
+    const meta = entry.metadata as Record<string, unknown>;
+    expect(meta.prompt).toBe("Create a 5000 yuan purchase request for IT");
+    expect(meta.durationMs).toBe(42);
+    expect(meta.catalogSize).toBe(7);
+    expect(meta.scoped).toBe(true);
+    expect(meta.serviceUnavailable).toBe(false);
+    const result = meta.result as { matched: boolean; action: string | null; confidence: number };
+    expect(result.matched).toBe(true);
+    expect(result.action).toBe("create_purchase_request");
+    expect(result.confidence).toBe(0.85);
+  });
+
+  it("logIntentResolution captures unavailable / unmatched calls with sane defaults", () => {
+    const audit = new AIAuditLogger();
+    const unavailable = audit.logIntentResolution({
+      actorId: "user-2",
+      prompt: "anything",
+      matched: false,
+      action: null,
+      confidence: null,
+      durationMs: 0,
+      catalogSize: 0,
+      scoped: false,
+      serviceUnavailable: true,
+    });
+    expect(unavailable.eventType).toBe("intent_resolution");
+    expect(unavailable.actionName).toBe("(none)");
+    expect(unavailable.recommendation).toBe("AI service unavailable");
+
+    const noMatch = audit.logIntentResolution({
+      actorId: "user-3",
+      prompt: "haiku please",
+      matched: false,
+      action: null,
+      confidence: null,
+      durationMs: 7,
+      catalogSize: 5,
+      scoped: true,
+      serviceUnavailable: false,
+    });
+    expect(noMatch.recommendation).toBe("No matching action proposal");
+  });
+
   it("should log approval events", () => {
     const audit = new AIAuditLogger();
     const entry = audit.logApproval({

--- a/packages/core/src/ai/ai-audit.ts
+++ b/packages/core/src/ai/ai-audit.ts
@@ -23,7 +23,38 @@ export type AIAuditEventType =
   | "ai_boundary_violation"
   | "ai_proposal_generated"
   | "ai_proposal_applied"
-  | "ai_data_access";
+  | "ai_data_access"
+  | "intent_resolution";
+
+/**
+ * Structured payload for `logIntentResolution()` (Spec 52 §8.1.4).
+ *
+ * Mirrors the per-call shape emitted by the `/api/ai/resolve-intent`
+ * endpoint so downstream consumers (compliance dashboards, fine-grained
+ * AI cost analysis) get a uniform schema regardless of AI provider.
+ */
+export interface IntentResolutionAuditPayload {
+  /** Calling actor — a user id, agent id, or system id. */
+  actorId: string;
+  /** Tenant context for the call. */
+  tenantId?: string;
+  /** Raw natural-language prompt the user sent. */
+  prompt: string;
+  /** True when the resolver returned an actionable proposal. */
+  matched: boolean;
+  /** Resolved action name (null when no match). */
+  action: string | null;
+  /** Confidence in [0, 1] (null when no match). */
+  confidence: number | null;
+  /** Wall-clock duration of the resolver call (ms). */
+  durationMs: number;
+  /** De-duplicated number of actions visible to the actor. */
+  catalogSize: number;
+  /** True when permission scoping was applied to the catalog. */
+  scoped: boolean;
+  /** True when the AI service was unreachable / not configured. */
+  serviceUnavailable: boolean;
+}
 
 /** Risk level classification for audit entries */
 export type AIAuditRiskLevel = "low" | "medium" | "high" | "critical";
@@ -234,6 +265,44 @@ export class AIAuditLogger {
       actionName: params.actionName,
       recommendation: params.recommendation,
       metadata: params.metadata,
+    });
+  }
+
+  /**
+   * Log a Spec 52 intent-resolution call (one entry per `/api/ai/resolve-intent`
+   * invocation, regardless of match outcome).
+   *
+   * Distinct from `logRecommendation()`: intent resolution is a search-style
+   * read that produces a candidate action; the recommendation event is for
+   * the AI suggesting an action be performed. The split keeps audit
+   * dashboards able to count NL-resolution traffic separately from genuine
+   * AI-driven workflow proposals.
+   */
+  logIntentResolution(params: IntentResolutionAuditPayload): AIAuditEntry {
+    const recommendation = params.matched
+      ? `Resolved → ${params.action ?? "(unknown)"}`
+      : params.serviceUnavailable
+        ? "AI service unavailable"
+        : "No matching action proposal";
+    return this.addEntry({
+      eventType: "intent_resolution",
+      riskLevel: "low",
+      actorId: params.actorId,
+      tenantId: params.tenantId,
+      actionName: params.action ?? "(none)",
+      recommendation,
+      metadata: {
+        prompt: params.prompt,
+        result: {
+          matched: params.matched,
+          action: params.action,
+          confidence: params.confidence,
+        },
+        durationMs: params.durationMs,
+        catalogSize: params.catalogSize,
+        scoped: params.scoped,
+        serviceUnavailable: params.serviceUnavailable,
+      },
     });
   }
 

--- a/packages/core/src/ai/index.ts
+++ b/packages/core/src/ai/index.ts
@@ -9,6 +9,7 @@ export type {
   AIAuditLoggerOptions,
   AIAuditQueryOptions,
   AIAuditRiskLevel,
+  IntentResolutionAuditPayload,
 } from "./ai-audit";
 export { AIAuditLogger } from "./ai-audit";
 export type { AIBoundaryOptions } from "./ai-boundary";

--- a/packages/core/src/server-entry.ts
+++ b/packages/core/src/server-entry.ts
@@ -217,6 +217,7 @@ export {
   type AIAuditLoggerOptions,
   type AIAuditQueryOptions,
   type AIAuditRiskLevel,
+  type IntentResolutionAuditPayload,
 } from "./ai";
 
 // === AI Prompt Sanitizer (server-only — injection detection + PII redaction) ===


### PR DESCRIPTION
## Summary

Two small, independent improvements to the Spec 52 NL → ActionProposal flow, both flagged in PR #269's commit message and the #262 follow-up issue. Bundled in one PR because they're both small and touch the same Spec 52 surface.

## 1. N-best alternatives (Spec 52 §2.2 step 4)

`resolveIntent()` now returns up to 3 alternative proposals when the primary match's confidence is below 0.7. The public `ActionProposal.alternatives` field has been declared since the Phase 0 PoC; the resolver simply wasn't populating it.

- Alternatives are validated against the same scoped-catalog allowlist as the primary, dedupe against the primary, sort descending by confidence, capped at 3.
- `alternatives` is `undefined` (not empty array) when no usable alternatives survive — keeps the shape minimal.
- Tunables exported: `ALTERNATIVES_CONFIDENCE_THRESHOLD = 0.7`, `MAX_ALTERNATIVES = 3`.

## 2. `intent_resolution` audit event type

`AIAuditEventType` gains the `'intent_resolution'` literal (was previously stashed under `metadata.kind`). New `AIAuditLogger.logIntentResolution(payload)` helper takes a typed `IntentResolutionAuditPayload`. Route migrated to the dedicated helper; the stash + follow-up comment are removed.

Wire contract unchanged.

## Cross-model review

Gemini cross-review attempted but the rate-limit quota (`gemini-3-flash-preview`) was exhausted across all three parallel agents this round. Self-reviewed against the agent's detailed report and the diff. Implementation is conservative: allowlist-validated alternatives, explicit dedupe + cap + sort; audit migration is mechanical (one helper added, one route migrated, two fixtures updated); no other `AIAuditEventType` consumers touched.

## Test plan

- [x] `bun test addons/ai-provider/cap-ai-provider` — 176 pass / 0 fail.
- [x] `bun test packages/core` — 3019 pass / 0 fail.
- [x] `bun test addons/adapter-server/cap-adapter-server` — 603 pass / 0 fail.
- [x] `bun test` (full repo) — 4746 pass / 0 fail.
- [x] `bun run typecheck` — clean.
- [x] `bun run check` — clean for changed files.

10 new tests:

`addons/ai-provider/cap-ai-provider/__tests__/intent-resolver.test.ts` (+8) — alternatives suppressed at/above threshold; primary-uncertain sort desc; capped at 3 from 5-item response; out-of-scope alternatives dropped; malformed entries silently dropped; empty-vs-undefined; per-alternative input reconciliation; nested alternatives ignored.

`packages/core/__tests__/ai-security.test.ts` (+2) — `logIntentResolution` writes the right `eventType` + payload; recommendation strings for the unavailable / no-match paths.

## Out of scope (follow-ups)

- `enrichProposal()` in the route does NOT currently enrich alternatives with `schema`/`actionLabel`/`actionDescription`/`inputSchema` like it does for the primary. UI can look up action metadata by name from the permission-scoped catalog; a future PR can add `enrichProposal(alt)` recursion if the round-trip turns out to be a friction point.
- `IntentResolution` interface in Spec 52 §2.2 narrows alternatives to `{ action; confidence; explanation }`; the implementation surfaces full `ActionProposal` entries (strict superset). Worth a spec note if anyone is round-tripping narrowly.

Refs Spec 52 §2.2, §8.1.4. Refs #262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)