### PR TITLE
feat(adapter-ui): action proposal card alternatives + 503 fallback (refs #78)

### DIFF
--- a/addons/adapter-ui/cap-adapter-ui/__tests__/action-proposal-card.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/action-proposal-card.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Tests for `swapAlternative` and `resolveIntent` (Spec 52 §2.6 follow-up).
+ *
+ * The existing test setup is logic-only (no happy-dom / jsdom), so the
+ * `ActionProposalCard` swap behavior is exercised through the pure helper
+ * `swapAlternative` exported from the component module — the helper covers
+ * every observable state transition the click-handler triggers (primary
+ * replacement, alternatives reorder, reversibility).
+ *
+ * `resolveIntent` is covered with fetch mocks for the three discriminated
+ * outcomes the consumer (`ai-assistant.tsx`) needs to switch on: proposal,
+ * service-unavailable (503), and no-match (200 + null).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+// Minimal localStorage shim — api.ts reads `linchkit:token` for auth headers.
+const _store = new Map<string, string>();
+if (typeof globalThis.localStorage === "undefined") {
+  Object.defineProperty(globalThis, "localStorage", {
+    value: {
+      getItem: (key: string) => _store.get(key) ?? null,
+      setItem: (key: string, value: string) => _store.set(key, value),
+      removeItem: (key: string) => _store.delete(key),
+      clear: () => _store.clear(),
+      get length() {
+        return _store.size;
+      },
+      key: (index: number) => [..._store.keys()][index] ?? null,
+    },
+    configurable: true,
+  });
+}
+
+import { swapAlternative } from "../src/components/action-proposal-card";
+import type { IntentAlternative, IntentResolution } from "../src/lib/api";
+import { resolveIntent } from "../src/lib/api";
+
+// ── Fixtures ────────────────────────────────────────────────
+
+function makeIntent(overrides: Partial<IntentResolution> = {}): IntentResolution {
+  return {
+    action: "primary_action",
+    schema: "primary_entity",
+    input: { x: 1 },
+    missingFields: [],
+    confidence: 0.6,
+    explanation: "Primary explanation",
+    actionLabel: "Primary",
+    actionDescription: "Primary description",
+    inputSchema: {
+      x: { type: "number", required: false },
+    },
+    ...overrides,
+  };
+}
+
+function makeAlt(overrides: Partial<IntentAlternative> = {}): IntentAlternative {
+  return {
+    action: "alt_action",
+    input: { y: 2 },
+    confidence: 0.55,
+    missingFields: [],
+    explanation: "Alt explanation",
+    ...overrides,
+  };
+}
+
+// ── swapAlternative ────────────────────────────────────────
+
+describe("swapAlternative", () => {
+  test("returns null when alternatives is undefined", () => {
+    const intent = makeIntent({ alternatives: undefined });
+    expect(swapAlternative(intent, 0)).toBeNull();
+  });
+
+  test("returns null when alternatives is empty", () => {
+    const intent = makeIntent({ alternatives: [] });
+    expect(swapAlternative(intent, 0)).toBeNull();
+  });
+
+  test("returns null on out-of-range index", () => {
+    const intent = makeIntent({ alternatives: [makeAlt()] });
+    expect(swapAlternative(intent, -1)).toBeNull();
+    expect(swapAlternative(intent, 1)).toBeNull();
+    expect(swapAlternative(intent, 99)).toBeNull();
+  });
+
+  test("promotes the chosen alternative into the primary slot", () => {
+    const alt = makeAlt({
+      action: "approve_order",
+      input: { id: "o1" },
+      confidence: 0.5,
+      missingFields: ["reason"],
+      explanation: "Approve order o1",
+    });
+    const intent = makeIntent({ alternatives: [alt] });
+
+    const next = swapAlternative(intent, 0);
+    expect(next).not.toBeNull();
+    if (!next) return;
+
+    expect(next.action).toBe("approve_order");
+    expect(next.input).toEqual({ id: "o1" });
+    expect(next.confidence).toBe(0.5);
+    expect(next.missingFields).toEqual(["reason"]);
+    expect(next.explanation).toBe("Approve order o1");
+    // Display metadata is synthesized when the backend did not enrich the alt.
+    expect(next.actionLabel).toBe("approve_order");
+    expect(next.actionDescription).toBeUndefined();
+    expect(next.inputSchema).toEqual({});
+    expect(next.schema).toBe("approve_order");
+  });
+
+  test("demotes the previous primary into alternatives so the user can swap back", () => {
+    const intent = makeIntent({
+      action: "primary_action",
+      input: { x: 1 },
+      confidence: 0.6,
+      explanation: "Primary explanation",
+      missingFields: ["m"],
+      alternatives: [makeAlt({ action: "alt_a", confidence: 0.55 })],
+    });
+
+    const next = swapAlternative(intent, 0);
+    expect(next).not.toBeNull();
+    if (!next) return;
+
+    expect(next.alternatives).toBeDefined();
+    expect(next.alternatives?.length).toBe(1);
+    const restoredPrimary = next.alternatives?.[0];
+    expect(restoredPrimary?.action).toBe("primary_action");
+    expect(restoredPrimary?.input).toEqual({ x: 1 });
+    expect(restoredPrimary?.confidence).toBe(0.6);
+    expect(restoredPrimary?.missingFields).toEqual(["m"]);
+    expect(restoredPrimary?.explanation).toBe("Primary explanation");
+  });
+
+  test("swap is reversible — swapping back restores the original primary identity", () => {
+    const intent = makeIntent({
+      action: "primary_action",
+      input: { x: 1 },
+      confidence: 0.6,
+      missingFields: [],
+      explanation: "Primary explanation",
+      alternatives: [makeAlt({ action: "alt_a", confidence: 0.55, input: { y: 2 } })],
+    });
+
+    const after = swapAlternative(intent, 0);
+    expect(after).not.toBeNull();
+    if (!after) return;
+    expect(after.action).toBe("alt_a");
+
+    // The previous primary now sits at index 0 of alternatives.
+    const restored = swapAlternative(after, 0);
+    expect(restored).not.toBeNull();
+    if (!restored) return;
+    expect(restored.action).toBe("primary_action");
+    expect(restored.input).toEqual({ x: 1 });
+    expect(restored.confidence).toBe(0.6);
+  });
+
+  test("preserves remaining alternatives sorted by confidence DESC", () => {
+    const intent = makeIntent({
+      action: "primary_action",
+      confidence: 0.65,
+      alternatives: [
+        makeAlt({ action: "alt_high", confidence: 0.6 }),
+        makeAlt({ action: "alt_mid", confidence: 0.5 }),
+        makeAlt({ action: "alt_low", confidence: 0.45 }),
+      ],
+    });
+
+    // Swap the lowest-confidence alternative in. Remaining should be
+    // [previousPrimary@0.65, alt_high@0.6, alt_mid@0.5] sorted DESC.
+    const next = swapAlternative(intent, 2);
+    expect(next).not.toBeNull();
+    if (!next) return;
+    expect(next.action).toBe("alt_low");
+    expect(next.alternatives?.map((a) => a.action)).toEqual([
+      "primary_action",
+      "alt_high",
+      "alt_mid",
+    ]);
+  });
+});
+
+// ── resolveIntent transport ─────────────────────────────────
+
+interface CapturedRequest {
+  url: string;
+  method?: string;
+  body: unknown;
+  headers: Record<string, string>;
+}
+
+let captured: CapturedRequest | null;
+let originalFetch: typeof fetch;
+
+function installFetch(response: { status: number; body: unknown }) {
+  originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    captured = {
+      url: typeof input === "string" ? input : (input as URL).toString(),
+      method: init?.method,
+      body: init?.body ? JSON.parse(init.body as string) : undefined,
+      headers: (init?.headers as Record<string, string>) ?? {},
+    };
+    return new Response(JSON.stringify(response.body), {
+      status: response.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+}
+
+beforeEach(() => {
+  captured = null;
+});
+
+afterEach(() => {
+  if (originalFetch) {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+describe("resolveIntent", () => {
+  test("returns { kind: 'proposal' } when the server returns a proposal", async () => {
+    const proposalView: IntentResolution = makeIntent({
+      action: "submit_request",
+      alternatives: [makeAlt({ action: "draft_request", confidence: 0.5 })],
+    });
+    installFetch({ status: 200, body: { proposal: proposalView } });
+
+    const result = await resolveIntent("submit a request");
+    expect(result.kind).toBe("proposal");
+    if (result.kind !== "proposal") return;
+    expect(result.proposal.action).toBe("submit_request");
+    expect(result.proposal.alternatives?.[0]?.action).toBe("draft_request");
+    expect(captured?.url).toBe("/api/ai/resolve-intent");
+    expect(captured?.method).toBe("POST");
+    expect(captured?.body).toEqual({ prompt: "submit a request", scope: undefined });
+  });
+
+  test("returns { kind: 'unavailable' } on 503 instead of throwing or returning null", async () => {
+    installFetch({
+      status: 503,
+      body: {
+        success: false,
+        error: { code: "AI.UNAVAILABLE", message: "AI service is not configured." },
+      },
+    });
+
+    const result = await resolveIntent("anything");
+    expect(result).toEqual({ kind: "unavailable" });
+  });
+
+  test("returns { kind: 'no-match' } when server returns 200 + proposal:null", async () => {
+    installFetch({ status: 200, body: { proposal: null } });
+
+    const result = await resolveIntent("gibberish");
+    expect(result).toEqual({ kind: "no-match" });
+  });
+
+  test("returns { kind: 'no-match' } when server omits the proposal field", async () => {
+    installFetch({ status: 200, body: {} });
+
+    const result = await resolveIntent("anything");
+    expect(result).toEqual({ kind: "no-match" });
+  });
+
+  test("throws on non-2xx, non-503 responses", async () => {
+    installFetch({
+      status: 500,
+      body: { success: false, error: { code: "AI.INTERNAL", message: "boom" } },
+    });
+
+    await expect(resolveIntent("anything")).rejects.toThrow("AI intent resolution failed");
+  });
+
+  test("forwards optional scope in the request body", async () => {
+    installFetch({ status: 200, body: { proposal: null } });
+
+    await resolveIntent("create a request", {
+      entityFilter: ["request"],
+      actionFilter: ["submit_request"],
+    });
+    expect(captured?.body).toEqual({
+      prompt: "create a request",
+      scope: { entityFilter: ["request"], actionFilter: ["submit_request"] },
+    });
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/action-proposal-card.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/action-proposal-card.test.ts
@@ -112,9 +112,13 @@ describe("swapAlternative", () => {
     expect(next.schema).toBe("approve_order");
   });
 
-  test("demotes the previous primary into alternatives so the user can swap back", () => {
+  test("demotes the previous primary into alternatives, preserving display metadata", () => {
     const intent = makeIntent({
       action: "primary_action",
+      schema: "primary_entity",
+      actionLabel: "Primary",
+      actionDescription: "Primary description",
+      inputSchema: { x: { type: "number", required: false } },
       input: { x: 1 },
       confidence: 0.6,
       explanation: "Primary explanation",
@@ -134,11 +138,21 @@ describe("swapAlternative", () => {
     expect(restoredPrimary?.confidence).toBe(0.6);
     expect(restoredPrimary?.missingFields).toEqual(["m"]);
     expect(restoredPrimary?.explanation).toBe("Primary explanation");
+    // Display metadata must round-trip on the demoted primary so swap-back
+    // is fully reversible.
+    expect(restoredPrimary?.schema).toBe("primary_entity");
+    expect(restoredPrimary?.actionLabel).toBe("Primary");
+    expect(restoredPrimary?.actionDescription).toBe("Primary description");
+    expect(restoredPrimary?.inputSchema).toEqual({ x: { type: "number", required: false } });
   });
 
-  test("swap is reversible — swapping back restores the original primary identity", () => {
+  test("swap is reversible — swap-back restores ALL display metadata, not just identity", () => {
     const intent = makeIntent({
       action: "primary_action",
+      schema: "primary_entity",
+      actionLabel: "Primary",
+      actionDescription: "Primary description",
+      inputSchema: { x: { type: "number", required: false } },
       input: { x: 1 },
       confidence: 0.6,
       missingFields: [],
@@ -151,13 +165,39 @@ describe("swapAlternative", () => {
     if (!after) return;
     expect(after.action).toBe("alt_a");
 
-    // The previous primary now sits at index 0 of alternatives.
+    // The previous primary now sits at index 0 of alternatives. Swap back.
     const restored = swapAlternative(after, 0);
     expect(restored).not.toBeNull();
     if (!restored) return;
     expect(restored.action).toBe("primary_action");
     expect(restored.input).toEqual({ x: 1 });
     expect(restored.confidence).toBe(0.6);
+    // Non-lossy: display metadata fully restored.
+    expect(restored.schema).toBe("primary_entity");
+    expect(restored.actionLabel).toBe("Primary");
+    expect(restored.actionDescription).toBe("Primary description");
+    expect(restored.inputSchema).toEqual({ x: { type: "number", required: false } });
+  });
+
+  test("swap-IN uses backend-enriched alternative metadata when present", () => {
+    const enrichedAlt = makeAlt({
+      action: "alt_a",
+      confidence: 0.55,
+      input: { id: "x" },
+      schema: "alt_entity",
+      actionLabel: "Alternative A",
+      actionDescription: "Does the alternative thing",
+      inputSchema: { id: { type: "string", required: true } },
+    });
+    const intent = makeIntent({ alternatives: [enrichedAlt] });
+
+    const next = swapAlternative(intent, 0);
+    expect(next).not.toBeNull();
+    if (!next) return;
+    expect(next.schema).toBe("alt_entity");
+    expect(next.actionLabel).toBe("Alternative A");
+    expect(next.actionDescription).toBe("Does the alternative thing");
+    expect(next.inputSchema).toEqual({ id: { type: "string", required: true } });
   });
 
   test("preserves remaining alternatives sorted by confidence DESC", () => {

--- a/addons/adapter-ui/cap-adapter-ui/src/components/action-proposal-card.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/action-proposal-card.tsx
@@ -43,6 +43,26 @@ export interface ActionProposalCardProps {
 /** Maximum number of alternatives to render in the "Did you mean" section. */
 export const MAX_DISPLAYED_ALTERNATIVES = 3;
 
+/**
+ * Confidence-band thresholds used for both the primary card badge and the
+ * alternatives pills. Aligned with Spec 52 §2.2 surfacing thresholds.
+ *
+ * - confidence < MEDIUM → destructive (red) — low confidence
+ * - MEDIUM ≤ confidence < HIGH → secondary (neutral) — passable
+ * - confidence ≥ HIGH → default (positive) — high confidence
+ */
+export const CONFIDENCE_THRESHOLD_MEDIUM = 0.5;
+export const CONFIDENCE_THRESHOLD_HIGH = 0.8;
+
+/**
+ * Minimum confidence required to render an action proposal card at all.
+ * Below this, the AI Assistant falls back to general chat instead of
+ * surfacing a card the user is unlikely to confirm. Currently aligned with
+ * `CONFIDENCE_THRESHOLD_MEDIUM`, but kept as a separate symbol so the
+ * surfacing gate can move independently of the badge color band.
+ */
+export const MIN_PROPOSAL_CONFIDENCE = CONFIDENCE_THRESHOLD_MEDIUM;
+
 function resolveTranslatableLabel(
   raw: string | undefined,
   fallback: string,
@@ -231,8 +251,9 @@ function formatConfidencePct(confidence: number): string {
 }
 
 function confidenceBadgeVariant(confidence: number): "default" | "secondary" | "destructive" {
-  if (!Number.isFinite(confidence) || confidence < 0.5) return "destructive";
-  if (confidence >= 0.8) return "default";
+  if (!Number.isFinite(confidence) || confidence < CONFIDENCE_THRESHOLD_MEDIUM)
+    return "destructive";
+  if (confidence >= CONFIDENCE_THRESHOLD_HIGH) return "default";
   return "secondary";
 }
 
@@ -304,12 +325,12 @@ export function ActionProposalCard({ intent, onComplete, onCancel }: ActionPropo
   const inputFields = Object.entries(currentIntent.inputSchema);
   const actionLabel = resolveTranslatableLabel(currentIntent.actionLabel, currentIntent.action, t);
 
-  // Defensive sort + cap — backend already returns sorted N-best, but this
-  // guarantees the contract when swap mutates the list.
-  const displayedAlternatives = (currentIntent.alternatives ?? [])
-    .slice()
-    .sort((a, b) => b.confidence - a.confidence)
-    .slice(0, MAX_DISPLAYED_ALTERNATIVES);
+  // Backend returns alternatives sorted DESC by confidence and swapAlternative
+  // re-sorts after each swap, so we only need to cap to the display limit here.
+  const displayedAlternatives = (currentIntent.alternatives ?? []).slice(
+    0,
+    MAX_DISPLAYED_ALTERNATIVES,
+  );
 
   return (
     <div className="rounded-lg border bg-card text-card-foreground shadow-sm">

--- a/addons/adapter-ui/cap-adapter-ui/src/components/action-proposal-card.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/action-proposal-card.tsx
@@ -65,12 +65,16 @@ function resolveTranslatableLabel(
  *   - the previous primary (now reversible — the user can swap back),
  *   - all other previous alternatives, in original order.
  *
- * The chosen alternative carries no display metadata of its own (the server
- * only enriches the primary), so we synthesize minimal placeholders:
- *   - `schema` and `actionLabel` fall back to the action name,
- *   - `actionDescription` is dropped,
- *   - `inputSchema` is empty (the user keeps the AI-extracted inputs as a
- *     read-only summary; editing is disabled until the next round-trip).
+ * Reversibility: the previous primary's display metadata (`schema`,
+ * `actionLabel`, `actionDescription`, `inputSchema`) is preserved on the
+ * demoted `IntentAlternative` so swapping BACK to it later restores a
+ * fully-rendered card with editable fields.
+ *
+ * Server-returned alternatives carry no display metadata (the route only
+ * enriches the primary). When such an alternative is swapped IN, we surface
+ * placeholders (`actionLabel = action`, empty `inputSchema`) — the AI-
+ * extracted `input` is still shown as a read-only summary; field editing
+ * unlocks on the next round-trip when the user re-prompts.
  *
  * Returns `null` when `index` is out of range so callers can no-op safely.
  */
@@ -81,13 +85,18 @@ export function swapAlternative(current: IntentResolution, index: number): Inten
   const chosen = alternatives[index];
   if (!chosen) return null;
 
-  // Demote the previous primary into an alternative entry.
+  // Demote the previous primary into an alternative entry, preserving its
+  // display metadata so a future swap-back is non-lossy.
   const previousPrimary: IntentAlternative = {
     action: current.action,
     input: current.input,
     confidence: current.confidence,
     missingFields: current.missingFields,
     explanation: current.explanation,
+    schema: current.schema,
+    actionLabel: current.actionLabel,
+    actionDescription: current.actionDescription,
+    inputSchema: current.inputSchema,
   };
 
   // New alternatives = [previousPrimary, ...alternatives without chosen].
@@ -100,14 +109,14 @@ export function swapAlternative(current: IntentResolution, index: number): Inten
 
   return {
     action: chosen.action,
-    schema: chosen.action,
+    schema: chosen.schema ?? chosen.action,
     input: chosen.input,
     missingFields: chosen.missingFields,
     confidence: chosen.confidence,
     explanation: chosen.explanation,
-    actionLabel: chosen.action,
-    actionDescription: undefined,
-    inputSchema: {},
+    actionLabel: chosen.actionLabel ?? chosen.action,
+    actionDescription: chosen.actionDescription,
+    inputSchema: chosen.inputSchema ?? {},
     alternatives: nextAlternatives,
   };
 }
@@ -211,12 +220,26 @@ function FieldEditor({
 
 // ── Confidence badge ────────────────────────────────────
 
+/**
+ * Format a confidence score (0-1) as a percentage string. Defensive against
+ * NaN/Infinity/undefined that could leak from a malformed AI response —
+ * returns "—" instead of "NaN%" in those cases.
+ */
+function formatConfidencePct(confidence: number): string {
+  if (!Number.isFinite(confidence)) return "—";
+  return `${Math.round(confidence * 100)}%`;
+}
+
+function confidenceBadgeVariant(confidence: number): "default" | "secondary" | "destructive" {
+  if (!Number.isFinite(confidence) || confidence < 0.5) return "destructive";
+  if (confidence >= 0.8) return "default";
+  return "secondary";
+}
+
 function ConfidenceBadge({ confidence }: { confidence: number }) {
-  const pct = Math.round(confidence * 100);
-  const variant = confidence >= 0.8 ? "default" : confidence >= 0.5 ? "secondary" : "destructive";
   return (
-    <Badge variant={variant} className="text-[10px]">
-      {pct}%
+    <Badge variant={confidenceBadgeVariant(confidence)} className="text-[10px]">
+      {formatConfidencePct(confidence)}
     </Badge>
   );
 }
@@ -344,31 +367,30 @@ export function ActionProposalCard({ intent, onComplete, onCancel }: ActionPropo
             {t("ai.didYouMean")}
           </p>
           <div className="flex flex-wrap gap-1.5">
-            {displayedAlternatives.map((alt, index) => (
-              <button
-                key={alt.action}
-                type="button"
-                data-testid="proposal-alternative-pill"
-                data-action={alt.action}
-                onClick={() => handleSwapAlternative(index)}
-                className="flex items-center gap-1 rounded-full border bg-background px-2 py-0.5 text-[11px] transition-colors hover:bg-accent"
-                title={alt.explanation}
-              >
-                <span>{alt.action}</span>
-                <Badge
-                  variant={
-                    alt.confidence >= 0.8
-                      ? "default"
-                      : alt.confidence >= 0.5
-                        ? "secondary"
-                        : "destructive"
-                  }
-                  className="text-[10px]"
+            {displayedAlternatives.map((alt, index) => {
+              const altLabel = resolveTranslatableLabel(alt.actionLabel, alt.action, t);
+              return (
+                <button
+                  key={alt.action}
+                  type="button"
+                  data-testid="proposal-alternative-pill"
+                  data-action={alt.action}
+                  onClick={() => handleSwapAlternative(index)}
+                  aria-label={t("ai.swapAction", {
+                    action: altLabel,
+                    pct: formatConfidencePct(alt.confidence),
+                    defaultValue: `Switch to ${altLabel} (${formatConfidencePct(alt.confidence)})`,
+                  })}
+                  className="flex items-center gap-1 rounded-full border bg-background px-2 py-0.5 text-[11px] transition-colors hover:bg-accent"
+                  title={alt.explanation}
                 >
-                  {Math.round(alt.confidence * 100)}%
-                </Badge>
-              </button>
-            ))}
+                  <span>{altLabel}</span>
+                  <Badge variant={confidenceBadgeVariant(alt.confidence)} className="text-[10px]">
+                    {formatConfidencePct(alt.confidence)}
+                  </Badge>
+                </button>
+              );
+            })}
           </div>
         </div>
       )}

--- a/addons/adapter-ui/cap-adapter-ui/src/components/action-proposal-card.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/action-proposal-card.tsx
@@ -22,7 +22,12 @@ import {
 import { AlertTriangleIcon, CheckCircle2Icon, Loader2Icon, PlayIcon, XIcon } from "lucide-react";
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
-import type { ActionResult, IntentFieldSchema, IntentResolution } from "../lib/api";
+import type {
+  ActionResult,
+  IntentAlternative,
+  IntentFieldSchema,
+  IntentResolution,
+} from "../lib/api";
 import { executeAction } from "../lib/api";
 
 // ── Types ────────────────────────────────────────────────
@@ -35,6 +40,9 @@ export interface ActionProposalCardProps {
   onCancel?: () => void;
 }
 
+/** Maximum number of alternatives to render in the "Did you mean" section. */
+export const MAX_DISPLAYED_ALTERNATIVES = 3;
+
 function resolveTranslatableLabel(
   raw: string | undefined,
   fallback: string,
@@ -45,6 +53,63 @@ function resolveTranslatableLabel(
     return t(raw.slice(2), { defaultValue: fallback });
   }
   return raw;
+}
+
+// ── Pure swap helper (exported for unit testing) ─────────
+
+/**
+ * Swap an alternative at the given index into the primary slot.
+ *
+ * Returns a new `IntentResolution` whose primary is the chosen alternative
+ * and whose alternatives list contains:
+ *   - the previous primary (now reversible — the user can swap back),
+ *   - all other previous alternatives, in original order.
+ *
+ * The chosen alternative carries no display metadata of its own (the server
+ * only enriches the primary), so we synthesize minimal placeholders:
+ *   - `schema` and `actionLabel` fall back to the action name,
+ *   - `actionDescription` is dropped,
+ *   - `inputSchema` is empty (the user keeps the AI-extracted inputs as a
+ *     read-only summary; editing is disabled until the next round-trip).
+ *
+ * Returns `null` when `index` is out of range so callers can no-op safely.
+ */
+export function swapAlternative(current: IntentResolution, index: number): IntentResolution | null {
+  const alternatives = current.alternatives ?? [];
+  if (index < 0 || index >= alternatives.length) return null;
+
+  const chosen = alternatives[index];
+  if (!chosen) return null;
+
+  // Demote the previous primary into an alternative entry.
+  const previousPrimary: IntentAlternative = {
+    action: current.action,
+    input: current.input,
+    confidence: current.confidence,
+    missingFields: current.missingFields,
+    explanation: current.explanation,
+  };
+
+  // New alternatives = [previousPrimary, ...alternatives without chosen].
+  // Sort DESC by confidence so the highest-confidence alternative renders
+  // first regardless of swap history.
+  const remaining = alternatives.filter((_, i) => i !== index);
+  const nextAlternatives = [previousPrimary, ...remaining].sort(
+    (a, b) => b.confidence - a.confidence,
+  );
+
+  return {
+    action: chosen.action,
+    schema: chosen.action,
+    input: chosen.input,
+    missingFields: chosen.missingFields,
+    confidence: chosen.confidence,
+    explanation: chosen.explanation,
+    actionLabel: chosen.action,
+    actionDescription: undefined,
+    inputSchema: {},
+    alternatives: nextAlternatives,
+  };
 }
 
 // ── Field Editor ────────────────────────────────────────
@@ -161,6 +226,11 @@ function ConfidenceBadge({ confidence }: { confidence: number }) {
 export function ActionProposalCard({ intent, onComplete, onCancel }: ActionProposalCardProps) {
   const { t } = useTranslation();
   const [status, setStatus] = useState<ProposalStatus>("pending");
+  // Track current intent in state so alternatives can be swapped into the
+  // primary slot without a server round-trip. Initialized from the prop on
+  // first render only — subsequent prop changes are ignored to avoid clobbering
+  // user-driven swaps.
+  const [currentIntent, setCurrentIntent] = useState<IntentResolution>(intent);
   const [editedInput, setEditedInput] = useState<Record<string, unknown>>({ ...intent.input });
   const [_result, setResult] = useState<ActionResult | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -169,12 +239,23 @@ export function ActionProposalCard({ intent, onComplete, onCancel }: ActionPropo
     setEditedInput((prev) => ({ ...prev, [field]: value }));
   }, []);
 
+  const handleSwapAlternative = useCallback((index: number) => {
+    setCurrentIntent((prev) => {
+      const next = swapAlternative(prev, index);
+      if (!next) return prev;
+      // Reset edited inputs to the chosen alternative's AI-extracted inputs.
+      setEditedInput({ ...next.input });
+      setErrorMessage(null);
+      return next;
+    });
+  }, []);
+
   const handleExecute = useCallback(async () => {
     setStatus("executing");
     setErrorMessage(null);
 
     try {
-      const actionResult = await executeAction(intent.action, editedInput);
+      const actionResult = await executeAction(currentIntent.action, editedInput);
       setResult(actionResult);
 
       if (actionResult.success) {
@@ -189,7 +270,7 @@ export function ActionProposalCard({ intent, onComplete, onCancel }: ActionPropo
       setStatus("error");
       setErrorMessage(err instanceof Error ? err.message : t("ai.actionExecFailed"));
     }
-  }, [intent.action, editedInput, onComplete, t]);
+  }, [currentIntent.action, editedInput, onComplete, t]);
 
   const handleCancel = useCallback(() => {
     setStatus("cancelled");
@@ -197,8 +278,15 @@ export function ActionProposalCard({ intent, onComplete, onCancel }: ActionPropo
   }, [onCancel]);
 
   const isEditable = status === "pending";
-  const inputFields = Object.entries(intent.inputSchema);
-  const actionLabel = resolveTranslatableLabel(intent.actionLabel, intent.action, t);
+  const inputFields = Object.entries(currentIntent.inputSchema);
+  const actionLabel = resolveTranslatableLabel(currentIntent.actionLabel, currentIntent.action, t);
+
+  // Defensive sort + cap — backend already returns sorted N-best, but this
+  // guarantees the contract when swap mutates the list.
+  const displayedAlternatives = (currentIntent.alternatives ?? [])
+    .slice()
+    .sort((a, b) => b.confidence - a.confidence)
+    .slice(0, MAX_DISPLAYED_ALTERNATIVES);
 
   return (
     <div className="rounded-lg border bg-card text-card-foreground shadow-sm">
@@ -209,16 +297,18 @@ export function ActionProposalCard({ intent, onComplete, onCancel }: ActionPropo
             <PlayIcon className="size-3 text-primary" />
             <span className="text-xs font-semibold">{actionLabel}</span>
           </div>
-          <ConfidenceBadge confidence={intent.confidence} />
+          <ConfidenceBadge confidence={currentIntent.confidence} />
         </div>
-        {intent.actionDescription && (
-          <p className="mt-0.5 text-[11px] text-muted-foreground">{intent.actionDescription}</p>
+        {currentIntent.actionDescription && (
+          <p className="mt-0.5 text-[11px] text-muted-foreground">
+            {currentIntent.actionDescription}
+          </p>
         )}
       </div>
 
       {/* Explanation */}
       <div className="border-b px-3 py-2">
-        <p className="text-xs text-muted-foreground">{intent.explanation}</p>
+        <p className="text-xs text-muted-foreground">{currentIntent.explanation}</p>
       </div>
 
       {/* Input fields */}
@@ -238,12 +328,48 @@ export function ActionProposalCard({ intent, onComplete, onCancel }: ActionPropo
       )}
 
       {/* Missing fields warning */}
-      {intent.missingFields.length > 0 && status === "pending" && (
+      {currentIntent.missingFields.length > 0 && status === "pending" && (
         <div className="flex items-start gap-1.5 border-t px-3 py-2">
           <AlertTriangleIcon className="mt-0.5 size-3 text-amber-500 shrink-0" />
           <p className="text-[11px] text-amber-600">
-            {t("ai.missingFields")}: {intent.missingFields.join(", ")}
+            {t("ai.missingFields")}: {currentIntent.missingFields.join(", ")}
           </p>
+        </div>
+      )}
+
+      {/* Alternatives — "Did you mean" pills, only while pending */}
+      {displayedAlternatives.length > 0 && status === "pending" && (
+        <div className="border-t px-3 py-2" data-testid="proposal-alternatives">
+          <p className="mb-1.5 text-[11px] font-medium text-muted-foreground">
+            {t("ai.didYouMean")}
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            {displayedAlternatives.map((alt, index) => (
+              <button
+                key={alt.action}
+                type="button"
+                data-testid="proposal-alternative-pill"
+                data-action={alt.action}
+                onClick={() => handleSwapAlternative(index)}
+                className="flex items-center gap-1 rounded-full border bg-background px-2 py-0.5 text-[11px] transition-colors hover:bg-accent"
+                title={alt.explanation}
+              >
+                <span>{alt.action}</span>
+                <Badge
+                  variant={
+                    alt.confidence >= 0.8
+                      ? "default"
+                      : alt.confidence >= 0.5
+                        ? "secondary"
+                        : "destructive"
+                  }
+                  className="text-[10px]"
+                >
+                  {Math.round(alt.confidence * 100)}%
+                </Badge>
+              </button>
+            ))}
+          </div>
         </div>
       )}
 

--- a/addons/adapter-ui/cap-adapter-ui/src/components/ai-assistant.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/ai-assistant.tsx
@@ -36,7 +36,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { type ActionResult, type IntentResolution, isAiEnabled, resolveIntent } from "../lib/api";
-import { ActionProposalCard } from "./action-proposal-card";
+import { ActionProposalCard, MIN_PROPOSAL_CONFIDENCE } from "./action-proposal-card";
 
 // ── Proposal state ───────────────────────────────────────
 
@@ -153,7 +153,10 @@ export function AIAssistant({
           // attempts the general endpoint, which itself may also be down — but
           // that path produces its own error UI in the message stream.
           toast.error(t("ai.serviceUnavailable"));
-        } else if (result.kind === "proposal" && result.proposal.confidence >= 0.5) {
+        } else if (
+          result.kind === "proposal" &&
+          result.proposal.confidence >= MIN_PROPOSAL_CONFIDENCE
+        ) {
           setMessages((prev) => [...prev, createTextMessage("user", trimmed)]);
           const proposalId = crypto.randomUUID();
           setProposals((prev) => [...prev, { id: proposalId, intent: result.proposal }]);

--- a/addons/adapter-ui/cap-adapter-ui/src/components/ai-assistant.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/ai-assistant.tsx
@@ -20,6 +20,7 @@ import {
   SheetContent,
   SheetHeader,
   SheetTitle,
+  toast,
 } from "@linchkit/ui-kit/components";
 import { useParams } from "@tanstack/react-router";
 import type { UIMessage, UIMessagePart } from "ai";
@@ -146,21 +147,28 @@ export function AIAssistant({
         const result = await resolveIntent(trimmed, {
           entityFilter: params.name ? [params.name] : undefined,
         });
-        if (result && result.confidence >= 0.5) {
+        if (result.kind === "unavailable") {
+          // Spec 52 §1.1 — surface a non-blocking toast so 503 isn't silently
+          // swallowed. The user is informed and the chat fallback below still
+          // attempts the general endpoint, which itself may also be down — but
+          // that path produces its own error UI in the message stream.
+          toast.error(t("ai.serviceUnavailable"));
+        } else if (result.kind === "proposal" && result.proposal.confidence >= 0.5) {
           setMessages((prev) => [...prev, createTextMessage("user", trimmed)]);
           const proposalId = crypto.randomUUID();
-          setProposals((prev) => [...prev, { id: proposalId, intent: result }]);
+          setProposals((prev) => [...prev, { id: proposalId, intent: result.proposal }]);
           return;
         }
       } catch {
-        // AI intent resolution unavailable — fall back to general chat
+        // Transport-level error (network, non-503 non-2xx) — fall back to
+        // general chat. The unavailable-503 case is handled above.
       } finally {
         setIsResolvingIntent(false);
       }
     }
 
     sendMessage({ text: trimmed });
-  }, [isLoading, isResolvingIntent, params.name, sendMessage, setMessages]);
+  }, [isLoading, isResolvingIntent, params.name, sendMessage, setMessages, t]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
@@ -316,6 +316,7 @@
     "stop": "Stop",
     "resolvingIntent": "Detecting action intent...",
     "didYouMean": "Did you mean:",
+    "swapAction": "Switch to {{action}} ({{pct}})",
     "serviceUnavailable": "AI service unavailable. Please try again later.",
     "insights": {
       "title": "AI Insights",

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
@@ -315,6 +315,8 @@
     "missingFields": "Missing required fields",
     "stop": "Stop",
     "resolvingIntent": "Detecting action intent...",
+    "didYouMean": "Did you mean:",
+    "serviceUnavailable": "AI service unavailable. Please try again later.",
     "insights": {
       "title": "AI Insights",
       "analyze": "Analyze Record",

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
@@ -315,7 +315,8 @@
     "missingFields": "缺少必填字段",
     "stop": "停止",
     "resolvingIntent": "正在识别操作意图...",
-    "didYouMean": "你是不是想问：",
+    "didYouMean": "您是指：",
+    "swapAction": "切换到 {{action}}（{{pct}}）",
     "serviceUnavailable": "AI 服务暂时不可用，请稍后再试。",
     "insights": {
       "title": "AI 洞察",

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
@@ -315,6 +315,8 @@
     "missingFields": "缺少必填字段",
     "stop": "停止",
     "resolvingIntent": "正在识别操作意图...",
+    "didYouMean": "你是不是想问：",
+    "serviceUnavailable": "AI 服务暂时不可用，请稍后再试。",
     "insights": {
       "title": "AI 洞察",
       "analyze": "分析记录",

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/api.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/api.ts
@@ -666,6 +666,16 @@ export interface IntentAlternative {
   missingFields: string[];
   /** Human-readable summary suitable for UI display. */
   explanation: string;
+  /**
+   * Display metadata. Server-returned alternatives never carry these (the
+   * route only enriches the primary), but when the UI demotes a previous
+   * primary into the alternatives list it preserves the metadata here so
+   * swapping back is fully reversible (no degraded fields / labels).
+   */
+  schema?: string;
+  actionLabel?: string;
+  actionDescription?: string;
+  inputSchema?: Record<string, IntentFieldSchema>;
 }
 
 /** Result from AI intent resolution */

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/api.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/api.ts
@@ -644,6 +644,30 @@ export interface IntentFieldSchema {
   description?: string;
 }
 
+/**
+ * Bare alternative interpretation returned alongside a primary proposal.
+ *
+ * The server returns N-best alternatives sorted by confidence DESC (capped at
+ * 3) when the primary's confidence is below the AI provider's surfacing
+ * threshold. Each alternative is a bare `ActionProposal` from the resolver —
+ * the route enriches only the primary with display metadata, so alternatives
+ * carry no `actionLabel` / `inputSchema` of their own. When a user swaps an
+ * alternative into the primary slot the UI must look up its display metadata
+ * (label, description, input schema) on demand.
+ */
+export interface IntentAlternative {
+  /** Matched action name. */
+  action: string;
+  /** Pre-filled input parameters validated against the action's schema. */
+  input: Record<string, unknown>;
+  /** Confidence in [0, 1]. */
+  confidence: number;
+  /** Required fields the AI did not fill. */
+  missingFields: string[];
+  /** Human-readable summary suitable for UI display. */
+  explanation: string;
+}
+
 /** Result from AI intent resolution */
 export interface IntentResolution {
   action: string;
@@ -655,6 +679,8 @@ export interface IntentResolution {
   actionLabel: string;
   actionDescription?: string;
   inputSchema: Record<string, IntentFieldSchema>;
+  /** Optional N-best alternatives surfaced when primary confidence is low. */
+  alternatives?: IntentAlternative[];
 }
 
 /** Optional scoping mirrors the server's `ResolveIntentInput.scope`. */
@@ -666,20 +692,39 @@ export interface ResolveIntentScope {
 }
 
 /**
+ * Discriminated result of `resolveIntent`.
+ *
+ * Three outcomes need to be distinguished by the caller:
+ *
+ *  - `{ kind: "proposal" }` — the server returned a usable proposal; render
+ *    the Action Proposal Card.
+ *  - `{ kind: "unavailable" }` — the server returned 503 (AI not configured
+ *    or upstream provider unreachable); the caller should surface a
+ *    non-blocking toast/banner instead of silently falling through.
+ *  - `{ kind: "no-match" }` — the server returned 200 with `proposal: null`
+ *    (no usable match for the prompt); the caller should fall back to the
+ *    general chat endpoint.
+ */
+export type ResolveIntentResult =
+  | { kind: "proposal"; proposal: IntentResolution }
+  | { kind: "unavailable" }
+  | { kind: "no-match" };
+
+/**
  * Resolve a natural-language prompt to an action intent.
  *
  * Wire contract (Spec 52 §2.6 — POST /api/ai/resolve-intent):
  *   request:  { prompt, scope? }
  *   response: { proposal: ActionProposalView | null }
  *
- * Returns null when:
- *   - AI is not configured (server returns 503).
- *   - No usable proposal could be produced (server returns 200 + null).
+ * Returns a discriminated `ResolveIntentResult` so callers can distinguish
+ * "no usable match" (200 + null) from "service unavailable" (503). Network
+ * errors and other non-2xx responses still throw.
  */
 export async function resolveIntent(
   prompt: string,
   scope?: ResolveIntentScope,
-): Promise<IntentResolution | null> {
+): Promise<ResolveIntentResult> {
   const res = await fetch("/api/ai/resolve-intent", {
     method: "POST",
     headers: { "Content-Type": "application/json", ...getAuthHeaders() },
@@ -687,15 +732,19 @@ export async function resolveIntent(
   });
   handleUnauthorized(res);
   if (res.status === 503) {
-    // Graceful degradation per Spec 52 §1.1 — caller treats null as
-    // "AI unavailable" and surfaces the appropriate UX.
-    return null;
+    // Graceful degradation per Spec 52 §1.1 — caller surfaces the
+    // appropriate "AI unavailable" UX (toast / banner).
+    return { kind: "unavailable" };
   }
   if (!res.ok) {
     throw new Error("AI intent resolution failed");
   }
   const json = await res.json();
-  return (json.proposal as IntentResolution | null) ?? null;
+  const proposal = (json.proposal as IntentResolution | null | undefined) ?? null;
+  if (!proposal) {
+    return { kind: "no-match" };
+  }
+  return { kind: "proposal", proposal };
 }
 
 // ── Chatter ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes the UX gap from #272 (which shipped backend N-best alternatives + `intent_resolution` audit kind). Frontend now consumes the `alternatives` field and surfaces 503 (AI unavailable) instead of silently swallowing it.

- `IntentResolution` gains `alternatives?: IntentAlternative[]`; `resolveIntent` returns a discriminated `ResolveIntentResult` (`proposal` / `unavailable` / `no-match`).
- `ActionProposalCard` renders a "Did you mean" section with up to 3 alternatives sorted DESC by confidence. Clicking swaps the chosen alternative into the primary slot; the previous primary is demoted into alternatives **with full display metadata preserved** so the swap is fully reversible (no degraded labels / fields after swap-back).

## Wiring

- `ai-assistant.tsx` switches on the discriminated result and triggers `toast.error(t("ai.serviceUnavailable"))` on the `unavailable` branch (Spec 52 §2.6 graceful fallback).
- New i18n keys in en + zh-CN: `ai.didYouMean`, `ai.swapAction` (pill aria-label), `ai.serviceUnavailable`.
- `formatConfidencePct` / `confidenceBadgeVariant` defensively handle non-finite confidence values (renders `—` instead of `NaN%`).

## Known limitation (follow-up worthy)

The route currently only enriches the primary with display metadata — server-returned alternatives are bare `ActionProposal`s. So when the user swaps a server-returned alternative in, `swapAlternative` synthesizes minimal placeholders (`actionLabel = action`, empty `inputSchema`); field editing on a swapped alternative is disabled until the next round-trip. A future change can enrich alternatives server-side. Note: round-trip from a previous-primary IS non-lossy because we store its metadata when demoting.

## Cross-model review

gemini round 1 raised: lossy reversibility (SHOULD), NaN% (NIT), missing aria-label (NIT), awkward zh-CN copy (NIT). All addressed in the fix-up commit. Round 2 verified.

## Test plan

- [x] action-proposal-card tests: 14 pass / 0 fail / 56 expect
- [x] Full UI suite: 313 pass / 0 fail (22 files)
- [x] typecheck clean
- [x] lint check clean

## Test infra note

The cap-adapter-ui package has no happy-dom / RTL today (existing tests are logic-only). Per existing convention, swap behavior is extracted into a pure exported helper (`swapAlternative`) and unit-tested for every observable transition. Adding RTL is a separate infra ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Did you mean" alternative action suggestions, allowing users to instantly swap between proposed actions without server round-trips
  * Improved confidence display with visual indicators and threshold-based formatting

* **Bug Fixes**
  * Added user-friendly error notification when the AI service is temporarily unavailable

* **Tests**
  * Added comprehensive test coverage for alternative action swapping and intent resolution

* **Chores**
  * Extended localization support (English and Chinese)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->