### PR TITLE
fix(ci): replace Checks API with Statuses API in review-gate (#296)

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -124,7 +124,25 @@ jobs:
             // threads 101+ are resolved would be incorrect, and silently
             // failing would be opaque. Loud failure surfaces the limitation
             // so a follow-up adds pagination if a real PR ever hits it.
+            //
+            // Post a conservative failure status BEFORE returning so that a
+            // prior success on this SHA cannot keep branch protection green
+            // while we have an incomplete picture of the review threads.
             if (totalCount > threads.length) {
+              const overflowDescription =
+                `Unable to evaluate all review threads (${threads.length}/${totalCount} fetched).`;
+              try {
+                await github.rest.repos.createCommitStatus({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  sha: prHeadSha,
+                  state: 'failure',
+                  context: 'review-threads',
+                  description: overflowDescription.substring(0, 140),
+                });
+              } catch (err) {
+                core.warning(`Could not post overflow failure status: ${String(err)}`);
+              }
               core.setFailed(
                 `PR has ${totalCount} review threads but the gate only fetched ${threads.length}. ` +
                   'Pagination is not yet implemented — file a workflow follow-up.',
@@ -197,6 +215,11 @@ jobs:
             const isPullRequest = eventName === 'pull_request';
             if (isPullRequest && unresolved.length > 0) {
               core.setFailed(`${unresolved.length} unresolved review thread(s). Resolve all before merging.`);
+            } else if (isPullRequest && !statusPosted) {
+              core.setFailed(
+                'Failed to post required review-threads commit status on the PR head. ' +
+                  'Use /check-reviews to retry from base-repo context.',
+              );
             } else if (!isPullRequest && !statusPosted) {
               core.setFailed(
                 'Failed to post review-threads commit status on the PR head. ' +

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -9,30 +9,41 @@ on:
 # Why these triggers (and not `pull_request_review: submitted`):
 #   AI review bots (CodeRabbit / Gemini) post reviews while threads are still
 #   unresolved. Listening to `pull_request_review: submitted` guaranteed a
-#   FAILURE on every bot review, leaving the PR BLOCKED even after threads
-#   are resolved. The recommended path: after resolving threads, post
-#   `/check-reviews` on the PR to re-run the gate.
+#   FAILURE signal on every bot review, leaving the PR BLOCKED even after
+#   every thread is resolved and the latest run SUCCEEDS. The recommended
+#   path: after resolving threads, post `/check-reviews` on the PR to re-run
+#   the gate.
 #
 # Note: `pull_request_review_thread` was tried as a trigger to auto-rerun on
 # thread resolution, but caused a workflow registration parse failure on
 # GitHub Actions (synthetic "push" failure with no logs). Reverted to the
 # `/check-reviews` manual escape hatch until that's understood.
 #
-# Why Statuses API instead of Checks API (#296):
-#   GitHub's Feb-2025 change prevents a workflow run from updating check-runs
-#   created by a different run of the same workflow. The previous dedup loop
-#   therefore received 403/422 on every `/check-reviews` invocation, leaving
-#   stale FAILURE check-runs permanently blocking the PR.
+# Why Commit Statuses API (not Check Runs):
+#   GitHub's Feb-2025 change restricts check-run updates to the same workflow
+#   run that created them. A different workflow invocation (e.g. `/check-reviews`
+#   triggering via issue_comment) cannot call `checks.update()` on a prior run's
+#   check-run — the API returns 403/422. The dedup loop that neutralized stale
+#   FAILURE check-runs therefore stopped working, and PRs stayed BLOCKED even
+#   after all threads were resolved.
 #
-#   The Statuses API (POST /repos/{owner}/{repo}/statuses/{sha}) is keyed by
-#   (sha, context): the latest status for a given context always wins, with no
-#   historical-stickiness and no cross-workflow-run restriction. This eliminates
-#   both the dedup loop and the Feb-2025 restriction in one change.
+#   The Commit Statuses API (`POST /repos/{owner}/{repo}/statuses/{sha}`) does
+#   not have this restriction. Statuses are keyed by (commit, context) and the
+#   latest status by timestamp always wins — no historical-stickiness, no dedup
+#   loop needed. Branch protection evaluates only the latest status for the
+#   configured context, so a new SUCCESS overwrites the prior FAILURE immediately.
 #
-#   BRANCH PROTECTION NOTE: After merging this PR, an admin must update the
-#   branch protection rule from requiring check-run "Review Threads" to
-#   requiring commit status context "review-threads". See the PR body for
-#   the exact gh CLI command.
+#   Migration note: branch protection must require status context `review-threads`
+#   (not check-run name `Review Threads`). See PR #296 for the ruleset change.
+#
+# How `/check-reviews` unblocks the PR:
+#   `issue_comment` events run on the default branch's HEAD SHA, NOT the PR
+#   head SHA. We resolve the PR head SHA via GraphQL `headRefOid` and post the
+#   status directly on that SHA, so branch protection evaluates the fresh verdict
+#   without needing an empty commit. The workflow itself always succeeds for
+#   `issue_comment` events — the gate verdict is carried by the commit status.
+#   For `pull_request` events we keep `core.setFailed()` so the workflow's own
+#   conclusion mirrors the gate (matches UX in the PR's Checks tab).
 
 permissions:
   pull-requests: read
@@ -71,7 +82,7 @@ jobs:
             // Fetch review threads + the PR head SHA. We need `headRefOid`
             // because for `issue_comment` events the workflow runs against
             // the default branch's HEAD, not the PR head — so we must post
-            // the status onto the PR head SHA explicitly.
+            // the resulting status onto the PR head SHA explicitly.
             const { repository } = await github.graphql(`
               query($owner: String!, $repo: String!, $number: Int!) {
                 repository(owner: $owner, name: $repo) {
@@ -124,17 +135,19 @@ jobs:
             const unresolved = threads.filter(t => !t.isResolved);
             const total = threads.length;
 
-            // Build status description (Statuses API caps description at 140 chars).
+            // Build a short description for the commit status (140 char limit).
             let description;
             if (unresolved.length > 0) {
-              description = `${unresolved.length} of ${total} thread(s) unresolved — resolve before merging.`;
+              description = `${unresolved.length} unresolved review thread(s) — resolve before merging.`;
+              core.info(`${unresolved.length}/${total} review thread(s) unresolved.`);
               for (const t of unresolved) {
                 const c = t.comments.nodes[0];
                 const author = c && c.author ? c.author.login : 'unknown';
-                const snippet = ((c && c.body) || '').substring(0, 120).replace(/\r?\n/g, ' ');
+                const snippet = ((c && c.body) || '')
+                  .substring(0, 200)
+                  .replace(/\r?\n/g, ' ');
                 core.info(`  - [${author}] ${snippet}`);
               }
-              core.info(`${unresolved.length}/${total} review thread(s) unresolved.`);
             } else if (total === 0) {
               description = 'No review threads — gate passes.';
               core.info(description);
@@ -143,15 +156,19 @@ jobs:
               core.info(description);
             }
 
-            // Statuses API: keyed by (sha, context). Latest status wins —
-            // no historical stickiness, no dedup loop needed. This is the
-            // core fix for the Feb-2025 restriction that broke check-run
-            // neutralization across workflow runs (#296).
+            const state = unresolved.length > 0 ? 'failure' : 'success';
+
+            // Post a commit status on the PR head SHA. The Statuses API is
+            // keyed by (commit, context): the latest status for a given context
+            // always wins, so a new SUCCESS immediately overwrites any prior
+            // FAILURE without a dedup loop.
             //
             // Fork-PR caveat: GitHub downgrades GITHUB_TOKEN to read-only for
-            // `pull_request` events whose head ref lives on a fork. Catch the
-            // 403 and fall back to workflow status only (same behavior as before).
-            const state = unresolved.length > 0 ? 'failure' : 'success';
+            // `pull_request` events from forks. `repos.createCommitStatus()`
+            // therefore 403s for those runs. Fall back to `core.setFailed()`
+            // below — the workflow's own conclusion still conveys the verdict.
+            // For `issue_comment` events the token is the base repo's, so the
+            // call always succeeds.
             let statusPosted = false;
             try {
               await github.rest.repos.createCommitStatus({
@@ -160,7 +177,8 @@ jobs:
                 sha: prHeadSha,
                 state,
                 context: 'review-threads',
-                description,
+                description: description.substring(0, 140),
+                target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${prNumber}`,
               });
               statusPosted = true;
               core.info(`Posted review-threads status (${state}) on ${prHeadSha}.`);
@@ -170,18 +188,18 @@ jobs:
                 `Could not post review-threads status on ${prHeadSha} (${message}). ` +
                   'This is expected for pull_request events from forked repositories — ' +
                   'GitHub downgrades GITHUB_TOKEN to read-only in that case. The workflow ' +
-                  'run status itself will still convey the gate verdict.',
+                  "run status itself will still convey the gate verdict.",
               );
             }
 
-            // For `pull_request` events the workflow's own conclusion mirrors
-            // the gate verdict (shown in the PR's Checks tab). Keep that
-            // behavior — and on fork PRs where the status post was refused,
-            // this is the ONLY signal the gate ran at all.
+            // For `pull_request` events mirror the gate verdict on the workflow
+            // run itself, matching the UX contributors expect in the Checks tab.
+            // On fork PRs where `repos.createCommitStatus()` was refused, this
+            // is the ONLY signal the gate ran at all.
             //
-            // For `issue_comment` events the verdict is carried by the commit
-            // status on the PR head — so when posting succeeded the workflow
-            // always succeeds. Surface a failure if the post itself failed.
+            // For `issue_comment` events the verdict is on the commit status —
+            // so the workflow itself succeeds when posting succeeded. Surface
+            // a failure only when the status post failed (rare).
             const isPullRequest = eventName === 'pull_request';
             if (isPullRequest && unresolved.length > 0) {
               core.setFailed(`${unresolved.length} unresolved review thread(s). Resolve all before merging.`);

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -9,40 +9,30 @@ on:
 # Why these triggers (and not `pull_request_review: submitted`):
 #   AI review bots (CodeRabbit / Gemini) post reviews while threads are still
 #   unresolved. Listening to `pull_request_review: submitted` guaranteed a
-#   FAILURE on every bot review, and GitHub's branch protection keeps those
-#   historical FAILUREs — leaving the PR BLOCKED even after every thread is
-#   resolved and the latest run SUCCEEDS. The recommended path: after resolving
-#   threads, post `/check-reviews` on the PR to re-run the gate.
+#   FAILURE on every bot review, leaving the PR BLOCKED even after threads
+#   are resolved. The recommended path: after resolving threads, post
+#   `/check-reviews` on the PR to re-run the gate.
 #
 # Note: `pull_request_review_thread` was tried as a trigger to auto-rerun on
 # thread resolution, but caused a workflow registration parse failure on
 # GitHub Actions (synthetic "push" failure with no logs). Reverted to the
 # `/check-reviews` manual escape hatch until that's understood.
 #
-# How `/check-reviews` unblocks the PR:
-#   `issue_comment` events run on the default branch's HEAD SHA, NOT the PR
-#   head SHA. This workflow resolves the PR head SHA via GraphQL `headRefOid`
-#   and writes a commit status directly onto that SHA via the Statuses API.
-#   Branch protection evaluates the latest status for context `review-threads`
-#   on the PR head SHA — so posting a new status always overwrites the prior
-#   verdict without any dedup loop or empty-commit workaround.
+# Why Statuses API instead of Checks API (#296):
+#   GitHub's Feb-2025 change prevents a workflow run from updating check-runs
+#   created by a different run of the same workflow. The previous dedup loop
+#   therefore received 403/422 on every `/check-reviews` invocation, leaving
+#   stale FAILURE check-runs permanently blocking the PR.
 #
-# Why Statuses API instead of Checks API (changed in fix/#296):
-#   GitHub's Feb-2025 restriction prevents one workflow run from updating a
-#   check-run created by a different run of the same workflow file. The
-#   dedup loop in the previous implementation (merged in #292) therefore
-#   received 403/422 errors and could not neutralize stale FAILURE check-runs,
-#   leaving PRs BLOCKED after thread resolution.
+#   The Statuses API (POST /repos/{owner}/{repo}/statuses/{sha}) is keyed by
+#   (sha, context): the latest status for a given context always wins, with no
+#   historical-stickiness and no cross-workflow-run restriction. This eliminates
+#   both the dedup loop and the Feb-2025 restriction in one change.
 #
-#   The Statuses API has no such restriction: statuses are keyed by
-#   (commit SHA, context name) and the latest POST wins — no historical
-#   stickiness, no cross-run ownership issues. The dedup loop is eliminated.
-#
-#   Branch protection must reference the status context `review-threads`
-#   (not the check-run name `Review Threads`). Update the ruleset once this
-#   workflow is merged: Settings → Branches → main → require status check
-#   `review-threads`. The old `Review Threads` check-run requirement can be
-#   removed at the same time.
+#   BRANCH PROTECTION NOTE: After merging this PR, an admin must update the
+#   branch protection rule from requiring check-run "Review Threads" to
+#   requiring commit status context "review-threads". See the PR body for
+#   the exact gh CLI command.
 
 permissions:
   pull-requests: read
@@ -81,7 +71,7 @@ jobs:
             // Fetch review threads + the PR head SHA. We need `headRefOid`
             // because for `issue_comment` events the workflow runs against
             // the default branch's HEAD, not the PR head — so we must post
-            // the resulting commit status onto the PR head SHA explicitly.
+            // the status onto the PR head SHA explicitly.
             const { repository } = await github.graphql(`
               query($owner: String!, $repo: String!, $number: Int!) {
                 repository(owner: $owner, name: $repo) {
@@ -124,25 +114,7 @@ jobs:
             // threads 101+ are resolved would be incorrect, and silently
             // failing would be opaque. Loud failure surfaces the limitation
             // so a follow-up adds pagination if a real PR ever hits it.
-            //
-            // Post a conservative failure status BEFORE returning so that a
-            // prior success on this SHA cannot keep branch protection green
-            // while we have an incomplete picture of the review threads.
             if (totalCount > threads.length) {
-              const overflowDescription =
-                `Unable to evaluate all review threads (${threads.length}/${totalCount} fetched).`;
-              try {
-                await github.rest.repos.createCommitStatus({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  sha: prHeadSha,
-                  state: 'failure',
-                  context: 'review-threads',
-                  description: overflowDescription.substring(0, 140),
-                });
-              } catch (err) {
-                core.warning(`Could not post overflow failure status: ${String(err)}`);
-              }
               core.setFailed(
                 `PR has ${totalCount} review threads but the gate only fetched ${threads.length}. ` +
                   'Pagination is not yet implemented — file a workflow follow-up.',
@@ -152,14 +124,14 @@ jobs:
             const unresolved = threads.filter(t => !t.isResolved);
             const total = threads.length;
 
-            // Build a short description (Statuses API caps description at 140 chars).
+            // Build status description (Statuses API caps description at 140 chars).
             let description;
             if (unresolved.length > 0) {
-              description = `${unresolved.length} unresolved review thread(s)`;
+              description = `${unresolved.length} of ${total} thread(s) unresolved — resolve before merging.`;
               for (const t of unresolved) {
                 const c = t.comments.nodes[0];
                 const author = c && c.author ? c.author.login : 'unknown';
-                const snippet = ((c && c.body) || '').substring(0, 200).replace(/\r?\n/g, ' ');
+                const snippet = ((c && c.body) || '').substring(0, 120).replace(/\r?\n/g, ' ');
                 core.info(`  - [${author}] ${snippet}`);
               }
               core.info(`${unresolved.length}/${total} review thread(s) unresolved.`);
@@ -171,20 +143,15 @@ jobs:
               core.info(description);
             }
 
-            const state = unresolved.length > 0 ? 'failure' : 'success';
-
-            // Post a commit status on the PR head SHA via the Statuses API.
-            // Statuses are keyed by (SHA, context): the latest POST always wins.
-            // No dedup loop needed — re-running this gate simply overwrites the
-            // previous status for context `review-threads`, regardless of which
-            // workflow run or GitHub App created it. This is immune to the
-            // Feb-2025 GitHub Actions restriction that blocked the old check-run
-            // dedup approach (#296).
+            // Statuses API: keyed by (sha, context). Latest status wins —
+            // no historical stickiness, no dedup loop needed. This is the
+            // core fix for the Feb-2025 restriction that broke check-run
+            // neutralization across workflow runs (#296).
             //
-            // Fork-PR caveat: GITHUB_TOKEN is read-only for `pull_request`
-            // events whose head ref lives on a fork — same restriction as before.
-            // Fall back to core.setFailed() so the workflow run itself signals
-            // the verdict, matching pre-#292 behavior for fork PRs.
+            // Fork-PR caveat: GitHub downgrades GITHUB_TOKEN to read-only for
+            // `pull_request` events whose head ref lives on a fork. Catch the
+            // 403 and fall back to workflow status only (same behavior as before).
+            const state = unresolved.length > 0 ? 'failure' : 'success';
             let statusPosted = false;
             try {
               await github.rest.repos.createCommitStatus({
@@ -193,36 +160,34 @@ jobs:
                 sha: prHeadSha,
                 state,
                 context: 'review-threads',
-                description: description.substring(0, 140),
+                description,
               });
               statusPosted = true;
               core.info(`Posted review-threads status (${state}) on ${prHeadSha}.`);
             } catch (err) {
               const message = err instanceof Error ? err.message : String(err);
               core.warning(
-                `Could not post review-threads commit status on ${prHeadSha} (${message}). ` +
+                `Could not post review-threads status on ${prHeadSha} (${message}). ` +
                   'This is expected for pull_request events from forked repositories — ' +
                   'GitHub downgrades GITHUB_TOKEN to read-only in that case. The workflow ' +
                   'run status itself will still convey the gate verdict.',
               );
             }
 
-            // Mirror the verdict on the workflow run itself.
-            // For `pull_request` events this keeps the Checks tab consistent and
-            // is the only signal on fork PRs where the status post was refused.
-            // For `issue_comment` events the commit status is the primary signal;
-            // only fail the workflow if the status post itself failed.
+            // For `pull_request` events the workflow's own conclusion mirrors
+            // the gate verdict (shown in the PR's Checks tab). Keep that
+            // behavior — and on fork PRs where the status post was refused,
+            // this is the ONLY signal the gate ran at all.
+            //
+            // For `issue_comment` events the verdict is carried by the commit
+            // status on the PR head — so when posting succeeded the workflow
+            // always succeeds. Surface a failure if the post itself failed.
             const isPullRequest = eventName === 'pull_request';
             if (isPullRequest && unresolved.length > 0) {
               core.setFailed(`${unresolved.length} unresolved review thread(s). Resolve all before merging.`);
-            } else if (isPullRequest && !statusPosted) {
-              core.setFailed(
-                'Failed to post required review-threads commit status on the PR head. ' +
-                  'Use /check-reviews to retry from base-repo context.',
-              );
             } else if (!isPullRequest && !statusPosted) {
               core.setFailed(
-                'Failed to post review-threads commit status on the PR head. ' +
+                'Failed to post review-threads status on the PR head. ' +
                   'See warning above for details.',
               );
             }

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -9,38 +9,44 @@ on:
 # Why these triggers (and not `pull_request_review: submitted`):
 #   AI review bots (CodeRabbit / Gemini) post reviews while threads are still
 #   unresolved. Listening to `pull_request_review: submitted` guaranteed a
-#   FAILURE check-run on every bot review, and GitHub's branch protection
-#   keeps those historical FAILUREs as part of the same required-check name
-#   — leaving the PR BLOCKED even after every thread is resolved and the
-#   latest run SUCCEEDS. The recommended path: after resolving threads, post
-#   `/check-reviews` on the PR to re-run the gate.
+#   FAILURE on every bot review, and GitHub's branch protection keeps those
+#   historical FAILUREs — leaving the PR BLOCKED even after every thread is
+#   resolved and the latest run SUCCEEDS. The recommended path: after resolving
+#   threads, post `/check-reviews` on the PR to re-run the gate.
 #
 # Note: `pull_request_review_thread` was tried as a trigger to auto-rerun on
 # thread resolution, but caused a workflow registration parse failure on
 # GitHub Actions (synthetic "push" failure with no logs). Reverted to the
 # `/check-reviews` manual escape hatch until that's understood.
 #
-# How `/check-reviews` actually unblocks the PR:
+# How `/check-reviews` unblocks the PR:
 #   `issue_comment` events run on the default branch's HEAD SHA, NOT the PR
-#   head SHA. Previously the workflow relied on `core.setFailed()` to mark
-#   the run, which let GitHub auto-create a check-run on the workflow's run
-#   SHA (= main's HEAD). The PR head SHA therefore kept its stale FAILURE
-#   from the most recent `pull_request: synchronize` run, and contributors
-#   had to push an empty commit to force a fresh check on the PR head.
+#   head SHA. This workflow resolves the PR head SHA via GraphQL `headRefOid`
+#   and writes a commit status directly onto that SHA via the Statuses API.
+#   Branch protection evaluates the latest status for context `review-threads`
+#   on the PR head SHA — so posting a new status always overwrites the prior
+#   verdict without any dedup loop or empty-commit workaround.
 #
-#   The fix below is to call `octokit.rest.checks.create()` ourselves with
-#   an explicit `head_sha` resolved from the PR (via GraphQL `headRefOid`).
-#   That writes the new SUCCESS / FAILURE conclusion directly onto the PR
-#   head SHA, which is what branch protection evaluates. For `issue_comment`
-#   events the workflow itself always succeeds — the gate verdict is carried
-#   by the check-run, so a green Actions run for `/check-reviews` is correct
-#   even when the gate concludes FAILURE. For `pull_request` events we keep
-#   `core.setFailed()` so the workflow's own conclusion mirrors the gate
-#   (matches today's UX in the PR's "Checks" tab).
+# Why Statuses API instead of Checks API (changed in fix/#296):
+#   GitHub's Feb-2025 restriction prevents one workflow run from updating a
+#   check-run created by a different run of the same workflow file. The
+#   dedup loop in the previous implementation (merged in #292) therefore
+#   received 403/422 errors and could not neutralize stale FAILURE check-runs,
+#   leaving PRs BLOCKED after thread resolution.
+#
+#   The Statuses API has no such restriction: statuses are keyed by
+#   (commit SHA, context name) and the latest POST wins — no historical
+#   stickiness, no cross-run ownership issues. The dedup loop is eliminated.
+#
+#   Branch protection must reference the status context `review-threads`
+#   (not the check-run name `Review Threads`). Update the ruleset once this
+#   workflow is merged: Settings → Branches → main → require status check
+#   `review-threads`. The old `Review Threads` check-run requirement can be
+#   removed at the same time.
 
 permissions:
   pull-requests: read
-  checks: write
+  statuses: write
   contents: read
 
 jobs:
@@ -75,10 +81,7 @@ jobs:
             // Fetch review threads + the PR head SHA. We need `headRefOid`
             // because for `issue_comment` events the workflow runs against
             // the default branch's HEAD, not the PR head — so we must post
-            // the resulting check-run onto the PR head SHA explicitly,
-            // otherwise branch protection keeps evaluating the stale
-            // FAILURE check from the previous `pull_request: synchronize`
-            // run and the PR remains BLOCKED.
+            // the resulting commit status onto the PR head SHA explicitly.
             const { repository } = await github.graphql(`
               query($owner: String!, $repo: String!, $number: Int!) {
                 repository(owner: $owner, name: $repo) {
@@ -131,200 +134,72 @@ jobs:
             const unresolved = threads.filter(t => !t.isResolved);
             const total = threads.length;
 
-            // Build human-readable output for the check-run.
-            let title;
-            let summary;
+            // Build a short description (Statuses API caps description at 140 chars).
+            let description;
             if (unresolved.length > 0) {
-              title = `${unresolved.length} unresolved review thread(s)`;
-              const lines = [
-                `${unresolved.length} of ${total} review thread(s) are still unresolved.`,
-                '',
-                'Resolve every thread (or post `/check-reviews` after resolving) before merging.',
-                '',
-                '### Unresolved threads',
-                '',
-              ];
+              description = `${unresolved.length} unresolved review thread(s)`;
               for (const t of unresolved) {
                 const c = t.comments.nodes[0];
                 const author = c && c.author ? c.author.login : 'unknown';
-                const snippet = ((c && c.body) || '')
-                  .substring(0, 200)
-                  .replace(/\r?\n/g, ' ');
-                lines.push(`- **@${author}**: ${snippet}`);
+                const snippet = ((c && c.body) || '').substring(0, 200).replace(/\r?\n/g, ' ');
                 core.info(`  - [${author}] ${snippet}`);
               }
-              summary = lines.join('\n');
               core.info(`${unresolved.length}/${total} review thread(s) unresolved.`);
             } else if (total === 0) {
-              title = 'No review threads';
-              summary = 'No review threads on this PR — gate passes.';
-              core.info(summary);
+              description = 'No review threads — gate passes.';
+              core.info(description);
             } else {
-              title = `All ${total} review thread(s) resolved.`;
-              summary = `All ${total} review thread(s) resolved — gate passes.`;
-              core.info(summary);
+              description = `All ${total} review thread(s) resolved — gate passes.`;
+              core.info(description);
             }
 
-            const conclusion = unresolved.length > 0 ? 'failure' : 'success';
+            const state = unresolved.length > 0 ? 'failure' : 'success';
 
-            // Explicitly create a check-run on the PR head SHA. This is the
-            // SHA branch protection evaluates, so writing here updates the
-            // PR's required-check status without needing an empty commit.
+            // Post a commit status on the PR head SHA via the Statuses API.
+            // Statuses are keyed by (SHA, context): the latest POST always wins.
+            // No dedup loop needed — re-running this gate simply overwrites the
+            // previous status for context `review-threads`, regardless of which
+            // workflow run or GitHub App created it. This is immune to the
+            // Feb-2025 GitHub Actions restriction that blocked the old check-run
+            // dedup approach (#296).
             //
-            // Order matters: we POST the new run BEFORE neutralizing prior
-            // runs. If we neutralized first and `create` then failed (e.g.
-            // fork-PR token downgrade), the SHA could end up with no
-            // FAILURE check-run AND no SUCCESS — leaving the gate in a
-            // muddled state. Posting first guarantees that the latest
-            // verdict lands on the SHA before any history is rewritten.
-            //
-            // Fork-PR caveat: GitHub downgrades GITHUB_TOKEN to read-only for
-            // `pull_request` events whose head ref lives on a fork, regardless
-            // of the workflow-level `permissions:` block. `checks.create()`
-            // therefore 403s for those runs. Catch the failure and fall back
-            // to the workflow's own status — `core.setFailed` below still
-            // marks the workflow run, and GitHub auto-attaches a check-run
-            // with that status to the head SHA, matching today's behavior.
-            // For `issue_comment` events the token is the base repo's, so
-            // the call always succeeds.
-            let checkRunPosted = false;
+            // Fork-PR caveat: GITHUB_TOKEN is read-only for `pull_request`
+            // events whose head ref lives on a fork — same restriction as before.
+            // Fall back to core.setFailed() so the workflow run itself signals
+            // the verdict, matching pre-#292 behavior for fork PRs.
+            let statusPosted = false;
             try {
-              await github.rest.checks.create({
+              await github.rest.repos.createCommitStatus({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                name: 'Review Threads',
-                head_sha: prHeadSha,
-                status: 'completed',
-                conclusion,
-                output: {
-                  title,
-                  summary,
-                },
+                sha: prHeadSha,
+                state,
+                context: 'review-threads',
+                description: description.substring(0, 140),
               });
-              checkRunPosted = true;
-              core.info(`Posted Review Threads check-run (${conclusion}) on ${prHeadSha}.`);
+              statusPosted = true;
+              core.info(`Posted review-threads status (${state}) on ${prHeadSha}.`);
             } catch (err) {
               const message = err instanceof Error ? err.message : String(err);
               core.warning(
-                `Could not post Review Threads check-run on ${prHeadSha} (${message}). ` +
+                `Could not post review-threads commit status on ${prHeadSha} (${message}). ` +
                   'This is expected for pull_request events from forked repositories — ' +
                   'GitHub downgrades GITHUB_TOKEN to read-only in that case. The workflow ' +
-                  "run status itself will still convey the gate verdict.",
+                  'run status itself will still convey the gate verdict.',
               );
             }
 
-            // Neutralize any prior `Review Threads` check-runs on this same
-            // SHA. GitHub branch protection treats ANY historical FAILURE
-            // check-run on a SHA as blocking, even when a newer SUCCESS
-            // check-run with the same name exists for the same SHA. Without
-            // this dedup, a PR that had unresolved threads at
-            // `pull_request: synchronize` time stays BLOCKED even after
-            // threads are resolved and `/check-reviews` posts a SUCCESS —
-            // the historical FAILURE check-run is still counted. Marking
-            // older runs as `neutral` (instead of deleting them) preserves
-            // history while telling branch protection to ignore them.
-            //
-            // Only runs the loop when the new check-run actually posted.
-            // Otherwise we'd be silencing the OLD failure without anything
-            // newer in its place — leaving the SHA with no current verdict.
-            //
-            // Per-run try/catch: a 403/422 on one update must not abort
-            // cleanup of the rest. Possible causes include same-name runs
-            // posted by a different GitHub App (which our token can't
-            // touch) or transient API errors. Each failure is logged at
-            // warning level; the worst case degrades to today's behavior
-            // for that one run.
-            //
-            // In-progress runs are intentionally NOT skipped: a still-
-            // running prior gate could complete after we post and end up
-            // re-blocking the PR with a stale verdict on the same SHA.
-            // Attempting `update(... conclusion: neutral)` on an
-            // in-progress run will 422 from the API; the per-run catch
-            // logs and moves on, accepting the small race that the run
-            // finishes between our list and update. The next gate event
-            // (synchronize / `/check-reviews`) re-runs this dedup.
-            //
-            // Idempotent: when no prior runs exist (first synchronize
-            // event), the loop simply does nothing.
-            //
-            // App scope: we filter by `check_name` server-side but NOT by
-            // `app_id`. Our gate's name "Review Threads" is unlikely to
-            // collide with any other app's runs in this repo, and our
-            // installation token cannot mutate runs owned by a different
-            // GitHub App anyway — those calls return 403, which the
-            // per-run catch handles. Adding an `app_id` filter would
-            // require an extra API call to discover our own ID and is
-            // not worth the round-trip given the per-run safety net.
-            if (checkRunPosted) {
-              let existing;
-              try {
-                existing = await github.paginate(
-                  github.rest.checks.listForRef,
-                  {
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    ref: prHeadSha,
-                    check_name: 'Review Threads',
-                    per_page: 100,
-                  },
-                );
-              } catch (err) {
-                const message = err instanceof Error ? err.message : String(err);
-                core.warning(
-                  `Could not list prior Review Threads check-runs on ${prHeadSha} (${message}). ` +
-                    'Continuing — the fresh check-run was posted, but stale FAILUREs ' +
-                    'may keep the PR BLOCKED until manually cleared.',
-                );
-                existing = [];
-              }
-              for (const run of existing) {
-                try {
-                  await github.rest.checks.update({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    check_run_id: run.id,
-                    status: 'completed',
-                    conclusion: 'neutral',
-                    output: {
-                      title: 'Superseded by a newer Review Threads run',
-                      summary:
-                        'This check-run was neutralized because the gate re-evaluated ' +
-                        'this SHA. See the latest Review Threads check-run for the ' +
-                        'current verdict.',
-                    },
-                  });
-                  core.info(
-                    `Neutralized prior Review Threads check-run #${run.id} (was ${run.conclusion ?? run.status}) on ${prHeadSha}.`,
-                  );
-                } catch (err) {
-                  const message = err instanceof Error ? err.message : String(err);
-                  core.warning(
-                    `Skipped neutralizing Review Threads check-run #${run.id} on ${prHeadSha} (${message}). ` +
-                      'A 422 here typically means the run is still in progress; a 403 ' +
-                      'means it belongs to a different GitHub App.',
-                  );
-                }
-              }
-            }
-
-            // For `pull_request` events the workflow's own conclusion has
-            // historically mirrored the gate verdict (the check shown in
-            // the PR's Checks tab matches the workflow's run status). Keep
-            // that behavior — and on fork PRs where `checks.create()` was
-            // refused, this is the ONLY signal the gate ran at all.
-            //
-            // For `issue_comment` events the verdict is carried by the
-            // explicit check-run on the PR head — so when posting succeeded
-            // the workflow always succeeds. If the post FAILED (rare, but
-            // possible if base-repo token rotation hit the API), surface the
-            // failure on the workflow itself so contributors see something
-            // went wrong.
+            // Mirror the verdict on the workflow run itself.
+            // For `pull_request` events this keeps the Checks tab consistent and
+            // is the only signal on fork PRs where the status post was refused.
+            // For `issue_comment` events the commit status is the primary signal;
+            // only fail the workflow if the status post itself failed.
             const isPullRequest = eventName === 'pull_request';
             if (isPullRequest && unresolved.length > 0) {
               core.setFailed(`${unresolved.length} unresolved review thread(s). Resolve all before merging.`);
-            } else if (!isPullRequest && !checkRunPosted) {
+            } else if (!isPullRequest && !statusPosted) {
               core.setFailed(
-                'Failed to post Review Threads check-run on the PR head. ' +
+                'Failed to post review-threads commit status on the PR head. ' +
                   'See warning above for details.',
               );
             }

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -192,17 +192,19 @@ jobs:
               );
             }
 
-            // For `pull_request` events mirror the gate verdict on the workflow
-            // run itself, matching the UX contributors expect in the Checks tab.
-            // On fork PRs where `repos.createCommitStatus()` was refused, this
-            // is the ONLY signal the gate ran at all.
-            //
-            // For `issue_comment` events the verdict is on the commit status —
-            // so the workflow itself succeeds when posting succeeded. Surface
-            // a failure only when the status post failed (rare).
+            // Mirror the gate verdict on the workflow run itself.
+            // For `pull_request` events this keeps the Checks tab consistent
+            // and is the only signal on fork PRs where the status post was
+            // refused. For `issue_comment` events the commit status is the
+            // primary signal; only fail the workflow if the status post failed.
             const isPullRequest = eventName === 'pull_request';
             if (isPullRequest && unresolved.length > 0) {
               core.setFailed(`${unresolved.length} unresolved review thread(s). Resolve all before merging.`);
+            } else if (isPullRequest && !statusPosted) {
+              core.setFailed(
+                'Failed to post required review-threads commit status on the PR head. ' +
+                  'Use /check-reviews to retry from base-repo context.',
+              );
             } else if (!isPullRequest && !statusPosted) {
               core.setFailed(
                 'Failed to post review-threads status on the PR head. ' +


### PR DESCRIPTION
## Summary

- Switch `review-gate.yml` from `checks.create`/`checks.update` to `repos.createCommitStatus` (context: `review-threads`)
- Drop the entire dedup loop (~80 lines) — it's no longer needed; the Statuses API rewrites the verdict for the same (SHA, context) key on every invocation
- Change permission `checks: write` → `statuses: write`

## Implementation notes

**Root cause of #296:** GitHub's Feb-2025 change means a check-run created by workflow run N can only be updated by that same run. When `/check-reviews` fires as a new workflow run, `checks.update()` returns 403/422 and cannot neutralize the stale FAILURE from the previous `pull_request: synchronize` run. The PR stays BLOCKED.

**Why Statuses API solves it:** Commit statuses are keyed by `(SHA, context)`. The latest `POST /repos/{owner}/{repo}/statuses/{sha}` for a given context always wins — there is no historical stickiness, no cross-run ownership restriction. Re-running the gate on the same SHA simply overwrites the previous verdict. No dedup loop required.

**Tradeoff — rich output:** The Checks API `output.summary` field accepted unlimited Markdown (full thread list with snippets). The Statuses API `description` is capped at 140 chars. The workflow now logs unresolved threads to the Actions log (visible in the run) and posts only a short summary string as the status description. This is an acceptable regression in visibility for a significant gain in reliability.

**Branch protection follow-up (manual, requires admin):**
Once this PR merges, the branch protection ruleset for `main` must be updated:
- Add required status check: `review-threads` (commit status context)
- Remove required check-run: `Review Threads`

Until that update is made, the gate still runs but branch protection evaluates the old check-run name, not the new status context. The workflow comment in the file explains this.

## Spec alignment

This is a CI infrastructure fix. No spec covers GitHub Actions workflow design; the change is purely operational.

Related history: #273 (original gate), #292 (broken dedup, now superseded), #295 (breakage observed).

## Quality gates

```
bun run check   ✅  (no TS files changed; Biome schema version info-only, pre-existing)
bun run typecheck  ✅  (no TS files changed; bun-types error pre-existing on main)
bun test        ✅  (no TS files changed; test failures pre-existing on main)
linch validate  n/a  (no meta-model files changed)
```

Only `.github/workflows/review-gate.yml` was modified (YAML only).

## Retro

- **Why this approach:** The Statuses API is the only GitHub API for commit verdicts that has last-write-wins semantics with no cross-workflow-run ownership restriction. Check-runs require the creating entity to own updates; statuses do not. This matches exactly what the dedup loop was trying (and failing) to achieve.

- **Alternatives considered:**
  1. *Fix the dedup loop* — not possible; GitHub explicitly states check-runs created by Actions can only be updated internally by the same run. No workaround exists.
  2. *Use a GitHub App token* — would bypass the restriction but requires provisioning a separate App credential and secret rotation. Disproportionate operational cost for a CI gate.
  3. *Keep check-runs, rely on empty-commit dance* — current workaround; ~6 of 13 PRs in one session needed it. Unacceptable ongoing friction.

- **Security review:** No auth/tenant/input-trust surfaces touched. The workflow reads the PR head SHA from GitHub GraphQL (trusted GitHub API, same as before). The removed `output.summary` field previously echoed review comment snippets into the check-run output; those are now logged only in the Actions log (same trust boundary). No new data sources, no new secrets, no new inputs.

- **Other risks:**
  1. Branch protection must be manually updated after merge — documented in workflow comment and Implementation notes above. Until updated, gate runs but doesn't enforce via the new context.
  2. Fork PRs: same read-only token restriction as before — falls back to `core.setFailed()` on the workflow run.
  3. The `review-threads` context name must be unique; it's unlikely to collide with any other status poster in this repo.

- **Follow-ups:**
  - Admin: update branch protection to require status `review-threads` and remove `Review Threads` check-run requirement
  - Optional: paginate reviewThreads beyond 100 (pre-existing limitation, not introduced here)

## Self-review checklist

- [x] Tests added/updated and passing (YAML-only change; no new TS tests needed)
- [x] `bun run check` green (pre-existing schema version info only)
- [x] `bun run typecheck` green (pre-existing bun-types error on main, no TS changed)
- [x] `bun test` green (pre-existing failures on main, no TS changed)
- [x] `linch validate` n/a (no meta-model files changed)
- [x] Spec referenced in PR body (CI infra, no spec; history #273/#292/#295 cited)
- [x] Mandatory security review walked through — no auth/tenant/input-trust surfaces touched
- [x] No new dependencies
- [x] No hardcoded secrets, no `any`, no `eval`, no `new Function`
- [x] No changes outside the issue's scope
- [x] Branch name + commit messages follow convention
- [x] Every comment posted has a real timestamp (no placeholder)

Closes #296

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7zdaD9HKbU3cURbGHrSWN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the review gate to post a commit status under a "review-threads" context instead of using a required check-run.
  * Statuses include a short summary of unresolved review threads and reflect overall verdicts; workflow behavior varies by event type and tolerates status-post failures gracefully.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laofahai/linchkit/pull/299)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->