### PR TITLE
feat(core): EvolutionCycle wires Insight → Proposal end-to-end (Spec 55 §7, closes #88)

### DIFF
--- a/packages/core/src/life-system/__tests__/evolution-cycle.test.ts
+++ b/packages/core/src/life-system/__tests__/evolution-cycle.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import type { EntityDescriptor, OntologyRegistry } from "../../ontology/ontology-registry";
-import type { SensorSignal } from "../../types/life-system";
+import type { Insight, SensorSignal } from "../../types/life-system";
+import { createAttentionBudget } from "../attention-budget";
 import { createAwarenessEngine } from "../awareness-engine";
 import { defineSensor } from "../define-sensor";
 import { createEvolutionCycle } from "../evolution-cycle";
 import { InMemoryMemoryStore } from "../in-memory-memory-store";
+import {
+  createDefaultInsightTranslatorRegistry,
+  createInsightTranslatorRegistry,
+} from "../insight-to-proposal";
 import { MemoryEngine } from "../memory-engine";
 import { createSignalBus } from "../signal-bus";
 
@@ -251,5 +256,147 @@ describe("EvolutionCycle", () => {
     expect(cycle.insightEngine).toBeDefined();
     expect(cycle.awarenessEngine).toBeDefined();
     expect(cycle.awarenessEngine.usageGraph).toBeDefined();
+  });
+
+  // ── Slice 3: Insight → Proposal wiring (Spec 55 §7) ──────
+
+  test("without translator registry: returns empty proposals (regression)", async () => {
+    // Entity with no view → structural insight surfaces. Without a registry
+    // the cycle must NOT emit any proposals — pre-Slice-3 behavior preserved.
+    const signalBus = createSignalBus();
+    const memoryEngine = new MemoryEngine({
+      store: new InMemoryMemoryStore(),
+      driftThreshold: 0.3,
+    });
+    const ontology = makeOntology({ Order: { views: [], actions: [] } });
+    const awareness = createAwarenessEngine({ ontology });
+    const cycle = createEvolutionCycle({ signalBus, memoryEngine, awareness });
+
+    const result = await cycle.runCycle();
+
+    expect(result.newInsights.some((i) => i.type === "structural")).toBe(true);
+    expect(result.proposals).toEqual([]);
+  });
+
+  test("with default translator: structural schema_no_view surfaces a proposal", async () => {
+    const signalBus = createSignalBus();
+    const memoryEngine = new MemoryEngine({
+      store: new InMemoryMemoryStore(),
+      driftThreshold: 0.3,
+    });
+    // Order has no views and one field so the translator can enrich the
+    // default view from the ontology.
+    const ontology = makeOntology({
+      Order: { views: [], actions: [], fields: { id: { type: "string" } } as never },
+    });
+    const awareness = createAwarenessEngine({ ontology });
+    const cycle = createEvolutionCycle({
+      signalBus,
+      memoryEngine,
+      awareness,
+      translatorRegistry: createDefaultInsightTranslatorRegistry(),
+      ontology,
+      proposalCapability: "test-cap",
+    });
+
+    const result = await cycle.runCycle();
+
+    expect(result.newInsights.some((i) => i.type === "structural")).toBe(true);
+    expect(result.proposals).toHaveLength(1);
+
+    const proposal = result.proposals[0];
+    if (!proposal) throw new Error("expected proposal");
+    expect(proposal.capability).toBe("test-cap");
+    expect(proposal.changes).toHaveLength(1);
+    const change = proposal.changes[0];
+    if (!change) throw new Error("expected change");
+    expect(change.target).toBe("view");
+    expect(change.operation).toBe("create");
+    // Trace: proposal description echoes insight summary.
+    const sourceInsight = result.newInsights.find((i) => i.type === "structural");
+    if (!sourceInsight) throw new Error("expected structural insight");
+    expect(proposal.description).toBe(sourceInsight.summary);
+  });
+
+  test("budget caps surfaced insights AND proposals match surfaced only", async () => {
+    // Three entities each missing a view → three structural insights. Cap
+    // the budget at maxInsightsPerCycle=2 and assert: exactly two insights
+    // surface this cycle, exactly two proposals are emitted, and the
+    // proposals correspond 1:1 to the surfaced (not budget-dropped) insights.
+    const signalBus = createSignalBus();
+    const memoryEngine = new MemoryEngine({
+      store: new InMemoryMemoryStore(),
+      driftThreshold: 0.3,
+    });
+    const ontology = makeOntology({
+      Alpha: { views: [], actions: [] },
+      Beta: { views: [], actions: [] },
+      Gamma: { views: [], actions: [] },
+    });
+    const cappedBudget = createAttentionBudget({ maxInsightsPerCycle: 2 });
+    const awareness = createAwarenessEngine({
+      ontology,
+      attentionBudget: cappedBudget,
+    });
+    const cycle = createEvolutionCycle({
+      signalBus,
+      memoryEngine,
+      awareness,
+      translatorRegistry: createDefaultInsightTranslatorRegistry(),
+      // ontology intentionally omitted — translator falls back to empty
+      // field list, keeping this test focused on the budget/proposal-pairing
+      // contract instead of view enrichment.
+    });
+
+    const result = await cycle.runCycle();
+
+    expect(result.newInsights).toHaveLength(2);
+    expect(result.proposals).toHaveLength(2);
+
+    // Every emitted proposal must reference one of the surfaced insights'
+    // entities — the budget-dropped insight must not have produced a proposal.
+    const surfacedEntities = new Set(result.newInsights.map((i) => i.entity));
+    for (const proposal of result.proposals) {
+      const change = proposal.changes[0];
+      if (!change) throw new Error("expected change");
+      const view = change.definition as { entity: string };
+      expect(surfacedEntities.has(view.entity)).toBe(true);
+    }
+
+    // Total promoted insights still 3 — the dropped one stays in the
+    // unsurfaced pool for a future cycle (InsightEngine internal contract).
+    expect(result.totalInsights).toBe(3);
+  });
+
+  test("translator that declines: insight surfaces, no proposal emitted", async () => {
+    const signalBus = createSignalBus();
+    const memoryEngine = new MemoryEngine({
+      store: new InMemoryMemoryStore(),
+      driftThreshold: 0.3,
+    });
+    const ontology = makeOntology({ Order: { views: [], actions: [] } });
+    const awareness = createAwarenessEngine({ ontology });
+
+    // A registry whose lone translator always declines. We register it on
+    // the structural:schema_no_view key so the dispatcher reaches it.
+    const decliningRegistry = createInsightTranslatorRegistry();
+    let declineCalls = 0;
+    decliningRegistry.register("structural:schema_no_view", (_insight: Insight) => {
+      declineCalls++;
+      return null;
+    });
+
+    const cycle = createEvolutionCycle({
+      signalBus,
+      memoryEngine,
+      awareness,
+      translatorRegistry: decliningRegistry,
+    });
+
+    const result = await cycle.runCycle();
+
+    expect(result.newInsights.some((i) => i.type === "structural")).toBe(true);
+    expect(declineCalls).toBeGreaterThanOrEqual(1);
+    expect(result.proposals).toEqual([]);
   });
 });

--- a/packages/core/src/life-system/__tests__/evolution-cycle.test.ts
+++ b/packages/core/src/life-system/__tests__/evolution-cycle.test.ts
@@ -299,7 +299,11 @@ describe("EvolutionCycle", () => {
       proposalCapability: "test-cap",
     });
 
-    const result = await cycle.runCycle();
+    // Pin the cycle to a known signal-time so we can assert the proposal's
+    // createdAt was stamped from sensorContext.timestamp (not from the
+    // wall clock).
+    const cycleTimestamp = new Date("2026-05-08T00:00:00.000Z");
+    const result = await cycle.runCycle({ timestamp: cycleTimestamp });
 
     expect(result.newInsights.some((i) => i.type === "structural")).toBe(true);
     expect(result.proposals).toHaveLength(1);
@@ -316,6 +320,10 @@ describe("EvolutionCycle", () => {
     const sourceInsight = result.newInsights.find((i) => i.type === "structural");
     if (!sourceInsight) throw new Error("expected structural insight");
     expect(proposal.description).toBe(sourceInsight.summary);
+    // Proposal createdAt inherits sensorContext.timestamp so historical
+    // replay and fixed-clock tests reproduce identical proposals.
+    expect(proposal.createdAt.getTime()).toBe(cycleTimestamp.getTime());
+    expect(proposal.updatedAt.getTime()).toBe(cycleTimestamp.getTime());
   });
 
   test("budget caps surfaced insights AND proposals match surfaced only", async () => {

--- a/packages/core/src/life-system/evolution-cycle.ts
+++ b/packages/core/src/life-system/evolution-cycle.ts
@@ -1,23 +1,34 @@
 /**
  * EvolutionCycle — end-to-end orchestrator (Spec 55 §2.2).
  *
- * Wires the full pipeline: Sense → Memory → Awareness → Insight.
+ * Wires the full pipeline: Sense → Memory → Awareness → Insight → Proposal.
  * A single `runCycle()` call:
  *   1. Collects signals from all registered sensors (SignalBus)
  *   2. Ingests each signal into Memory (MemoryEngine)
  *   3. Feeds each signal into Awareness (AwarenessEngine)
  *   4. Detects drift and records candidates (MemoryEngine → InsightEngine)
- *   5. Generates and promotes Insights (InsightEngine)
+ *   5. Generates Insights, capped by AwarenessEngine.attentionBudget
+ *   6. Translates surfaced Insights into Proposals via the translator
+ *      registry, when one is supplied (Spec 55 §7).
+ *
+ * Slice 3 closes the Insight → Proposal half of the cycle. The pre-analysis
+ * pipeline (`proposal-preanalysis/*`, Spec 55 §7.3) is NOT invoked here —
+ * proposal validation, dedup, and impact analysis stay separate concerns
+ * orchestrated by capabilities (TODO: wire pre-analysis once proposal flow
+ * is finalized — Spec 55 §7.3).
  */
 
+import type { OntologyRegistry } from "../ontology/ontology-registry";
 import type {
   AwarenessEngine,
   EvolutionCycle,
   EvolutionCycleResult,
   SensorContext,
 } from "../types/life-system";
+import type { ProposalAuthor, ProposalDefinition } from "../types/proposal";
 import type { InsightEngineOptions } from "./insight-engine";
 import { createInsightEngine } from "./insight-engine";
+import type { InsightTranslatorRegistry, TranslatorContext } from "./insight-to-proposal";
 import type { MemoryEngine } from "./memory-engine";
 import type { SignalBus } from "./signal-bus";
 
@@ -27,15 +38,48 @@ export interface EvolutionCycleOptions {
   awareness: AwarenessEngine;
   /** Override insight engine promotion config */
   insightPromotion?: InsightEngineOptions["promotion"];
+  /**
+   * Optional Insight → Proposal translator registry (Spec 55 §7).
+   *
+   * When supplied, every insight surfaced by `generateInsights` is passed
+   * through `registry.translate(insight, ctx)`. Non-null returns are
+   * collected into `result.proposals`. When omitted, the cycle behaves as
+   * pre-Slice-3 — no proposals emitted, just insights — preserving zero
+   * regression for callers that never wired the translator.
+   */
+  translatorRegistry?: InsightTranslatorRegistry;
+  /**
+   * Optional ontology forwarded into {@link TranslatorContext}. Lets
+   * structural translators (e.g. `schema_no_view`) enrich their default
+   * view fields from real entity descriptors. AwarenessEngine consumes the
+   * ontology internally but does not re-expose it, so we accept it
+   * separately here rather than reaching through the awareness instance.
+   */
+  ontology?: OntologyRegistry;
+  /**
+   * Optional capability label stamped onto every translated proposal.
+   * Defaults to the translator's own default ("evolution") when omitted.
+   */
+  proposalCapability?: string;
+  /** Optional default author stamped onto every translated proposal. */
+  proposalAuthor?: ProposalAuthor;
 }
 
 export function createEvolutionCycle(opts: EvolutionCycleOptions): EvolutionCycle {
-  const { signalBus, memoryEngine, awareness } = opts;
+  const { signalBus, memoryEngine, awareness, translatorRegistry } = opts;
 
   const insightEngine = createInsightEngine({
     awareness,
     promotion: opts.insightPromotion,
   });
+
+  // Build a TranslatorContext template once. The same instance is reused
+  // for every translation in a cycle — translators must not mutate it.
+  const translatorCtxTemplate: TranslatorContext = {
+    ontology: opts.ontology,
+    capability: opts.proposalCapability,
+    author: opts.proposalAuthor,
+  };
 
   return {
     get insightEngine() {
@@ -67,14 +111,33 @@ export function createEvolutionCycle(opts: EvolutionCycleOptions): EvolutionCycl
         awareness.ingestSignal(signal);
       }
 
-      // 5. Insight: generate and promote insights
-      const newInsights = await insightEngine.generateInsights();
+      // 5. Insight: generate and promote insights, capped by the attention
+      // budget exposed on the AwarenessEngine. Without a budget the engine
+      // returns every newly produced insight (legacy behavior).
+      const surfacedInsights = await insightEngine.generateInsights({
+        budget: awareness.attentionBudget,
+      });
+
+      // 6. Proposal: translate ONLY surfaced insights. Budget-dropped
+      // insights stay in the unsurfaced pool inside InsightEngine and may
+      // surface (and translate) on a later cycle. When no registry is
+      // wired, proposals stays empty — preserves pre-Slice-3 contract.
+      let proposals: ProposalDefinition[] = [];
+      if (translatorRegistry && surfacedInsights.length > 0) {
+        const translated = await Promise.all(
+          surfacedInsights.map((insight) =>
+            translatorRegistry.translate(insight, translatorCtxTemplate),
+          ),
+        );
+        proposals = translated.filter((p): p is ProposalDefinition => p !== null);
+      }
 
       return {
         signalsCollected: signals.length,
         driftsDetected,
-        newInsights,
+        newInsights: surfacedInsights,
         totalInsights: insightEngine.getInsights().length,
+        proposals,
       };
     },
   };

--- a/packages/core/src/life-system/evolution-cycle.ts
+++ b/packages/core/src/life-system/evolution-cycle.ts
@@ -122,11 +122,20 @@ export function createEvolutionCycle(opts: EvolutionCycleOptions): EvolutionCycl
       // insights stay in the unsurfaced pool inside InsightEngine and may
       // surface (and translate) on a later cycle. When no registry is
       // wired, proposals stays empty — preserves pre-Slice-3 contract.
+      //
+      // The translator context inherits the sensor cycle's timestamp via
+      // `now`, so proposals stamp their createdAt/updatedAt with the
+      // signal-time rather than the wall clock — important for historical
+      // replay (out-of-band log ingestion) and tests with a fixed clock.
       let proposals: ProposalDefinition[] = [];
       if (translatorRegistry && surfacedInsights.length > 0) {
+        const cycleTranslatorCtx: TranslatorContext = {
+          ...translatorCtxTemplate,
+          now: () => sensorContext.timestamp,
+        };
         const translated = await Promise.all(
           surfacedInsights.map((insight) =>
-            translatorRegistry.translate(insight, translatorCtxTemplate),
+            translatorRegistry.translate(insight, cycleTranslatorCtx),
           ),
         );
         proposals = translated.filter((p): p is ProposalDefinition => p !== null);

--- a/packages/core/src/life-system/runtime.ts
+++ b/packages/core/src/life-system/runtime.ts
@@ -26,10 +26,12 @@ import type {
   Sensor,
   SensorContext,
 } from "../types/life-system";
+import type { ProposalAuthor } from "../types/proposal";
 import { createAwarenessEngine } from "./awareness-engine";
 import { createEvolutionCycle } from "./evolution-cycle";
 import { InMemoryMemoryStore } from "./in-memory-memory-store";
 import type { InsightEngineOptions } from "./insight-engine";
+import type { InsightTranslatorRegistry } from "./insight-to-proposal";
 import type { MemoryEngineOptions } from "./memory-engine";
 import { MemoryEngine } from "./memory-engine";
 import type { SignalBus } from "./signal-bus";
@@ -70,6 +72,17 @@ export interface EvolutionRuntimeOptions {
   memoryEngine?: Pick<MemoryEngineOptions, "windowSize" | "driftThreshold">;
   /** Override InsightEngine promotion config. */
   insightPromotion?: InsightEngineOptions["promotion"];
+  /**
+   * Optional Insight → Proposal translator registry (Spec 55 §7).
+   * When omitted, the cycle emits insights only — `result.proposals` is
+   * an empty array. Pass `createDefaultInsightTranslatorRegistry()` (from
+   * `./insight-to-proposal`) to enable structural proposal generation.
+   */
+  translatorRegistry?: InsightTranslatorRegistry;
+  /** Capability label stamped onto every translated proposal. */
+  proposalCapability?: string;
+  /** Default author stamped onto every translated proposal. */
+  proposalAuthor?: ProposalAuthor;
 }
 
 /** Empty OntologyRegistry stub for environments where no ontology is supplied. */
@@ -109,14 +122,17 @@ export function createEvolutionRuntime(opts: EvolutionRuntimeOptions): Evolution
     windowSize: opts.memoryEngine?.windowSize,
     driftThreshold: opts.memoryEngine?.driftThreshold,
   });
-  const awareness = createAwarenessEngine({
-    ontology: opts.ontology ?? createEmptyOntology(),
-  });
+  const ontology = opts.ontology ?? createEmptyOntology();
+  const awareness = createAwarenessEngine({ ontology });
   const innerCycle = createEvolutionCycle({
     signalBus,
     memoryEngine,
     awareness,
     insightPromotion: opts.insightPromotion,
+    translatorRegistry: opts.translatorRegistry,
+    ontology,
+    proposalCapability: opts.proposalCapability,
+    proposalAuthor: opts.proposalAuthor,
   });
 
   // Register sensors, guarding against duplicate names. SignalBus stores sensors

--- a/packages/core/src/types/life-system.ts
+++ b/packages/core/src/types/life-system.ts
@@ -7,6 +7,8 @@
  * These are abstract contracts. Concrete implementations live in capabilities.
  */
 
+import type { ProposalDefinition } from "./proposal";
+
 // ── Signal sources (Spec 55 §3.1) ──────────────────────────
 
 /** Channels through which signals enter the system. */
@@ -277,6 +279,16 @@ export interface EvolutionCycleResult {
   driftsDetected: number;
   newInsights: Insight[];
   totalInsights: number;
+  /**
+   * Proposals translated from this cycle's surfaced insights (Spec 55 §7).
+   *
+   * Empty array when no `translatorRegistry` was supplied to
+   * {@link createEvolutionCycle}, or when no surfaced insight matched a
+   * registered translator. Only insights that *surfaced* in this cycle are
+   * candidates — budget-dropped insights stay in the unsurfaced pool and
+   * may produce proposals on a future cycle once they surface.
+   */
+  proposals: ProposalDefinition[];
 }
 
 /**


### PR DESCRIPTION
## Summary

Final slice for closing #88. EvolutionCycle.runCycle now closes the Sense → Memory → Awareness → Insight → **Proposal** loop:

1. Pipes `awareness.attentionBudget` into `insightEngine.generateInsights` so the budget actually applies in the runtime cycle (Slice 2's gemini review explicitly flagged this as the missing wire).
2. Translates surfaced insights into `ProposalDefinition`s via the `InsightTranslator` from Slice 1 (#274). Translator registry is optional; without it the cycle returns insights only, no proposals.
3. Returns both insights and proposals from `runCycle`.

## Return shape

```ts
interface EvolutionCycleResult {
  signalsCollected: number;
  driftsDetected: number;
  totalInsights: number;
  newInsights: Insight[];          // budget-surfaced insights only
  proposals: ProposalDefinition[]; // translated from newInsights
}
```

Backward-compatible — the existing four fields are unchanged; `proposals` is `[]` when no translator is supplied (zero regression for existing callers).

## What's deferred

- Pre-analysis pipeline integration (Spec 55 §7.3, `proposal-preanalysis/*`) — TODO comment in `evolution-cycle.ts`. The pipeline accepts proposals; future slice can pipe `result.proposals` through `dedup → conflict → impact → backtest` for surface validation.
- `cap-life-demo` update — separate change.
- Shadow / Champion-Challenger / promotion stages (§7.5) — post-M6.
- TS-file graduation (§7.6) — post-M6.

## Tests

`evolution-cycle.test.ts` +4 cases:
- Regression: without translator returns insights only, no proposals
- Structural `schema_no_view` insight → corresponding add-view proposal
- Budget capping affects both insights and proposals (translator only sees surfaced insights)
- Declining translator (returns null) → insight surfaces, no proposal emitted

## Cross-model review

gemini round 1 reported zero CRITICAL / SHOULD. Two NITs were hallucinated (referenced spec files / lines that don't exist in the diff) — disregarded after manual verification.

## Test plan

- [x] `bun test packages/core/src/life-system/__tests__/evolution-cycle.test.ts` — 11 pass / 0 fail / 37 expect (7 pre-existing + 4 new)
- [x] `bun test packages/core` (full) — 3058 pass / 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run check` — 0 errors

## Closes

Closes #88 once merged (combines Slice 1 #274, Slice 2 #276, and this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)