### PR TITLE
fix(cap-ai-provider): JSON parser hardening + allowEmpty opt-in (closes #262 items 2+3)

### DIFF
--- a/addons/ai-provider/cap-ai-provider/__tests__/intent-resolver.test.ts
+++ b/addons/ai-provider/cap-ai-provider/__tests__/intent-resolver.test.ts
@@ -27,6 +27,7 @@ import type {
 } from "@linchkit/core";
 import {
   ALTERNATIVES_CONFIDENCE_THRESHOLD,
+  extractFirstJsonObject,
   MAX_ALTERNATIVES,
   MIN_CONFIDENCE,
   type OntologyRegistryLike,
@@ -884,5 +885,175 @@ describe("resolveIntent — N-best alternatives (Spec 52 §2.2 step 4)", () => {
     expect(proposal?.alternatives?.length).toBe(1);
     // The alternative itself has no nested alternatives.
     expect(proposal?.alternatives?.[0]?.alternatives).toBeUndefined();
+  });
+});
+
+// ── #262 item 2 — extractFirstJsonObject hardening ──────────
+
+describe("extractFirstJsonObject — JSON extraction hardening (#262 item 2)", () => {
+  it("returns plain JSON unchanged", () => {
+    expect(extractFirstJsonObject('{"a":1}')).toBe('{"a":1}');
+  });
+
+  it("extracts JSON from a fenced code block", () => {
+    // Matches the substring ignoring the fence wrappers.
+    expect(extractFirstJsonObject('```json\n{"a":1}\n```')).toBe('{"a":1}');
+  });
+
+  it("extracts JSON surrounded by prose", () => {
+    expect(extractFirstJsonObject('Here is the JSON: {"a":1}. Done.')).toBe('{"a":1}');
+  });
+
+  it("returns the OUTER object when an embedded JSON example lives in a string field", () => {
+    // Regression for the brace-counting drift bug: `lastIndexOf('}')` would
+    // pick the inner brace of the example. The lexical scanner returns the
+    // outer object verbatim.
+    const raw = '{"action":"x","explanation":"e.g. {\\"foo\\":\\"bar\\"}"}';
+    const extracted = extractFirstJsonObject(raw);
+    expect(extracted).toBe(raw);
+    // Round-trip parse to confirm structural validity.
+    const parsed = JSON.parse(extracted ?? "") as { action: string; explanation: string };
+    expect(parsed.action).toBe("x");
+    expect(parsed.explanation).toBe('e.g. {"foo":"bar"}');
+  });
+
+  it("ignores braces inside a quoted string", () => {
+    // The string content has unbalanced braces, but quote-tracking keeps
+    // depth accurate so the full object is returned.
+    const raw = '{"a":"}{"}';
+    expect(extractFirstJsonObject(raw)).toBe(raw);
+  });
+
+  it("ignores escaped quotes inside string contents", () => {
+    const raw = '{"a":"\\"hi\\""}';
+    expect(extractFirstJsonObject(raw)).toBe(raw);
+  });
+
+  it("returns null when no JSON object is present", () => {
+    expect(extractFirstJsonObject("Just prose here.")).toBeNull();
+  });
+
+  it("returns null when the JSON is truncated (no closing brace)", () => {
+    expect(extractFirstJsonObject('{"a":1')).toBeNull();
+  });
+});
+
+describe("resolveIntent — embedded JSON example regression (#262 item 2)", () => {
+  it("parses the outer object even when explanation contains an inline JSON example", async () => {
+    // Without the lexical extractor, `lastIndexOf('}')` would slice off the
+    // closing brace of the example inside `explanation` and JSON.parse would
+    // fail or — worse — succeed with truncated data.
+    const ai = makeFakeAi(
+      '{"action":"create_vendor","input":{"name":"Acme"},"confidence":0.9,' +
+        '"explanation":"Like {\\"name\\":\\"Acme\\"}"}',
+    );
+
+    const proposal = await resolveIntent(
+      { prompt: "Add vendor Acme" },
+      { ai: ai.service, ontology: makeOntology() },
+    );
+
+    expect(proposal).not.toBeNull();
+    expect(proposal?.action).toBe("create_vendor");
+    expect(proposal?.input).toEqual({ name: "Acme" });
+    expect(proposal?.explanation).toBe('Like {"name":"Acme"}');
+  });
+});
+
+// ── #262 item 3 — allowEmpty opt-in for required fields ─────
+
+describe("resolveIntent — allowEmpty opt-in (#262 item 3)", () => {
+  // Per-test ontology: a required `note` field whose `allowEmpty` we toggle.
+  function makeNoteOntology(allowEmpty: boolean | undefined): OntologyRegistryLike {
+    const action: ActionDefinition = {
+      name: "leave_note",
+      entity: "note",
+      label: "Leave Note",
+      input: {
+        // `required: true` means absent/null is missing. `allowEmpty: true`
+        // additionally relaxes the empty-string-as-missing rule.
+        note: { type: "text", required: true, label: "Note", allowEmpty },
+      },
+      policy: { mode: "sync", transaction: true },
+    };
+    return {
+      listEntities: () => ["note"],
+      actionsFor: (e) => (e === "note" ? [action] : []),
+    };
+  }
+
+  it("treats empty string as missing when allowEmpty is unset (default)", async () => {
+    const ai = makeFakeAi(
+      JSON.stringify({
+        action: "leave_note",
+        input: { note: "" },
+        confidence: 0.8,
+        explanation: "Empty note",
+      }),
+    );
+
+    const proposal = await resolveIntent(
+      { prompt: "leave an empty note" },
+      { ai: ai.service, ontology: makeNoteOntology(undefined) },
+    );
+
+    expect(proposal?.missingFields).toEqual(["note"]);
+  });
+
+  it("treats empty string as present when allowEmpty=true (preserves the value)", async () => {
+    const ai = makeFakeAi(
+      JSON.stringify({
+        action: "leave_note",
+        input: { note: "" },
+        confidence: 0.8,
+        explanation: "Empty note",
+      }),
+    );
+
+    const proposal = await resolveIntent(
+      { prompt: "leave an empty note" },
+      { ai: ai.service, ontology: makeNoteOntology(true) },
+    );
+
+    expect(proposal?.missingFields).toEqual([]);
+    // The empty string is kept on the proposal input — UI may render it as
+    // an explicitly-cleared value rather than prompting again.
+    expect(proposal?.input).toEqual({ note: "" });
+  });
+
+  it("treats null as missing even when allowEmpty=true (only relaxes the empty-string rule)", async () => {
+    const ai = makeFakeAi(
+      JSON.stringify({
+        action: "leave_note",
+        input: { note: null },
+        confidence: 0.8,
+        explanation: "Null note",
+      }),
+    );
+
+    const proposal = await resolveIntent(
+      { prompt: "leave note" },
+      { ai: ai.service, ontology: makeNoteOntology(true) },
+    );
+
+    expect(proposal?.missingFields).toEqual(["note"]);
+  });
+
+  it("treats absent key as missing even when allowEmpty=true", async () => {
+    const ai = makeFakeAi(
+      JSON.stringify({
+        action: "leave_note",
+        input: {},
+        confidence: 0.8,
+        explanation: "No note key",
+      }),
+    );
+
+    const proposal = await resolveIntent(
+      { prompt: "leave note" },
+      { ai: ai.service, ontology: makeNoteOntology(true) },
+    );
+
+    expect(proposal?.missingFields).toEqual(["note"]);
   });
 });

--- a/addons/ai-provider/cap-ai-provider/src/intent-prompt.ts
+++ b/addons/ai-provider/cap-ai-provider/src/intent-prompt.ts
@@ -25,6 +25,11 @@ export interface ActionCatalogEntry {
     required: boolean;
     label?: string;
     description?: string;
+    /**
+     * When true, an empty string ("") is treated as a present value during
+     * input reconciliation even if `required` is true. Default: false.
+     */
+    allowEmpty?: boolean;
   }>;
 }
 
@@ -77,6 +82,12 @@ export function buildIntentSystemPrompt(
       name: f.name,
       type: f.type,
       required: f.required,
+      // Forward the empty-string opt-in to the model so it knows ""
+      // is a legitimate value for fields that mark `allowEmpty: true`,
+      // not a missing-field signal (codex P2 / gemini NIT review on
+      // PR #287). Omitted when false/undefined to keep the prompt
+      // compact for the common case.
+      ...(f.allowEmpty === true ? { allowEmpty: true } : {}),
       label: f.label ? sanitizeText(f.label) : undefined,
       description: f.description ? sanitizeText(f.description) : undefined,
     })),
@@ -101,7 +112,7 @@ Rules:
 1. Pick at most ONE primary action whose "name" appears in the JSON array above. NEVER invent an action that is not listed.
 2. If no listed action is a reasonable fit, set "action" to null and explain in plain English what was unclear.
 3. Extract input parameters that the user explicitly stated. Do NOT guess or hallucinate values.
-4. Use only field names that appear in the chosen action's "inputFields" list. Drop anything else.
+4. Use only field names that appear in the chosen action's "inputFields" list. Drop anything else. A field marked \`"allowEmpty": true\` accepts an empty string \`""\` as a valid present value — only set the field to \`""\` when the user explicitly indicated an empty value; otherwise omit the field.
 5. Provide a confidence score in [0, 1] reflecting how confident you are that this is the user's intent.
 6. Provide a one-sentence English explanation suitable for showing to the user inside a confirmation card.
 7. If the primary "confidence" is below ${opts.alternativesConfidenceThreshold}, OPTIONALLY include an "alternatives" array with up to ${opts.maxAlternatives} other plausible matches, each with the same JSON shape as the primary (action, input, confidence, explanation). Each alternative's "action" MUST also appear in the JSON array above; do not invent. Sort alternatives by confidence descending. Omit "alternatives" entirely (or use an empty array) when confidence is high or when no other reasonable match exists.

--- a/addons/ai-provider/cap-ai-provider/src/intent-resolver.ts
+++ b/addons/ai-provider/cap-ai-provider/src/intent-resolver.ts
@@ -263,6 +263,7 @@ function toCatalogEntry(action: ActionDefinition): ActionCatalogEntry {
         required: field.required === true,
         label: field.label,
         description: field.description,
+        allowEmpty: field.allowEmpty === true ? true : undefined,
       });
     }
   }
@@ -328,11 +329,83 @@ function extractJsonCandidate(raw: string): string | null {
     return trimmed;
   }
 
-  // Fall back to extracting the first balanced {...} block.
+  // Prefer the FIRST balanced JSON object — robust against prose wrapping
+  // and embedded JSON examples inside string fields like `explanation`.
+  const balanced = extractFirstJsonObject(trimmed);
+  if (balanced) return balanced;
+
+  // Fall back to the legacy first/last brace heuristic for inputs the
+  // string-aware scanner couldn't reconcile (e.g. truncated streams that
+  // still happen to JSON.parse via prior tolerant parsers).
   const start = trimmed.indexOf("{");
   const end = trimmed.lastIndexOf("}");
   if (start === -1 || end === -1 || end <= start) return null;
   return trimmed.slice(start, end + 1);
+}
+
+/**
+ * Walk `text` once and return the first balanced top-level JSON object as
+ * a substring (inclusive of the outer braces), or `null` if no balanced
+ * object exists.
+ *
+ * Tracks brace depth while ignoring `{` / `}` that appear inside string
+ * literals. Honors `\\` and `\"` escapes inside strings so an escaped quote
+ * does not accidentally close the string scanner.
+ *
+ * Intentionally simple — no JSON5, no regex backtracking. The output is
+ * still passed to `JSON.parse`, which is the source of truth for structural
+ * validity.
+ */
+export function extractFirstJsonObject(text: string): string | null {
+  const start = text.indexOf("{");
+  if (start === -1) return null;
+
+  let depth = 0;
+  let inString = false;
+  let escapeNext = false;
+
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+
+    if (inString) {
+      if (escapeNext) {
+        // Previous char was a backslash — consume this char literally,
+        // even if it is a quote.
+        escapeNext = false;
+        continue;
+      }
+      if (ch === "\\") {
+        escapeNext = true;
+        continue;
+      }
+      if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (ch === "{") {
+      depth++;
+      continue;
+    }
+    if (ch === "}") {
+      depth--;
+      if (depth === 0) {
+        return text.slice(start, i + 1);
+      }
+      if (depth < 0) {
+        // Unbalanced — bail out rather than return a malformed slice.
+        return null;
+      }
+    }
+  }
+
+  // Reached end of input without closing the outer object.
+  return null;
 }
 
 interface ReconciledInput {
@@ -366,7 +439,13 @@ function reconcileInput(
   for (const field of entry.inputFields) {
     if (!field.required) continue;
     const value = cleaned[field.name];
-    if (value === undefined || value === null || value === "") {
+    // `undefined` (absent) and `null` are always missing. `""` is missing
+    // unless the field opts in via `allowEmpty: true` (Spec 52 #262 item 3).
+    if (value === undefined || value === null) {
+      missingFields.push(field.name);
+      continue;
+    }
+    if (value === "" && field.allowEmpty !== true) {
       missingFields.push(field.name);
     }
   }

--- a/packages/core/src/types/entity.ts
+++ b/packages/core/src/types/entity.ts
@@ -108,6 +108,14 @@ export interface BaseFieldDefinition extends FieldConstraints {
   ui?: FieldUIHints;
   /** Capability required for this field. Field is hidden when capability is absent. */
   requiresCapability?: string;
+  /**
+   * When true and the field is `required`, an empty string ("") is treated as
+   * a present value rather than missing during NL intent reconciliation
+   * (Spec 52). Defaults to false — the resolver continues to surface "" as a
+   * missing required field for normal scalar inputs. Has no effect on `null`
+   * or absent values, which are always treated as missing.
+   */
+  allowEmpty?: boolean;
   /** Derived field configuration (spec 48). When set, field value is computed, not user-input. */
   derived?: {
     /** Derivation type */


### PR DESCRIPTION
## Summary

- **Item 2** — `extractFirstJsonObject` lexical scanner prefers the first balanced object and ignores braces inside JSON strings (with proper escape handling). Wired ahead of the existing first/last fallback in `extractJsonCandidate()`. Fixes the case where the AI's `explanation` field embeds a JSON example — the legacy heuristic would drift into the embedded object.
- **Item 3** — `allowEmpty?: boolean` opt-in on `BaseFieldDefinition`, propagated through `ActionCatalogEntry` to `reconcileInput()` AND into the prompt JSON catalog so the LLM sees it. When `true`, an empty string `""` for a `required` field is treated as a present value, not missing.

Existing intent-resolver tests pass without modification (28 → still pass; 13 new tests bring the file to 41).

## Cross-model review

| Reviewer | Finding | Decision |
|---|---|---|
| **codex P2** | `allowEmpty` was captured in `ActionCatalogEntry` but DROPPED in the prompt's `safeCatalog`. AI never sees the flag, so reconcileInput's relaxation works only with canned tests, not real model output. | **FIX** — `safeCatalog` now forwards `allowEmpty: true` (omitted when false/undefined to keep prompt compact); Rules clause #4 documents the semantics for the model. |
| **gemini NIT** | Same as codex P2 — preserve `allowEmpty` in prompt | **FIX** (same change) |
| **gemini approval** | "Robust improvement … excellent coverage … no regressions" | — |

## Test plan

- [x] `bun run check` — green
- [x] `bun run typecheck` — green
- [x] `bun test` — 4844 pass / 0 fail / 3 skip
- [x] Item 2 tests (9 — 8 unit + 1 e2e regression): plain, fenced, prose-wrapped, **embedded JSON example in explanation** (the bug), quoted brace, escaped quote, no JSON, truncated, end-to-end "outer object even when explanation contains inline JSON example"
- [x] Item 3 tests (4): default treats empty as missing, allowEmpty=true keeps it, null still missing, absent still missing

## Refs

- Spec 52 §3 — NL intent resolver hardening
- Issue #262 items 2 & 3
- Item 1 (catalog truncation) closed by PR #284
- Item 5 (JSON-mode AIService variant) deferred — depends on provider capability detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)