### PR TITLE
refactor(core): rename approvalsTable.metadata → actorsSnapshot (actors_snapshot) (#223)

### DIFF
--- a/drizzle/migrations/0006_rename_approvals_metadata_to_actors_snapshot.sql
+++ b/drizzle/migrations/0006_rename_approvals_metadata_to_actors_snapshot.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "_linchkit"."approvals" RENAME COLUMN "metadata" TO "actors_snapshot";

--- a/drizzle/migrations/meta/0006_snapshot.json
+++ b/drizzle/migrations/meta/0006_snapshot.json
@@ -1,0 +1,1081 @@
+{
+  "id": "d59a9244-f921-443f-8dd8-0faa2adeeb87",
+  "prevId": "bbd29386-9972-415e-8e5c-1f11abe31f5a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "_linchkit.approvals": {
+      "name": "approvals",
+      "schema": "_linchkit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capability": {
+          "name": "capability",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_rules": {
+          "name": "trigger_rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_type": {
+          "name": "assignee_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignee_value": {
+          "name": "assignee_value",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "approval_status",
+          "typeSchema": "_linchkit",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_note": {
+          "name": "decision_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_policy": {
+          "name": "timeout_policy",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reject'"
+        },
+        "original_execution_id": {
+          "name": "original_execution_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_error": {
+          "name": "execution_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_system_meta": {
+          "name": "actor_system_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actors_snapshot": {
+          "name": "actors_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.department": {
+      "name": "department",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_version": {
+          "name": "_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_extensions": {
+          "name": "_extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manager": {
+          "name": "manager",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budget_limit": {
+          "name": "budget_limit",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "department_name_unique": {
+          "name": "department_name_unique",
+          "columns": ["name"],
+          "nullsNotDistinct": false
+        },
+        "department_code_unique": {
+          "name": "department_code_unique",
+          "columns": ["code"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "_linchkit.events": {
+      "name": "events",
+      "schema": "_linchkit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_action": {
+          "name": "source_action",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_execution_id": {
+          "name": "source_execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_status",
+          "typeSchema": "_linchkit",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_events_type_status": {
+          "name": "idx_events_type_status",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_events_retry": {
+          "name": "idx_events_retry",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_events_tenant": {
+          "name": "idx_events_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "_linchkit.executions": {
+      "name": "executions",
+      "schema": "_linchkit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capability": {
+          "name": "capability",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "execution_status",
+          "typeSchema": "_linchkit",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_execution_id": {
+          "name": "parent_execution_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_executions_action_created": {
+          "name": "idx_executions_action_created",
+          "columns": [
+            {
+              "expression": "action_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_executions_tenant": {
+          "name": "idx_executions_tenant",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_executions_idempotency_key": {
+          "name": "idx_executions_idempotency_key",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "_linchkit.field_overlays": {
+      "name": "field_overlays",
+      "schema": "_linchkit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_name": {
+          "name": "field_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_type": {
+          "name": "field_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "overlay_status",
+          "typeSchema": "_linchkit",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_field_overlays_entity_field": {
+          "name": "idx_field_overlays_entity_field",
+          "columns": [
+            {
+              "expression": "entity_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_item": {
+      "name": "purchase_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_version": {
+          "name": "_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_extensions": {
+          "name": "_extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specification": {
+          "name": "specification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_total": {
+          "name": "line_total",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_request_id": {
+          "name": "purchase_request_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_item_purchase_request_id_purchase_request_id_fk": {
+          "name": "purchase_item_purchase_request_id_purchase_request_id_fk",
+          "tableFrom": "purchase_item",
+          "columnsFrom": ["purchase_request_id"],
+          "tableTo": "purchase_request",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_request": {
+      "name": "purchase_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_version": {
+          "name": "_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_extensions": {
+          "name": "_extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester": {
+          "name": "requester",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requester_email": {
+          "name": "requester_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audit_notes": {
+          "name": "audit_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department_id": {
+          "name": "department_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_request_department_id_department_id_fk": {
+          "name": "purchase_request_department_id_department_id_fk",
+          "tableFrom": "purchase_request",
+          "columnsFrom": ["department_id"],
+          "tableTo": "department",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "_linchkit.approval_status": {
+      "name": "approval_status",
+      "schema": "_linchkit",
+      "values": ["pending", "approved", "rejected", "expired", "cancelled"]
+    },
+    "_linchkit.event_status": {
+      "name": "event_status",
+      "schema": "_linchkit",
+      "values": ["pending", "processing", "completed", "failed", "dead_letter"]
+    },
+    "_linchkit.execution_status": {
+      "name": "execution_status",
+      "schema": "_linchkit",
+      "values": ["succeeded", "failed", "blocked", "pending_approval"]
+    },
+    "_linchkit.overlay_status": {
+      "name": "overlay_status",
+      "schema": "_linchkit",
+      "values": ["active", "deprecated", "promoted"]
+    }
+  },
+  "schemas": {
+    "_linchkit": "_linchkit"
+  },
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1778069771875,
       "tag": "0005_shallow_dreadnoughts",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1778465994937,
+      "tag": "0006_rename_approvals_metadata_to_actors_snapshot",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/persistence/drizzle-approval-store.ts
+++ b/packages/core/src/persistence/drizzle-approval-store.ts
@@ -20,7 +20,7 @@ export class DrizzleApprovalStore {
   constructor(private db: PostgresJsDatabase) {}
 
   async create(request: ApprovalRequest): Promise<void> {
-    const metadata: ApprovalMetadata = {
+    const actorsSnapshot: ApprovalMetadata = {
       requestedBy: request.requestedBy,
       decidedBy: request.decidedBy,
     };
@@ -48,7 +48,7 @@ export class DrizzleApprovalStore {
       originalExecutionId: request.originalExecutionId,
       executionId: request.executionId ?? null,
       executionError: request.executionError ?? null,
-      metadata,
+      actorsSnapshot,
       meta: request.meta ?? null,
       actorSystemMeta: request.actorSystemMeta ?? null,
       createdAt: request.createdAt,
@@ -74,12 +74,12 @@ export class DrizzleApprovalStore {
     if (data.status !== undefined) updateValues.status = data.status;
     if (data.decidedBy !== undefined) {
       updateValues.decidedBy = data.decidedBy.id;
-      // Also update metadata JSONB with full Actor object
-      const meta: ApprovalMetadata = {
+      // Also update actors_snapshot JSONB with full Actor object
+      const actorsSnapshot: ApprovalMetadata = {
         requestedBy: existing.requestedBy,
         decidedBy: data.decidedBy,
       };
-      updateValues.metadata = meta;
+      updateValues.actorsSnapshot = actorsSnapshot;
     }
     if (data.decidedAt !== undefined) updateValues.decidedAt = data.decidedAt;
     if (data.decisionNote !== undefined) updateValues.decisionNote = data.decisionNote;
@@ -117,7 +117,7 @@ export class DrizzleApprovalStore {
 type ApprovalRow = typeof approvalsTable.$inferSelect;
 
 function rowToRequest(row: ApprovalRow): ApprovalRequest {
-  const meta = (row.metadata ?? {}) as ApprovalMetadata;
+  const actorsMeta = (row.actorsSnapshot ?? {}) as ApprovalMetadata;
   const fallbackActor: Actor = {
     type: (row.actorType ?? "system") as ActorType,
     id: row.actorId ?? "unknown",
@@ -133,11 +133,11 @@ function rowToRequest(row: ApprovalRow): ApprovalRequest {
     level: row.level,
     reason: row.reason,
     triggerRules: (row.triggerRules as string[]) ?? [],
-    requestedBy: meta.requestedBy ?? fallbackActor,
+    requestedBy: actorsMeta.requestedBy ?? fallbackActor,
     assignee: { type: row.assigneeType as "role" | "user" | "group", value: row.assigneeValue },
     status: row.status as ApprovalStatus,
     decidedBy:
-      meta.decidedBy ??
+      actorsMeta.decidedBy ??
       (row.decidedBy ? { type: "human" as ActorType, id: row.decidedBy, groups: [] } : undefined),
     decidedAt: row.decidedAt ?? undefined,
     decisionNote: row.decisionNote ?? undefined,

--- a/packages/core/src/persistence/drizzle-approval-store.ts
+++ b/packages/core/src/persistence/drizzle-approval-store.ts
@@ -11,7 +11,7 @@ import type { ApprovalQuery, ApprovalRequest, ApprovalStatus } from "../types/ap
 import { approvalsTable } from "./system-tables";
 
 /** Full actor objects stored in JSONB to avoid lossy column mapping */
-interface ApprovalMetadata {
+interface ApprovalActorsSnapshot {
   requestedBy?: Actor;
   decidedBy?: Actor;
 }
@@ -20,7 +20,7 @@ export class DrizzleApprovalStore {
   constructor(private db: PostgresJsDatabase) {}
 
   async create(request: ApprovalRequest): Promise<void> {
-    const actorsSnapshot: ApprovalMetadata = {
+    const actorsSnapshot: ApprovalActorsSnapshot = {
       requestedBy: request.requestedBy,
       decidedBy: request.decidedBy,
     };
@@ -75,7 +75,7 @@ export class DrizzleApprovalStore {
     if (data.decidedBy !== undefined) {
       updateValues.decidedBy = data.decidedBy.id;
       // Also update actors_snapshot JSONB with full Actor object
-      const actorsSnapshot: ApprovalMetadata = {
+      const actorsSnapshot: ApprovalActorsSnapshot = {
         requestedBy: existing.requestedBy,
         decidedBy: data.decidedBy,
       };
@@ -117,7 +117,7 @@ export class DrizzleApprovalStore {
 type ApprovalRow = typeof approvalsTable.$inferSelect;
 
 function rowToRequest(row: ApprovalRow): ApprovalRequest {
-  const actorsMeta = (row.actorsSnapshot ?? {}) as ApprovalMetadata;
+  const actorsSnapshot = (row.actorsSnapshot ?? {}) as ApprovalActorsSnapshot;
   const fallbackActor: Actor = {
     type: (row.actorType ?? "system") as ActorType,
     id: row.actorId ?? "unknown",
@@ -133,11 +133,11 @@ function rowToRequest(row: ApprovalRow): ApprovalRequest {
     level: row.level,
     reason: row.reason,
     triggerRules: (row.triggerRules as string[]) ?? [],
-    requestedBy: actorsMeta.requestedBy ?? fallbackActor,
+    requestedBy: actorsSnapshot.requestedBy ?? fallbackActor,
     assignee: { type: row.assigneeType as "role" | "user" | "group", value: row.assigneeValue },
     status: row.status as ApprovalStatus,
     decidedBy:
-      actorsMeta.decidedBy ??
+      actorsSnapshot.decidedBy ??
       (row.decidedBy ? { type: "human" as ActorType, id: row.decidedBy, groups: [] } : undefined),
     decidedAt: row.decidedAt ?? undefined,
     decisionNote: row.decisionNote ?? undefined,

--- a/packages/core/src/persistence/system-tables.ts
+++ b/packages/core/src/persistence/system-tables.ts
@@ -145,6 +145,12 @@ export const approvalsTable = linchkitSchema.table("approvals", {
   originalExecutionId: varchar("original_execution_id", { length: 255 }),
   executionId: varchar("execution_id", { length: 255 }),
   executionError: text("execution_error"),
+  /**
+   * Full Actor JSON snapshot for `requestedBy` / `decidedBy`, captured at
+   * create/decide time so historical attribution survives even if the
+   * referenced actor is later renamed or deleted. Distinct from `meta`
+   * (ExecutionMeta, Spec 65) — see issue #223.
+   */
   actorsSnapshot: jsonb("actors_snapshot"),
   /** Spec 65 §14 M6 — Original ExecutionMeta captured at suspend, replayed on approve(). */
   meta: jsonb("meta"),

--- a/packages/core/src/persistence/system-tables.ts
+++ b/packages/core/src/persistence/system-tables.ts
@@ -145,7 +145,7 @@ export const approvalsTable = linchkitSchema.table("approvals", {
   originalExecutionId: varchar("original_execution_id", { length: 255 }),
   executionId: varchar("execution_id", { length: 255 }),
   executionError: text("execution_error"),
-  metadata: jsonb("metadata"),
+  actorsSnapshot: jsonb("actors_snapshot"),
   /** Spec 65 §14 M6 — Original ExecutionMeta captured at suspend, replayed on approve(). */
   meta: jsonb("meta"),
   /**


### PR DESCRIPTION
## Summary

- Rename `_linchkit.approvals.metadata` (DB column) → `actors_snapshot`
- Rename Drizzle ORM field `approvalsTable.metadata` → `actorsSnapshot`
- Rename local variable `meta` (actors snapshot context) → `actorsSnapshot` in `rowToRequest` to disambiguate from `row.meta` (ExecutionMeta)
- Add Drizzle migration `0006_rename_approvals_metadata_to_actors_snapshot.sql`

## Implementation notes

The `metadata` and `meta` columns sit adjacent on `_linchkit.approvals`:
- `metadata` — full Actor JSON for `requestedBy`/`decidedBy` fallback (predates `meta`)
- `meta` — ExecutionMeta snapshot (Spec 65, added in #199)

The near-identical property names caused confusion at call sites, surfaced by CodeRabbit during PR #222 review (see `system-tables.ts:141-146`). This rename makes the column purpose self-documenting.

**Migration strategy:** `ALTER TABLE "_linchkit"."approvals" RENAME COLUMN "metadata" TO "actors_snapshot"` — lossless, reversible, no data loss.

**drizzle-kit generate note:** The sandbox environment cannot install `node_modules` (npm mirror returns 403). drizzle-kit was run via cached bunx packages in a temp directory. Because drizzle-kit's interactive TTY prompt (for rename vs. drop+add disambiguation) cannot be answered non-interactively, the migration was generated using `drizzle-kit generate --custom` and the SQL filled in manually — exactly the SQL drizzle-kit would have produced. The drizzle snapshot (`0006_snapshot.json`) was also updated to reflect the rename. This is the same approach taken in prior PRs (#298, #299) for this environment.

## Spec alignment

No spec covers internal column naming conventions. The change is purely a readability/maintenance improvement to the persistence layer. Related history: CodeRabbit nitpick on `system-tables.ts:141-146` during PR #222.

## Quality gates

| Gate | Status | Notes |
|------|--------|-------|
| `bun run check` | ✅ | 1060 files checked, no errors (pre-existing schema version info only) |
| `bun run typecheck` | ⚠️ | Pre-existing `bun-types` error (missing node_modules, no TS files introduced) |
| `bun test` | ⚠️ | Pre-existing failures (missing node_modules); our code has no test coverage gap since `DrizzleApprovalStore` is a DB-backed store with no dedicated unit tests in the suite |
| `linch validate` | N/A | No meta-model files changed |

## Retro

- **Why this approach:** The rename fixes a real readability problem at no functional cost. `RENAME COLUMN` is atomic in PostgreSQL and fully reversible; no data movement occurs. The Drizzle ORM rename is a pure search-and-replace in two files.

- **Alternatives considered:**
  1. *Keep both names, add a comment* — mitigates confusion but leaves the root issue. Future contributors still need to remember which `meta*` column is which.
  2. *Rename `meta` instead of `metadata`* — `meta` is the canonical Spec 65 name used consistently across `executionsTable` and `eventsTable`; renaming it would create cross-table inconsistency.

- **Security review:** No auth/tenant/input-trust surfaces touched. `actorsSnapshot` stores the same Actor JSON as before — only the column name changes. No new data sources, no permission checks modified, no input validation affected.

- **Other risks:**
  - Any code outside this repo that queries `_linchkit.approvals.metadata` directly (raw SQL or separate drizzle schema) will break after migration. The only known consumer is `DrizzleApprovalStore` in this package, which is updated here.
  - The migration must be applied before deploying the code change.

- **Follow-ups:** None required. The rename is self-contained.

## Self-review checklist

- [x] Tests added/updated and passing — N/A: `DrizzleApprovalStore` has no unit tests in the suite (DB-only); no test logic changed
- [x] `bun run check` green — ✅ confirmed
- [x] `bun run typecheck` green — pre-existing `bun-types` error; no TS introduced
- [x] `bun test` green — pre-existing failures; no test files changed
- [x] `linch validate` — N/A (no meta-model files changed)
- [x] Spec referenced in PR body — CodeRabbit nitpick on system-tables.ts:141-146 during PR #222
- [x] Mandatory security review walked through — no auth/tenant/input-trust surfaces touched
- [x] No new dependencies
- [x] No hardcoded secrets, no `any`, no `eval`, no `new Function`
- [x] No changes outside the issue's scope
- [x] Branch name + commit messages follow convention
- [x] Every comment posted has a real timestamp (no placeholder)

Closes #223

---
_Generated by [Claude Code](https://claude.ai/code/session_014f2Gg7ymTKKuftd2pTMKvo)_



## Summary by CodeRabbit

* **Chores**
  * Updated internal database schema to improve how approval information is stored and managed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.io/change-stack/laofahai/linchkit/pull/300)