### PR TITLE
fix(cli): linch install nonexistent-package test deterministic (closes #221)

### DIFF
--- a/packages/cli/__tests__/install-capability.test.ts
+++ b/packages/cli/__tests__/install-capability.test.ts
@@ -452,15 +452,29 @@ describe("linch install", () => {
         },
       );
 
+      let timedOut = false;
       const killTimer = setTimeout(() => {
+        timedOut = true;
         proc.kill();
       }, 8_000);
 
       try {
         const exitCode = await proc.exited;
-        // `bun add` should fail (or be killed by the timer above); either
-        // path lands a non-zero exit, which is what the assertion checks.
+        // `bun add` should fail with ECONNREFUSED in well under 1s. If the
+        // kill-timer ever fires, the spawn will still exit non-zero (a
+        // killed process satisfies the "should fail" assertion), but that
+        // means `bun add` blocked instead of failing fast — exactly the
+        // Bun regression mode we want to surface (oven-sh/bun#5831,
+        // #11526). Throw a descriptive error instead of silently passing,
+        // so the regression doesn't hide behind a green test.
         expect(exitCode).not.toBe(0);
+        if (timedOut) {
+          throw new Error(
+            "bun add did not fail fast against an unreachable registry — " +
+              "the 8s kill-timer fired. This may indicate a Bun regression " +
+              "(oven-sh/bun#5831, #11526). Investigate before merging.",
+          );
+        }
       } finally {
         clearTimeout(killTimer);
       }

--- a/packages/cli/__tests__/install-capability.test.ts
+++ b/packages/cli/__tests__/install-capability.test.ts
@@ -425,18 +425,45 @@ describe("linch install", () => {
     }, 30_000);
 
     test("exits with error for a nonexistent package", async () => {
+      // Override the npm registry to an unreachable address so `bun add` fails
+      // fast with ConnectionRefused instead of waiting on the live npm registry
+      // (which can hang and cause flaky timeouts). This still exercises the
+      // real failure path: bun add returns non-zero, install.ts calls
+      // process.exit(1), and the CLI exits with a non-zero code.
+      //
+      // We do NOT rely on `BUN_CONFIG_REGISTRY=...:1` being inherently
+      // fail-fast — past Bun releases shipped hangs against unreachable
+      // registries (oven-sh/bun#5831, #11526) and CI pins `bun-version: latest`,
+      // so a future regression could quietly turn this back into a 30s
+      // timeout flake. The kill-timer below caps the spawn at 8s regardless:
+      // a killed process exits non-zero, which is what the assertion checks,
+      // so the test stays deterministic whether `bun add` exits cleanly or
+      // hangs. The test budget (15s) leaves headroom for cold CI startup.
       const proc = Bun.spawn(
         ["bun", "run", CLI_ENTRY, "install", "@linchkit/this-package-does-not-exist-xyz"],
         {
           cwd: TEST_DIR,
           stdout: "pipe",
           stderr: "pipe",
+          env: {
+            ...process.env,
+            BUN_CONFIG_REGISTRY: "http://127.0.0.1:1",
+          },
         },
       );
 
-      const exitCode = await proc.exited;
-      // bun add should fail, which causes a non-zero exit
-      expect(exitCode).not.toBe(0);
-    }, 30_000);
+      const killTimer = setTimeout(() => {
+        proc.kill();
+      }, 8_000);
+
+      try {
+        const exitCode = await proc.exited;
+        // `bun add` should fail (or be killed by the timer above); either
+        // path lands a non-zero exit, which is what the assertion checks.
+        expect(exitCode).not.toBe(0);
+      } finally {
+        clearTimeout(killTimer);
+      }
+    }, 15_000);
   });
 });


### PR DESCRIPTION
## Summary

- Test "exits with error for a nonexistent package" hit 30s timeouts under flaky-network conditions because it relied on the live npm registry.
- Two-layer fix: unreachable registry (\`BUN_CONFIG_REGISTRY=http://127.0.0.1:1\`) so \`bun add\` fails fast in the happy path, **plus** an 8s kill-timer that guarantees a non-zero exit even if a future Bun version regresses to hanging on a refused socket.
- Test budget bumped from 5s (original PR draft) → 15s after codex flagged the original 30s as too tight for cold CI startup. The kill-timer caps the spawn well within budget.

## Test plan

- [x] \`bun test ./packages/cli/__tests__/install-capability.test.ts\` — 25/25 pass, target test runs in ~294ms locally
- [x] Full \`bun test\` — 4874 pass / 0 fail
- [x] \`bun run check\` clean
- [x] \`bun run typecheck\` clean

## Cross-model review

- **Codex** flagged 2 issues — both addressed:
  1. \`BUN_CONFIG_REGISTRY=...:1\` is not a documented fail-fast guarantee; past Bun versions shipped hangs against unreachable registries (oven-sh/bun#5831, #11526). Fix: add explicit kill-timer.
  2. Original 5s budget too tight for cold CI startup. Fix: bump to 15s test budget + 8s kill-timer.
- **Gemini**: hour-quota exhausted earlier in session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for package installation failure scenarios with enhanced timeout management and faster failure detection to prevent hanging processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->