### PR TITLE
ci(review-gate): switch from Checks API to Commit Statuses API (closes #296)

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -131,7 +131,6 @@ jobs:
               );
               return;
             }
-
             const unresolved = threads.filter(t => !t.isResolved);
             const total = threads.length;
 
@@ -169,8 +168,8 @@ jobs:
             //
             // Fork-PR caveat: GitHub downgrades GITHUB_TOKEN to read-only for
             // `pull_request` events whose head ref lives on a fork, regardless
-            // of the workflow-level `permissions:` block. Catch the failure and
-            // fall back to the workflow's own status via `core.setFailed`.
+            // of the workflow-level `permissions:` block. The status post will
+            // 403; the workflow's own failure then signals the gate result.
             let statusPosted = false;
             try {
               await github.rest.repos.createCommitStatus({
@@ -190,23 +189,28 @@ jobs:
                 `Could not post review-threads commit status on ${prHeadSha} (${message}). ` +
                   'This is expected for pull_request events from forked repositories — ' +
                   'GitHub downgrades GITHUB_TOKEN to read-only in that case. The workflow ' +
-                  "run status itself will still convey the gate verdict.",
+                  'failure below will convey the gate verdict.',
               );
             }
 
-            // For `pull_request` events mirror the gate verdict on the workflow run
-            // (visible in the PR Checks tab). For fork PRs where `createCommitStatus`
-            // was refused, this is the only signal the gate ran at all.
+            // Fail the workflow whenever the required commit status could not be
+            // posted — regardless of event type. A missing `review-threads` status
+            // on the PR head SHA leaves branch protection in a blocking "pending"
+            // state even when all threads are resolved and the workflow appears green.
             //
-            // For `issue_comment` events the verdict is carried by the commit status
-            // on the PR head — the workflow itself should succeed unless the status
-            // post failed.
+            // For `pull_request` events from forks the status post is always expected
+            // to fail (GITHUB_TOKEN is read-only); the workflow failure itself signals
+            // the gate result in that case.
+            //
+            // For `issue_comment` events the verdict is carried by the commit status;
+            // the workflow succeeds only when the status was posted successfully and
+            // threads are resolved (the status state carries the failure signal).
             const isPullRequest = eventName === 'pull_request';
-            if (isPullRequest && unresolved.length > 0) {
-              core.setFailed(`${unresolved.length} unresolved review thread(s). Resolve all before merging.`);
-            } else if (!isPullRequest && !statusPosted) {
+            if (!statusPosted) {
               core.setFailed(
                 'Failed to post review-threads commit status on the PR head. ' +
                   'See warning above for details.',
               );
+            } else if (isPullRequest && unresolved.length > 0) {
+              core.setFailed(`${unresolved.length} unresolved review thread(s). Resolve all before merging.`);
             }

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -9,38 +9,40 @@ on:
 # Why these triggers (and not `pull_request_review: submitted`):
 #   AI review bots (CodeRabbit / Gemini) post reviews while threads are still
 #   unresolved. Listening to `pull_request_review: submitted` guaranteed a
-#   FAILURE check-run on every bot review, and GitHub's branch protection
-#   keeps those historical FAILUREs as part of the same required-check name
-#   — leaving the PR BLOCKED even after every thread is resolved and the
-#   latest run SUCCEEDS. The recommended path: after resolving threads, post
-#   `/check-reviews` on the PR to re-run the gate.
+#   FAILURE on every bot review. The recommended path: after resolving threads,
+#   post `/check-reviews` on the PR to re-run the gate.
 #
 # Note: `pull_request_review_thread` was tried as a trigger to auto-rerun on
 # thread resolution, but caused a workflow registration parse failure on
 # GitHub Actions (synthetic "push" failure with no logs). Reverted to the
 # `/check-reviews` manual escape hatch until that's understood.
 #
-# How `/check-reviews` actually unblocks the PR:
-#   `issue_comment` events run on the default branch's HEAD SHA, NOT the PR
-#   head SHA. Previously the workflow relied on `core.setFailed()` to mark
-#   the run, which let GitHub auto-create a check-run on the workflow's run
-#   SHA (= main's HEAD). The PR head SHA therefore kept its stale FAILURE
-#   from the most recent `pull_request: synchronize` run, and contributors
-#   had to push an empty commit to force a fresh check on the PR head.
+# Why Commit Statuses API instead of Checks API:
+#   GitHub's Feb-2025 change restricts check-runs: only the same workflow run
+#   that created a check-run can update it. A different run calling
+#   `checks.update()` on a prior run's check-run gets 403/422. This broke
+#   the dedup loop in the previous approach that tried to neutralize stale
+#   FAILURE check-runs after threads were resolved.
 #
-#   The fix below is to call `octokit.rest.checks.create()` ourselves with
-#   an explicit `head_sha` resolved from the PR (via GraphQL `headRefOid`).
-#   That writes the new SUCCESS / FAILURE conclusion directly onto the PR
-#   head SHA, which is what branch protection evaluates. For `issue_comment`
-#   events the workflow itself always succeeds — the gate verdict is carried
-#   by the check-run, so a green Actions run for `/check-reviews` is correct
-#   even when the gate concludes FAILURE. For `pull_request` events we keep
-#   `core.setFailed()` so the workflow's own conclusion mirrors the gate
-#   (matches today's UX in the PR's "Checks" tab).
+#   The Commit Statuses API has no such restriction. Statuses are keyed by
+#   (sha, context); the latest status for a given context automatically wins —
+#   no historical stickiness, no dedup loop needed. A FAILURE status from run N
+#   is fully superseded by a SUCCESS status from run N+1.
+#
+#   For `issue_comment` events the workflow runs against the default branch HEAD,
+#   not the PR head. We resolve the PR head SHA via GraphQL `headRefOid` and
+#   post the status directly onto it, so branch protection evaluates the fresh
+#   verdict without needing an empty commit.
+#
+# IMPORTANT — branch protection migration required after deploying this workflow:
+#   Update the branch protection ruleset to require status context "review-threads"
+#   instead of the old check-run name "Review Threads". These are different GitHub
+#   concepts; the Checks API is no longer used.
+#   See: gh api repos/{owner}/{repo}/rules/branches/main
 
 permissions:
   pull-requests: read
-  checks: write
+  statuses: write
   contents: read
 
 jobs:
@@ -67,18 +69,19 @@ jobs:
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           EVENT_NAME: ${{ github.event_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           script: |
             const prNumber = Number(process.env.PR_NUMBER);
             const eventName = process.env.EVENT_NAME;
+            const runUrl = process.env.RUN_URL;
 
             // Fetch review threads + the PR head SHA. We need `headRefOid`
             // because for `issue_comment` events the workflow runs against
             // the default branch's HEAD, not the PR head — so we must post
-            // the resulting check-run onto the PR head SHA explicitly,
+            // the resulting commit status onto the PR head SHA explicitly,
             // otherwise branch protection keeps evaluating the stale
-            // FAILURE check from the previous `pull_request: synchronize`
-            // run and the PR remains BLOCKED.
+            // status from the previous `pull_request: synchronize` run.
             const { repository } = await github.graphql(`
               query($owner: String!, $repo: String!, $number: Int!) {
                 repository(owner: $owner, name: $repo) {
@@ -128,203 +131,82 @@ jobs:
               );
               return;
             }
+
             const unresolved = threads.filter(t => !t.isResolved);
             const total = threads.length;
 
-            // Build human-readable output for the check-run.
-            let title;
-            let summary;
+            // Build status state and description (Statuses API max: 140 chars).
+            const state = unresolved.length > 0 ? 'failure' : 'success';
+            let description;
             if (unresolved.length > 0) {
-              title = `${unresolved.length} unresolved review thread(s)`;
-              const lines = [
-                `${unresolved.length} of ${total} review thread(s) are still unresolved.`,
-                '',
-                'Resolve every thread (or post `/check-reviews` after resolving) before merging.',
-                '',
-                '### Unresolved threads',
-                '',
-              ];
+              description = `${unresolved.length} of ${total} thread(s) unresolved. Resolve all before merging.`;
+            } else if (total === 0) {
+              description = 'No review threads — gate passes.';
+            } else {
+              description = `All ${total} review thread(s) resolved — gate passes.`;
+            }
+
+            // Log unresolved thread details to the workflow step log.
+            if (unresolved.length > 0) {
+              core.info(`${unresolved.length}/${total} review thread(s) unresolved.`);
               for (const t of unresolved) {
                 const c = t.comments.nodes[0];
                 const author = c && c.author ? c.author.login : 'unknown';
                 const snippet = ((c && c.body) || '')
                   .substring(0, 200)
                   .replace(/\r?\n/g, ' ');
-                lines.push(`- **@${author}**: ${snippet}`);
                 core.info(`  - [${author}] ${snippet}`);
               }
-              summary = lines.join('\n');
-              core.info(`${unresolved.length}/${total} review thread(s) unresolved.`);
-            } else if (total === 0) {
-              title = 'No review threads';
-              summary = 'No review threads on this PR — gate passes.';
-              core.info(summary);
             } else {
-              title = `All ${total} review thread(s) resolved.`;
-              summary = `All ${total} review thread(s) resolved — gate passes.`;
-              core.info(summary);
+              core.info(description);
             }
 
-            const conclusion = unresolved.length > 0 ? 'failure' : 'success';
-
-            // Explicitly create a check-run on the PR head SHA. This is the
-            // SHA branch protection evaluates, so writing here updates the
-            // PR's required-check status without needing an empty commit.
-            //
-            // Order matters: we POST the new run BEFORE neutralizing prior
-            // runs. If we neutralized first and `create` then failed (e.g.
-            // fork-PR token downgrade), the SHA could end up with no
-            // FAILURE check-run AND no SUCCESS — leaving the gate in a
-            // muddled state. Posting first guarantees that the latest
-            // verdict lands on the SHA before any history is rewritten.
+            // Post a commit status on the PR head SHA using the Statuses API.
+            // Statuses are keyed by (sha, context); the latest status for a given
+            // context automatically supersedes all older statuses for the same
+            // context. No dedup loop is needed — a FAILURE from run N is fully
+            // overwritten by a SUCCESS from run N+1 without any extra API calls.
             //
             // Fork-PR caveat: GitHub downgrades GITHUB_TOKEN to read-only for
             // `pull_request` events whose head ref lives on a fork, regardless
-            // of the workflow-level `permissions:` block. `checks.create()`
-            // therefore 403s for those runs. Catch the failure and fall back
-            // to the workflow's own status — `core.setFailed` below still
-            // marks the workflow run, and GitHub auto-attaches a check-run
-            // with that status to the head SHA, matching today's behavior.
-            // For `issue_comment` events the token is the base repo's, so
-            // the call always succeeds.
-            let checkRunPosted = false;
+            // of the workflow-level `permissions:` block. Catch the failure and
+            // fall back to the workflow's own status via `core.setFailed`.
+            let statusPosted = false;
             try {
-              await github.rest.checks.create({
+              await github.rest.repos.createCommitStatus({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                name: 'Review Threads',
-                head_sha: prHeadSha,
-                status: 'completed',
-                conclusion,
-                output: {
-                  title,
-                  summary,
-                },
+                sha: prHeadSha,
+                state,
+                description: description.substring(0, 140),
+                context: 'review-threads',
+                target_url: runUrl,
               });
-              checkRunPosted = true;
-              core.info(`Posted Review Threads check-run (${conclusion}) on ${prHeadSha}.`);
+              statusPosted = true;
+              core.info(`Posted review-threads status (${state}) on ${prHeadSha}.`);
             } catch (err) {
               const message = err instanceof Error ? err.message : String(err);
               core.warning(
-                `Could not post Review Threads check-run on ${prHeadSha} (${message}). ` +
+                `Could not post review-threads commit status on ${prHeadSha} (${message}). ` +
                   'This is expected for pull_request events from forked repositories — ' +
                   'GitHub downgrades GITHUB_TOKEN to read-only in that case. The workflow ' +
                   "run status itself will still convey the gate verdict.",
               );
             }
 
-            // Neutralize any prior `Review Threads` check-runs on this same
-            // SHA. GitHub branch protection treats ANY historical FAILURE
-            // check-run on a SHA as blocking, even when a newer SUCCESS
-            // check-run with the same name exists for the same SHA. Without
-            // this dedup, a PR that had unresolved threads at
-            // `pull_request: synchronize` time stays BLOCKED even after
-            // threads are resolved and `/check-reviews` posts a SUCCESS —
-            // the historical FAILURE check-run is still counted. Marking
-            // older runs as `neutral` (instead of deleting them) preserves
-            // history while telling branch protection to ignore them.
+            // For `pull_request` events mirror the gate verdict on the workflow run
+            // (visible in the PR Checks tab). For fork PRs where `createCommitStatus`
+            // was refused, this is the only signal the gate ran at all.
             //
-            // Only runs the loop when the new check-run actually posted.
-            // Otherwise we'd be silencing the OLD failure without anything
-            // newer in its place — leaving the SHA with no current verdict.
-            //
-            // Per-run try/catch: a 403/422 on one update must not abort
-            // cleanup of the rest. Possible causes include same-name runs
-            // posted by a different GitHub App (which our token can't
-            // touch) or transient API errors. Each failure is logged at
-            // warning level; the worst case degrades to today's behavior
-            // for that one run.
-            //
-            // In-progress runs are intentionally NOT skipped: a still-
-            // running prior gate could complete after we post and end up
-            // re-blocking the PR with a stale verdict on the same SHA.
-            // Attempting `update(... conclusion: neutral)` on an
-            // in-progress run will 422 from the API; the per-run catch
-            // logs and moves on, accepting the small race that the run
-            // finishes between our list and update. The next gate event
-            // (synchronize / `/check-reviews`) re-runs this dedup.
-            //
-            // Idempotent: when no prior runs exist (first synchronize
-            // event), the loop simply does nothing.
-            //
-            // App scope: we filter by `check_name` server-side but NOT by
-            // `app_id`. Our gate's name "Review Threads" is unlikely to
-            // collide with any other app's runs in this repo, and our
-            // installation token cannot mutate runs owned by a different
-            // GitHub App anyway — those calls return 403, which the
-            // per-run catch handles. Adding an `app_id` filter would
-            // require an extra API call to discover our own ID and is
-            // not worth the round-trip given the per-run safety net.
-            if (checkRunPosted) {
-              let existing;
-              try {
-                existing = await github.paginate(
-                  github.rest.checks.listForRef,
-                  {
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    ref: prHeadSha,
-                    check_name: 'Review Threads',
-                    per_page: 100,
-                  },
-                );
-              } catch (err) {
-                const message = err instanceof Error ? err.message : String(err);
-                core.warning(
-                  `Could not list prior Review Threads check-runs on ${prHeadSha} (${message}). ` +
-                    'Continuing — the fresh check-run was posted, but stale FAILUREs ' +
-                    'may keep the PR BLOCKED until manually cleared.',
-                );
-                existing = [];
-              }
-              for (const run of existing) {
-                try {
-                  await github.rest.checks.update({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    check_run_id: run.id,
-                    status: 'completed',
-                    conclusion: 'neutral',
-                    output: {
-                      title: 'Superseded by a newer Review Threads run',
-                      summary:
-                        'This check-run was neutralized because the gate re-evaluated ' +
-                        'this SHA. See the latest Review Threads check-run for the ' +
-                        'current verdict.',
-                    },
-                  });
-                  core.info(
-                    `Neutralized prior Review Threads check-run #${run.id} (was ${run.conclusion ?? run.status}) on ${prHeadSha}.`,
-                  );
-                } catch (err) {
-                  const message = err instanceof Error ? err.message : String(err);
-                  core.warning(
-                    `Skipped neutralizing Review Threads check-run #${run.id} on ${prHeadSha} (${message}). ` +
-                      'A 422 here typically means the run is still in progress; a 403 ' +
-                      'means it belongs to a different GitHub App.',
-                  );
-                }
-              }
-            }
-
-            // For `pull_request` events the workflow's own conclusion has
-            // historically mirrored the gate verdict (the check shown in
-            // the PR's Checks tab matches the workflow's run status). Keep
-            // that behavior — and on fork PRs where `checks.create()` was
-            // refused, this is the ONLY signal the gate ran at all.
-            //
-            // For `issue_comment` events the verdict is carried by the
-            // explicit check-run on the PR head — so when posting succeeded
-            // the workflow always succeeds. If the post FAILED (rare, but
-            // possible if base-repo token rotation hit the API), surface the
-            // failure on the workflow itself so contributors see something
-            // went wrong.
+            // For `issue_comment` events the verdict is carried by the commit status
+            // on the PR head — the workflow itself should succeed unless the status
+            // post failed.
             const isPullRequest = eventName === 'pull_request';
             if (isPullRequest && unresolved.length > 0) {
               core.setFailed(`${unresolved.length} unresolved review thread(s). Resolve all before merging.`);
-            } else if (!isPullRequest && !checkRunPosted) {
+            } else if (!isPullRequest && !statusPosted) {
               core.setFailed(
-                'Failed to post Review Threads check-run on the PR head. ' +
+                'Failed to post review-threads commit status on the PR head. ' +
                   'See warning above for details.',
               );
             }


### PR DESCRIPTION
## Summary

- Replace `checks.create()` / `checks.update()` with `repos.createCommitStatus()` in `.github/workflows/review-gate.yml`
- Remove the now-unnecessary dedup loop (~140 lines removed)
- Change permission `checks: write` → `statuses: write`
- Add `RUN_URL` env var so the status links back to the workflow run

## Implementation notes

GitHub's Feb-2025 change ([changelog](https://github.blog/changelog/2025-02-12-notice-of-upcoming-deprecations-and-breaking-changes-for-github-actions/#changes-to-check-run-status-modification)) prevents a workflow run from updating check-runs created by a **different** workflow run — the API returns 403/422. This broke the dedup loop added in PR #292: when `/check-reviews` tried to neutralize the stale FAILURE check-run from the previous `pull_request: synchronize` event, it was refused, leaving the PR permanently blocked.

**Why Commit Statuses API solves this:**
Statuses are keyed by `(sha, context)`. The latest status for a given context automatically supersedes all older statuses for the same context on the same SHA — there is no historical stickiness and no "owner" restriction. A FAILURE posted by run N is fully overwritten by a SUCCESS posted by run N+1 with zero extra API calls.

**Branch protection migration (manual step required after merge):**
The branch ruleset must be updated to require the status context `review-threads` instead of the old check-run name `Review Threads`. These are different GitHub concepts. Until this is done, the old required check will be missing (not failing), so merges will be gated by the absence of the check-run rather than the status.

```bash
# Inspect current ruleset:
gh api repos/laofahai/linchkit/rules/branches/main
# Then update the required status check from "Review Threads" (check-run) to "review-threads" (status context)
```

## Spec alignment

This change is infrastructure-only (CI workflow). No meta-model elements (Entity/Action/Rule/State/View/Flow/Relation) are touched. No spec covers GitHub Actions workflow design; nearest reference is the operational constraints in CLAUDE.md (Git Workflow section).

## Quality gates

| Gate | Status | Notes |
|------|--------|-------|
| `bun run check` | ✅ | No errors — 1 info (pre-existing biome schema version mismatch) |
| `bun run typecheck` | ⚠️ | Could not run — sandbox network unreachable, `node_modules` cannot install |
| `bun test` | ⚠️ | Could not run — same sandbox env constraint |
| `linch validate` | N/A | No meta-model files changed |

> **Note on quality gates:** The sandbox environment's npm mirror returns 403 for all package downloads, preventing `node_modules` from being installed. This is a pre-existing environment constraint unrelated to this change. The change is purely YAML (a GitHub workflow file) — no TypeScript source files were modified. GitHub Actions CI will run the authoritative test suite on this PR.

## Retro

- **Why this approach:** The Commit Statuses API is the simplest correct fix — it eliminates historical stickiness by design, removing the need for the dedup loop entirely. The alternative (Checks API workarounds like creating a new GitHub App or using workflow-level auto-cancel) would add complexity without addressing the root cause.

- **Alternatives considered:**
  - *Keep Checks API + use a GitHub App token:* A dedicated GitHub App could update its own check-runs across workflow runs, but requires provisioning a new App and secret — disproportionate for this use case.
  - *Auto-cancel prior runs on synchronize:* GitHub's concurrency groups can cancel prior in-progress runs, but can't retroactively neutralize completed FAILURE check-runs.
  - *Empty commit dance (current workaround):* Forces a fresh SHA, which gets a new check-run on `pull_request: synchronize`. Works but creates noise commits and requires contributor awareness.

- **Security review:** No auth/tenant/input-trust surfaces touched. This change modifies only:
  - The GitHub Actions permission block (`checks: write` → `statuses: write` — narrower scope)
  - The API call used to report gate results (same trust boundary: GITHUB_TOKEN, same scope of effect)
  - No user input is processed; the only external data is `prHeadSha` from GitHub's own GraphQL API

- **Other risks:**
  - *Branch protection gap:* Until the branch ruleset is updated (manual step), the required `review-threads` status won't exist, meaning the protection is weakened rather than enforced. The PR description includes the migration command. This must be done immediately after merge.
  - *Existing open PRs:* PRs that already have a stale FAILURE check-run for `Review Threads` will still be blocked by the old check-run requirement (until branch protection is migrated). After migration, only the `review-threads` status matters, which this new workflow will post correctly.
  - *Fork PRs:* Same limitation as before — GITHUB_TOKEN is downgraded to read-only, so `createCommitStatus` will 403, and the workflow falls back to `core.setFailed`. No regression.

- **Follow-ups:**
  - Coordinate branch protection update immediately post-merge
  - Consider auto-triggering `/check-reviews` on review thread resolve (if the `pull_request_review_thread` registration issue is ever resolved)

## Self-review checklist

- [x] Tests added/updated and passing — N/A (YAML-only change; no TypeScript logic)
- [x] `bun run check` green — ✅ confirmed
- [x] `bun run typecheck` green — ⚠️ env constraint (no TS changed)
- [x] `bun test` green — ⚠️ env constraint (no tests changed)
- [x] `linch validate` green — N/A
- [x] Spec referenced in PR body — N/A (infra-only)
- [x] Mandatory security review walked through — see Retro above
- [x] No new dependencies — ✅ (switched from one built-in octokit method to another)
- [x] No hardcoded secrets, no `any`, no `eval`, no `new Function` — ✅
- [x] No changes outside the issue's scope — ✅
- [x] Branch name + commit messages follow convention — ✅ `ci/fix-review-gate-statuses-api-296`
- [x] Every comment posted has a real timestamp — ✅

Closes #296

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZvWFRwdcRf9w9toVvu1ch)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the review gate workflow to use an improved status reporting mechanism for GitHub's review enforcement system.
  * Updated required branch protection context configuration—teams using this workflow should review their branch protection rules to ensure compatibility with the updated review gate system.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laofahai/linchkit/pull/298)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->