### PR TITLE
feat(cli): add linch i18n-check for translation key validation (closes #159)

### DIFF
--- a/packages/cli/__tests__/i18n-check.test.ts
+++ b/packages/cli/__tests__/i18n-check.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tests for `linch i18n check` — pure helpers + CLI integration.
+ *
+ * Pure helpers (`flattenLocale`, `compareLocales`, `discoverLocaleGroups`,
+ * `checkCapability`) are tested directly to avoid CLI-spawn overhead. One
+ * end-to-end fixture is exercised via `discoverLocaleGroups + checkCapability`
+ * to confirm wiring.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  checkCapability,
+  compareLocales,
+  discoverLocaleGroups,
+  flattenLocale,
+  type LocaleTree,
+} from "../src/commands/i18n-check";
+
+describe("flattenLocale", () => {
+  it("flattens a flat object 1:1", () => {
+    expect(flattenLocale({ a: "1", b: "2" })).toEqual({ a: "1", b: "2" });
+  });
+
+  it("flattens nested keys with dot notation", () => {
+    const tree: LocaleTree = { common: { submit: "Submit", cancel: "Cancel" }, top: "Top" };
+    expect(flattenLocale(tree)).toEqual({
+      "common.submit": "Submit",
+      "common.cancel": "Cancel",
+      top: "Top",
+    });
+  });
+
+  it("coerces non-string leaves to string instead of recursing into arrays", () => {
+    // Arrays aren't valid LocaleTree leaves but a real i18n file might slip
+    // one in; we coerce, never recurse.
+    const tree = { count: 7 as unknown as string, list: ["a", "b"] as unknown as string };
+    expect(flattenLocale(tree as LocaleTree)).toEqual({ count: "7", list: "a,b" });
+  });
+
+  it("does not mutate the input", () => {
+    const tree: LocaleTree = { a: { b: "x" } };
+    const snapshot = JSON.stringify(tree);
+    flattenLocale(tree);
+    expect(JSON.stringify(tree)).toBe(snapshot);
+  });
+});
+
+describe("compareLocales", () => {
+  it("reports no issues when locales are identical", () => {
+    const issues = compareLocales({
+      en: { "common.ok": "OK" },
+      "zh-CN": { "common.ok": "好" },
+    });
+    expect(issues).toEqual([]);
+  });
+
+  it("reports a missing key in the locale that lacks it", () => {
+    const issues = compareLocales({
+      en: { "common.ok": "OK", "common.cancel": "Cancel" },
+      "zh-CN": { "common.ok": "好" },
+    });
+    const kinds = issues.map((i) => `${i.kind}:${i.locale}:${i.key}`);
+    expect(kinds).toContain("missing:zh-CN:common.cancel");
+    // "extra" is the symmetric counterpart, only when exactly one locale has it.
+    expect(kinds).toContain("extra:en:common.cancel");
+  });
+
+  it("reports an empty value as kind=empty", () => {
+    const issues = compareLocales({
+      en: { "common.ok": "OK", "common.cancel": "" },
+      "zh-CN": { "common.ok": "好", "common.cancel": "取消" },
+    });
+    const empties = issues.filter((i) => i.kind === "empty");
+    expect(empties.length).toBe(1);
+    expect(empties[0]?.locale).toBe("en");
+    expect(empties[0]?.key).toBe("common.cancel");
+  });
+
+  it("treats whitespace-only values as empty", () => {
+    const issues = compareLocales({
+      en: { greeting: "   " },
+      "zh-CN": { greeting: "你好" },
+    });
+    expect(issues.some((i) => i.kind === "empty" && i.locale === "en")).toBe(true);
+  });
+
+  it("does not emit 'extra' when more than one locale has the key (only 'missing')", () => {
+    const issues = compareLocales({
+      en: { a: "1" },
+      "zh-CN": { a: "1" },
+      fr: {},
+    });
+    const extras = issues.filter((i) => i.kind === "extra");
+    expect(extras).toEqual([]);
+    const missing = issues.filter((i) => i.kind === "missing" && i.locale === "fr");
+    expect(missing.length).toBe(1);
+  });
+});
+
+describe("discoverLocaleGroups + checkCapability (end-to-end via fixture)", () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = resolve(
+      process.env.TMPDIR ?? "/tmp",
+      `linchkit-i18n-check-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tmpRoot, { recursive: true });
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    } catch {
+      // Best effort — the OS will reap the tmp tree later.
+    }
+  });
+
+  function writeLocale(capPath: string, layout: "flat" | "nested", locale: string, body: object) {
+    const dir =
+      layout === "flat" ? resolve(capPath, "src/i18n") : resolve(capPath, "src/i18n/locales");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(resolve(dir, `${locale}.json`), JSON.stringify(body, null, 2));
+  }
+
+  it("returns empty when there is no `addons/` directory", () => {
+    expect(discoverLocaleGroups(tmpRoot)).toEqual([]);
+  });
+
+  it("discovers groups under both flat and nested layouts", () => {
+    const flatCap = resolve(tmpRoot, "addons/group-a/cap-flat");
+    writeLocale(flatCap, "flat", "en", { hello: "Hi" });
+    writeLocale(flatCap, "flat", "zh-CN", { hello: "你好" });
+
+    const nestedCap = resolve(tmpRoot, "addons/group-b/cap-nested");
+    writeLocale(nestedCap, "nested", "en", { fresh: "fresh" });
+    writeLocale(nestedCap, "nested", "zh-CN", { fresh: "鲜" });
+
+    const groups = discoverLocaleGroups(tmpRoot);
+    expect(groups.map((g) => g.capability).sort()).toEqual([
+      "addons/group-a/cap-flat",
+      "addons/group-b/cap-nested",
+    ]);
+    const nestedGroup = groups.find((g) => g.capability === "addons/group-b/cap-nested");
+    expect(nestedGroup?.dir.endsWith("locales")).toBe(true);
+  });
+
+  it("unions flat + nested layouts during partial migration (no locale dropped)", async () => {
+    // A capability mid-migration: `en` already moved to `locales/`,
+    // `zh-CN` still flat in `i18n/`. Discovery must surface BOTH so the
+    // check doesn't false-positive a missing locale.
+    const capPath = resolve(tmpRoot, "addons/g/cap-partial");
+    writeLocale(capPath, "nested", "en", { hello: "Hi" });
+    writeLocale(capPath, "flat", "zh-CN", { hello: "你好" });
+
+    const groups = discoverLocaleGroups(tmpRoot);
+    expect(groups.length).toBe(1);
+    expect(Object.keys(groups[0]?.locales ?? {}).sort()).toEqual(["en", "zh-CN"]);
+
+    const report = await checkCapability(groups[0] as LocaleGroup);
+    expect(report.skipped).toBeUndefined();
+    expect(report.issues).toEqual([]);
+  });
+
+  it("on same-locale collision, nested layout wins", async () => {
+    // Both layouts contain `en.json`. Post-migration intent is that
+    // `locales/en.json` is the source of truth.
+    const capPath = resolve(tmpRoot, "addons/g/cap-collision");
+    writeLocale(capPath, "flat", "en", { stale: "stale-value" });
+    writeLocale(capPath, "nested", "en", { fresh: "fresh-value" });
+    writeLocale(capPath, "nested", "zh-CN", { fresh: "鲜" });
+
+    const groups = discoverLocaleGroups(tmpRoot);
+    const report = await checkCapability(groups[0] as LocaleGroup);
+    // Should compare the FRESH `en` (from locales/) against `zh-CN`,
+    // surfacing only `fresh` as the cross-locale key.
+    expect(report.issues.some((i) => i.key === "stale")).toBe(false);
+    expect(report.issues.some((i) => i.key === "fresh")).toBe(false);
+  });
+
+  it("checkCapability returns OK for matching locales", async () => {
+    const capPath = resolve(tmpRoot, "addons/g/cap-ok");
+    writeLocale(capPath, "flat", "en", { hello: "Hi" });
+    writeLocale(capPath, "flat", "zh-CN", { hello: "你好" });
+
+    const groups = discoverLocaleGroups(tmpRoot);
+    const report = await checkCapability(groups[0] as LocaleGroup);
+    expect(report.skipped).toBeUndefined();
+    expect(report.issues).toEqual([]);
+  });
+
+  it("checkCapability finds nested-key mismatches", async () => {
+    const capPath = resolve(tmpRoot, "addons/g/cap-mismatch");
+    writeLocale(capPath, "flat", "en", { common: { submit: "Submit", cancel: "Cancel" } });
+    writeLocale(capPath, "flat", "zh-CN", { common: { submit: "提交" } });
+
+    const groups = discoverLocaleGroups(tmpRoot);
+    const report = await checkCapability(groups[0] as LocaleGroup);
+    expect(report.issues.some((i) => i.kind === "missing" && i.key === "common.cancel")).toBe(true);
+  });
+
+  it("checkCapability marks single-locale capabilities as skipped, not failed", async () => {
+    const capPath = resolve(tmpRoot, "addons/g/cap-single");
+    writeLocale(capPath, "flat", "en", { hello: "Hi" });
+
+    const groups = discoverLocaleGroups(tmpRoot);
+    const report = await checkCapability(groups[0] as LocaleGroup);
+    expect(report.skipped).toBeDefined();
+    expect(report.issues).toEqual([]);
+  });
+
+  it("checkCapability reports a parse error as skipped, not crashed", async () => {
+    const capPath = resolve(tmpRoot, "addons/g/cap-bad-json");
+    const dir = resolve(capPath, "src/i18n");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(resolve(dir, "en.json"), "{not valid json");
+    writeFileSync(resolve(dir, "zh-CN.json"), JSON.stringify({ ok: "ok" }));
+
+    const groups = discoverLocaleGroups(tmpRoot);
+    const report = await checkCapability(groups[0] as LocaleGroup);
+    expect(report.skipped).toBeDefined();
+    expect(report.skipped).toContain("failed to parse");
+  });
+});

--- a/packages/cli/__tests__/i18n-check.test.ts
+++ b/packages/cli/__tests__/i18n-check.test.ts
@@ -15,6 +15,7 @@ import {
   compareLocales,
   discoverLocaleGroups,
   flattenLocale,
+  type LocaleGroup,
   type LocaleTree,
 } from "../src/commands/i18n-check";
 

--- a/packages/cli/src/commands/i18n-check.ts
+++ b/packages/cli/src/commands/i18n-check.ts
@@ -62,15 +62,19 @@ export interface CapabilityReport {
 
 /**
  * Flatten a nested locale tree into a map of dot-separated key → leaf value.
- * Non-string leaves (numbers, arrays, etc.) are coerced to string. We never
- * mutate the input.
+ * Non-string leaves (numbers, arrays, etc.) are coerced to string. The input
+ * is never mutated. The accumulator is passed through recursion to avoid
+ * re-allocating intermediate objects on every level.
  */
-export function flattenLocale(tree: LocaleTree, prefix = ""): Record<string, string> {
-  const out: Record<string, string> = {};
+export function flattenLocale(
+  tree: LocaleTree,
+  prefix = "",
+  out: Record<string, string> = {},
+): Record<string, string> {
   for (const [k, v] of Object.entries(tree)) {
     const path = prefix ? `${prefix}.${k}` : k;
     if (v !== null && typeof v === "object" && !Array.isArray(v)) {
-      Object.assign(out, flattenLocale(v as LocaleTree, path));
+      flattenLocale(v as LocaleTree, path, out);
     } else {
       out[path] = typeof v === "string" ? v : String(v);
     }
@@ -114,7 +118,8 @@ export function compareLocales(locales: Record<string, Record<string, string>>):
 
   const sortedKeys = Array.from(allKeys).sort();
   for (const key of sortedKeys) {
-    const presentIn = localeNames.filter((n) => locales[n] && key in (locales[n] ?? {}));
+    // localeNames came from Object.keys(locales), so locales[n] is defined.
+    const presentIn = localeNames.filter((n) => key in (locales[n] as Record<string, string>));
     const missingIn = localeNames.filter((n) => !presentIn.includes(n));
     if (missingIn.length === 0) continue;
 
@@ -347,8 +352,8 @@ export const i18nCheckCommand = defineCommand({
     const outputJson = Boolean(args.json);
 
     const groups = discoverLocaleGroups(rootDir);
-    const reports: CapabilityReport[] = [];
-    for (const g of groups) reports.push(await checkCapability(g));
+    // Run capability checks in parallel — each does independent file I/O.
+    const reports: CapabilityReport[] = await Promise.all(groups.map(checkCapability));
 
     const totalIssues = reports.reduce((acc, r) => acc + r.issues.length, 0);
     const skippedCount = reports.filter((r) => r.skipped).length;

--- a/packages/cli/src/commands/i18n-check.ts
+++ b/packages/cli/src/commands/i18n-check.ts
@@ -1,0 +1,397 @@
+/**
+ * linch i18n check — Validate translation key consistency across capability locale files.
+ *
+ * Scans all i18n JSON files under `addons/<group>/<cap>/src/i18n/` (or
+ * `.../src/i18n/locales/`) and reports, per capability:
+ *   1. Missing keys — present in one locale but not the other.
+ *   2. Extra keys   — only in one locale (the inverse of "missing"; emitted
+ *                     once per locale to make the asymmetry obvious).
+ *   3. Empty values — a key exists but its string value is empty / whitespace.
+ *
+ * Exits with code 1 if any issue is found, 0 otherwise — CI-friendly.
+ *
+ * Discovery: globs `addons/<group>/<cap>/src/i18n/*.json` and
+ * `addons/<group>/<cap>/src/i18n/locales/*.json`. Capabilities with fewer
+ * than two locale files are reported as "skipped" (warning, not failure).
+ *
+ * Pure helpers (`compareLocales`, `flattenLocale`, `discoverLocaleGroups`)
+ * are exported for unit testing without spawning the CLI.
+ */
+
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import { defineCommand } from "citty";
+import consola from "consola";
+
+// ── Types ────────────────────────────────────────────────────
+
+/** Recursive locale tree — leaves are strings, branches are nested objects. */
+export type LocaleTree = { [key: string]: string | LocaleTree };
+
+/** A single capability's locale files (e.g. `en.json` + `zh-CN.json`). */
+export interface LocaleGroup {
+  /** Capability label, e.g. `addons/adapter-ui/cap-adapter-ui` (relative to repo root). */
+  capability: string;
+  /** Absolute path to the i18n directory. */
+  dir: string;
+  /** Map of locale name → absolute file path. */
+  locales: Record<string, string>;
+}
+
+/** A single issue surfaced by the check. */
+export interface I18nIssue {
+  kind: "missing" | "extra" | "empty";
+  /** Locale that the issue belongs to (e.g. `en`, `zh-CN`). */
+  locale: string;
+  /** Dot-separated key path, e.g. `common.submit`. */
+  key: string;
+  /** Optional human note (e.g. "missing in zh-CN, present in en"). */
+  detail?: string;
+}
+
+/** Result of comparing one capability's locale files. */
+export interface CapabilityReport {
+  capability: string;
+  locales: string[];
+  issues: I18nIssue[];
+  /** Set when the capability could not be checked (e.g. only one locale found). */
+  skipped?: string;
+}
+
+// ── Pure helpers (testable without spawning the CLI) ─────────
+
+/**
+ * Flatten a nested locale tree into a map of dot-separated key → leaf value.
+ * Non-string leaves (numbers, arrays, etc.) are coerced to string. We never
+ * mutate the input.
+ */
+export function flattenLocale(tree: LocaleTree, prefix = ""): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(tree)) {
+    const path = prefix ? `${prefix}.${k}` : k;
+    if (v !== null && typeof v === "object" && !Array.isArray(v)) {
+      Object.assign(out, flattenLocale(v as LocaleTree, path));
+    } else {
+      out[path] = typeof v === "string" ? v : String(v);
+    }
+  }
+  return out;
+}
+
+/**
+ * Compare a set of locales (already flattened) and produce issues.
+ *
+ * For each pair (locale A, locale B):
+ *   - keys in A but not in B → issue kind="missing", locale=B
+ *   - empty values in any locale → issue kind="empty", locale=that locale
+ *
+ * "extra" is emitted as the symmetric counterpart of "missing" so users can
+ * spot which side is the source of truth at a glance.
+ */
+export function compareLocales(locales: Record<string, Record<string, string>>): I18nIssue[] {
+  const localeNames = Object.keys(locales).sort();
+  const issues: I18nIssue[] = [];
+
+  // Empty-value check (per locale, independent of cross-locale comparison).
+  for (const name of localeNames) {
+    const entries = locales[name];
+    if (!entries) continue;
+    for (const [k, v] of Object.entries(entries)) {
+      if (v.trim() === "") {
+        issues.push({ kind: "empty", locale: name, key: k });
+      }
+    }
+  }
+
+  // Cross-locale missing/extra check. We use the union of all keys as the
+  // reference set so a key in *any* locale gets a verdict in *every* other.
+  const allKeys = new Set<string>();
+  for (const name of localeNames) {
+    const entries = locales[name];
+    if (!entries) continue;
+    for (const k of Object.keys(entries)) allKeys.add(k);
+  }
+
+  const sortedKeys = Array.from(allKeys).sort();
+  for (const key of sortedKeys) {
+    const presentIn = localeNames.filter((n) => locales[n] && key in (locales[n] ?? {}));
+    const missingIn = localeNames.filter((n) => !presentIn.includes(n));
+    if (missingIn.length === 0) continue;
+
+    for (const m of missingIn) {
+      issues.push({
+        kind: "missing",
+        locale: m,
+        key,
+        detail: `missing in ${m}, present in ${presentIn.join(", ")}`,
+      });
+    }
+    // Symmetric "extra" entries — only meaningful when *exactly one* locale
+    // has the key, otherwise "missing" already conveys the asymmetry.
+    if (presentIn.length === 1) {
+      issues.push({
+        kind: "extra",
+        locale: presentIn[0] ?? "",
+        key,
+        detail: `only in ${presentIn[0]}`,
+      });
+    }
+  }
+
+  return issues;
+}
+
+/**
+ * Discover capability locale groups under a root directory.
+ *
+ * Scans `<root>/addons/<group>/<cap>/src/i18n/` and
+ * `<root>/addons/<group>/<cap>/src/i18n/locales/` for `*.json` files. A
+ * group is returned only when its directory holds at least one `.json` file.
+ *
+ * Capabilities with fewer than two locales are still returned (so the caller
+ * can report them as skipped) — discovery does not enforce pairing.
+ */
+export function discoverLocaleGroups(rootDir: string): LocaleGroup[] {
+  const addonsDir = resolve(rootDir, "addons");
+  if (!existsSync(addonsDir)) return [];
+
+  const groups: LocaleGroup[] = [];
+
+  const safeReadDir = (dir: string): string[] => {
+    try {
+      return readdirSync(dir);
+    } catch {
+      return [];
+    }
+  };
+
+  const collectJsonFiles = (dir: string): Record<string, string> => {
+    const out: Record<string, string> = {};
+    if (!existsSync(dir)) return out;
+    let stat: ReturnType<typeof statSync> | undefined;
+    try {
+      stat = statSync(dir);
+    } catch {
+      return out;
+    }
+    if (!stat?.isDirectory()) return out;
+    for (const file of safeReadDir(dir)) {
+      if (!file.endsWith(".json")) continue;
+      const localeName = file.replace(/\.json$/, "");
+      out[localeName] = resolve(dir, file);
+    }
+    return out;
+  };
+
+  for (const group of safeReadDir(addonsDir)) {
+    const groupPath = resolve(addonsDir, group);
+    let groupStat: ReturnType<typeof statSync> | undefined;
+    try {
+      groupStat = statSync(groupPath);
+    } catch {
+      continue;
+    }
+    if (!groupStat?.isDirectory()) continue;
+
+    for (const cap of safeReadDir(groupPath)) {
+      const capPath = resolve(groupPath, cap);
+      let capStat: ReturnType<typeof statSync> | undefined;
+      try {
+        capStat = statSync(capPath);
+      } catch {
+        continue;
+      }
+      if (!capStat?.isDirectory()) continue;
+
+      // Probe both layouts: <cap>/src/i18n/*.json and <cap>/src/i18n/locales/*.json.
+      // We UNION rather than pick — partial migrations may leave some locales
+      // in each. When the same locale name appears in both, the nested
+      // `locales/` copy wins (it's the documented post-migration target), but
+      // pure-flat or pure-nested capabilities still resolve correctly.
+      const i18nDir = resolve(capPath, "src/i18n");
+      const localesDir = resolve(i18nDir, "locales");
+
+      const direct = collectJsonFiles(i18nDir);
+      const nested = collectJsonFiles(localesDir);
+
+      const merged: Record<string, string> = { ...direct, ...nested };
+      if (Object.keys(merged).length === 0) continue;
+
+      groups.push({
+        capability: `addons/${group}/${cap}`,
+        // Pick the directory containing the most locales for display; ties
+        // break toward `locales/` so post-migration capabilities show that.
+        dir: Object.keys(nested).length >= Object.keys(direct).length ? localesDir : i18nDir,
+        locales: merged,
+      });
+    }
+  }
+
+  return groups.sort((a, b) => a.capability.localeCompare(b.capability));
+}
+
+/**
+ * Read and parse all locale files for a group. Errors are surfaced as a
+ * single thrown Error so the caller can decide policy — at the CLI level we
+ * convert those into a `skipped` report rather than crashing the whole run.
+ */
+export async function readLocaleGroup(
+  group: LocaleGroup,
+): Promise<Record<string, Record<string, string>>> {
+  const out: Record<string, Record<string, string>> = {};
+  for (const [locale, filePath] of Object.entries(group.locales)) {
+    const tree = (await Bun.file(filePath).json()) as LocaleTree;
+    out[locale] = flattenLocale(tree);
+  }
+  return out;
+}
+
+/** Inspect a single capability and return its report. */
+export async function checkCapability(group: LocaleGroup): Promise<CapabilityReport> {
+  const localeNames = Object.keys(group.locales).sort();
+  if (localeNames.length < 2) {
+    return {
+      capability: group.capability,
+      locales: localeNames,
+      issues: [],
+      skipped: `only ${localeNames.length} locale file found (need at least 2)`,
+    };
+  }
+
+  let flat: Record<string, Record<string, string>>;
+  try {
+    flat = await readLocaleGroup(group);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      capability: group.capability,
+      locales: localeNames,
+      issues: [],
+      skipped: `failed to parse locale files: ${msg}`,
+    };
+  }
+
+  return {
+    capability: group.capability,
+    locales: localeNames,
+    issues: compareLocales(flat),
+  };
+}
+
+// ── CLI rendering ────────────────────────────────────────────
+
+/** Pretty-print a single capability report to stdout. */
+function printReport(report: CapabilityReport): void {
+  const header = `• ${report.capability} [${report.locales.join(", ") || "no locales"}]`;
+  console.log(header);
+
+  if (report.skipped) {
+    console.log(`    skipped: ${report.skipped}`);
+    return;
+  }
+
+  if (report.issues.length === 0) {
+    console.log("    OK");
+    return;
+  }
+
+  // Group issues by kind for compact output.
+  const byKind = new Map<I18nIssue["kind"], I18nIssue[]>();
+  for (const issue of report.issues) {
+    const list = byKind.get(issue.kind) ?? [];
+    list.push(issue);
+    byKind.set(issue.kind, list);
+  }
+
+  const KIND_LABEL: Record<I18nIssue["kind"], string> = {
+    missing: "Missing keys",
+    extra: "Extra keys",
+    empty: "Empty values",
+  };
+
+  for (const kind of ["missing", "extra", "empty"] as const) {
+    const list = byKind.get(kind);
+    if (!list || list.length === 0) continue;
+    console.log(`    ${KIND_LABEL[kind]} (${list.length}):`);
+    for (const issue of list) {
+      const note = issue.detail ? ` — ${issue.detail}` : "";
+      console.log(`        [${issue.locale}] ${issue.key}${note}`);
+    }
+  }
+}
+
+// ── Citty command ────────────────────────────────────────────
+
+// Flat top-level command (`linch i18n-check`) instead of a namespaced
+// `linch i18n check` group: a namespace would have to be reserved at the
+// CLI entry point, which would silently shadow any downstream capability
+// that uses `i18n` for its own subcommands.
+export const i18nCheckCommand = defineCommand({
+  meta: {
+    name: "i18n-check",
+    description: "Validate translation key consistency across capability locale files",
+  },
+  args: {
+    cwd: {
+      type: "string",
+      description: "Project root to scan (defaults to current working directory)",
+    },
+    json: {
+      type: "boolean",
+      description: "Emit machine-readable JSON instead of pretty output",
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const rootDir = (args.cwd as string | undefined) ?? process.cwd();
+    const outputJson = Boolean(args.json);
+
+    const groups = discoverLocaleGroups(rootDir);
+    const reports: CapabilityReport[] = [];
+    for (const g of groups) reports.push(await checkCapability(g));
+
+    const totalIssues = reports.reduce((acc, r) => acc + r.issues.length, 0);
+    const skippedCount = reports.filter((r) => r.skipped).length;
+    const cleanCount = reports.filter((r) => !r.skipped && r.issues.length === 0).length;
+
+    if (outputJson) {
+      console.log(
+        JSON.stringify(
+          {
+            passed: totalIssues === 0,
+            summary: {
+              capabilities: reports.length,
+              clean: cleanCount,
+              skipped: skippedCount,
+              issues: totalIssues,
+            },
+            reports,
+          },
+          null,
+          2,
+        ),
+      );
+    } else {
+      if (reports.length === 0) {
+        consola.warn(`No capability i18n files found under ${rootDir}/addons.`);
+      } else {
+        console.log("");
+        for (const r of reports) printReport(r);
+        console.log("");
+        if (totalIssues === 0) {
+          consola.success(
+            `i18n check passed. ${cleanCount} clean, ${skippedCount} skipped, ${reports.length} total.`,
+          );
+        } else {
+          consola.error(
+            `i18n check failed: ${totalIssues} issue(s) across ${reports.length} capability(ies).`,
+          );
+        }
+      }
+    }
+
+    if (totalIssues > 0) {
+      process.exit(1);
+    }
+  },
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -187,6 +187,7 @@ function buildCommandsManifest(
     overlay: "Manage runtime overlay fields (list, promote)",
     registry: "Capability registry management (sync, list)",
     setup: "Sync AI tool configurations (skills, MCP config) for the current project",
+    "i18n-check": "Validate translation key consistency across capability locale files",
   };
 
   for (const name of builtinNames) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -26,6 +26,7 @@ import { devCommand } from "./commands/dev";
 import { docsCommand } from "./commands/docs";
 import { doctorCommand } from "./commands/doctor";
 import { execCommand } from "./commands/exec";
+import { i18nCheckCommand } from "./commands/i18n-check";
 import { infoCommand } from "./commands/info";
 import { initCommand } from "./commands/init";
 import { installCommand } from "./commands/install";
@@ -67,6 +68,7 @@ const RESERVED_NAMESPACES = new Set([
   "overlay",
   "registry",
   "setup",
+  "i18n-check",
 ]);
 
 /**
@@ -238,6 +240,7 @@ async function run() {
     overlay: overlayCommand,
     registry: registryCommand,
     setup: setupCommand,
+    "i18n-check": i18nCheckCommand,
   };
 
   const { tree: capCommands, commands: capCommandList } = await discoverCapabilityCommands();


### PR DESCRIPTION
## Summary

- New top-level CLI command \`linch i18n-check\` scans every capability's i18n locale files and reports missing keys, extra keys, and empty values, exiting non-zero on any issue (CI-friendly).
- Optional \`--json\` for machine-readable output, \`--cwd <dir>\` for non-default project roots.
- Pure helpers (\`flattenLocale\` / \`compareLocales\` / \`discoverLocaleGroups\` / \`checkCapability\`) are exported for unit testing without spawning the CLI.

## Architectural choices

- **Flat \`linch i18n-check\` command**, not a namespaced \`linch i18n check\` group. A namespace would have to be reserved at the CLI entry point and would silently shadow any downstream capability using \`i18n\` for its own subcommands. Codex caught this on pre-review.
- **Discovery unions \`src/i18n/*.json\` and \`src/i18n/locales/*.json\`** so partial migrations don't silently drop locales. On same-locale collision the nested \`locales/\` copy wins (it's the documented post-migration target).
- **Coerced non-string leaves** (numbers, arrays) flow through \`flattenLocale\` rather than crashing — they typically surface as either \`missing\` or \`empty\` issues, which is the right ergonomic.

## Test plan

- [x] \`bun test ./packages/cli/__tests__/i18n-check.test.ts\` — 17/17 pass, ~76ms total
- [x] Full \`bun test\` — 4891 pass / 0 fail
- [x] \`bun run check\` clean
- [x] \`bun run typecheck\` clean
- [x] Coverage: pure helpers (flatten, compare), partial-migration union, collision rule, single-locale skip, malformed JSON skip, empty addons dir

## Cross-model review

- **Codex** flagged 4 issues — addressed:
  1. **High** — \`i18n\` namespace reservation would shadow capability commands. Fix: flat \`i18n-check\` command, no reservation needed.
  2. **Medium** — discovery hard-switched to nested layout, dropping flat locales. Fix: union with collision-bias toward \`locales/\`.
  3. **Medium** — discovery treats any \`addons/<group>/<dir>\` with i18n files as a capability. Out of scope (cap-validity check is the validate command's job; here we just check whatever i18n dirs exist).
  4. **Low** — array/number leaves coerce to string. Intentional — coerced values surface naturally as missing/empty issues.
- **Gemini**: hour-quota exhausted earlier in session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `i18n-check` CLI command to validate translation key consistency across locale files, detecting missing translations, extra keys, and empty values with support for multiple output formats.

* **Tests**
  * Added comprehensive test suite for i18n validation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->