### PR TITLE
feat(core): InsightTranslator — Insight → Proposal bridge (Spec 55 §7, refs #88)

### DIFF
--- a/packages/core/src/__tests__/life-system/insight-to-proposal.test.ts
+++ b/packages/core/src/__tests__/life-system/insight-to-proposal.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "bun:test";
+import {
+  createDefaultInsightTranslatorRegistry,
+  createInsightTranslatorRegistry,
+  insightTranslatorKey,
+  schemaNoViewTranslator,
+} from "../../life-system/insight-to-proposal";
+import type { Insight } from "../../types/life-system";
+import type { ViewDefinition } from "../../types/view";
+
+const FROZEN_NOW = new Date("2026-05-07T00:00:00.000Z");
+
+const makeStructuralInsight = (overrides: Partial<Insight> = {}): Insight => ({
+  id: "insight_1",
+  type: "structural",
+  confidence: 1.0,
+  impact: "low",
+  evidence: {
+    signals: [],
+    context: { kind: "schema_no_view", target: undefined },
+  },
+  summary: 'Schema "purchase_request" has no view defined.',
+  causality: "structural",
+  entity: "purchase_request",
+  createdAt: FROZEN_NOW,
+  ...overrides,
+});
+
+describe("insightTranslatorKey", () => {
+  it("builds structural keys from evidence.context.kind", () => {
+    const insight = makeStructuralInsight();
+    expect(insightTranslatorKey(insight)).toBe("structural:schema_no_view");
+  });
+
+  it("falls back to a sentinel when structural kind is missing", () => {
+    const insight = makeStructuralInsight({
+      evidence: { signals: [], context: {} },
+    });
+    expect(insightTranslatorKey(insight)).toBe("structural:unknown");
+  });
+
+  it("uses bare insight type for non-structural insights", () => {
+    const insight: Insight = {
+      ...makeStructuralInsight(),
+      type: "anomaly",
+      causality: "correlational",
+    };
+    expect(insightTranslatorKey(insight)).toBe("anomaly");
+  });
+});
+
+describe("schemaNoViewTranslator", () => {
+  it("emits an add-view ProposalDefinition tracing back to the insight", async () => {
+    const insight = makeStructuralInsight();
+    const proposal = await schemaNoViewTranslator(insight, {
+      now: () => FROZEN_NOW,
+      idGenerator: () => "proposal_test_1",
+    });
+
+    expect(proposal).not.toBeNull();
+    if (!proposal) throw new Error("expected proposal");
+
+    expect(proposal.id).toBe("proposal_test_1");
+    expect(proposal.status).toBe("draft");
+    expect(proposal.changeType).toBe("minor");
+    expect(proposal.capability).toBe("evolution");
+    expect(proposal.author).toEqual({
+      type: "ai",
+      id: "insight-translator",
+      name: "Insight Translator",
+    });
+    expect(proposal.createdAt).toBe(FROZEN_NOW);
+    expect(proposal.updatedAt).toBe(FROZEN_NOW);
+    expect(proposal.description).toBe(insight.summary);
+    expect(proposal.title).toContain("purchase_request");
+
+    expect(proposal.changes).toHaveLength(1);
+    const change = proposal.changes[0];
+    if (!change) throw new Error("expected one change");
+    expect(change.target).toBe("view");
+    expect(change.operation).toBe("create");
+    expect(change.name).toBe("purchase_request_default_list");
+
+    const def = change.definition as ViewDefinition;
+    expect(def.entity).toBe("purchase_request");
+    expect(def.type).toBe("list");
+    expect(Array.isArray(def.fields)).toBe(true);
+
+    expect(proposal.impact.schemasAffected).toEqual(["purchase_request"]);
+    expect(proposal.impact.migrationRequired).toBe(false);
+
+    // Evidence is attached as a sidecar that traces back to the insight.
+    const sidecar = (proposal as unknown as { evidence: { context: Record<string, unknown> } })
+      .evidence;
+    expect(sidecar).toBeDefined();
+    expect(sidecar.context.insightId).toBe(insight.id);
+    expect(sidecar.context.kind).toBe("schema_no_view");
+  });
+
+  it("returns null for non-structural insights", async () => {
+    const insight: Insight = {
+      ...makeStructuralInsight(),
+      type: "anomaly",
+      causality: "correlational",
+    };
+    const result = await schemaNoViewTranslator(insight, {});
+    expect(result).toBeNull();
+  });
+
+  it("returns null when structural kind is not schema_no_view", async () => {
+    const insight = makeStructuralInsight({
+      evidence: { signals: [], context: { kind: "rule_never_triggered" } },
+    });
+    const result = await schemaNoViewTranslator(insight, {});
+    expect(result).toBeNull();
+  });
+
+  it("does not mutate the originating insight evidence", async () => {
+    const original = makeStructuralInsight();
+    const beforeContext = { ...original.evidence.context };
+    await schemaNoViewTranslator(original, {});
+    expect(original.evidence.context).toEqual(beforeContext);
+    // Translator-side context mutation must not have leaked back.
+    expect((original.evidence.context as { insightId?: string }).insightId).toBeUndefined();
+  });
+});
+
+describe("InsightTranslatorRegistry", () => {
+  it("translates via the registered translator", async () => {
+    const registry = createInsightTranslatorRegistry();
+    registry.register("structural:schema_no_view", schemaNoViewTranslator);
+
+    const insight = makeStructuralInsight();
+    const result = await registry.translate(insight);
+    expect(result).not.toBeNull();
+    expect(result?.changes[0]?.target).toBe("view");
+  });
+
+  it("returns null for unsupported insight kinds without throwing", async () => {
+    const registry = createInsightTranslatorRegistry();
+    registry.register("structural:schema_no_view", schemaNoViewTranslator);
+
+    const unsupported = makeStructuralInsight({
+      id: "insight_unsupported",
+      evidence: { signals: [], context: { kind: "field_constant_value" } },
+      summary: "Field is always the same value.",
+    });
+    const result = await registry.translate(unsupported);
+    expect(result).toBeNull();
+  });
+
+  it("supports register / unregister / has / keys", () => {
+    const registry = createInsightTranslatorRegistry();
+    expect(registry.has("structural:schema_no_view")).toBe(false);
+
+    registry.register("structural:schema_no_view", schemaNoViewTranslator);
+    expect(registry.has("structural:schema_no_view")).toBe(true);
+    expect(registry.keys()).toContain("structural:schema_no_view");
+
+    registry.unregister("structural:schema_no_view");
+    expect(registry.has("structural:schema_no_view")).toBe(false);
+  });
+
+  it("default registry is pre-loaded with the structural schema_no_view translator", async () => {
+    const registry = createDefaultInsightTranslatorRegistry();
+    expect(registry.has("structural:schema_no_view")).toBe(true);
+
+    const insight = makeStructuralInsight();
+    const result = await registry.translate(insight, {
+      now: () => FROZEN_NOW,
+      idGenerator: () => "proposal_default_1",
+    });
+    expect(result?.id).toBe("proposal_default_1");
+  });
+
+  it("a translator that returns null does not throw and propagates null", async () => {
+    const registry = createInsightTranslatorRegistry();
+    registry.register("structural:schema_no_view", () => null);
+    const insight = makeStructuralInsight();
+    const result = await registry.translate(insight);
+    expect(result).toBeNull();
+  });
+});

--- a/packages/core/src/life-system/index.ts
+++ b/packages/core/src/life-system/index.ts
@@ -37,6 +37,19 @@ export { createEvolutionCycle } from "./evolution-cycle";
 export { InMemoryMemoryStore } from "./in-memory-memory-store";
 export type { InsightEngineOptions } from "./insight-engine";
 export { createInsightEngine } from "./insight-engine";
+// Spec 55 §7 — Insight → Proposal translator (Slice 1: structural-only).
+export type {
+  InsightTranslator,
+  InsightTranslatorKey,
+  InsightTranslatorRegistry,
+  TranslatorContext,
+} from "./insight-to-proposal";
+export {
+  createDefaultInsightTranslatorRegistry,
+  createInsightTranslatorRegistry,
+  insightTranslatorKey,
+  schemaNoViewTranslator,
+} from "./insight-to-proposal";
 export type { MemoryEngineOptions } from "./memory-engine";
 export { MemoryEngine } from "./memory-engine";
 // Proposal pre-analysis pipeline (Spec 55 §7.3 — dedup + impact)

--- a/packages/core/src/life-system/insight-to-proposal.ts
+++ b/packages/core/src/life-system/insight-to-proposal.ts
@@ -11,7 +11,7 @@
  */
 
 import type { OntologyRegistry } from "../ontology/ontology-registry";
-import type { Insight, InsightEvidence, InsightType, SensorSignal } from "../types/life-system";
+import type { Insight, InsightEvidence, InsightType } from "../types/life-system";
 import type { ProposalAuthor, ProposalChange, ProposalDefinition } from "../types/proposal";
 import type { ViewDefinition } from "../types/view";
 
@@ -135,27 +135,21 @@ export function createInsightTranslatorRegistry(): InsightTranslatorRegistry {
 
 // ── Helpers ─────────────────────────────────────────────────
 
-let monotonic = 0;
 function defaultIdGenerator(): string {
-  monotonic += 1;
-  return `proposal_${Date.now()}_${monotonic}`;
+  return `proposal_${crypto.randomUUID()}`;
 }
 
 /**
- * Deep-immutable-ish copy of evidence so translators cannot accidentally
- * mutate the originating Insight. Signals are cloned shallowly (their
- * fields are primitives + plain objects); context is cloned via spread.
+ * Deep copy of evidence so translators cannot mutate the originating
+ * Insight, and downstream consumers cannot back-leak edits into Memory.
+ * Uses structuredClone for nested-safe semantics; falls back to JSON
+ * round-trip when structuredClone is unavailable (older runtimes).
  */
 function cloneEvidence(evidence: InsightEvidence): InsightEvidence {
-  return {
-    signals: evidence.signals.map((s: SensorSignal) => ({
-      ...s,
-      context: { ...s.context },
-    })),
-    baseline: evidence.baseline ? { ...evidence.baseline } : undefined,
-    context: { ...evidence.context },
-    counterExamples: evidence.counterExamples ? [...evidence.counterExamples] : undefined,
-  };
+  if (typeof structuredClone === "function") {
+    return structuredClone(evidence) as InsightEvidence;
+  }
+  return JSON.parse(JSON.stringify(evidence)) as InsightEvidence;
 }
 
 /**

--- a/packages/core/src/life-system/insight-to-proposal.ts
+++ b/packages/core/src/life-system/insight-to-proposal.ts
@@ -1,0 +1,275 @@
+/**
+ * InsightTranslator — Spec 55 §7 Insight → Proposal bridge.
+ *
+ * A registry of per-insight-kind translators. Each translator converts an
+ * evidence-backed Insight into a ProposalDefinition the rest of the proposal
+ * pipeline (validate → preanalyse → approve → commit) can consume.
+ *
+ * Slice 1 ships the contract plus ONE deterministic translator
+ * (structural `schema_no_view` → `add_view`). AI-backed translators will be
+ * registered later via capability extensions (mirrors `extensions.sensors`).
+ */
+
+import type { OntologyRegistry } from "../ontology/ontology-registry";
+import type { Insight, InsightEvidence, InsightType, SensorSignal } from "../types/life-system";
+import type { ProposalAuthor, ProposalChange, ProposalDefinition } from "../types/proposal";
+import type { ViewDefinition } from "../types/view";
+
+// ── Translator key ──────────────────────────────────────────
+
+/**
+ * Key used to look up a translator. Built from `Insight.type` plus an
+ * insight-type-specific discriminator.
+ *
+ * - `structural` insights discriminate on `evidence.context.kind`
+ *   (one of {@link import("../types/life-system").StructuralIssueKind}).
+ * - Non-structural insights fall back to `Insight.type` alone for now;
+ *   later slices may refine (e.g. anomaly + sensor name).
+ */
+export type InsightTranslatorKey = string;
+
+/** Build the lookup key for an insight. */
+export function insightTranslatorKey(insight: Insight): InsightTranslatorKey {
+  if (insight.type === "structural") {
+    const kind = (insight.evidence.context as { kind?: unknown }).kind;
+    if (typeof kind === "string" && kind.length > 0) {
+      return `structural:${kind}`;
+    }
+    return "structural:unknown";
+  }
+  return insight.type;
+}
+
+// ── Translator context ──────────────────────────────────────
+
+/**
+ * Context passed into every translator invocation.
+ * Optional fields let tests stub deterministic ids/timestamps; production
+ * code wires the real OntologyRegistry so translators can introspect
+ * existing entities/views/fields when needed.
+ */
+export interface TranslatorContext {
+  /** Optional ontology lookup. Required by translators that need to
+   *  introspect existing entities (e.g. infer view fields). */
+  ontology?: OntologyRegistry;
+  /** Capability the proposal will target. Defaults to "evolution". */
+  capability?: string;
+  /** Author attached to the proposal. Defaults to the system bot. */
+  author?: ProposalAuthor;
+  /** Clock override (tests). */
+  now?: () => Date;
+  /** ID generator override (tests). */
+  idGenerator?: () => string;
+}
+
+/** Default author used when context omits one. */
+const DEFAULT_AUTHOR: ProposalAuthor = {
+  type: "ai",
+  id: "insight-translator",
+  name: "Insight Translator",
+};
+
+const DEFAULT_CAPABILITY = "evolution";
+
+// ── Translator function shape ───────────────────────────────
+
+/**
+ * A single translator. Receives the originating Insight plus context and
+ * returns either a ProposalDefinition (translation succeeded) or `null`
+ * (translator declined — the registry will fall through).
+ *
+ * Translators must NOT throw for "I don't know how to handle this kind";
+ * they must return `null`. Throwing is reserved for genuinely broken state
+ * (e.g. a structural translator was wired up but the insight evidence is
+ * malformed).
+ */
+export type InsightTranslator = (
+  insight: Insight,
+  ctx: TranslatorContext,
+) => ProposalDefinition | null | Promise<ProposalDefinition | null>;
+
+// ── Registry ────────────────────────────────────────────────
+
+export interface InsightTranslatorRegistry {
+  /** Register a translator for a given key. Replaces any existing one. */
+  register(key: InsightTranslatorKey, translator: InsightTranslator): void;
+  /** Remove a translator. No-op if absent. */
+  unregister(key: InsightTranslatorKey): void;
+  /** Whether a translator is registered for the given key. */
+  has(key: InsightTranslatorKey): boolean;
+  /** List all registered keys (insertion order). */
+  keys(): InsightTranslatorKey[];
+  /**
+   * Translate an Insight into a ProposalDefinition.
+   * Returns `null` if no translator is registered for the insight's key,
+   * OR if the matching translator declined (returned null).
+   */
+  translate(insight: Insight, ctx?: TranslatorContext): Promise<ProposalDefinition | null>;
+}
+
+/** Create an empty translator registry. */
+export function createInsightTranslatorRegistry(): InsightTranslatorRegistry {
+  const translators = new Map<InsightTranslatorKey, InsightTranslator>();
+
+  return {
+    register(key, translator) {
+      translators.set(key, translator);
+    },
+    unregister(key) {
+      translators.delete(key);
+    },
+    has(key) {
+      return translators.has(key);
+    },
+    keys() {
+      return [...translators.keys()];
+    },
+    async translate(insight, ctx = {}) {
+      const key = insightTranslatorKey(insight);
+      const fn = translators.get(key);
+      if (!fn) return null;
+      return await fn(insight, ctx);
+    },
+  };
+}
+
+// ── Helpers ─────────────────────────────────────────────────
+
+let monotonic = 0;
+function defaultIdGenerator(): string {
+  monotonic += 1;
+  return `proposal_${Date.now()}_${monotonic}`;
+}
+
+/**
+ * Deep-immutable-ish copy of evidence so translators cannot accidentally
+ * mutate the originating Insight. Signals are cloned shallowly (their
+ * fields are primitives + plain objects); context is cloned via spread.
+ */
+function cloneEvidence(evidence: InsightEvidence): InsightEvidence {
+  return {
+    signals: evidence.signals.map((s: SensorSignal) => ({
+      ...s,
+      context: { ...s.context },
+    })),
+    baseline: evidence.baseline ? { ...evidence.baseline } : undefined,
+    context: { ...evidence.context },
+    counterExamples: evidence.counterExamples ? [...evidence.counterExamples] : undefined,
+  };
+}
+
+/**
+ * Build a default ViewDefinition stub for an entity with no view.
+ * Slice 1 emits a syntactically valid placeholder. Later slices may
+ * pull fields from the OntologyRegistry to produce a richer default.
+ */
+function buildDefaultListView(entity: string, ctx: TranslatorContext): ViewDefinition {
+  // Try to enrich from ontology when available; fall back to empty fields.
+  const descriptor = ctx.ontology?.describe(entity);
+  const fields = descriptor
+    ? Object.keys(descriptor.fields)
+        .slice(0, 5)
+        .map((name) => ({ field: name }))
+    : [];
+
+  return {
+    name: `${entity}_default_list`,
+    entity,
+    type: "list",
+    label: `${entity} (default)`,
+    description: `Auto-proposed default list view for "${entity}".`,
+    fields,
+  };
+}
+
+// ── Built-in translators ────────────────────────────────────
+
+/**
+ * Translator for structural `schema_no_view` insights.
+ *
+ * Emits a ProposalDefinition that creates a default list view for the
+ * entity. Deterministic — no AI call. The resulting proposal is
+ * `status: "draft"` and follows the same shape AI-generated proposals use
+ * so the downstream pipeline (validate / preanalyse / approve) does not
+ * need to special-case it.
+ */
+export const schemaNoViewTranslator: InsightTranslator = (insight, ctx) => {
+  if (insight.type !== "structural") return null;
+  const evidenceContext = insight.evidence.context as { kind?: unknown };
+  if (evidenceContext.kind !== "schema_no_view") return null;
+
+  const now = ctx.now?.() ?? new Date();
+  const idGen = ctx.idGenerator ?? defaultIdGenerator;
+  const author = ctx.author ?? DEFAULT_AUTHOR;
+  const capability = ctx.capability ?? DEFAULT_CAPABILITY;
+
+  const view = buildDefaultListView(insight.entity, ctx);
+
+  const change: ProposalChange = {
+    target: "view",
+    operation: "create",
+    name: view.name,
+    definition: view,
+    diff: `Add default list view for "${insight.entity}".`,
+  };
+
+  // Trace the proposal back to the originating insight by stamping its id
+  // onto the (cloned) evidence context. Downstream consumers can read
+  // `proposal.changes[0].definition` for the actual change and the proposal
+  // metadata below for provenance.
+  const evidence = cloneEvidence(insight.evidence);
+  const traceContext: Record<string, unknown> = {
+    ...evidence.context,
+    insightId: insight.id,
+    insightSummary: insight.summary,
+    insightCausality: insight.causality,
+  };
+
+  const proposal: ProposalDefinition = {
+    id: idGen(),
+    title: `Add default view for "${insight.entity}"`,
+    description: insight.summary,
+    author,
+    capability,
+    changeType: "minor",
+    changes: [change],
+    impact: {
+      schemasAffected: [insight.entity],
+      actionsAffected: [],
+      rulesAffected: [],
+      dependentsAffected: [],
+      migrationRequired: false,
+    },
+    status: "draft",
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  // Attach evidence trace via a non-typed sidecar so we don't widen the
+  // ProposalDefinition shape in Slice 1. Slice 3 may promote this to a
+  // first-class field once the wiring is proven.
+  Object.defineProperty(proposal, "evidence", {
+    value: { ...evidence, context: traceContext },
+    enumerable: true,
+    writable: false,
+    configurable: false,
+  });
+
+  return proposal;
+};
+
+// ── Default registry factory ────────────────────────────────
+
+/**
+ * Create a registry pre-loaded with the Slice 1 deterministic translators.
+ * Capabilities can register additional translators via
+ * `extensions.insightTranslators` in later slices.
+ */
+export function createDefaultInsightTranslatorRegistry(): InsightTranslatorRegistry {
+  const registry = createInsightTranslatorRegistry();
+  registry.register("structural:schema_no_view", schemaNoViewTranslator);
+  return registry;
+}
+
+// Re-exported for downstream typing convenience.
+export type { Insight, InsightType };

--- a/packages/core/src/life-system/insight-to-proposal.ts
+++ b/packages/core/src/life-system/insight-to-proposal.ts
@@ -140,16 +140,25 @@ function defaultIdGenerator(): string {
 }
 
 /**
+ * Maximum number of fields the deterministic structural translator inlines
+ * into a default list view stub. Pulled from the head of the entity's
+ * field map (insertion order). Later slices may replace this with an
+ * importance-graph-aware selection.
+ */
+const DEFAULT_VIEW_FIELD_LIMIT = 5;
+
+/**
  * Deep copy of evidence so translators cannot mutate the originating
  * Insight, and downstream consumers cannot back-leak edits into Memory.
- * Uses structuredClone for nested-safe semantics; falls back to JSON
- * round-trip when structuredClone is unavailable (older runtimes).
+ *
+ * Requires `structuredClone` (Bun and Node 17+ both provide it). We
+ * intentionally do NOT use a JSON round-trip fallback because evidence
+ * carries `Date` instances (`SensorSignal.timestamp`, baseline timestamps)
+ * which JSON.stringify silently coerces to ISO strings — that would break
+ * the `InsightEvidence` type contract for downstream consumers.
  */
 function cloneEvidence(evidence: InsightEvidence): InsightEvidence {
-  if (typeof structuredClone === "function") {
-    return structuredClone(evidence) as InsightEvidence;
-  }
-  return JSON.parse(JSON.stringify(evidence)) as InsightEvidence;
+  return structuredClone(evidence) as InsightEvidence;
 }
 
 /**
@@ -162,7 +171,7 @@ function buildDefaultListView(entity: string, ctx: TranslatorContext): ViewDefin
   const descriptor = ctx.ontology?.describe(entity);
   const fields = descriptor
     ? Object.keys(descriptor.fields)
-        .slice(0, 5)
+        .slice(0, DEFAULT_VIEW_FIELD_LIMIT)
         .map((name) => ({ field: name }))
     : [];
 


### PR DESCRIPTION
## Summary

Slice 1 of three for closing #88. Introduces `InsightTranslator` — a typed registry that converts evidence-backed `Insight` records into `ProposalDefinition`s the existing proposal pipeline (validate → preanalyse → approve → commit) can consume. AI-backed translators register later via capability extensions, mirroring `extensions.sensors`.

Ships ONE deterministic translator: structural `schema_no_view` insights → `add_view` proposal with a default list view stub. No AI call; proves the contract end-to-end.

## In / out of scope

In:
- `createInsightTranslatorRegistry()` + `createDefaultInsightTranslatorRegistry()` factories
- `insightTranslatorKey()` lookup helper (composes `structural:<StructuralIssueKind>` for structural insights; falls back to `Insight.type` otherwise)
- `schemaNoViewTranslator` — emits a syntactically valid `ProposalDefinition`, enriching field list from `OntologyRegistry` when available
- Evidence cloning (deep, via `structuredClone`) so translators cannot mutate the originating insight

Out (deferred to Slice 2/3):
- Wiring into `evolution-cycle.ts`
- Attention budget integration
- Shadow / Champion-Challenger / promotion stages
- TS-file graduation (Spec 55 §7.6 — post-M6)
- AI-backed translators for non-structural insight types

## Notes

The evidence trace is currently attached as a non-typed sidecar via `Object.defineProperty` so we don't widen `ProposalDefinition` in Slice 1. Slice 3 may promote `evidence?` to a first-class field once the wiring is proven (flagged in code comment).

## Cross-model review

gemini round 1 raised CRITICAL (shallow clone) + SHOULD (monotonic global counter); both addressed in fix-up commit. NIT on `defineProperty` sidecar acknowledged and deferred to Slice 3.

## Test plan

- [x] Translator tests: 12 pass / 0 fail / 39 expect
- [x] Full life-system suite: 45 pass / 0 fail (no regressions)
- [x] typecheck clean
- [x] lint check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an insight→proposal translation system with a pluggable registry and a built-in translator that generates default list-view proposals for structural insights; includes a customizable translation context (ontology, time/ID overrides).
* **Tests**
  * Added comprehensive tests covering translator behavior, registry operations, provenance handling, and non‑structural/unsupported cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->