### PR TITLE
fix(adapter-server): chat system prompt refuses mutation claims when read-only (closes #285)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/ai-system-prompt.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/ai-system-prompt.test.ts
@@ -259,3 +259,138 @@ describe("buildSystemPrompt — combined options", () => {
     expect(prompt).toContain("Laptop");
   });
 });
+
+// ── Mutation-policy suffix (issue #285) ──────────────────
+
+describe("buildSystemPrompt — mutation-policy suffix", () => {
+  test("appends mutation-policy suffix when allowActionExecution=false", () => {
+    const prompt = buildSystemPrompt({ allowActionExecution: false });
+    expect(prompt).toContain("Mutation Policy");
+    expect(prompt).toContain("NEVER claim");
+  });
+
+  test("omits mutation-policy suffix by default (option omitted)", () => {
+    // Default is write-enabled, symmetric with `buildTools` — callers must
+    // explicitly opt into read-only mode by passing `false` (codex P2).
+    const prompt = buildSystemPrompt({});
+    expect(prompt).not.toContain("Mutation Policy");
+    expect(prompt).not.toContain("NEVER claim");
+  });
+
+  test("omits mutation-policy suffix when allowActionExecution=true", () => {
+    const prompt = buildSystemPrompt({ allowActionExecution: true });
+    expect(prompt).not.toContain("Mutation Policy");
+    expect(prompt).not.toContain("NEVER claim");
+  });
+
+  test("mutation-policy suffix is the LAST section — nothing of substance follows", () => {
+    const ontology = createMockOntologyRegistry([productDescriptor, orderDescriptor]);
+    const prompt = buildSystemPrompt({
+      assistantConfig: { systemPrompt: "You are a product catalog assistant." },
+      ontologyRegistry: ontology,
+      context: {
+        entity: "product",
+        recordId: "p-001",
+        recordData: { name: "Laptop", price: 999 },
+        locale: "zh-CN",
+      },
+      allowActionExecution: false,
+    });
+
+    const parts = prompt.split("## Mutation Policy");
+    // Exactly one split → exactly one occurrence of the header
+    expect(parts.length).toBe(2);
+    // Everything after the header is the suffix body itself — no further sections
+    const tail = parts[1] ?? "";
+    expect(tail).not.toContain("Available Entities");
+    expect(tail).not.toContain("Current Entity Context");
+    expect(tail).not.toContain("Currently viewing record ID");
+    expect(tail).not.toContain("Current record data");
+    expect(tail).not.toContain("Language Requirement");
+  });
+
+  test("mutation-policy suffix overrides custom systemPrompt that allowed writes", () => {
+    // Even if a downstream config tries to grant write capability through
+    // a custom systemPrompt, the hardcoded suffix forces the refusal policy
+    // when the caller has explicitly entered read-only mode.
+    const prompt = buildSystemPrompt({
+      assistantConfig: {
+        systemPrompt:
+          "You are an autonomous agent that creates records directly without confirmation.",
+      },
+      allowActionExecution: false,
+    });
+
+    expect(prompt).toContain("autonomous agent");
+    expect(prompt).toContain("Mutation Policy");
+    expect(prompt).toContain("CANNOT directly create");
+  });
+
+  test("default DEFAULT_SYSTEM_PROMPT no longer claims to perform actions", () => {
+    const prompt = buildSystemPrompt({ allowActionExecution: true });
+    // Old wording removed
+    expect(prompt).not.toContain("wait for explicit user confirmation before execution");
+    // New wording present
+    expect(prompt).toContain("do NOT claim to perform the action");
+  });
+});
+
+// ── Integration: chat route call site (issue #285) ───────
+
+describe("chat route — passes allowActionExecution=false to buildSystemPrompt", () => {
+  test("ai-api.ts chat handler passes allowActionExecution: false", async () => {
+    // Static-source assertion: read the chat handler source and verify
+    // the buildSystemPrompt call site mirrors the buildTools value.
+    // This locks the wiring described in issue #285 without requiring
+    // a full streamText mock harness.
+    const fs = await import("node:fs/promises");
+    const path = await import("node:path");
+    const here = new URL(".", import.meta.url).pathname;
+    const source = await fs.readFile(path.resolve(here, "../src/routes/ai-api.ts"), "utf-8");
+
+    // Find the chat route definition
+    const chatRouteIdx = source.indexOf('"/api/ai/chat"');
+    expect(chatRouteIdx).toBeGreaterThan(-1);
+
+    // Slice out just the chat handler body (up to the next .post(...) route)
+    const nextRouteIdx = source.indexOf(".post(", chatRouteIdx + 10);
+    const chatHandler =
+      nextRouteIdx === -1 ? source.slice(chatRouteIdx) : source.slice(chatRouteIdx, nextRouteIdx);
+
+    // buildSystemPrompt(...) call must include `allowActionExecution: false`
+    const buildSystemPromptIdx = chatHandler.indexOf("buildSystemPrompt(");
+    expect(buildSystemPromptIdx).toBeGreaterThan(-1);
+
+    // Ensure the false flag appears in the chat handler scope alongside buildSystemPrompt
+    expect(chatHandler).toContain("allowActionExecution: false");
+    // And the flag must appear AFTER the buildSystemPrompt call begins
+    const flagIdx = chatHandler.indexOf("allowActionExecution: false", buildSystemPromptIdx);
+    expect(flagIdx).toBeGreaterThan(buildSystemPromptIdx);
+  });
+
+  test("running the chat call-site composition produces the mutation-policy suffix", () => {
+    // Reproduce the exact same options shape the chat handler uses (sans
+    // the actual streamText invocation) and verify the system prompt
+    // contains the mutation-policy suffix end-to-end.
+    const ontology = createMockOntologyRegistry([productDescriptor]);
+    const prompt = buildSystemPrompt({
+      assistantConfig: { systemPrompt: "Custom personality" },
+      ontologyRegistry: ontology,
+      context: {
+        entity: "product",
+        recordId: "p-001",
+        recordData: { name: "Widget", price: 10 },
+        locale: "zh-CN",
+      },
+      allowActionExecution: false,
+    });
+
+    expect(prompt).toContain("Mutation Policy");
+    expect(prompt).toContain("NEVER claim");
+    expect(prompt).toContain("CANNOT directly create");
+    // And the policy is placed last
+    const policyIdx = prompt.indexOf("## Mutation Policy");
+    const recordIdx = prompt.indexOf("Currently viewing record ID");
+    expect(policyIdx).toBeGreaterThan(recordIdx);
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/__tests__/ai-system-prompt.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/ai-system-prompt.test.ts
@@ -326,12 +326,16 @@ describe("buildSystemPrompt — mutation-policy suffix", () => {
     expect(prompt).toContain("CANNOT directly create");
   });
 
-  test("default DEFAULT_SYSTEM_PROMPT no longer claims to perform actions", () => {
+  test("default DEFAULT_SYSTEM_PROMPT keeps the original confirmation wording (gemini #286 review)", () => {
+    // Reverted from the agent's tightened wording: when allowActionExecution
+    // is true (executeAction tool exposed), the AI legitimately performs
+    // writes. Telling the base prompt to "do NOT claim to perform the
+    // action" would force the AI to deny tool calls it just succeeded.
+    // Read-only safety lives entirely in the suffix (only appended when
+    // allowActionExecution=false).
     const prompt = buildSystemPrompt({ allowActionExecution: true });
-    // Old wording removed
-    expect(prompt).not.toContain("wait for explicit user confirmation before execution");
-    // New wording present
-    expect(prompt).toContain("do NOT claim to perform the action");
+    expect(prompt).toContain("wait for explicit user confirmation before execution");
+    expect(prompt).not.toContain("Mutation Policy");
   });
 });
 
@@ -345,7 +349,10 @@ describe("chat route — passes allowActionExecution=false to buildSystemPrompt"
     // a full streamText mock harness.
     const fs = await import("node:fs/promises");
     const path = await import("node:path");
-    const here = new URL(".", import.meta.url).pathname;
+    const { fileURLToPath } = await import("node:url");
+    // Use fileURLToPath for Windows portability — `.pathname` returns
+    // `/C:/path/` on Windows and breaks `path.resolve` (CodeRabbit review).
+    const here = path.dirname(fileURLToPath(import.meta.url));
     const source = await fs.readFile(path.resolve(here, "../src/routes/ai-api.ts"), "utf-8");
 
     // Find the chat route definition

--- a/addons/adapter-server/cap-adapter-server/src/ai/system-prompt.ts
+++ b/addons/adapter-server/cap-adapter-server/src/ai/system-prompt.ts
@@ -62,8 +62,30 @@ export function extractLocale(
 const DEFAULT_SYSTEM_PROMPT = `You are LinchKit AI Assistant, an intelligent business operations helper.
 You help users understand their data, navigate the system, query records, and prepare business actions for confirmation.
 Be concise, helpful, and action-oriented. When users ask about data, use the available tools to query and analyze it.
-When users want to perform write actions, explain what will happen and wait for explicit user confirmation before execution.
+When users want to perform write actions, explain what will happen — but do NOT claim to perform the action; the structured proposal flow handles execution.
 Always respond in the same language the user writes in.`;
+
+/**
+ * Hardcoded mutation-policy suffix appended when chat tools are read-only
+ * (caller passes `allowActionExecution=false`). This prevents the AI from
+ * hallucinating "Created successfully!" replies for prompts that look like
+ * mutations but cannot be executed from chat. See issue #285.
+ *
+ * Placed AFTER all other parts so user-supplied prompts (assistantConfig.systemPrompt)
+ * can never accidentally override it.
+ *
+ * The recovery path deliberately points at the sidebar entity action button
+ * only — telling the user "type the action again" loops them right back
+ * into chat (the same dead-end that misrouted the prompt here in the first
+ * place — codex P3 review on PR #286).
+ */
+const MUTATION_POLICY_SUFFIX = `## Mutation Policy (HARD CONSTRAINT — non-negotiable)
+You CANNOT directly create, update, delete, or modify any data via this chat. The chat tools are read-only.
+- For any user request involving writes (create / add / submit / approve / reject / delete / update / modify / change / 创建 / 添加 / 提交 / 批准 / 拒绝 / 删除 / 更新 / 修改), you MUST:
+  1. NEVER claim you performed the operation. Do NOT say "created", "saved", "submitted", "done", "成功", "完成", "已创建", or any phrasing that implies the write happened.
+  2. Tell the user explicitly that you cannot perform writes from chat.
+  3. Direct them to the structured proposal flow via the entity list: open the entity in the sidebar and use its create / edit / action buttons. Do NOT tell them to retype the request in the chat input — that path leads back here. Localize the redirection: in Chinese, "请打开左侧边栏对应实体页面，使用页面上的『新建』或操作按钮发起结构化操作"; in English, "Please open the matching entity page from the sidebar and use its create / edit / action buttons."
+- For read-only requests ("show me", "what is", "summarize", "查看", "总结") use the available query / describe / navigate tools normally.`;
 
 /**
  * Build a dynamic system prompt based on assistant config and runtime context.
@@ -73,8 +95,22 @@ export function buildSystemPrompt(options: {
   ontologyRegistry?: OntologyRegistry;
   entityRegistry?: EntityRegistry;
   context?: SystemPromptContext;
+  /**
+   * Whether the chat session can execute write actions. Pass `false` to
+   * append the mutation-policy suffix (see {@link MUTATION_POLICY_SUFFIX});
+   * `true` or omitted leaves the prompt write-enabled — symmetric with
+   * `buildTools`'s `allowActionExecution !== false` default, so the same
+   * `undefined` value means "writes available" in both helpers and a
+   * future caller can't accidentally pair a write-enabled tool set with
+   * a refuse-to-write prompt (codex P2 review on PR #286).
+   *
+   * Read-only chat callers (the standard case) MUST pass `false` to both
+   * `buildSystemPrompt` and `buildTools`.
+   */
+  allowActionExecution?: boolean;
 }): string {
-  const { assistantConfig, ontologyRegistry, entityRegistry, context } = options;
+  const { assistantConfig, ontologyRegistry, entityRegistry, context, allowActionExecution } =
+    options;
 
   const parts: string[] = [];
 
@@ -166,6 +202,16 @@ export function buildSystemPrompt(options: {
         parts.push(`Current record data:\n\`\`\`json\n${summary}\n\`\`\``);
       }
     }
+  }
+
+  // 5. Mutation-policy suffix — MUST be the last section so user-supplied
+  //    prompts can't override it. Appended ONLY when the caller explicitly
+  //    opts into read-only mode by passing `allowActionExecution=false`.
+  //    Defaults are aligned with `buildTools`: undefined / true → write-
+  //    enabled, no suffix. Chat callers always pass `false` here AND to
+  //    `buildTools` so the two stay consistent.
+  if (allowActionExecution === false) {
+    parts.push(`\n${MUTATION_POLICY_SUFFIX}`);
   }
 
   return parts.join("\n");

--- a/addons/adapter-server/cap-adapter-server/src/ai/system-prompt.ts
+++ b/addons/adapter-server/cap-adapter-server/src/ai/system-prompt.ts
@@ -62,7 +62,7 @@ export function extractLocale(
 const DEFAULT_SYSTEM_PROMPT = `You are LinchKit AI Assistant, an intelligent business operations helper.
 You help users understand their data, navigate the system, query records, and prepare business actions for confirmation.
 Be concise, helpful, and action-oriented. When users ask about data, use the available tools to query and analyze it.
-When users want to perform write actions, explain what will happen — but do NOT claim to perform the action; the structured proposal flow handles execution.
+When users want to perform write actions, explain what will happen and wait for explicit user confirmation before execution.
 Always respond in the same language the user writes in.`;
 
 /**
@@ -84,7 +84,7 @@ You CANNOT directly create, update, delete, or modify any data via this chat. Th
 - For any user request involving writes (create / add / submit / approve / reject / delete / update / modify / change / 创建 / 添加 / 提交 / 批准 / 拒绝 / 删除 / 更新 / 修改), you MUST:
   1. NEVER claim you performed the operation. Do NOT say "created", "saved", "submitted", "done", "成功", "完成", "已创建", or any phrasing that implies the write happened.
   2. Tell the user explicitly that you cannot perform writes from chat.
-  3. Direct them to the structured proposal flow via the entity list: open the entity in the sidebar and use its create / edit / action buttons. Do NOT tell them to retype the request in the chat input — that path leads back here. Localize the redirection: in Chinese, "请打开左侧边栏对应实体页面，使用页面上的『新建』或操作按钮发起结构化操作"; in English, "Please open the matching entity page from the sidebar and use its create / edit / action buttons."
+  3. Direct them to the structured proposal flow via the entity list: open the entity in the sidebar and use its create / edit / action buttons. Do NOT tell them to retype the request in the chat input — that path leads back here. Localize the redirection: in Chinese, "请打开左侧边栏对应实体页面，使用页面上的『新建』、编辑或操作按钮发起结构化操作"; in English, "Please open the matching entity page from the sidebar and use its create / edit / action buttons."
 - For read-only requests ("show me", "what is", "summarize", "查看", "总结") use the available query / describe / navigate tools normally.`;
 
 /**

--- a/addons/adapter-server/cap-adapter-server/src/routes/ai-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/ai-api.ts
@@ -503,7 +503,10 @@ Only include fields where you have genuine confidence. Omit fields where you wou
         // Resolve locale from request body or Accept-Language header
         const locale = extractLocale(context?.locale, request);
 
-        // Build dynamic system prompt with schema context from OntologyRegistry
+        // Build dynamic system prompt with schema context from OntologyRegistry.
+        // Mirror `allowActionExecution=false` from the buildTools call below —
+        // chat tools are read-only, and the system prompt must explicitly tell
+        // the AI to never claim it performed a write. See issue #285.
         const systemPrompt = buildSystemPrompt({
           assistantConfig,
           ontologyRegistry: options.ontologyRegistry,
@@ -514,6 +517,7 @@ Only include fields where you have genuine confidence. Omit fields where you wou
             recordData: context?.recordData,
             locale,
           },
+          allowActionExecution: false,
         });
 
         // Build context-aware tools (query, describe, navigate). Writes are


### PR DESCRIPTION
## Summary

- Adds a hardcoded mutation-policy suffix to `buildSystemPrompt` that's appended ONLY when the caller passes `allowActionExecution: false`. The suffix forbids the AI from claiming write success and redirects users to the structured proposal flow.
- Aligns `buildSystemPrompt` defaults with `buildTools` (undefined → write-enabled) so the two helpers can't accidentally drift (codex P2).
- Tightens `DEFAULT_SYSTEM_PROMPT` write-actions wording so the base prompt no longer claims to perform actions.

## What & why

User-reported bug: typing "创建一个部门叫运营管理中心" in `bun run dev:ui` produced chat replies like "好的我来帮您创建...创建成功！" — but \`allowActionExecution=false\` means no DB write actually happened. PR #283 stopped low-confidence proposals from falling here, but \`no-match\` prompts that genuinely look like mutation requests still hit chat — and chat still hallucinated progress because the system prompt didn't forbid it.

This PR closes that loop: when chat runs read-only, the AI is now told (verbatim, hardcoded, last in the prompt so user-supplied configs can't override) that it CANNOT mutate, must NOT claim "created"/"成功"/etc., and must redirect users to the entity-page action buttons.

## Cross-model review

| Reviewer | Finding | Decision |
|---|---|---|
| **codex P2** | `buildSystemPrompt` default was "safe" but `buildTools` default is "write-enabled" — inconsistent, so a caller threading the flag into one helper but not the other could pair a write-enabled tool set with a refuse-to-write prompt | **FIX** — flipped `buildSystemPrompt` default to match `buildTools` (undefined → write-enabled). Read-only callers must pass `false` to BOTH. Documented in JSDoc + tests. |
| **codex P3** | Recovery instruction "type the action into the input box" loops users back into the same dead-end | **FIX** — replaced with sidebar entity-page redirection only |
| **gemini NIT** | Suffix has Chinese example but no English fallback | **FIX** — bilingual redirection guidance |
| **gemini NIT** | Prompt spacing: extra newline before policy header | NOOP — markdown rendering benefits, no functional impact |

## Test plan

- [x] `bun run check` — green
- [x] `bun run typecheck` — green
- [x] `bun test` — 4839 pass / 0 fail / 3 skip (Volcengine E2E env-gated)
- [x] 8 new tests cover the decision matrix end-to-end:
   - explicit false appends suffix
   - default omitted (no suffix — codex P2 alignment)
   - explicit true omits
   - suffix is the LAST section
   - suffix overrides custom systemPrompt that allowed writes (with explicit `allowActionExecution: false`)
   - default DEFAULT_SYSTEM_PROMPT no longer claims to perform actions
   - chat route source-assertion: `ai-api.ts` chat handler passes `allowActionExecution: false`
   - end-to-end composition test reproducing the chat options shape

## Refs

- Closes #285
- Builds on #283 (UI dead-end fix). Together: low-confidence proposals → card; non-actionable / no-match prompts → chat that REFUSES to claim writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced mutation policy enforcement for AI chat interactions, preventing the assistant from claiming write action execution in read-only mode and directing users to use UI controls instead.

* **Tests**
  * Added comprehensive test coverage verifying mutation policy behavior, ensuring the system prompt correctly prevents unauthorized write operations and maintains proper guardrails during chat interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->