### PR TITLE
fix(adapter-ui): low-confidence proposals always render the card (closes #238)

### DIFF
--- a/addons/adapter-ui/cap-adapter-ui/__tests__/ai-assistant.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/ai-assistant.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for `decideIntentRouting` (issue #238).
+ *
+ * The AI assistant previously gated proposals at `confidence >= 0.5` and
+ * silently fell back to the general `/api/ai/chat` endpoint for everything
+ * else (low-confidence proposals, no-match, unavailable, transport errors).
+ * That endpoint runs with `allowActionExecution=false`, so actionable
+ * prompts dead-ended as "creating..." chat replies that never mutated
+ * the database.
+ *
+ * The fix targets the specific dead-end without regressing read-only chat:
+ *  - ANY proposal (regardless of confidence) → render the card. The card
+ *    already exposes alternatives + "Did you mean" pills for low confidence.
+ *  - no-match / transport-error → fall back to chat (preserves Q&A,
+ *    "summarize this record", and other read-only flows).
+ *  - unavailable → fall back to chat AND emit a toast notification, since
+ *    the user should know the structured action path is degraded.
+ *
+ * The component itself is JSX-only — we test the pure decision helper
+ * here since the existing test setup is logic-only (no happy-dom / jsdom),
+ * matching the pattern of `proposal-impact-preview.test.ts`.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { decideIntentRouting } from "../src/components/ai-assistant";
+import type { IntentResolution } from "../src/lib/api";
+
+function makeIntent(overrides: Partial<IntentResolution> = {}): IntentResolution {
+  return {
+    action: "create_department",
+    schema: "department",
+    input: { name: "Operations Management Center" },
+    missingFields: [],
+    confidence: 0.6,
+    explanation: "Create a department",
+    actionLabel: "Create Department",
+    actionDescription: "Create a new department record",
+    inputSchema: {
+      name: { type: "string", required: true },
+    },
+    ...overrides,
+  };
+}
+
+describe("decideIntentRouting (issue #238)", () => {
+  test("routes a high-confidence proposal to the proposal card", () => {
+    const proposal = makeIntent({ confidence: 0.9 });
+    const decision = decideIntentRouting({ kind: "proposal", proposal });
+    expect(decision).toEqual({ kind: "proposal", proposal });
+  });
+
+  test("routes a low-confidence proposal to the proposal card (no chat fallback)", () => {
+    // Pre-fix this branch fell through to chat with `allowActionExecution=false`,
+    // producing the "creating..." dead-end reported by the user. Now the card
+    // surfaces — its alternative pills let the user disambiguate inline.
+    const proposal = makeIntent({ confidence: 0.3 });
+    const decision = decideIntentRouting({ kind: "proposal", proposal });
+    expect(decision.kind).toBe("proposal");
+    if (decision.kind !== "proposal") return;
+    expect(decision.proposal.confidence).toBe(0.3);
+    expect(decision.proposal).toBe(proposal);
+  });
+
+  test("routes a borderline-confidence proposal (just below 0.5) to the card", () => {
+    const proposal = makeIntent({ confidence: 0.49 });
+    const decision = decideIntentRouting({ kind: "proposal", proposal });
+    expect(decision.kind).toBe("proposal");
+  });
+
+  test("routes a no-match outcome to chat fallback (preserves Q&A / read-only flows)", () => {
+    // Read-only conversational prompts ("hello", "summarize this record")
+    // resolve to no-match; they must still reach chat, otherwise the
+    // assistant becomes useless for non-action tasks (codex P1 review).
+    const decision = decideIntentRouting({ kind: "no-match" });
+    expect(decision).toEqual({ kind: "chat-fallback" });
+  });
+
+  test("routes an unavailable outcome to chat fallback with service-unavailable notice", () => {
+    // 503 should still try chat (it may be up while resolver is down) but
+    // surface a toast so the user knows the structured action path is
+    // degraded.
+    const decision = decideIntentRouting({ kind: "unavailable" });
+    expect(decision).toEqual({
+      kind: "chat-fallback",
+      notify: "service-unavailable",
+    });
+  });
+
+  test("routes a transport-error outcome to chat fallback (no toast)", () => {
+    const decision = decideIntentRouting({ kind: "transport-error" });
+    expect(decision).toEqual({ kind: "chat-fallback" });
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/src/components/action-proposal-card.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/action-proposal-card.tsx
@@ -54,15 +54,6 @@ export const MAX_DISPLAYED_ALTERNATIVES = 3;
 export const CONFIDENCE_THRESHOLD_MEDIUM = 0.5;
 export const CONFIDENCE_THRESHOLD_HIGH = 0.8;
 
-/**
- * Minimum confidence required to render an action proposal card at all.
- * Below this, the AI Assistant falls back to general chat instead of
- * surfacing a card the user is unlikely to confirm. Currently aligned with
- * `CONFIDENCE_THRESHOLD_MEDIUM`, but kept as a separate symbol so the
- * surfacing gate can move independently of the badge color band.
- */
-export const MIN_PROPOSAL_CONFIDENCE = CONFIDENCE_THRESHOLD_MEDIUM;
-
 function resolveTranslatableLabel(
   raw: string | undefined,
   fallback: string,

--- a/addons/adapter-ui/cap-adapter-ui/src/components/ai-assistant.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/ai-assistant.tsx
@@ -7,9 +7,21 @@
  * - Tool/function calling support (server-side tools rendered automatically)
  * - Context-aware: passes current schema/record context with each request
  *
- * When AI is enabled, it resolves intent first. Actionable requests show an
- * ActionProposalCard directly; only non-actionable prompts fall back to the
- * general chat endpoint.
+ * Intent-resolution routing when AI is enabled (#238):
+ *
+ *  - `proposal` (any confidence) → render `ActionProposalCard`. Low-
+ *    confidence proposals are intentionally NOT gated — the card itself
+ *    exposes alternative pills + a "Did you mean" affordance, so the user
+ *    can disambiguate or pick a different action without typing again.
+ *    Previously a `>= MIN_PROPOSAL_CONFIDENCE` gate dropped these into
+ *    chat, which then hallucinated "creating..." replies that never
+ *    touched the database — the original #238 dead-end.
+ *  - `no-match` / `unavailable` / transport-error → fall back to the
+ *    general chat endpoint. Chat runs with `allowActionExecution=false`
+ *    so it cannot mutate, but it remains useful for read-only / Q&A /
+ *    "summarize this record" flows. Actionable prompts that misroute
+ *    here are a separate concern tracked in the chat system-prompt
+ *    follow-up — see issue link in the PR for #238.
  */
 
 import { useChat } from "@ai-sdk/react";
@@ -35,8 +47,14 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { type ActionResult, type IntentResolution, isAiEnabled, resolveIntent } from "../lib/api";
-import { ActionProposalCard, MIN_PROPOSAL_CONFIDENCE } from "./action-proposal-card";
+import {
+  type ActionResult,
+  type IntentResolution,
+  isAiEnabled,
+  type ResolveIntentResult,
+  resolveIntent,
+} from "../lib/api";
+import { ActionProposalCard } from "./action-proposal-card";
 
 // ── Proposal state ───────────────────────────────────────
 
@@ -51,6 +69,49 @@ function createTextMessage(role: "user" | "assistant", text: string): UIMessage 
     role,
     parts: [{ type: "text", text }],
   };
+}
+
+// ── Intent routing decision ──────────────────────────────
+
+/**
+ * Outcome of inspecting an intent-resolution result. Drives the UX in
+ * `handleSend` and is exported as a pure helper so the decision matrix can
+ * be unit-tested without mounting the component (the existing test setup
+ * is logic-only — no jsdom).
+ *
+ *  - `proposal`        — render the Action Proposal Card. ALL proposals are
+ *                        surfaced regardless of confidence (#238); the card
+ *                        itself disambiguates via alternative pills.
+ *  - `chat-fallback`   — let the general chat endpoint take the prompt.
+ *                        Used for `no-match`, `unavailable`, and transport-
+ *                        error outcomes so read-only conversational prompts
+ *                        ("summarize this record", "hello") still work.
+ *                        For `unavailable`, callers should also raise a
+ *                        toast — `notify` carries that hint.
+ */
+export type IntentRoutingDecision =
+  | { kind: "proposal"; proposal: IntentResolution }
+  | { kind: "chat-fallback"; notify?: "service-unavailable" };
+
+/**
+ * Pure routing helper — maps a `ResolveIntentResult` (or transport-error
+ * sentinel) onto the UX action the assistant should take. We drop the
+ * historical `>= MIN_PROPOSAL_CONFIDENCE` gate so low-confidence proposals
+ * become cards (the #238 fix); other outcomes fall through to chat to
+ * preserve the "ask the AI a read-only question" UX.
+ */
+export function decideIntentRouting(
+  outcome: ResolveIntentResult | { kind: "transport-error" },
+): IntentRoutingDecision {
+  switch (outcome.kind) {
+    case "proposal":
+      return { kind: "proposal", proposal: outcome.proposal };
+    case "unavailable":
+      return { kind: "chat-fallback", notify: "service-unavailable" };
+    case "no-match":
+    case "transport-error":
+      return { kind: "chat-fallback" };
+  }
 }
 
 // ── Component ────────────────────────────────────────────
@@ -139,37 +200,47 @@ export function AIAssistant({
 
     if (isAiEnabled()) {
       setIsResolvingIntent(true);
+      let outcome: ResolveIntentResult | { kind: "transport-error" };
       try {
         // Narrow the catalog to the current entity when the user is on a
         // record page. `recordId` does not have a direct equivalent in the
         // new resolver scope today; UX follow-up if record-context priming
         // turns out to matter for accuracy.
-        const result = await resolveIntent(trimmed, {
+        outcome = await resolveIntent(trimmed, {
           entityFilter: params.name ? [params.name] : undefined,
         });
-        if (result.kind === "unavailable") {
-          // Spec 52 §1.1 — surface a non-blocking toast so 503 isn't silently
-          // swallowed. The user is informed and the chat fallback below still
-          // attempts the general endpoint, which itself may also be down — but
-          // that path produces its own error UI in the message stream.
-          toast.error(t("ai.serviceUnavailable"));
-        } else if (
-          result.kind === "proposal" &&
-          result.proposal.confidence >= MIN_PROPOSAL_CONFIDENCE
-        ) {
-          setMessages((prev) => [...prev, createTextMessage("user", trimmed)]);
-          const proposalId = crypto.randomUUID();
-          setProposals((prev) => [...prev, { id: proposalId, intent: result.proposal }]);
-          return;
-        }
       } catch {
-        // Transport-level error (network, non-503 non-2xx) — fall back to
-        // general chat. The unavailable-503 case is handled above.
+        // Transport-level error (network, non-503 non-2xx). We surface this
+        // inline rather than falling back to chat — the chat endpoint runs
+        // with `allowActionExecution=false`, so silently routing actionable
+        // prompts there produces "creating..." replies that never mutate
+        // (#238).
+        outcome = { kind: "transport-error" };
       } finally {
         setIsResolvingIntent(false);
       }
+
+      const decision = decideIntentRouting(outcome);
+
+      if (decision.kind === "proposal") {
+        // Echo the user prompt only for the card path — chat fallback adds
+        // the user message itself via `sendMessage` and double-echoing
+        // would duplicate it in the stream.
+        setMessages((prev) => [...prev, createTextMessage("user", trimmed)]);
+        const proposalId = crypto.randomUUID();
+        setProposals((prev) => [...prev, { id: proposalId, intent: decision.proposal }]);
+        return;
+      }
+
+      if (decision.notify === "service-unavailable") {
+        toast.error(t("ai.serviceUnavailable"));
+      }
+      // Fall through to chat — preserves read-only Q&A and chit-chat for
+      // prompts the resolver couldn't classify as actionable.
     }
 
+    // AI disabled OR resolver returned a non-action outcome: send the
+    // prompt to the general chat endpoint.
     sendMessage({ text: trimmed });
   }, [isLoading, isResolvingIntent, params.name, sendMessage, setMessages, t]);
 

--- a/addons/adapter-ui/cap-adapter-ui/src/components/ai-assistant.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/ai-assistant.tsx
@@ -210,11 +210,11 @@ export function AIAssistant({
           entityFilter: params.name ? [params.name] : undefined,
         });
       } catch {
-        // Transport-level error (network, non-503 non-2xx). We surface this
-        // inline rather than falling back to chat — the chat endpoint runs
-        // with `allowActionExecution=false`, so silently routing actionable
-        // prompts there produces "creating..." replies that never mutate
-        // (#238).
+        // Transport-level error (network, non-503 non-2xx). The decision
+        // helper routes this to chat-fallback so the user still gets some
+        // response — chat may be reachable even when the resolver isn't.
+        // Actionable prompts that misroute through chat are tracked by
+        // the chat-system-prompt follow-up linked from PR #283.
         outcome = { kind: "transport-error" };
       } finally {
         setIsResolvingIntent(false);


### PR DESCRIPTION
## Summary

- Drops the historical `>= MIN_PROPOSAL_CONFIDENCE` confidence gate in `AIAssistant.handleSend` so every \`kind: \"proposal\"\` outcome surfaces an `ActionProposalCard`, regardless of confidence.
- Other resolver outcomes (`no-match`, `unavailable`, `transport-error`) keep their chat fallback so read-only / conversational prompts still work — codex P1 caught the agent's first cut over-correcting.
- Removes dead `MIN_PROPOSAL_CONFIDENCE` constant + unused i18n keys.

## What & why

User report: typing "创建一个部门叫运营管理中心" in `bun run dev:ui` produced "creating..." chat replies but no card and no actual database mutation. Classic #238 dead-end: the proposal had confidence < 0.5, the gate dropped it into chat, chat ran with `allowActionExecution=false`, hallucinated progress, never wrote anything.

The card already exposes alternative pills + "Did you mean" affordance for low confidence (PR #275). The gate was the only reason low-conf proposals ever escaped the card path.

## Cross-model review

- **codex** P1 — over-corrected: the agent's first cut also blocked chat fallback for `no-match`/`unavailable`/`transport-error`, regressing read-only Q&A flows. Fixed: only the proposal confidence gate is dropped; other branches preserve chat fallback.
- **gemini** SHOULD — `MIN_PROPOSAL_CONFIDENCE` now dead code → removed.

## Test plan

- [x] `bun run check` — green
- [x] `bun run typecheck` — green
- [x] `bun test` — 4819 pass / 0 fail / 3 skip
- [x] New tests cover all 5 routing decisions: high-conf proposal, low-conf proposal (the bug), borderline, no-match (chat-fallback), unavailable (chat-fallback + toast), transport-error (chat-fallback)

## Refs

- Closes #238
- Surfaces a follow-up: chat system prompt should NOT claim to perform mutations when `allowActionExecution=false` — separate concern; will track as a new issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced AI assistant routing logic for more intelligent proposal suggestions and chat response handling across various scenarios.
  * Improved decision-making for when to display actionable proposals versus fallback to conversational responses.

* **Bug Fixes**
  * Better error handling for unavailable services with user notifications.
  * Improved transport error handling to properly route errors without silent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->