### PR TITLE
feat(demo): cap-life-demo demonstrates full Spec 55 evolution loop (closes #279)

### DIFF
--- a/addons/demo/cap-life-demo/__tests__/full-cycle-demo.test.ts
+++ b/addons/demo/cap-life-demo/__tests__/full-cycle-demo.test.ts
@@ -1,0 +1,68 @@
+/**
+ * End-to-end test for the full Spec 55 life-system demo.
+ *
+ * Drives `runFullCycleDemo()` once and asserts the observable cycle output:
+ *   - Sense layer produced one signal
+ *   - Awareness surfaced a `schema_no_view` structural insight
+ *   - InsightTranslator emitted exactly one proposal targeting a view create
+ *   - Pre-analysis pipeline ran and attached dedup + impact envelopes
+ */
+
+import { describe, expect, test } from "bun:test";
+import { runFullCycleDemo } from "../src/full-cycle-demo";
+
+describe("runFullCycleDemo (Spec 55 full loop)", () => {
+  test("produces insights, proposals, and pre-analysis envelopes in one run", async () => {
+    const fixedTimestamp = new Date("2026-05-08T00:00:00.000Z");
+    const { cycle, proposalAnalyses } = await runFullCycleDemo({
+      timestamp: fixedTimestamp,
+    });
+
+    // Sense + Memory: one synthetic signal collected and ingested.
+    expect(cycle.signalsCollected).toBe(1);
+
+    // Awareness + Insight: schema_no_view structural insight surfaced.
+    const structural = cycle.newInsights.filter((i) => i.type === "structural");
+    expect(structural).toHaveLength(1);
+    expect(structural[0]?.entity).toBe("synthetic_metric");
+
+    // Proposal: default registry translates the insight into a view-create change.
+    expect(cycle.proposals).toHaveLength(1);
+    const proposal = cycle.proposals[0];
+    if (!proposal) throw new Error("expected proposal");
+    expect(proposal.capability).toBe("cap-life-demo");
+    expect(proposal.changes).toHaveLength(1);
+    const change = proposal.changes[0];
+    if (!change) throw new Error("expected change");
+    expect(change.target).toBe("view");
+    expect(change.operation).toBe("create");
+    // Cycle timestamp propagates through to the proposal's createdAt stamp,
+    // proving the translator context inherited the SensorContext.timestamp.
+    expect(proposal.createdAt.getTime()).toBe(fixedTimestamp.getTime());
+
+    // Pre-analysis: dedup + impact envelopes attached to every proposal.
+    expect(proposalAnalyses).toHaveLength(1);
+    const analysis = proposalAnalyses[0];
+    if (!analysis) throw new Error("expected analysis");
+    expect(analysis.proposal.id).toBe(proposal.id);
+    expect(analysis.preAnalysis.stages.dedup?.status).toBe("ok");
+    expect(analysis.preAnalysis.stages.impact?.status).toBe("ok");
+    // No prior proposals + view target → empty similar list, code-only impact.
+    expect(analysis.preAnalysis.stages.dedup?.data?.similar).toEqual([]);
+    expect(analysis.preAnalysis.stages.dedup?.data?.exactMatch).toBeNull();
+    expect(analysis.preAnalysis.stages.impact?.data?.affectedRecordCount).toBe(0);
+    expect(analysis.preAnalysis.stages.impact?.data?.reason).toBe("not-a-data-change");
+    expect(analysis.preAnalysis.allStagesSucceeded).toBe(true);
+  });
+
+  test("two consecutive runs produce identical proposal counts (idempotent setup)", async () => {
+    // Each call constructs fresh engines, so the structural promotion key
+    // can't leak between runs. Both runs should emit exactly one proposal.
+    const a = await runFullCycleDemo();
+    const b = await runFullCycleDemo();
+    expect(a.cycle.proposals).toHaveLength(1);
+    expect(b.cycle.proposals).toHaveLength(1);
+    expect(a.proposalAnalyses).toHaveLength(1);
+    expect(b.proposalAnalyses).toHaveLength(1);
+  });
+});

--- a/addons/demo/cap-life-demo/package.json
+++ b/addons/demo/cap-life-demo/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",
+  "scripts": {
+    "demo": "bun run src/cli.ts"
+  },
   "peerDependencies": {
     "@linchkit/core": "workspace:*"
   }

--- a/addons/demo/cap-life-demo/src/cli.ts
+++ b/addons/demo/cap-life-demo/src/cli.ts
@@ -1,0 +1,88 @@
+/**
+ * CLI entry for `bun --cwd addons/demo/cap-life-demo run demo`.
+ *
+ * Executes the full Sense → Memory → Awareness → Insight → Proposal cycle
+ * (see `./full-cycle-demo.ts`) and pretty-prints a human-readable summary
+ * to stdout. Output sections mirror the five life-system layers plus the
+ * proposal pre-analysis envelopes, so a reader can verify each stage ran.
+ *
+ * Pure stdout — no env vars, no flags, no exit codes other than 0/1.
+ * Failures bubble up as a thrown error and exit code 1.
+ */
+
+import { runFullCycleDemo } from "./full-cycle-demo";
+
+function bannerLine(label: string): string {
+  // Fixed-width banner so eyeballing the sections in a terminal stays aligned.
+  const padded = ` ${label} `;
+  const total = 60;
+  const dashes = Math.max(0, total - padded.length);
+  const left = Math.floor(dashes / 2);
+  const right = dashes - left;
+  return `${"─".repeat(left)}${padded}${"─".repeat(right)}`;
+}
+
+async function main(): Promise<void> {
+  const { cycle, proposalAnalyses } = await runFullCycleDemo();
+
+  console.log(bannerLine("Spec 55 life-system demo — full cycle"));
+  console.log(`Signals collected     : ${cycle.signalsCollected}`);
+  console.log(`Drifts detected       : ${cycle.driftsDetected}`);
+  console.log(`Insights surfaced     : ${cycle.newInsights.length}`);
+  console.log(`Total promoted        : ${cycle.totalInsights}`);
+  console.log(`Proposals emitted     : ${cycle.proposals.length}`);
+
+  console.log(bannerLine("Insights"));
+  if (cycle.newInsights.length === 0) {
+    console.log("(none)");
+  } else {
+    for (const insight of cycle.newInsights) {
+      console.log(`- [${insight.type}] ${insight.entity}: ${insight.summary}`);
+      console.log(
+        `  confidence=${insight.confidence.toFixed(2)} impact=${insight.impact} causality=${insight.causality}`,
+      );
+    }
+  }
+
+  console.log(bannerLine("Proposals"));
+  if (cycle.proposals.length === 0) {
+    console.log("(none)");
+  } else {
+    for (const proposal of cycle.proposals) {
+      console.log(`- ${proposal.title}`);
+      console.log(`  capability=${proposal.capability} status=${proposal.status}`);
+      for (const change of proposal.changes) {
+        console.log(
+          `    change: target=${change.target} operation=${change.operation} name=${change.name}`,
+        );
+      }
+    }
+  }
+
+  console.log(bannerLine("Pre-analysis envelopes"));
+  if (proposalAnalyses.length === 0) {
+    console.log("(none)");
+  } else {
+    for (const { proposal, preAnalysis } of proposalAnalyses) {
+      console.log(`- proposal: ${proposal.title}`);
+      const dedupData = preAnalysis.stages.dedup?.data;
+      const impactData = preAnalysis.stages.impact?.data;
+      const dedupSimilar = dedupData ? dedupData.similar.length : "n/a";
+      const dedupExact = dedupData ? (dedupData.exactMatch ? "yes" : "no") : "n/a";
+      const impactCount = impactData ? impactData.affectedRecordCount : "n/a";
+      const impactReason = impactData?.reason ?? "—";
+      console.log(`  dedup    : similar=${dedupSimilar} exactMatch=${dedupExact}`);
+      console.log(`  impact   : affectedRecordCount=${impactCount} reason=${impactReason}`);
+      console.log(
+        `  pipeline : allStagesSucceeded=${preAnalysis.allStagesSucceeded} totalDurationMs=${preAnalysis.totalDurationMs.toFixed(2)}`,
+      );
+    }
+  }
+
+  console.log(bannerLine("done"));
+}
+
+main().catch((err: unknown) => {
+  console.error("[cap-life-demo] full-cycle demo failed:", err);
+  process.exit(1);
+});

--- a/addons/demo/cap-life-demo/src/full-cycle-demo.ts
+++ b/addons/demo/cap-life-demo/src/full-cycle-demo.ts
@@ -1,0 +1,219 @@
+/**
+ * Full Sense → Memory → Awareness → Insight → Proposal cycle demo (Spec 55).
+ *
+ * Wires every life-system layer end-to-end so a single `runFullCycleDemo()`
+ * call produces an observable trace of the complete evolution loop:
+ *
+ *   1. Sense — `tick_sensor` is registered with the runtime's SignalBus and
+ *      emits a synthetic `SensorSignal` on each cycle.
+ *
+ *   2. Memory — runtime's MemoryEngine ingests the signal into its default
+ *      InMemoryMemoryStore and (re)computes the entity baseline.
+ *
+ *   3. Awareness — runtime's AwarenessEngine consumes the signal, runs the
+ *      structural check, and surfaces a `schema_no_view` issue because the
+ *      bundled ontology contains an entity with NO view.
+ *
+ *   4. Insight — runtime's InsightEngine promotes the structural issue into
+ *      an `Insight` immediately (structural insights bypass drift-promotion
+ *      rules — Spec 55 §6.3).
+ *
+ *   5. Proposal — `createDefaultInsightTranslatorRegistry()` translates the
+ *      surfaced insight into a `ProposalDefinition` via the deterministic
+ *      `structural:schema_no_view` translator.
+ *
+ *   6. Pre-analysis — every emitted proposal is fed through a
+ *      `createPreAnalysisPipeline({ analyzers: [dedup, impact] })` so the
+ *      reviewer envelope (similar count, affectedRecordCount, durations,
+ *      allStagesSucceeded) is attached for inspection.
+ *
+ * The cycle is wired through {@link createEvolutionRuntime} — the same
+ * factory production code uses — rather than reaching into core internals,
+ * so the demo doubles as a reference for capability authors.
+ *
+ * Returns a {@link FullCycleDemoResult} containing the cycle's
+ * {@link EvolutionCycleResult} plus the per-proposal pre-analysis envelopes.
+ *
+ * The demo's job is observable evolution loop, per Spec 00a §2.3 — a reader
+ * running `bun run demo` should see "the system observed → remembered →
+ * understood → derived insights → proposed changes → pre-analyzed them" in
+ * one execution.
+ *
+ * In-memory dependencies are intentionally minimal:
+ *   - `PendingProposalStore.listPending()` returns `[]` (no prior proposals)
+ *   - `ImpactDataProvider.countRecords()` / `sampleRecordIds()` return
+ *     `0`/`[]`. The bundled demo entity is fictional, so the impact stage
+ *     proves the pipeline executed rather than producing a real-world hit.
+ */
+
+import {
+  createDedupAnalyzer,
+  createDefaultInsightTranslatorRegistry,
+  createEvolutionRuntime,
+  createImpactAnalyzer,
+  createPreAnalysisPipeline,
+  defineSensor,
+  type EntityDescriptor,
+  type EvolutionCycleResult,
+  type ImpactDataProvider,
+  type OntologyRegistry,
+  type PendingProposalStore,
+  type PreAnalysisPipeline,
+  type ProposalDefinition,
+  type ProposalPreAnalysisResult,
+  type SensorContext,
+  type SensorSignal,
+} from "@linchkit/core";
+
+/** Per-proposal pre-analysis envelope returned alongside the cycle result. */
+export interface ProposalAnalysis {
+  proposal: ProposalDefinition;
+  preAnalysis: ProposalPreAnalysisResult;
+}
+
+/** Aggregate output from {@link runFullCycleDemo}. */
+export interface FullCycleDemoResult {
+  cycle: EvolutionCycleResult;
+  proposalAnalyses: ProposalAnalysis[];
+}
+
+/**
+ * Build a tiny in-process {@link OntologyRegistry} carrying exactly the
+ * entities the demo needs. `synthetic_metric` has NO views — the trigger for
+ * the `schema_no_view` structural issue → insight → proposal pipeline.
+ *
+ * Returned object satisfies only the slice of OntologyRegistry that the
+ * AwarenessEngine and InsightTranslator touch (`describe`, `listEntities`).
+ * The other registry methods are unused in this demo and would force a
+ * pile of zero-info dependencies if implemented faithfully — KISS.
+ */
+function createDemoOntology(): OntologyRegistry {
+  const schemas: Record<string, Partial<EntityDescriptor>> = {
+    // Entity with no views — fires the schema_no_view structural insight.
+    synthetic_metric: {
+      views: [],
+      actions: [],
+      // Field map lets the schemaNoViewTranslator enrich the default list
+      // view with real columns (id, value) instead of an empty stub.
+      fields: {
+        id: { type: "string" },
+        value: { type: "number" },
+      } as EntityDescriptor["fields"],
+    },
+  };
+
+  return {
+    describe(entityName: string): EntityDescriptor | undefined {
+      return schemas[entityName] as EntityDescriptor | undefined;
+    },
+    listEntities(): string[] {
+      return Object.keys(schemas);
+    },
+  } as unknown as OntologyRegistry;
+}
+
+/**
+ * No-op pending-proposal store. Always returns an empty list so the dedup
+ * analyzer reports `similar: []` / `exactMatch: null` — the demo's goal is
+ * to prove the stage ran, not to engineer a dedup hit.
+ */
+function createEmptyPendingProposalStore(): PendingProposalStore {
+  return {
+    async listPending(): Promise<ProposalDefinition[]> {
+      return [];
+    },
+  };
+}
+
+/**
+ * No-op impact data provider. Returns zero counts and empty samples so the
+ * impact analyzer reports `affectedRecordCount: 0` for any data-target
+ * change. The bundled proposal targets a `view` (code-only) so the analyzer
+ * short-circuits with `reason: "not-a-data-change"` regardless — but the
+ * provider must still satisfy the {@link ImpactDataProvider} contract.
+ */
+function createEmptyImpactDataProvider(): ImpactDataProvider {
+  return {
+    async countRecords(): Promise<number> {
+      return 0;
+    },
+    async sampleRecordIds(): Promise<string[]> {
+      return [];
+    },
+  };
+}
+
+/** Construct the synthetic sensor used by the demo's SignalBus run. */
+function createTickSensor() {
+  let emitted = false;
+  return defineSensor({
+    name: "tick_sensor",
+    source: "server",
+    entity: "synthetic_metric",
+    async detect(ctx: SensorContext): Promise<SensorSignal | null> {
+      // Single-emit so a `runCycle()` call has exactly one signal to ingest.
+      if (emitted) return null;
+      emitted = true;
+      return {
+        sensor: "tick_sensor",
+        source: "server",
+        timestamp: ctx.timestamp,
+        value: 42,
+        baseline: 40,
+        deviation: 0.05,
+        confidence: 0.95,
+        context: { entity: "synthetic_metric", metric: "value", tenantId: "demo" },
+      };
+    },
+  });
+}
+
+export interface RunFullCycleDemoOptions {
+  /** Override the cycle's sensor context timestamp (tests). */
+  timestamp?: Date;
+}
+
+/**
+ * Run the full evolution loop once and return the observable result.
+ *
+ * Side-effect-free: the runtime is created fresh per call so multiple demo
+ * runs don't interfere.
+ */
+export async function runFullCycleDemo(
+  options: RunFullCycleDemoOptions = {},
+): Promise<FullCycleDemoResult> {
+  // 1–5. Build the runtime — same factory production wiring uses. The
+  // runtime constructs SignalBus, MemoryEngine (with InMemoryMemoryStore by
+  // default), AwarenessEngine, and InsightEngine internally; the demo only
+  // supplies the policy bits (sensors, ontology, translator registry).
+  const runtime = createEvolutionRuntime({
+    sensors: [createTickSensor()],
+    ontology: createDemoOntology(),
+    translatorRegistry: createDefaultInsightTranslatorRegistry(),
+    proposalCapability: "cap-life-demo",
+  });
+
+  const result = await runtime.evolutionCycle.runCycle({
+    timestamp: options.timestamp ?? new Date(),
+  });
+
+  // 6. Pre-analysis — fan every emitted proposal through the dedup + impact
+  // pipeline. The pipeline is constructed manually here (rather than via
+  // the runtime's optional `proposalPreAnalysisPipeline` option) so the
+  // demo stays compatible regardless of which Spec 55 §7.3 wiring slice
+  // has shipped.
+  const preAnalysisPipeline: PreAnalysisPipeline = createPreAnalysisPipeline({
+    analyzers: [
+      createDedupAnalyzer({ store: createEmptyPendingProposalStore() }),
+      createImpactAnalyzer({ dataProvider: createEmptyImpactDataProvider() }),
+    ],
+  });
+
+  const proposalAnalyses: ProposalAnalysis[] = [];
+  for (const proposal of result.proposals) {
+    const preAnalysis = await preAnalysisPipeline.analyze(proposal);
+    proposalAnalyses.push({ proposal, preAnalysis });
+  }
+
+  return { cycle: result, proposalAnalyses };
+}

--- a/addons/demo/cap-life-demo/src/full-cycle-demo.ts
+++ b/addons/demo/cap-life-demo/src/full-cycle-demo.ts
@@ -82,10 +82,12 @@ export interface FullCycleDemoResult {
  * entities the demo needs. `synthetic_metric` has NO views — the trigger for
  * the `schema_no_view` structural issue → insight → proposal pipeline.
  *
- * Returned object satisfies only the slice of OntologyRegistry that the
- * AwarenessEngine and InsightTranslator touch (`describe`, `listEntities`).
- * The other registry methods are unused in this demo and would force a
- * pile of zero-info dependencies if implemented faithfully — KISS.
+ * The full {@link OntologyRegistry} contract is satisfied with no-op stubs
+ * for the methods AwarenessEngine and InsightTranslator don't currently
+ * exercise. This keeps the demo as a robust reference for capability
+ * authors — adding a future structural check that calls, say,
+ * `actionsFor()` will yield empty results instead of "is not a function"
+ * runtime errors.
  */
 function createDemoOntology(): OntologyRegistry {
   const schemas: Record<string, Partial<EntityDescriptor>> = {
@@ -103,13 +105,20 @@ function createDemoOntology(): OntologyRegistry {
   };
 
   return {
-    describe(entityName: string): EntityDescriptor | undefined {
-      return schemas[entityName] as EntityDescriptor | undefined;
-    },
-    listEntities(): string[] {
-      return Object.keys(schemas);
-    },
-  } as unknown as OntologyRegistry;
+    describe: (entityName) => schemas[entityName] as EntityDescriptor | undefined,
+    listEntities: () => Object.keys(schemas),
+    searchEntities: () => [],
+    actionsFor: () => [],
+    rulesFor: () => [],
+    stateFor: () => undefined,
+    viewsFor: () => [],
+    flowsFor: () => [],
+    handlersFor: () => [],
+    relatedEntities: () => [],
+    entitiesImplementing: () => [],
+    toJSON: () => ({}) as ReturnType<OntologyRegistry["toJSON"]>,
+    toMarkdown: () => "",
+  };
 }
 
 /**

--- a/addons/demo/cap-life-demo/src/index.ts
+++ b/addons/demo/cap-life-demo/src/index.ts
@@ -17,6 +17,12 @@ import { defineCapability } from "@linchkit/core";
 
 export type { CountingBaselineOptions } from "./counting-baseline";
 export { CountingBaseline } from "./counting-baseline";
+export type {
+  FullCycleDemoResult,
+  ProposalAnalysis,
+  RunFullCycleDemoOptions,
+} from "./full-cycle-demo";
+export { runFullCycleDemo } from "./full-cycle-demo";
 export { InMemoryLifecycleStore } from "./in-memory-store";
 export type { PipelineController, RunPipelineOptions } from "./pipeline";
 export { run } from "./pipeline";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -268,6 +268,9 @@ export type {
   EvolutionRuntimeOptions,
   ImpactDataProvider,
   ImpactResult,
+  InsightTranslator,
+  InsightTranslatorKey,
+  InsightTranslatorRegistry,
   LifecycleBaseline,
   LifecycleMemoryStore,
   LifecycleSensor,
@@ -286,6 +289,7 @@ export type {
   SignalBus,
   SignalBusOptions,
   SignalHandler,
+  TranslatorContext,
   Unsubscribe,
   Watcher,
 } from "./life-system";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -297,9 +297,11 @@ export type {
 // sensor-registry module path.
 export {
   createDedupAnalyzer,
+  createDefaultInsightTranslatorRegistry,
   createDispatchQuery,
   createEvolutionRuntime,
   createImpactAnalyzer,
+  createInsightTranslatorRegistry,
   createPreAnalysisPipeline,
   createSignalBus,
   defineSensor,


### PR DESCRIPTION
## Summary

- Adds `runFullCycleDemo()` + `bun run demo` CLI that wires the full Spec 55 life-system loop (Sense → Memory → Awareness → Insight → Proposal → Pre-analysis) via `createEvolutionRuntime` and prints an observable trace per cycle.
- Demo doubles as a capability-author reference: it consumes only `@linchkit/core`'s public surface, never reaches into core internals.
- Re-exports `createDefaultInsightTranslatorRegistry` and `createInsightTranslatorRegistry` from the `@linchkit/core` package barrel so capabilities can pull a translator registry without sub-path imports.

## What & why

The cap-life-demo previously demonstrated only Sense → Memory → Awareness. With #88 closed (PRs #274/#276/#278), the full loop is wired in core. This PR catches the demo up so a reader running one command sees every stage produce output:

```
────────── Spec 55 life-system demo — full cycle ──────────
Signals collected     : 1
Drifts detected       : 0
Insights surfaced     : 1
Total promoted        : 1
Proposals emitted     : 1
───────────────────────── Insights ────────────────────────
- [structural] synthetic_metric: Entity "synthetic_metric" has no views defined
  confidence=1.00 impact=low causality=structural
──────────────────────── Proposals ────────────────────────
- Add default view for "synthetic_metric"
  capability=cap-life-demo status=draft
    change: target=view operation=create name=synthetic_metric_default_list
────────────────── Pre-analysis envelopes ────────────────
- proposal: Add default view for "synthetic_metric"
  dedup    : similar=0 exactMatch=no
  impact   : affectedRecordCount=0 reason=not-a-data-change
  pipeline : allStagesSucceeded=true totalDurationMs=0.73
─────────────────────────── done ──────────────────────────
```

The synthetic ontology contains an entity with no view — deterministic trigger for `schema_no_view` → InsightTranslator → ProposalDefinition. No AI provider, no drift, no DB; proves the wiring observably (Spec 00a §2.3).

Pre-analysis is constructed manually after `runCycle` rather than via the runtime's optional `proposalPreAnalysisPipeline` option (still in flight on PR #281), so this PR lands independently of #281's merge order.

## Cross-model review

- **codex**: no actionable issues.
- **gemini** CRITICAL "leading space in `@linchkit/core` import": **rejected — false positive**. Verified with octal dump that the import string is exactly `\"@linchkit/core\"`; tests + demo run successfully (a leading space would break resolution).
- **gemini** SHOULD on full `OntologyRegistry` stub: deferred. The demo uses the same `as unknown as` cast pattern as `evolution-cycle.test.ts`'s `makeOntology` helper — KISS for a demo.
- **gemini** NIT JSDoc-link false positive: rejected (code uses `{@link FullCycleDemoResult}` correctly).

## Test plan

- [x] `bun run check` — green
- [x] `bun run typecheck` — green
- [x] `bun test` — 4809 pass / 0 fail / 3 skip
- [x] New tests: `produces insights, proposals, and pre-analysis envelopes in one run` + `two consecutive runs produce identical proposal counts`
- [x] Demo manually executed via `bun --cwd addons/demo/cap-life-demo run demo` — output verified

## Refs

- Closes #279
- Related: #281 (Spec 55 §7.3 runtime wiring — independent merge)
- Spec 55 (full life-system), Spec 00a §2.3 (observable evolution loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)