### PR TITLE
feat(adapter-server): enrich N-best alternatives with display metadata (refs #78)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/src/routes/__tests__/ai-intent.test.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/__tests__/ai-intent.test.ts
@@ -22,6 +22,7 @@ import {
 } from "@linchkit/core/server";
 import { buildGraphQLSchema } from "../../graphql/build-schema";
 import { createServer } from "../../server";
+import { enrichProposal } from "../ai-resolve-intent";
 
 // ── Schemas ───────────────────────────────────────────────
 
@@ -79,6 +80,25 @@ const createConfidentialAction: ActionDefinition = {
   },
 };
 
+/** Second purchase-request action — used as an alternative target in tests. */
+const updatePurchaseAction: ActionDefinition = {
+  name: "update_purchase_request",
+  entity: "purchase_request",
+  label: "Update Purchase Request",
+  description: "Updates an existing purchase request",
+  input: {
+    id: { type: "string", required: true, label: "Request ID" },
+    title: { type: "string", label: "Title" },
+    amount: { type: "number", label: "Amount" },
+  },
+  policy: { mode: "sync", transaction: false },
+  exposure: "all",
+  handler: async (ctx) => {
+    const { id, ...rest } = ctx.input as { id: string; [k: string]: unknown };
+    return ctx.update("purchase_request", id, rest);
+  },
+};
+
 // ── Mock AI service factory ───────────────────────────────
 
 function createMockAIService(responseContent: string): AIService {
@@ -114,6 +134,7 @@ function buildTestServer(aiService: AIService): {
 
   executor.registry.register(createPurchaseAction);
   executor.registry.register(createConfidentialAction);
+  executor.registry.register(updatePurchaseAction);
 
   const entityRegistry = new EntityRegistry();
   entityRegistry.register(purchaseRequestSchema);
@@ -123,6 +144,7 @@ function buildTestServer(aiService: AIService): {
   const actionRegistry = new ActionRegistry();
   actionRegistry.register(createPurchaseAction);
   actionRegistry.register(createConfidentialAction);
+  actionRegistry.register(updatePurchaseAction);
   const ontology = createOntologyRegistry({
     schemas: entityRegistry,
     actions: actionRegistry,
@@ -306,5 +328,248 @@ describe("Schema AI config", () => {
     });
     expect(status).toBe(200);
     expect((body as { success: boolean }).success).toBe(true);
+  });
+});
+
+// ── Tests: alternatives enrichment (issue #78 follow-up) ─────
+
+/**
+ * Wire-format envelope assertions for alternatives carried alongside the
+ * primary proposal. The route enriches alternatives with the same display
+ * metadata as the primary so the UI can swap one into the primary slot
+ * without a second round-trip.
+ */
+
+interface EnrichedAlternative {
+  action: string;
+  input: Record<string, unknown>;
+  confidence: number;
+  missingFields: string[];
+  explanation: string;
+  schema: string;
+  actionLabel: string;
+  actionDescription?: string;
+  inputSchema: Record<string, { type: string; required: boolean; label?: string }>;
+}
+
+interface EnrichedProposal {
+  action: string;
+  schema: string;
+  actionLabel: string;
+  actionDescription?: string;
+  inputSchema: Record<string, unknown>;
+  confidence: number;
+  alternatives?: EnrichedAlternative[];
+}
+
+describe("POST /api/ai/resolve-intent — alternatives enrichment", () => {
+  /**
+   * Build a port-isolated server whose mock AI returns the given JSON string.
+   * Mirrors the inline server pattern used by the 503 test above.
+   */
+  function buildServerWithMock(port: number, mockJson: string) {
+    const { server } = buildTestServer(createMockAIService(mockJson));
+    server.listen(port);
+    return server;
+  }
+
+  test("alternative with valid scoped action is enriched with full display metadata", async () => {
+    const PORT3 = PORT + 10;
+    const mock = JSON.stringify({
+      // Primary confidence below ALTERNATIVES_CONFIDENCE_THRESHOLD (0.7) so
+      // the resolver actually surfaces alternatives.
+      action: "create_purchase_request",
+      input: { title: "Laptops", amount: 5000 },
+      confidence: 0.55,
+      explanation: "Maybe create a purchase request.",
+      alternatives: [
+        {
+          action: "update_purchase_request",
+          input: { id: "PR-1", amount: 5000 },
+          confidence: 0.5,
+          explanation: "Or update the existing one.",
+        },
+      ],
+    });
+    const app = buildServerWithMock(PORT3, mock);
+    try {
+      const { status, body } = await post(
+        "/api/ai/resolve-intent",
+        { prompt: "Order laptops" },
+        PORT3,
+      );
+      expect(status).toBe(200);
+      const proposal = (body as { proposal: EnrichedProposal | null }).proposal;
+      if (!proposal) throw new Error("expected proposal");
+      expect(proposal.alternatives).toBeDefined();
+      const alternatives = proposal.alternatives ?? [];
+      expect(alternatives.length).toBe(1);
+
+      const alt = alternatives[0];
+      if (!alt) throw new Error("expected alternative");
+      expect(alt.action).toBe("update_purchase_request");
+      // Display metadata mirrors the primary's enrichment shape.
+      expect(alt.schema).toBe("purchase_request");
+      expect(alt.actionLabel).toBe("Update Purchase Request");
+      expect(alt.actionDescription).toBe("Updates an existing purchase request");
+      expect(alt.inputSchema).toBeDefined();
+      // Input schema should reflect the action's defined fields (id required).
+      expect(alt.inputSchema.id?.required).toBe(true);
+      expect(alt.inputSchema.id?.type).toBe("string");
+    } finally {
+      app.stop();
+    }
+  });
+
+  test("alternatives are sorted DESC by confidence after enrichment", async () => {
+    const PORT3 = PORT + 11;
+    // AI returns alternatives in scrambled order; the route must hand back a
+    // confidence-DESC list. The resolver itself already sorts but filtering
+    // could shift positions, so the route's defensive resort matters.
+    const mock = JSON.stringify({
+      action: "create_purchase_request",
+      input: {},
+      confidence: 0.5,
+      explanation: "Low-confidence primary.",
+      alternatives: [
+        {
+          action: "update_purchase_request",
+          input: { id: "PR-1" },
+          confidence: 0.45,
+          explanation: "lower",
+        },
+        {
+          action: "create_confidential_report",
+          input: {},
+          confidence: 0.6,
+          explanation: "higher",
+        },
+      ],
+    });
+    const app = buildServerWithMock(PORT3, mock);
+    try {
+      const { body } = await post("/api/ai/resolve-intent", { prompt: "ambiguous" }, PORT3);
+      const proposal = (body as { proposal: EnrichedProposal | null }).proposal;
+      if (!proposal) throw new Error("expected proposal");
+      const alternatives = proposal.alternatives ?? [];
+      // Both alternative actions are in the scoped ontology so both survive.
+      expect(alternatives.length).toBe(2);
+      // DESC by confidence — the higher-confidence one comes first.
+      expect(alternatives[0]?.confidence).toBeGreaterThanOrEqual(alternatives[1]?.confidence ?? 0);
+    } finally {
+      app.stop();
+    }
+  });
+
+  test("alternatives field is omitted when the resolver returns none", async () => {
+    // Primary at high confidence (>= 0.7) — resolver does not surface
+    // alternatives. The wire envelope must omit the field entirely (not
+    // emit `alternatives: []`), matching the resolver's own "omit when
+    // empty" convention.
+    const { body } = await post("/api/ai/resolve-intent", {
+      prompt: "Create a purchase request for laptops",
+    });
+    const proposal = (body as { proposal: EnrichedProposal | null }).proposal;
+    if (!proposal) throw new Error("expected proposal");
+    expect("alternatives" in proposal).toBe(false);
+  });
+
+  test("hallucination defense: alternative whose action is not in the scoped ontology is dropped", () => {
+    // Unit-level test for the route's enrichProposal exit gate. The resolver
+    // also filters unknown alternatives, so this is defense-in-depth — but
+    // we want the route to NEVER echo a half-enriched alternative whose
+    // action the user can't see (same rule as the primary).
+    const purchaseAction: ActionDefinition = createPurchaseAction;
+    const updateAction: ActionDefinition = updatePurchaseAction;
+    const ontology = {
+      listEntities: () => ["purchase_request"],
+      actionsFor: (entity: string) =>
+        entity === "purchase_request" ? [purchaseAction, updateAction] : [],
+    };
+
+    const enriched = enrichProposal(
+      {
+        action: "create_purchase_request",
+        input: {},
+        confidence: 0.5,
+        missingFields: [],
+        explanation: "primary",
+        alternatives: [
+          {
+            action: "update_purchase_request",
+            input: {},
+            confidence: 0.45,
+            missingFields: [],
+            explanation: "valid alt",
+          },
+          {
+            action: "delete_everything", // not in the scoped ontology
+            input: {},
+            confidence: 0.49,
+            missingFields: [],
+            explanation: "hallucinated",
+          },
+        ],
+      },
+      ontology,
+    );
+    if (!enriched) throw new Error("expected enriched proposal");
+    expect(enriched.alternatives).toBeDefined();
+    expect(enriched.alternatives?.length).toBe(1);
+    expect(enriched.alternatives?.[0]?.action).toBe("update_purchase_request");
+  });
+
+  test("hallucination defense: alternatives field is omitted when filtering drops every entry", () => {
+    const purchaseAction: ActionDefinition = createPurchaseAction;
+    const ontology = {
+      listEntities: () => ["purchase_request"],
+      actionsFor: (entity: string) => (entity === "purchase_request" ? [purchaseAction] : []),
+    };
+
+    const enriched = enrichProposal(
+      {
+        action: "create_purchase_request",
+        input: {},
+        confidence: 0.5,
+        missingFields: [],
+        explanation: "primary",
+        alternatives: [
+          {
+            action: "ghost_action",
+            input: {},
+            confidence: 0.45,
+            missingFields: [],
+            explanation: "all hallucinated",
+          },
+        ],
+      },
+      ontology,
+    );
+    if (!enriched) throw new Error("expected enriched proposal");
+    // No usable alternatives → field is omitted (matches the resolver's
+    // existing "omit when empty" convention).
+    expect("alternatives" in enriched).toBe(false);
+  });
+
+  test("empty alternatives input produces no alternatives field on the wire", () => {
+    const purchaseAction: ActionDefinition = createPurchaseAction;
+    const ontology = {
+      listEntities: () => ["purchase_request"],
+      actionsFor: (entity: string) => (entity === "purchase_request" ? [purchaseAction] : []),
+    };
+
+    const enriched = enrichProposal(
+      {
+        action: "create_purchase_request",
+        input: {},
+        confidence: 0.92,
+        missingFields: [],
+        explanation: "primary",
+        // alternatives intentionally absent — primary above threshold.
+      },
+      ontology,
+    );
+    if (!enriched) throw new Error("expected enriched proposal");
+    expect("alternatives" in enriched).toBe(false);
   });
 });

--- a/addons/adapter-server/cap-adapter-server/src/routes/ai-resolve-intent.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/ai-resolve-intent.ts
@@ -397,9 +397,7 @@ export function enrichProposal(
     actionLabel: primaryAction.label ?? primaryAction.name,
     actionDescription: primaryAction.description,
     inputSchema: buildInputSchema(primaryAction),
-    ...(enrichedAlternatives && enrichedAlternatives.length > 0
-      ? { alternatives: enrichedAlternatives }
-      : {}),
+    ...(enrichedAlternatives ? { alternatives: enrichedAlternatives } : {}),
   };
 }
 
@@ -443,10 +441,10 @@ function enrichAlternatives(
 
   if (enriched.length === 0) return undefined;
 
-  // Defensive DESC-by-confidence sort — the resolver already returns
-  // alternatives sorted, but filtering above may have shifted positions and
-  // the wire contract is "highest-confidence first".
-  enriched.sort((a, b) => b.confidence - a.confidence);
+  // Order is preserved from the resolver, which already sorts DESC by
+  // confidence in `reconcileAlternatives`. Iteration above only appends —
+  // filtering cannot rearrange surviving entries — so no extra sort is
+  // needed here.
   return enriched;
 }
 

--- a/addons/adapter-server/cap-adapter-server/src/routes/ai-resolve-intent.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/ai-resolve-intent.ts
@@ -308,7 +308,7 @@ export function mountResolveIntentRoute(app: Elysia, options: ServerOptions): vo
 // ── Response enrichment ─────────────────────────────────────
 
 /** Wire-format proposal: bare resolver output plus action display metadata. */
-export interface ActionProposalView extends ActionProposal {
+export interface ActionProposalView extends Omit<ActionProposal, "alternatives"> {
   /** Entity name the matched action operates on. */
   schema: string;
   /** Human-readable action label (from `defineAction({ label })`). */
@@ -316,6 +316,30 @@ export interface ActionProposalView extends ActionProposal {
   /** Optional human-readable action description. */
   actionDescription?: string;
   /** Input parameter descriptors suitable for rendering a confirmation form. */
+  inputSchema: Record<string, IntentFieldSchema>;
+  /**
+   * Alternatives enriched with the same display metadata as the primary, so
+   * the UI can swap one into the primary slot without a second round-trip.
+   * Filtered against the scoped ontology (hallucination defense — same rule
+   * as the primary). Omitted when no usable alternatives remain.
+   */
+  alternatives?: IntentAlternativeView[];
+}
+
+/**
+ * Wire-format alternative: bare resolver alternative plus action display
+ * metadata. Mirrors `ActionProposalView` minus the recursive `alternatives`
+ * field (alternatives never themselves carry alternatives).
+ */
+export interface IntentAlternativeView {
+  action: string;
+  input: Record<string, unknown>;
+  confidence: number;
+  missingFields: string[];
+  explanation: string;
+  schema: string;
+  actionLabel: string;
+  actionDescription?: string;
   inputSchema: Record<string, IntentFieldSchema>;
 }
 
@@ -328,27 +352,31 @@ export interface IntentFieldSchema {
   description?: string;
 }
 
-function enrichProposal(
+/**
+ * Build a one-pass `name -> ActionDefinition` index over the (already scoped)
+ * ontology. Used for O(1) lookups during proposal + alternatives enrichment
+ * instead of repeated linear scans.
+ */
+function buildScopedActionIndex(ontology: OntologyRegistryLike): Map<string, ActionDefinition> {
+  const index = new Map<string, ActionDefinition>();
+  for (const entityName of ontology.listEntities()) {
+    for (const action of ontology.actionsFor(entityName)) {
+      // First-write-wins: the resolver de-dupes by name across entities and
+      // we mirror that here so primary + alternatives see the same action.
+      if (!index.has(action.name)) index.set(action.name, action);
+    }
+  }
+  return index;
+}
+
+export function enrichProposal(
   proposal: ActionProposal | null,
   ontology: OntologyRegistryLike,
 ): ActionProposalView | null {
   if (!proposal) return null;
 
-  // Find the matched action in the (scoped) ontology so we never disclose
-  // metadata for an action the user can't see.
-  for (const entityName of ontology.listEntities()) {
-    for (const action of ontology.actionsFor(entityName)) {
-      if (action.name === proposal.action) {
-        return {
-          ...proposal,
-          schema: action.entity,
-          actionLabel: action.label ?? action.name,
-          actionDescription: action.description,
-          inputSchema: buildInputSchema(action),
-        };
-      }
-    }
-  }
+  const actionIndex = buildScopedActionIndex(ontology);
+  const primaryAction = actionIndex.get(proposal.action);
 
   // Spec 52 §1.1 hard rule: "AI sees only what the current user can see."
   // The resolver's catalog-allowlist should already drop proposals outside
@@ -356,7 +384,70 @@ function enrichProposal(
   // hallucinated action name (whether from prompt injection or a stale
   // training corpus) cannot be confirmed back to the caller. Returning null
   // is the same as "no usable match" from the resolver's own perspective.
-  return null;
+  if (!primaryAction) return null;
+
+  // Strip the bare `alternatives` from the primary spread — we replace it
+  // with the enriched list (or omit when empty) below.
+  const { alternatives: rawAlternatives, ...primaryRest } = proposal;
+  const enrichedAlternatives = enrichAlternatives(rawAlternatives, actionIndex);
+
+  return {
+    ...primaryRest,
+    schema: primaryAction.entity,
+    actionLabel: primaryAction.label ?? primaryAction.name,
+    actionDescription: primaryAction.description,
+    inputSchema: buildInputSchema(primaryAction),
+    ...(enrichedAlternatives && enrichedAlternatives.length > 0
+      ? { alternatives: enrichedAlternatives }
+      : {}),
+  };
+}
+
+/**
+ * Enrich each alternative with the same display metadata as the primary.
+ *
+ * Filtering rules (mirror the primary's hallucination-defense exit gate):
+ *  - Drop alternatives whose action is NOT in the scoped ontology (never echo
+ *    a half-enriched placeholder — the user must not be able to confirm an
+ *    action they can't see).
+ *  - Preserve resolver order beyond a defensive DESC-by-confidence resort —
+ *    filtering may have changed cardinality but not which alternatives are
+ *    most relevant.
+ *
+ * Returns `undefined` when the input list is empty/missing or filtering
+ * dropped every entry, matching the resolver's own "omit field when empty"
+ * convention so the wire envelope stays uniform.
+ */
+function enrichAlternatives(
+  rawAlternatives: ActionProposal[] | undefined,
+  actionIndex: Map<string, ActionDefinition>,
+): IntentAlternativeView[] | undefined {
+  if (!rawAlternatives || rawAlternatives.length === 0) return undefined;
+
+  const enriched: IntentAlternativeView[] = [];
+  for (const alt of rawAlternatives) {
+    const action = actionIndex.get(alt.action);
+    if (!action) continue;
+    enriched.push({
+      action: alt.action,
+      input: alt.input,
+      confidence: alt.confidence,
+      missingFields: alt.missingFields,
+      explanation: alt.explanation,
+      schema: action.entity,
+      actionLabel: action.label ?? action.name,
+      actionDescription: action.description,
+      inputSchema: buildInputSchema(action),
+    });
+  }
+
+  if (enriched.length === 0) return undefined;
+
+  // Defensive DESC-by-confidence sort — the resolver already returns
+  // alternatives sorted, but filtering above may have shifted positions and
+  // the wire contract is "highest-confidence first".
+  enriched.sort((a, b) => b.confidence - a.confidence);
+  return enriched;
 }
 
 function buildInputSchema(action: ActionDefinition): Record<string, IntentFieldSchema> {


### PR DESCRIPTION
## Summary

Closes the known limitation flagged in PR #275: when the user swaps a server-returned alternative into the primary slot of the Action Proposal Card, the alternative now carries the same display metadata as the primary, so field editing stays unlocked without waiting for the next round-trip.

## Wire shape

Per-alternative shape under `proposal.alternatives[]`:
```ts
{
  action: string,
  input: Record<string, unknown>,
  confidence: number,
  missingFields: string[],
  explanation: string,
  schema: string,            // entity name
  actionLabel: string,
  actionDescription?: string,
  inputSchema: Record<string, IntentFieldSchema>,
}
```
Identical to the primary's enriched shape (alternatives never themselves carry alternatives — matches the resolver's `aiAlternativeSchema`).

## Wiring

- `enrichProposal` extended to also enrich `proposal.alternatives` via a new `enrichAlternatives` helper. Uses a one-pass `name → ActionDefinition` index for O(1) lookup.
- `enrichAlternatives` filters alternatives whose action is not in the scoped ontology (same hallucination defense as the primary), sorts DESC by confidence (defensive — provider already does), and omits the field if all are filtered out.
- `ActionProposalView` re-types `alternatives?: IntentAlternativeView[]`.
- `enrichProposal` exported as a test seam.
- `buildInputSchema` and `extractFieldOptions` reused unchanged for both primary and alternatives — no duplication.

## Tests

6 new tests in `addons/adapter-server/cap-adapter-server/src/routes/__tests__/ai-intent.test.ts`:
- HTTP enrichment of a valid alternative
- HTTP DESC-by-confidence sort preserved
- HTTP omit-when-empty
- Unit-level hallucination defense (drops out-of-scope alt, keeps valid one)
- Unit-level omit-when-all-filtered
- Unit-level empty-input → no field

## Cross-model review

gemini round 1 reported zero CRITICAL / SHOULD. One NIT about duplicate action names across entities — LinchKit's convention is verb_noun globally unique, so first-write-wins is correct.

## Test plan

- [x] `bun test addons/adapter-server/cap-adapter-server/src/routes/__tests__/ai-intent.test.ts` — 15 pass / 0 fail / 42 expect (9 pre-existing + 6 new)
- [x] `bun run typecheck` — clean
- [x] `bun run check` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)