### PR TITLE
ci(review-gate): neutralize prior FAILURE check-runs on same SHA (closes #273)

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -171,6 +171,13 @@ jobs:
             // SHA branch protection evaluates, so writing here updates the
             // PR's required-check status without needing an empty commit.
             //
+            // Order matters: we POST the new run BEFORE neutralizing prior
+            // runs. If we neutralized first and `create` then failed (e.g.
+            // fork-PR token downgrade), the SHA could end up with no
+            // FAILURE check-run AND no SUCCESS — leaving the gate in a
+            // muddled state. Posting first guarantees that the latest
+            // verdict lands on the SHA before any history is rewritten.
+            //
             // Fork-PR caveat: GitHub downgrades GITHUB_TOKEN to read-only for
             // `pull_request` events whose head ref lives on a fork, regardless
             // of the workflow-level `permissions:` block. `checks.create()`
@@ -204,6 +211,100 @@ jobs:
                   'GitHub downgrades GITHUB_TOKEN to read-only in that case. The workflow ' +
                   "run status itself will still convey the gate verdict.",
               );
+            }
+
+            // Neutralize any prior `Review Threads` check-runs on this same
+            // SHA. GitHub branch protection treats ANY historical FAILURE
+            // check-run on a SHA as blocking, even when a newer SUCCESS
+            // check-run with the same name exists for the same SHA. Without
+            // this dedup, a PR that had unresolved threads at
+            // `pull_request: synchronize` time stays BLOCKED even after
+            // threads are resolved and `/check-reviews` posts a SUCCESS —
+            // the historical FAILURE check-run is still counted. Marking
+            // older runs as `neutral` (instead of deleting them) preserves
+            // history while telling branch protection to ignore them.
+            //
+            // Only runs the loop when the new check-run actually posted.
+            // Otherwise we'd be silencing the OLD failure without anything
+            // newer in its place — leaving the SHA with no current verdict.
+            //
+            // Per-run try/catch: a 403/422 on one update must not abort
+            // cleanup of the rest. Possible causes include same-name runs
+            // posted by a different GitHub App (which our token can't
+            // touch) or transient API errors. Each failure is logged at
+            // warning level; the worst case degrades to today's behavior
+            // for that one run.
+            //
+            // In-progress runs are intentionally NOT skipped: a still-
+            // running prior gate could complete after we post and end up
+            // re-blocking the PR with a stale verdict on the same SHA.
+            // Attempting `update(... conclusion: neutral)` on an
+            // in-progress run will 422 from the API; the per-run catch
+            // logs and moves on, accepting the small race that the run
+            // finishes between our list and update. The next gate event
+            // (synchronize / `/check-reviews`) re-runs this dedup.
+            //
+            // Idempotent: when no prior runs exist (first synchronize
+            // event), the loop simply does nothing.
+            //
+            // App scope: we filter by `check_name` server-side but NOT by
+            // `app_id`. Our gate's name "Review Threads" is unlikely to
+            // collide with any other app's runs in this repo, and our
+            // installation token cannot mutate runs owned by a different
+            // GitHub App anyway — those calls return 403, which the
+            // per-run catch handles. Adding an `app_id` filter would
+            // require an extra API call to discover our own ID and is
+            // not worth the round-trip given the per-run safety net.
+            if (checkRunPosted) {
+              let existing;
+              try {
+                existing = await github.paginate(
+                  github.rest.checks.listForRef,
+                  {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    ref: prHeadSha,
+                    check_name: 'Review Threads',
+                    per_page: 100,
+                  },
+                );
+              } catch (err) {
+                const message = err instanceof Error ? err.message : String(err);
+                core.warning(
+                  `Could not list prior Review Threads check-runs on ${prHeadSha} (${message}). ` +
+                    'Continuing — the fresh check-run was posted, but stale FAILUREs ' +
+                    'may keep the PR BLOCKED until manually cleared.',
+                );
+                existing = [];
+              }
+              for (const run of existing) {
+                try {
+                  await github.rest.checks.update({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    check_run_id: run.id,
+                    status: 'completed',
+                    conclusion: 'neutral',
+                    output: {
+                      title: 'Superseded by a newer Review Threads run',
+                      summary:
+                        'This check-run was neutralized because the gate re-evaluated ' +
+                        'this SHA. See the latest Review Threads check-run for the ' +
+                        'current verdict.',
+                    },
+                  });
+                  core.info(
+                    `Neutralized prior Review Threads check-run #${run.id} (was ${run.conclusion ?? run.status}) on ${prHeadSha}.`,
+                  );
+                } catch (err) {
+                  const message = err instanceof Error ? err.message : String(err);
+                  core.warning(
+                    `Skipped neutralizing Review Threads check-run #${run.id} on ${prHeadSha} (${message}). ` +
+                      'A 422 here typically means the run is still in progress; a 403 ' +
+                      'means it belongs to a different GitHub App.',
+                  );
+                }
+              }
             }
 
             // For `pull_request` events the workflow's own conclusion has


### PR DESCRIPTION
## Summary

- After posting the new \`Review Threads\` check-run on the PR head SHA, neutralize any prior runs of the same name on that SHA so branch protection stops counting historical FAILUREs as blocking.
- This was the workaround pattern across the past 9 PRs in this session: \`git commit --allow-empty\` to bump the SHA. With this change, threading-resolved + \`/check-reviews\` is enough.
- Order of operations is deliberate: POST first, NEUTRALIZE after — so a fork-PR token-downgrade 403 on \`create\` cannot leave the SHA with neither verdict.

## Why per-run try/catch + don't skip in-progress

- A 403 (run owned by a different GitHub App) or 422 (in-progress run) on one entry must not abort cleanup of the rest.
- In-progress siblings are NOT skipped — that race lets a still-running prior gate land a stale verdict after our post. The 422 is logged and the loop moves on; the next gate event re-runs dedup.

## Trigger set unchanged

\`pull_request: opened/synchronize/reopened/ready\` + \`issue_comment: created\` (for \`/check-reviews\`). Both \`pull_request_review_thread\` and \`concurrency:\` are documented as breaking GH Actions workflow registration in this repo (see \`feedback_review_gate_trigger_fix.md\`).

## Test plan

- [x] \`bun run check\` clean
- [x] \`bun run typecheck\` clean
- [x] \`bun test\` 4874 pass / 0 fail
- [x] YAML reviewed for syntax — no js-yaml in deps but \`actions/github-script@v7\` parses on push
- [x] Octokit API shapes verified: \`paginate(checks.listForRef, { check_name })\` is server-side filter; \`checks.update\` accepts \`status: "completed", conclusion: "neutral"\` to mark superseded; both methods documented at https://docs.github.com/en/rest/checks
- [ ] End-to-end on a real PR — will be validated by the next PR after this one merges

## Cross-model review

- **Codex** flagged 3 issues — all addressed:
  1. Order: NEUTRALIZE-then-CREATE was unsafe → now CREATE-then-NEUTRALIZE.
  2. \`status !== 'completed'\` skip allowed in-progress siblings to land stale FAILURE → removed; per-run catch handles 422.
  3. Single try/catch wrapping all updates would abort on first 403 → per-run try/catch.
- **Gemini**: hour-quota exhausted earlier in session; codex coverage is sufficient for a CI workflow change of this size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)