### PR TITLE
feat(adapter-server): relevance-based catalog pre-selection in resolveIntent (closes #262 item 1)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/relevant-actions.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/relevant-actions.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Tests for `limitCatalogToRelevant()` — Spec 52 Phase 1 hardening (#262).
+ *
+ * Coverage matches the issue's checklist:
+ *   1. Small catalog passes through unchanged (K not exceeded).
+ *   2. Word-overlap ranking orders relevant entity first.
+ *   3. Entity-cap (K) enforced.
+ *   4. Per-entity action cap enforced.
+ *   5. Stable order on score ties.
+ *   6. Substring partial match (singular vs plural).
+ *   7. Empty prompt edge case → top-K by original order.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { ActionCatalogEntry } from "@linchkit/cap-ai-provider";
+import { limitCatalogToRelevant } from "../src/lib/relevant-actions";
+
+// ── Fixture helpers ─────────────────────────────────────────
+
+function action(opts: {
+  entity: string;
+  name: string;
+  label?: string;
+  description?: string;
+  fields?: Array<{ name: string; type?: string; required?: boolean }>;
+}): ActionCatalogEntry {
+  return {
+    name: opts.name,
+    entity: opts.entity,
+    label: opts.label ?? opts.name,
+    description: opts.description,
+    inputFields: (opts.fields ?? []).map((f) => ({
+      name: f.name,
+      type: f.type ?? "string",
+      required: f.required === true,
+    })),
+  };
+}
+
+/**
+ * Generate `count` synthetic entities each with a single create action.
+ * Names are deterministic (`entity_001`, `create_entity_001`, ...) so
+ * tests can assert on shape without coupling to specific business names.
+ */
+function syntheticCatalog(count: number): ActionCatalogEntry[] {
+  const out: ActionCatalogEntry[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const idx = String(i + 1).padStart(3, "0");
+    out.push(
+      action({
+        entity: `entity_${idx}`,
+        name: `create_entity_${idx}`,
+        label: `Create Entity ${idx}`,
+      }),
+    );
+  }
+  return out;
+}
+
+// ── Test 1 — small catalog passthrough ──────────────────────
+
+describe("limitCatalogToRelevant — small catalog passthrough", () => {
+  test("returns input unchanged when entity count is at or below maxEntities", () => {
+    const catalog = syntheticCatalog(5);
+    const out = limitCatalogToRelevant({
+      catalog,
+      prompt: "create something",
+      maxEntities: 20,
+      maxActionsPerEntity: 20,
+    });
+    expect(out.length).toBe(catalog.length);
+    expect(out.map((e) => e.name)).toEqual(catalog.map((e) => e.name));
+  });
+});
+
+// ── Test 2 — word-overlap ranking ───────────────────────────
+
+describe("limitCatalogToRelevant — word-overlap ranking", () => {
+  test("entity whose name matches the prompt ranks first", () => {
+    // Three entities, K capped at 1 so only the top scorer survives — that
+    // exercises the ranking instead of just relying on passthrough.
+    const catalog: ActionCatalogEntry[] = [
+      action({ entity: "user", name: "create_user", label: "Create User" }),
+      action({ entity: "product", name: "create_product", label: "Create Product" }),
+      action({ entity: "order", name: "create_order", label: "Create Order" }),
+    ];
+    const out = limitCatalogToRelevant({
+      catalog,
+      prompt: "create order",
+      maxEntities: 1,
+      maxActionsPerEntity: 20,
+    });
+    expect(out.length).toBe(1);
+    expect(out[0]?.entity).toBe("order");
+  });
+});
+
+// ── Test 3 — entity cap enforced ────────────────────────────
+
+describe("limitCatalogToRelevant — entity cap enforced", () => {
+  test("output retains exactly maxEntities groups for a 30-entity catalog", () => {
+    const catalog = syntheticCatalog(30);
+    const out = limitCatalogToRelevant({
+      catalog,
+      prompt: "create something",
+      maxEntities: 20,
+      maxActionsPerEntity: 20,
+    });
+    const distinctEntities = new Set(out.map((e) => e.entity));
+    expect(distinctEntities.size).toBe(20);
+  });
+});
+
+// ── Test 4 — per-entity action cap ──────────────────────────
+
+describe("limitCatalogToRelevant — per-entity action cap enforced", () => {
+  test("entity with 30 actions is capped to maxActionsPerEntity", () => {
+    // Build a single entity with 30 actions, plus 25 dummy entities so the
+    // entity-cap also engages.
+    const orderActions: ActionCatalogEntry[] = [];
+    for (let i = 0; i < 30; i += 1) {
+      const idx = String(i + 1).padStart(2, "0");
+      orderActions.push(
+        action({ entity: "order", name: `op_order_${idx}`, label: `Op Order ${idx}` }),
+      );
+    }
+    const filler = syntheticCatalog(25);
+    const catalog = [...orderActions, ...filler];
+    const out = limitCatalogToRelevant({
+      catalog,
+      prompt: "order",
+      maxEntities: 20,
+      maxActionsPerEntity: 20,
+    });
+    const orderOut = out.filter((e) => e.entity === "order");
+    expect(orderOut.length).toBe(20);
+  });
+});
+
+// ── Test 5 — stable order on ties ───────────────────────────
+
+describe("limitCatalogToRelevant — stable order on ties", () => {
+  test("three score-zero entities preserve original order", () => {
+    // Prompt has nothing in common with any candidate — every entity scores 0.
+    const catalog: ActionCatalogEntry[] = [
+      action({ entity: "alpha", name: "act_alpha" }),
+      action({ entity: "beta", name: "act_beta" }),
+      action({ entity: "gamma", name: "act_gamma" }),
+    ];
+    const out = limitCatalogToRelevant({
+      catalog,
+      prompt: "xyzzy plugh quux",
+      // Force ranking path: maxEntities < grouped.length triggers scoring.
+      maxEntities: 2,
+      maxActionsPerEntity: 20,
+    });
+    expect(out.map((e) => e.entity)).toEqual(["alpha", "beta"]);
+  });
+});
+
+// ── Test 6 — substring partial match ────────────────────────
+
+describe("limitCatalogToRelevant — substring partial match", () => {
+  test("plural prompt token still matches singular entity name", () => {
+    // 21 entities → entity-cap (default 20) engages; the relevance ranker
+    // must lift `department` above the unrelated synthetic entities via a
+    // partial-substring match.
+    const filler = syntheticCatalog(20);
+    const dept = action({
+      entity: "department",
+      name: "create_department",
+      label: "Create Department",
+    });
+    const catalog = [...filler, dept];
+    const out = limitCatalogToRelevant({
+      catalog,
+      prompt: "departments",
+      maxEntities: 1,
+      maxActionsPerEntity: 20,
+    });
+    expect(out.length).toBe(1);
+    expect(out[0]?.entity).toBe("department");
+  });
+});
+
+// ── Test 8 — small entity count, large action count ─────────
+
+describe("limitCatalogToRelevant — small entity count + large action count", () => {
+  test("ranks actions even when grouped.length <= maxEntities (codex P1)", () => {
+    // Single entity with 25 actions, only one matches the prompt. Default
+    // K is 20, so the matching action sits at original index 24 — a naive
+    // first-N truncation would drop it. The relevance pass must lift it
+    // into the kept window (codex P1 review on PR #283).
+    const actions: ActionCatalogEntry[] = [];
+    for (let i = 0; i < 24; i += 1) {
+      const idx = String(i + 1).padStart(2, "0");
+      actions.push(action({ entity: "order", name: `noop_order_${idx}` }));
+    }
+    actions.push(action({ entity: "order", name: "ship_order", label: "Ship Order" }));
+
+    const out = limitCatalogToRelevant({
+      catalog: actions,
+      prompt: "ship order",
+      maxEntities: 20,
+      maxActionsPerEntity: 20,
+    });
+
+    // Output is exactly 20 actions, the matching one is included.
+    expect(out.length).toBe(20);
+    expect(out.some((e) => e.name === "ship_order")).toBe(true);
+  });
+});
+
+// ── Test 9 — snake_case identifier tokenization ─────────────
+
+describe("limitCatalogToRelevant — snake_case action name", () => {
+  test("matches prompt 'submit purchase request' against 'submit_purchase_request' (codex P2)", () => {
+    // Default K is 20; we have 25 entities total so the entity-cap engages
+    // and ranking is mandatory. The intended action's identifier is
+    // snake_case (`submit_purchase_request`) — when the tokenizer keeps
+    // `_` as part of a token, the prompt's three space-separated words
+    // never align with the identifier and ranking misses (codex P2).
+    const filler = syntheticCatalog(24);
+    const target = action({
+      entity: "purchase_request",
+      name: "submit_purchase_request",
+      label: "Submit Purchase Request",
+    });
+    const catalog = [...filler, target];
+
+    const out = limitCatalogToRelevant({
+      catalog,
+      prompt: "submit purchase request",
+      maxEntities: 1,
+      maxActionsPerEntity: 20,
+    });
+
+    expect(out.length).toBe(1);
+    expect(out[0]?.entity).toBe("purchase_request");
+  });
+});
+
+// ── Test 7 — empty prompt edge case ─────────────────────────
+
+describe("limitCatalogToRelevant — empty prompt", () => {
+  test("empty prompt returns top-K by original order", () => {
+    const catalog = syntheticCatalog(30);
+    const out = limitCatalogToRelevant({
+      catalog,
+      prompt: "",
+      maxEntities: 20,
+      maxActionsPerEntity: 20,
+    });
+    // First 20 entities by original order, in order.
+    expect(out.length).toBe(20);
+    expect(out.map((e) => e.entity)).toEqual(catalog.slice(0, 20).map((e) => e.entity));
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/src/lib/relevant-actions.ts
+++ b/addons/adapter-server/cap-adapter-server/src/lib/relevant-actions.ts
@@ -1,0 +1,360 @@
+/**
+ * Spec 52 Phase 1 hardening — relevance-based catalog pre-selection.
+ *
+ * The natural-language intent resolver feeds the AI a JSON catalog of every
+ * action it might invoke. For real-world ontologies that catalog can be
+ * hundreds of entries — blowing past the model's context window and burning
+ * tokens. Issue #262 item 1 calls for a lightweight lexical pre-filter that
+ * keeps only the entries plausibly relevant to the user's prompt.
+ *
+ * Algorithm (KISS — no embeddings, no NLP libs):
+ *   1. Tokenize the prompt into lowercase word tokens.
+ *   2. For each candidate (entity OR action) compute a score:
+ *        +3 per exact word match in the candidate's `name` / `label`
+ *        +2 per exact word match in `description`
+ *        +1 per exact word match in field names (entities only)
+ *        +0.5 per partial substring match (length >= 3)
+ *   3. Order DESC by score, ties broken by original ontology order (stable).
+ *   4. Keep top `maxEntities` entities; within each kept entity keep
+ *      top `maxActionsPerEntity` actions.
+ *
+ * The function is PURE — no clock, no I/O — so it is trivially testable.
+ *
+ * NOTE: vector / embedding-based ranking is intentionally out of scope here;
+ * that work belongs to issue #165 (cap-vector-pgvector). Lexical scoring is
+ * good enough for Phase 1 and avoids a runtime dependency on embeddings.
+ */
+
+import type { ActionCatalogEntry } from "@linchkit/cap-ai-provider";
+
+// ── Public types ─────────────────────────────────────────────
+
+/**
+ * The catalog shape consumed by the limiter. Matches the (already
+ * permission-scoped) action list produced by the route before it is handed
+ * to `resolveIntent()`. We deliberately reuse `ActionCatalogEntry` from
+ * cap-ai-provider so the limiter operates on the same shape the resolver
+ * already understands — no extra translation layer.
+ */
+export type RelevanceCatalog = readonly ActionCatalogEntry[];
+
+export interface LimitCatalogToRelevantOptions {
+  /** Full catalog of action entries. */
+  catalog: RelevanceCatalog;
+  /** Raw user prompt — used to derive scoring tokens. */
+  prompt: string;
+  /** Maximum number of distinct entities to keep. Defaults to 20. */
+  maxEntities?: number;
+  /** Maximum actions per kept entity. Defaults to 20. */
+  maxActionsPerEntity?: number;
+}
+
+// ── Tunables ─────────────────────────────────────────────────
+
+/** Default cap on distinct entities returned. Mirrors task spec for #262. */
+export const DEFAULT_MAX_ENTITIES = 20;
+/** Default per-entity action cap. */
+export const DEFAULT_MAX_ACTIONS_PER_ENTITY = 20;
+
+/** Minimum token length required to participate in substring matching. */
+const MIN_PARTIAL_MATCH_LEN = 3;
+
+// Score weights — tuned to the task spec.
+const SCORE_NAME_MATCH = 3;
+const SCORE_DESCRIPTION_MATCH = 2;
+const SCORE_FIELD_MATCH = 1;
+const SCORE_PARTIAL_MATCH = 0.5;
+
+// ── Public API ───────────────────────────────────────────────
+
+/**
+ * Return a relevance-pruned subset of the catalog.
+ *
+ * Short-circuits when the catalog already has fewer than `maxEntities`
+ * distinct entities OR the prompt yields zero tokens — in either case the
+ * top-K-by-original-order projection is already correct, so we simply
+ * apply the cap without scoring.
+ *
+ * The output preserves original ordering wherever possible (stable sort),
+ * matching the resolver's existing assumption that the catalog order
+ * mirrors `OntologyRegistry.listEntities()` order. This keeps the
+ * downstream `actionFilter` allowlist deterministic across runs.
+ */
+export function limitCatalogToRelevant(
+  options: LimitCatalogToRelevantOptions,
+): ActionCatalogEntry[] {
+  const maxEntities = options.maxEntities ?? DEFAULT_MAX_ENTITIES;
+  const maxActionsPerEntity = options.maxActionsPerEntity ?? DEFAULT_MAX_ACTIONS_PER_ENTITY;
+
+  const catalog = options.catalog;
+  if (catalog.length === 0) return [];
+
+  const grouped = groupByEntity(catalog);
+  const tokens = tokenize(options.prompt);
+
+  // Empty / whitespace-only prompt → fall back to original order at both
+  // entity and per-entity action levels. No tokens → no scoring possible.
+  if (tokens.length === 0) {
+    const kept = grouped.slice(0, maxEntities);
+    return flattenGroups(kept, (group) => group.actions.slice(0, maxActionsPerEntity));
+  }
+
+  // Entity-level fast path: nothing to truncate at the entity level. We
+  // still rank actions WITHIN each entity — small entity counts can still
+  // expose a single broad entity with hundreds of actions, and dropping
+  // the 21st+ by original order would silently hide it from the resolver
+  // even when the prompt clearly targets it (codex P1 review on #262).
+  if (grouped.length <= maxEntities) {
+    return flattenGroups(grouped, (group) =>
+      pickTopActions(group.actions, tokens, maxActionsPerEntity),
+    );
+  }
+
+  // Score each entity group; stable sort by score DESC.
+  const scoredEntities = grouped.map((group, originalIndex) => ({
+    group,
+    originalIndex,
+    score: scoreEntity(group, tokens),
+  }));
+  scoredEntities.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.originalIndex - b.originalIndex;
+  });
+
+  const keptEntities = scoredEntities.slice(0, maxEntities);
+
+  // Re-establish original ontology order before flattening so the resulting
+  // action list mirrors `listEntities()` iteration. Within each entity we
+  // score actions and keep the top-K (preserving original order on ties).
+  keptEntities.sort((a, b) => a.originalIndex - b.originalIndex);
+
+  return flattenGroups(
+    keptEntities.map((e) => e.group),
+    (group) => pickTopActions(group.actions, tokens, maxActionsPerEntity),
+  );
+}
+
+// ── Internals ────────────────────────────────────────────────
+
+interface EntityGroup {
+  entity: string;
+  /** Actions in their original ontology order. */
+  actions: ActionCatalogEntry[];
+}
+
+/**
+ * Group a flat catalog by entity name, preserving the FIRST-SEEN order of
+ * both entities and actions. Stability is important — ties in scoring
+ * fall back to this order so callers get a deterministic projection.
+ */
+function groupByEntity(catalog: RelevanceCatalog): EntityGroup[] {
+  const indexByEntity = new Map<string, number>();
+  const groups: EntityGroup[] = [];
+  for (const entry of catalog) {
+    let idx = indexByEntity.get(entry.entity);
+    if (idx === undefined) {
+      idx = groups.length;
+      indexByEntity.set(entry.entity, idx);
+      groups.push({ entity: entry.entity, actions: [] });
+    }
+    const group = groups[idx];
+    if (group) group.actions.push(entry);
+  }
+  return groups;
+}
+
+function flattenGroups(
+  groups: readonly EntityGroup[],
+  selectActions: (group: EntityGroup) => ActionCatalogEntry[],
+): ActionCatalogEntry[] {
+  const out: ActionCatalogEntry[] = [];
+  for (const group of groups) {
+    for (const action of selectActions(group)) {
+      out.push(action);
+    }
+  }
+  return out;
+}
+
+/**
+ * Tokenize a free-form prompt into lowercase word tokens. LinchKit
+ * identifiers are snake_case by convention (`submit_purchase_request`),
+ * so we treat `_` and `-` as token separators in addition to whitespace
+ * and punctuation. This way a prompt like "submit purchase request"
+ * matches the action name `submit_purchase_request` (codex P2 review on
+ * #262 — preserving `_` made identifier scoring miss the most common
+ * pattern). Unicode word characters are preserved via `\p{L}` / `\p{N}`
+ * so non-ASCII identifiers still match.
+ */
+function tokenize(prompt: string): string[] {
+  if (!prompt) return [];
+  const lower = prompt.toLowerCase();
+  // Split on anything that isn't a unicode letter or digit — dashes,
+  // underscores, whitespace, and punctuation all separate tokens.
+  const raw = lower.split(/[^\p{L}\p{N}]+/u);
+  const out: string[] = [];
+  for (const t of raw) {
+    if (t.length > 0) out.push(t);
+  }
+  return out;
+}
+
+/**
+ * Score an entity group by combining entity-level signals (entity name
+ * match, field name match across all actions on the entity) with the
+ * MAX action-level score within the group. Taking the max — rather than
+ * summing — prevents an entity with many trivially-matching actions from
+ * dominating ranking when only one action actually matches.
+ */
+function scoreEntity(group: EntityGroup, tokens: readonly string[]): number {
+  let score = 0;
+
+  // Entity name signal — strongest, matches the algorithm's "+3 per word
+  // match in name". We treat the entity name itself as the candidate
+  // tokens (split on `_` and case boundaries).
+  const entityTokens = candidateTokens(group.entity);
+  score += SCORE_NAME_MATCH * countExactMatches(tokens, entityTokens);
+  score += SCORE_PARTIAL_MATCH * countPartialMatches(tokens, entityTokens);
+
+  // Field name signal across all actions on the entity (+1 per match).
+  const fieldTokens = new Set<string>();
+  for (const action of group.actions) {
+    for (const field of action.inputFields) {
+      for (const t of candidateTokens(field.name)) fieldTokens.add(t);
+    }
+  }
+  if (fieldTokens.size > 0) {
+    const fieldTokenList = Array.from(fieldTokens);
+    score += SCORE_FIELD_MATCH * countExactMatches(tokens, fieldTokenList);
+  }
+
+  // Action-level signal: best action score within the entity. Acts as a
+  // tie-breaker between entities whose names don't appear in the prompt
+  // but which contain a strongly-matching action (e.g. prompt "approve
+  // request" + action `approve_request` on entity `purchase_request`).
+  let bestActionScore = 0;
+  for (const action of group.actions) {
+    const s = scoreAction(action, tokens);
+    if (s > bestActionScore) bestActionScore = s;
+  }
+  score += bestActionScore;
+
+  return score;
+}
+
+function scoreAction(action: ActionCatalogEntry, tokens: readonly string[]): number {
+  let score = 0;
+
+  const nameTokens = candidateTokens(action.name);
+  const labelTokens = candidateTokens(action.label);
+  const nameOrLabel = mergeUnique(nameTokens, labelTokens);
+  score += SCORE_NAME_MATCH * countExactMatches(tokens, nameOrLabel);
+  score += SCORE_PARTIAL_MATCH * countPartialMatches(tokens, nameOrLabel);
+
+  if (action.description) {
+    const descTokens = tokenize(action.description);
+    score += SCORE_DESCRIPTION_MATCH * countExactMatches(tokens, descTokens);
+  }
+
+  return score;
+}
+
+/**
+ * Pick the top-K actions within an entity group by relevance score,
+ * stable on ties (preserving original order). When the group is already
+ * smaller than K we still iterate (cheap) and return the head — no
+ * special case needed.
+ */
+function pickTopActions(
+  actions: readonly ActionCatalogEntry[],
+  tokens: readonly string[],
+  cap: number,
+): ActionCatalogEntry[] {
+  if (actions.length <= cap) {
+    // Order preserved — no need to score when nothing is dropped.
+    return actions.slice();
+  }
+  const scored = actions.map((action, originalIndex) => ({
+    action,
+    originalIndex,
+    score: scoreAction(action, tokens),
+  }));
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.originalIndex - b.originalIndex;
+  });
+  const kept = scored.slice(0, cap);
+  // Restore original order so the action subset remains deterministic.
+  kept.sort((a, b) => a.originalIndex - b.originalIndex);
+  return kept.map((s) => s.action);
+}
+
+/**
+ * Break an identifier into match-friendly tokens. Splits on `_`, `-`,
+ * and case boundaries (camelCase). Always lowercased.
+ */
+function candidateTokens(identifier: string): string[] {
+  if (!identifier) return [];
+  // Insert spaces at lower→upper boundaries (camelCase / PascalCase).
+  const spaced = identifier.replace(/([a-z\d])([A-Z])/g, "$1 $2");
+  return tokenize(spaced);
+}
+
+function mergeUnique(a: readonly string[], b: readonly string[]): string[] {
+  if (a.length === 0) return b.slice();
+  if (b.length === 0) return a.slice();
+  const seen = new Set(a);
+  const out = a.slice();
+  for (const t of b) {
+    if (!seen.has(t)) {
+      seen.add(t);
+      out.push(t);
+    }
+  }
+  return out;
+}
+
+/**
+ * Count the number of (promptToken, candidateToken) exact matches across
+ * the cross-product. Each prompt token can match multiple candidate
+ * tokens — this rewards candidates that hit several distinct prompt
+ * tokens simultaneously.
+ */
+function countExactMatches(
+  promptTokens: readonly string[],
+  candidateTokens: readonly string[],
+): number {
+  if (promptTokens.length === 0 || candidateTokens.length === 0) return 0;
+  const candidateSet = new Set(candidateTokens);
+  let count = 0;
+  for (const p of promptTokens) {
+    if (candidateSet.has(p)) count += 1;
+  }
+  return count;
+}
+
+/**
+ * Count partial substring matches: a prompt token contained in a
+ * candidate token (or vice versa) when both are at least
+ * MIN_PARTIAL_MATCH_LEN characters. Exact matches are excluded so they
+ * are not double-counted with `countExactMatches`.
+ */
+function countPartialMatches(
+  promptTokens: readonly string[],
+  candidateTokens: readonly string[],
+): number {
+  if (promptTokens.length === 0 || candidateTokens.length === 0) return 0;
+  let count = 0;
+  for (const p of promptTokens) {
+    if (p.length < MIN_PARTIAL_MATCH_LEN) continue;
+    for (const c of candidateTokens) {
+      if (c.length < MIN_PARTIAL_MATCH_LEN) continue;
+      if (p === c) continue; // exact match — counted elsewhere
+      if (p.includes(c) || c.includes(p)) {
+        count += 1;
+        break; // one partial credit per prompt token
+      }
+    }
+  }
+  return count;
+}

--- a/addons/adapter-server/cap-adapter-server/src/routes/ai-resolve-intent.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/ai-resolve-intent.ts
@@ -21,7 +21,11 @@
  *    503 with a structured envelope so the UI can show "AI unavailable" UX.
  */
 
-import { type ActionProposal, resolveIntent } from "@linchkit/cap-ai-provider";
+import {
+  type ActionCatalogEntry,
+  type ActionProposal,
+  resolveIntent,
+} from "@linchkit/cap-ai-provider";
 import type {
   ActionDefinition,
   Actor,
@@ -34,6 +38,11 @@ import type { AIAuditLogger } from "@linchkit/core/server";
 import { checkActionPermission } from "@linchkit/core/server";
 import type { Elysia } from "elysia";
 import { z } from "zod";
+import {
+  DEFAULT_MAX_ACTIONS_PER_ENTITY,
+  DEFAULT_MAX_ENTITIES,
+  limitCatalogToRelevant,
+} from "../lib/relevant-actions";
 import type { ServerOptions } from "../server";
 import { resolveActor, serviceUnavailable } from "./shared";
 
@@ -234,13 +243,36 @@ export function mountResolveIntentRoute(app: Elysia, options: ServerOptions): vo
     // name across all entities).
     const catalogSize = computeUniqueCatalogSize(scopedOntology);
 
+    // Spec 52 Phase 1 hardening (#262 item 1) — relevance-based catalog
+    // pre-selection. For large ontologies the full action list blows past
+    // the AI provider's context window. Build a lightweight preview catalog,
+    // lexically rank it against the user's prompt, and pass the kept names
+    // through to the resolver via the existing scope filters. The pre-filter
+    // is a no-op when the catalog is already smaller than the entity cap,
+    // so default behavior on small fixtures is unchanged.
+    const intentOpts = options.intentResolverOptions ?? {};
+    const maxEntities = intentOpts.maxEntities ?? DEFAULT_MAX_ENTITIES;
+    const maxActionsPerEntity = intentOpts.maxActionsPerEntity ?? DEFAULT_MAX_ACTIONS_PER_ENTITY;
+    const previewCatalog = buildPreviewCatalog(scopedOntology, parsed.data.scope);
+    const filteredCatalog = limitCatalogToRelevant({
+      catalog: previewCatalog,
+      prompt: parsed.data.prompt,
+      maxEntities,
+      maxActionsPerEntity,
+    });
+    const augmentedScope = mergeScopeWithFilteredCatalog({
+      requestScope: parsed.data.scope,
+      filteredCatalog,
+      previewCatalog,
+    });
+
     const startedAt = Date.now();
     let proposal: Awaited<ReturnType<typeof resolveIntent>> = null;
     try {
       proposal = await resolveIntent(
         {
           prompt: parsed.data.prompt,
-          scope: parsed.data.scope,
+          scope: augmentedScope,
           tenant: tenantId,
           userId: actor.id,
         },
@@ -509,4 +541,102 @@ function computeUniqueCatalogSize(ontology: OntologyRegistryLike): number {
     }
   }
   return seen.size;
+}
+
+// ── Catalog preview + scope merging ─────────────────────────
+
+/**
+ * Build a flat `ActionCatalogEntry[]` snapshot of what the resolver would
+ * see. Mirrors `buildActionCatalog()` in cap-ai-provider but is owned by
+ * this route so we can run relevance ranking without invoking the resolver
+ * twice. Identical de-duplication semantics: the FIRST entity exposing an
+ * action wins (matching the iteration order of `listEntities()`).
+ *
+ * Honors the caller's `scope.entityFilter` / `scope.actionFilter` so the
+ * relevance ranker scores the same set of candidates the resolver will.
+ */
+function buildPreviewCatalog(
+  ontology: OntologyRegistryLike,
+  scope: { entityFilter?: string[]; actionFilter?: string[] } | undefined,
+): ActionCatalogEntry[] {
+  const entityFilter = toFilterSet(scope?.entityFilter);
+  const actionFilter = toFilterSet(scope?.actionFilter);
+
+  const seen = new Set<string>();
+  const catalog: ActionCatalogEntry[] = [];
+
+  for (const entityName of ontology.listEntities()) {
+    if (entityFilter && !entityFilter.has(entityName)) continue;
+    for (const action of ontology.actionsFor(entityName)) {
+      if (seen.has(action.name)) continue;
+      if (actionFilter && !actionFilter.has(action.name)) continue;
+      seen.add(action.name);
+      catalog.push(toCatalogPreviewEntry(action));
+    }
+  }
+  return catalog;
+}
+
+function toCatalogPreviewEntry(action: ActionDefinition): ActionCatalogEntry {
+  const inputFields: ActionCatalogEntry["inputFields"] = [];
+  if (action.input) {
+    for (const [name, raw] of Object.entries(action.input)) {
+      const field = raw as FieldDefinition;
+      inputFields.push({
+        name,
+        type: field.type,
+        required: field.required === true,
+        label: field.label,
+        description: field.description,
+      });
+    }
+  }
+
+  // Mirror cap-ai-provider's joining of description + promptHints so the
+  // relevance ranker scores the same text the resolver would feed the AI.
+  const hints = action.ai?.promptHints;
+  const description =
+    [action.description, ...(hints ?? [])].filter((s): s is string => Boolean(s)).join(" — ") ||
+    undefined;
+
+  return {
+    name: action.name,
+    entity: action.entity,
+    label: action.label,
+    description,
+    inputFields,
+  };
+}
+
+function toFilterSet(values: readonly string[] | undefined): Set<string> | undefined {
+  if (!values || values.length === 0) return undefined;
+  return new Set(values);
+}
+
+/**
+ * Merge the caller-supplied scope with the relevance-pruned action list.
+ *
+ * No-op when no truncation occurred (filteredCatalog has the same length as
+ * previewCatalog) — the caller's scope passes through unchanged so audit /
+ * test behavior on small fixtures is byte-for-byte identical.
+ *
+ * When truncation DID happen we narrow `actionFilter` to the kept set
+ * (intersected with any caller-supplied filter, which has already been
+ * applied in `buildPreviewCatalog`). `entityFilter` is similarly narrowed
+ * to the entities surviving truncation.
+ */
+function mergeScopeWithFilteredCatalog(opts: {
+  requestScope: { entityFilter?: string[]; actionFilter?: string[] } | undefined;
+  filteredCatalog: ActionCatalogEntry[];
+  previewCatalog: ActionCatalogEntry[];
+}): { entityFilter?: string[]; actionFilter?: string[] } | undefined {
+  if (opts.filteredCatalog.length === opts.previewCatalog.length) {
+    return opts.requestScope;
+  }
+  const keptActions = opts.filteredCatalog.map((e) => e.name);
+  const keptEntities = Array.from(new Set(opts.filteredCatalog.map((e) => e.entity)));
+  return {
+    entityFilter: keptEntities,
+    actionFilter: keptActions,
+  };
 }

--- a/addons/adapter-server/cap-adapter-server/src/server.ts
+++ b/addons/adapter-server/cap-adapter-server/src/server.ts
@@ -144,6 +144,19 @@ export interface ServerOptions {
    * `/api/ai/resolve-intent`) emit one entry per call (Spec 52 §8.1.4).
    */
   aiAuditLogger?: AIAuditLogger;
+  /**
+   * Intent resolver tunables — Spec 52 Phase 1 hardening (#262 item 1).
+   * When the actor-visible catalog is large, the intent resolver lexically
+   * pre-filters it to keep only the entries plausibly relevant to the
+   * user's prompt. Defaults are chosen to fit a comfortable AI context
+   * window for typical ontologies; override per-deployment if needed.
+   */
+  intentResolverOptions?: {
+    /** Max distinct entities surfaced to the AI. Default 20. */
+    maxEntities?: number;
+    /** Max actions per kept entity. Default 20. */
+    maxActionsPerEntity?: number;
+  };
   /** Metrics collector — when provided, /health includes metrics summary */
   metricsCollector?: InMemoryMetricsCollector;
   /** Flow definitions — used by /api/flows endpoints */


### PR DESCRIPTION
## Summary

- Spec 52 Phase 1 hardening — `/api/ai/resolve-intent` no longer sends the full ontology catalog to the AI. A pure lexical relevance ranker (`limitCatalogToRelevant`) keeps the top-K most relevant (entity, action) pairs before prompt construction. K=20/20 by default; configurable via `ServerOptions.intentResolverOptions`.
- Real production gap: ontologies with 50+ actions previously blew the model's context window. Lexical only — vector retrieval (#165 cap-vector-pgvector) is out of scope.
- Existing intent-resolver tests pass with no modification (small catalogs are byte-identical).

## What & why

`resolveIntent()` previously serialized every entity + action in scope into the prompt. For real-world ontologies that's a context-window cliff. Issue #262 item 1 tracks lightweight pre-selection. This PR ships:

- `limitCatalogToRelevant()` in `addons/adapter-server/cap-adapter-server/src/lib/relevant-actions.ts` — pure function, scores by prompt-token overlap (+3 name, +2 description, +1 field, +0.5 partial), stable on ties, top-K entities × top-K actions per entity.
- Route integration in `ai-resolve-intent.ts` — builds a parallel preview catalog mirroring `buildActionCatalog()` in `cap-ai-provider`, ranks against the prompt, forwards kept names via existing `scope.entityFilter` / `scope.actionFilter`. cap-ai-provider stays untouched.

## Cross-model review

- **codex P1** — fast-path for `grouped.length <= maxEntities` previously dropped the 21st+ action on a single broad entity by original order. **Fixed**: actions within each entity are now ranked + capped even when the entity count is small.
- **codex P2** — `tokenize()` previously preserved `_` so `submit_purchase_request` was a single token — invisible to a prompt like \"submit purchase request\". **Fixed**: tokenizer now splits on `_` / `-` to match LinchKit's snake_case naming convention.
- **gemini SHOULD** — code duplication of catalog-building logic between the route and `cap-ai-provider`. **Deferred** to a follow-up; current duplication is documented and stays close to the canonical version.
- **gemini NIT** — redundant `?? action.name` in preview catalog. **Fixed**.

## Test plan

- [x] `bun run check` — green
- [x] `bun run typecheck` — green
- [x] `bun test` — 4822 pass / 0 fail / 3 skip
- [x] 9 new tests in `relevant-actions.test.ts` covering: passthrough, ranking, entity cap, per-entity action cap, stable ties, partial match, codex P1 regression (small entity count + large action count), codex P2 regression (snake_case identifier), empty prompt.
- [x] Existing `ai-resolve-intent.test.ts` (8 tests) and `ai-intent.test.ts` (15 tests) pass without test-code changes.

## Refs

- Spec 52 §3 (NL intent resolver hardening)
- Closes #262 item 1
- Items 2/3/5 of #262 remain (JSON extraction hardening, empty-string validation, JSON-mode AIService variant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)