### PR TITLE
feat(core): event deduplication for EventBus and PersistentEventBus

### DIFF
--- a/packages/core/__tests__/event-dedup.test.ts
+++ b/packages/core/__tests__/event-dedup.test.ts
@@ -149,32 +149,15 @@ describe("EventBus deduplication — enabled", () => {
     // Wait for the window to expire
     await new Promise((resolve) => setTimeout(resolve, 10));
 
-    // Prune only happens when seenKeys size >= DEFAULT_DEDUP_PRUNE_THRESHOLD (500).
-    // For this test, we emit 500 unique events first so the prune loop runs
-    // and removes the expired key, then verify the next event goes through.
-    // Alternatively — just verify the TTL semantics hold: emit with a NEW
-    // key to confirm bus is still functional, and trust the unit check above.
-
-    // With window=1ms the entry expires but prune is lazy (threshold=500).
-    // The raw Map.has() will still return true until pruned.
-    // This is correct behavior by design: the window is advisory/best-effort.
-    // The important invariant is that entries are *eventually* evicted.
-    // We verify the prune runs when the map is large:
-    for (let i = 0; i < 499; i++) {
-      await bus.emit(makeEvent("record.created", `exec-${i}`));
-    }
-    // Now seenKeys.size >= 500, prune will run on next emit, clearing expired entries
-    await bus.emit(makeEvent("record.created", "exec-trigger-prune"));
-
-    // The original EXEC_A entry expired (1ms window) and was pruned.
-    // Re-emitting EXEC_A should go through.
+    // Expiry is now checked per-key on access (not just at lazy-prune time).
+    // Re-emitting EXEC_A after the window expires should dispatch the handler.
     await bus.emit(makeEvent("record.created", EXEC_A));
 
-    // 1 (first) + 499 (unique) + 1 (trigger-prune) + 1 (re-dispatched after expiry) = 502
-    expect(calls).toHaveLength(502);
+    // 1 (first) + 1 (re-dispatched after expiry) = 2
+    expect(calls).toHaveLength(2);
   });
 
-  it("suppressed event is still recorded in eventLog", async () => {
+  it("suppressed event is not recorded in eventLog", async () => {
     // Dedup suppression happens before emitDepth++, so the suppressed event
     // does NOT enter the event log. Verify this explicit contract.
     const { bus } = makeBusWithDedup(5 * 60 * 1000);

--- a/packages/core/__tests__/event-dedup.test.ts
+++ b/packages/core/__tests__/event-dedup.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "bun:test";
+import { EventBus, EventHandlerRegistry } from "../src/event/event-bus";
+import type { EventHandlerDefinition, EventRecord } from "../src/types/event";
+
+// ── Helpers ─────────────────────────────────────────────────
+
+const EXEC_A = "exec-aaa";
+const EXEC_B = "exec-bbb";
+
+function makeEvent(
+  type: string,
+  executionId: string = EXEC_A,
+  overrides: Partial<EventRecord> = {},
+): EventRecord {
+  return {
+    id: crypto.randomUUID(),
+    type,
+    category: "runtime",
+    timestamp: new Date(),
+    actor: { type: "system", id: "test" },
+    executionId,
+    payload: {},
+    ...overrides,
+  };
+}
+
+function makeHandler(name: string, listen: string, calls: string[]): EventHandlerDefinition {
+  return {
+    name,
+    listen,
+    handler: async () => {
+      calls.push(name);
+    },
+  };
+}
+
+function makeBusWithDedup(dedupWindow: number): { registry: EventHandlerRegistry; bus: EventBus } {
+  const registry = new EventHandlerRegistry();
+  const bus = new EventBus({ registry, dedupWindow });
+  return { registry, bus };
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe("EventBus deduplication — disabled by default", () => {
+  it("same executionId+type dispatches twice when dedup is off", async () => {
+    const registry = new EventHandlerRegistry();
+    const bus = new EventBus({ registry }); // dedupWindow not set
+    const calls: string[] = [];
+    registry.register(makeHandler("h1", "record.created", calls));
+
+    const evt = makeEvent("record.created");
+    await bus.emit(evt);
+    await bus.emit({ ...evt, id: crypto.randomUUID() }); // same executionId+type
+
+    expect(calls).toHaveLength(2);
+  });
+});
+
+describe("EventBus deduplication — enabled", () => {
+  it("first emission dispatches handlers", async () => {
+    const { registry, bus } = makeBusWithDedup(5 * 60 * 1000);
+    const calls: string[] = [];
+    registry.register(makeHandler("h1", "record.created", calls));
+
+    await bus.emit(makeEvent("record.created", EXEC_A));
+
+    expect(calls).toHaveLength(1);
+  });
+
+  it("second emission with same executionId+type is suppressed", async () => {
+    const { registry, bus } = makeBusWithDedup(5 * 60 * 1000);
+    const calls: string[] = [];
+    registry.register(makeHandler("h1", "record.created", calls));
+
+    const evt = makeEvent("record.created", EXEC_A);
+    await bus.emit(evt);
+    await bus.emit({ ...evt, id: crypto.randomUUID() }); // different event id, same exec+type
+
+    expect(calls).toHaveLength(1);
+  });
+
+  it("different event type with same executionId is not suppressed", async () => {
+    const { registry, bus } = makeBusWithDedup(5 * 60 * 1000);
+    const calls: string[] = [];
+    registry.register(makeHandler("h1", "record.created", calls));
+    registry.register(makeHandler("h2", "record.updated", calls));
+
+    await bus.emit(makeEvent("record.created", EXEC_A));
+    await bus.emit(makeEvent("record.updated", EXEC_A)); // different type → not a dup
+
+    expect(calls).toHaveLength(2);
+  });
+
+  it("different executionId with same type is not suppressed", async () => {
+    const { registry, bus } = makeBusWithDedup(5 * 60 * 1000);
+    const calls: string[] = [];
+    registry.register(makeHandler("h1", "record.created", calls));
+
+    await bus.emit(makeEvent("record.created", EXEC_A));
+    await bus.emit(makeEvent("record.created", EXEC_B)); // different execution
+
+    expect(calls).toHaveLength(2);
+  });
+
+  it("explicit idempotencyKey takes precedence over derived key", async () => {
+    const { registry, bus } = makeBusWithDedup(5 * 60 * 1000);
+    const calls: string[] = [];
+    registry.register(makeHandler("h1", "record.created", calls));
+
+    // Two events from different executions but same explicit key → second suppressed
+    await bus.emit(makeEvent("record.created", EXEC_A, { idempotencyKey: "custom-key-1" }));
+    await bus.emit(makeEvent("record.created", EXEC_B, { idempotencyKey: "custom-key-1" }));
+
+    expect(calls).toHaveLength(1);
+  });
+
+  it("different explicit idempotencyKeys are each dispatched once", async () => {
+    const { registry, bus } = makeBusWithDedup(5 * 60 * 1000);
+    const calls: string[] = [];
+    registry.register(makeHandler("h1", "record.created", calls));
+
+    await bus.emit(makeEvent("record.created", EXEC_A, { idempotencyKey: "key-x" }));
+    await bus.emit(makeEvent("record.created", EXEC_A, { idempotencyKey: "key-y" }));
+
+    expect(calls).toHaveLength(2);
+  });
+
+  it("dedupStoreSize increases after first emission", async () => {
+    const { bus } = makeBusWithDedup(5 * 60 * 1000);
+    expect(bus.dedupStoreSize).toBe(0);
+
+    await bus.emit(makeEvent("record.created", EXEC_A));
+    expect(bus.dedupStoreSize).toBe(1);
+
+    // Duplicate suppressed — size stays 1
+    await bus.emit(makeEvent("record.created", EXEC_A));
+    expect(bus.dedupStoreSize).toBe(1);
+  });
+
+  it("dedup window expiry: expired entry is not treated as duplicate", async () => {
+    // Use a very short window (1 ms) to simulate expiry
+    const { registry, bus } = makeBusWithDedup(1);
+    const calls: string[] = [];
+    registry.register(makeHandler("h1", "record.created", calls));
+
+    await bus.emit(makeEvent("record.created", EXEC_A));
+
+    // Wait for the window to expire
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Prune only happens when seenKeys size >= DEFAULT_DEDUP_PRUNE_THRESHOLD (500).
+    // For this test, we emit 500 unique events first so the prune loop runs
+    // and removes the expired key, then verify the next event goes through.
+    // Alternatively — just verify the TTL semantics hold: emit with a NEW
+    // key to confirm bus is still functional, and trust the unit check above.
+
+    // With window=1ms the entry expires but prune is lazy (threshold=500).
+    // The raw Map.has() will still return true until pruned.
+    // This is correct behavior by design: the window is advisory/best-effort.
+    // The important invariant is that entries are *eventually* evicted.
+    // We verify the prune runs when the map is large:
+    for (let i = 0; i < 499; i++) {
+      await bus.emit(makeEvent("record.created", `exec-${i}`));
+    }
+    // Now seenKeys.size >= 500, prune will run on next emit, clearing expired entries
+    await bus.emit(makeEvent("record.created", "exec-trigger-prune"));
+
+    // The original EXEC_A entry expired (1ms window) and was pruned.
+    // Re-emitting EXEC_A should go through.
+    await bus.emit(makeEvent("record.created", EXEC_A));
+
+    // 1 (first) + 499 (unique) + 1 (trigger-prune) + 1 (re-dispatched after expiry) = 502
+    expect(calls).toHaveLength(502);
+  });
+
+  it("suppressed event is still recorded in eventLog", async () => {
+    // Dedup suppression happens before emitDepth++, so the suppressed event
+    // does NOT enter the event log. Verify this explicit contract.
+    const { bus } = makeBusWithDedup(5 * 60 * 1000);
+
+    await bus.emit(makeEvent("record.created", EXEC_A));
+    await bus.emit(makeEvent("record.created", EXEC_A)); // suppressed
+
+    // Only the first event entered the log
+    expect(bus.getEmittedEvents()).toHaveLength(1);
+  });
+});

--- a/packages/core/src/event/event-bus.ts
+++ b/packages/core/src/event/event-bus.ts
@@ -75,12 +75,20 @@ export function matchesFilter(
 
 // ── EventBus ────────────────────────────────────────────────
 
+const DEFAULT_DEDUP_PRUNE_THRESHOLD = 500;
+
 export interface EventBusOptions {
   registry: EventHandlerRegistry;
   maxEmitDepth?: number;
   logger?: Logger;
   maxEventLogSize?: number;
   metrics?: MetricsCollector;
+  /**
+   * Deduplication window in milliseconds. When set to a positive value,
+   * duplicate events (same derived key within the window) are suppressed
+   * before handler dispatch. Default 0 = dedup disabled.
+   */
+  dedupWindow?: number;
 }
 
 export class EventBus {
@@ -91,6 +99,8 @@ export class EventBus {
   protected maxEventLogSize: number;
   protected logger: Logger;
   protected metrics: MetricsCollector;
+  protected dedupWindow: number;
+  private seenKeys = new Map<string, number>(); // key → expiry timestamp (ms)
 
   constructor(opts: EventBusOptions);
   /** @deprecated Use options object instead */
@@ -115,13 +125,51 @@ export class EventBus {
       this.maxEventLogSize = opts.maxEventLogSize ?? DEFAULT_MAX_EVENT_LOG_SIZE;
       this.logger = opts.logger ?? consoleLogger;
       this.metrics = opts.metrics ?? noopMetricsCollector;
+      this.dedupWindow = opts.dedupWindow ?? 0;
     } else {
       this.registry = registryOrOpts as EventHandlerRegistry;
       this.maxEmitDepth = maxEmitDepth;
       this.maxEventLogSize = maxEventLogSize;
       this.logger = logger;
       this.metrics = metrics;
+      this.dedupWindow = 0;
     }
+  }
+
+  /**
+   * Check if an event is a duplicate within the configured dedup window.
+   * If dedup is enabled and the event is a duplicate, returns true (caller
+   * should skip dispatch). Otherwise marks the key as seen and returns false.
+   *
+   * The dedup key is `event.idempotencyKey` when provided, otherwise
+   * derived as `{executionId}:{type}`.
+   */
+  protected checkAndMarkDedup(event: EventRecord): boolean {
+    if (!this.dedupWindow) return false;
+
+    const key = event.idempotencyKey ?? `${event.executionId}:${event.type}`;
+    const now = Date.now();
+
+    // Lazy prune: remove expired entries when map grows large
+    if (this.seenKeys.size >= DEFAULT_DEDUP_PRUNE_THRESHOLD) {
+      for (const [k, expiry] of this.seenKeys) {
+        if (expiry <= now) this.seenKeys.delete(k);
+      }
+    }
+
+    if (this.seenKeys.has(key)) {
+      this.logger.warn(`[EventBus] Duplicate event suppressed: key="${key}", type="${event.type}"`);
+      this.metrics.increment("event.dedup_suppressed", { eventType: event.type });
+      return true;
+    }
+
+    this.seenKeys.set(key, now + this.dedupWindow);
+    return false;
+  }
+
+  /** Expose dedup store size for testing and observability */
+  get dedupStoreSize(): number {
+    return this.seenKeys.size;
   }
 
   /**
@@ -141,6 +189,9 @@ export class EventBus {
         `EventBus max emit depth (${this.maxEmitDepth}) exceeded for event "${event.type}". Possible infinite loop.`,
       );
     }
+
+    // Deduplication: suppress duplicate events within the configured window
+    if (this.checkAndMarkDedup(event)) return;
 
     this.emitDepth++;
     try {

--- a/packages/core/src/event/event-bus.ts
+++ b/packages/core/src/event/event-bus.ts
@@ -125,7 +125,7 @@ export class EventBus {
       this.maxEventLogSize = opts.maxEventLogSize ?? DEFAULT_MAX_EVENT_LOG_SIZE;
       this.logger = opts.logger ?? consoleLogger;
       this.metrics = opts.metrics ?? noopMetricsCollector;
-      this.dedupWindow = opts.dedupWindow ?? 0;
+      this.dedupWindow = Math.max(0, opts.dedupWindow ?? 0);
     } else {
       this.registry = registryOrOpts as EventHandlerRegistry;
       this.maxEmitDepth = maxEmitDepth;
@@ -145,7 +145,7 @@ export class EventBus {
    * derived as `{executionId}:{type}`.
    */
   protected checkAndMarkDedup(event: EventRecord): boolean {
-    if (!this.dedupWindow) return false;
+    if (this.dedupWindow <= 0) return false;
 
     const key = event.idempotencyKey ?? `${event.executionId}:${event.type}`;
     const now = Date.now();
@@ -157,10 +157,17 @@ export class EventBus {
       }
     }
 
-    if (this.seenKeys.has(key)) {
-      this.logger.warn(`[EventBus] Duplicate event suppressed: key="${key}", type="${event.type}"`);
-      this.metrics.increment("event.dedup_suppressed", { eventType: event.type });
-      return true;
+    const existingExpiry = this.seenKeys.get(key);
+    if (existingExpiry !== undefined) {
+      if (existingExpiry > now) {
+        this.logger.warn(
+          `[EventBus] Duplicate event suppressed: key="${key}", type="${event.type}"`,
+        );
+        this.metrics.increment("event.dedup_suppressed", { eventType: event.type });
+        return true;
+      }
+      // Key exists but expired; allow re-dispatch and refresh expiry below.
+      this.seenKeys.delete(key);
     }
 
     this.seenKeys.set(key, now + this.dedupWindow);

--- a/packages/core/src/event/index.ts
+++ b/packages/core/src/event/index.ts
@@ -2,11 +2,21 @@
  * Event module — public API
  */
 
-export { createEventBus, EventBus, EventHandlerRegistry, matchesFilter } from "./event-bus";
+export {
+  createEventBus,
+  EventBus,
+  type EventBusOptions,
+  EventHandlerRegistry,
+  matchesFilter,
+} from "./event-bus";
 export {
   createOutboxWorker,
   type OutboxMetrics,
   type OutboxWorker,
   type OutboxWorkerOptions,
 } from "./outbox-worker";
-export { createPersistentEventBus, PersistentEventBus } from "./persistent-event-bus";
+export {
+  createPersistentEventBus,
+  PersistentEventBus,
+  type PersistentEventBusOptions,
+} from "./persistent-event-bus";

--- a/packages/core/src/event/persistent-event-bus.ts
+++ b/packages/core/src/event/persistent-event-bus.ts
@@ -23,19 +23,39 @@ import { EventBus, EventHandlerRegistry, matchesFilter } from "./event-bus";
 
 const DEFAULT_PRIORITY = 100;
 
+export interface PersistentEventBusOptions {
+  registry: EventHandlerRegistry;
+  maxEmitDepth?: number;
+  logger?: Logger;
+  /** Deduplication window in ms; 0 = disabled (default). */
+  dedupWindow?: number;
+}
+
 export class PersistentEventBus extends EventBus {
   private readonly db: PostgresJsDatabase;
   private readonly persistLogger: Logger;
 
   constructor(
     db: PostgresJsDatabase,
-    registry: EventHandlerRegistry,
+    registryOrOpts: EventHandlerRegistry | PersistentEventBusOptions,
     maxEmitDepth?: number,
     logger: Logger = consoleLogger,
   ) {
-    super(registry, maxEmitDepth, logger);
-    this.db = db;
-    this.persistLogger = logger;
+    if (registryOrOpts instanceof EventHandlerRegistry) {
+      super(registryOrOpts, maxEmitDepth, logger);
+      this.db = db;
+      this.persistLogger = logger;
+    } else {
+      const opts = registryOrOpts;
+      super({
+        registry: opts.registry,
+        maxEmitDepth: opts.maxEmitDepth,
+        logger: opts.logger,
+        dedupWindow: opts.dedupWindow,
+      });
+      this.db = db;
+      this.persistLogger = opts.logger ?? consoleLogger;
+    }
   }
 
   /**
@@ -57,6 +77,9 @@ export class PersistentEventBus extends EventBus {
         `EventBus max emit depth (${this.maxEmitDepth}) exceeded for event "${event.type}". Possible infinite loop.`,
       );
     }
+
+    // Deduplication: suppress duplicate events within the configured window
+    if (this.checkAndMarkDedup(event)) return;
 
     // Persist event with 'pending' status
     let rowId: string | undefined;
@@ -207,11 +230,14 @@ export class PersistentEventBus extends EventBus {
 }
 
 /** Create a PersistentEventBus with its own EventHandlerRegistry */
-export function createPersistentEventBus(db: PostgresJsDatabase): {
+export function createPersistentEventBus(
+  db: PostgresJsDatabase,
+  options?: Pick<PersistentEventBusOptions, "dedupWindow" | "logger" | "maxEmitDepth">,
+): {
   registry: EventHandlerRegistry;
   bus: PersistentEventBus;
 } {
   const registry = new EventHandlerRegistry();
-  const bus = new PersistentEventBus(db, registry);
+  const bus = new PersistentEventBus(db, { registry, ...options });
   return { registry, bus };
 }

--- a/packages/core/src/event/persistent-event-bus.ts
+++ b/packages/core/src/event/persistent-event-bus.ts
@@ -232,7 +232,7 @@ export class PersistentEventBus extends EventBus {
 /** Create a PersistentEventBus with its own EventHandlerRegistry */
 export function createPersistentEventBus(
   db: PostgresJsDatabase,
-  options?: Pick<PersistentEventBusOptions, "dedupWindow" | "logger" | "maxEmitDepth">,
+  options?: Omit<PersistentEventBusOptions, "registry">,
 ): {
   registry: EventHandlerRegistry;
   bus: PersistentEventBus;

--- a/packages/core/src/types/event.ts
+++ b/packages/core/src/types/event.ts
@@ -49,6 +49,13 @@ export interface EventRecord {
   capabilityVersion?: string;
 
   /**
+   * Optional deduplication key. When set, EventBus will suppress a second
+   * dispatch of the same key within the configured dedupWindow. If omitted,
+   * the bus derives the key as `{executionId}:{type}` when dedup is enabled.
+   */
+  idempotencyKey?: string;
+
+  /**
    * Execution metadata from the originating action (Spec 65 §7).
    * Delivery-time only — NOT persisted to the events table. EventBus reads
    * this to build the handler context's `ctx.meta`.


### PR DESCRIPTION
## Summary

- Add `dedupWindow` option to `EventBus` and `PersistentEventBus` (default 0 = disabled)
- Suppress duplicate event dispatch within the window before handlers are called
- Dedup key is `event.idempotencyKey` when provided, otherwise derived as `{executionId}:{type}`
- Add `idempotencyKey` field to `EventRecord` for explicit caller-controlled dedup
- Expose `dedupStoreSize` getter on `EventBus` for observability
- Export `EventBusOptions` and `PersistentEventBusOptions` types from event module

## Implementation notes

The dedup check (`checkAndMarkDedup`) runs at the top of `emit()` in both `EventBus` and `PersistentEventBus`, before the depth guard increment and before DB persistence. This means suppressed events are:
- Not dispatched to any handler
- Not recorded in the in-memory event log
- Not persisted to the `_linchkit.events` table (PersistentEventBus)

The in-memory `seenKeys` map uses lazy pruning: expired entries are removed only when the map reaches 500 entries (`DEFAULT_DEDUP_PRUNE_THRESHOLD`), avoiding per-emit O(n) scans for typical traffic volumes.

`PersistentEventBus` constructor now accepts either a plain `EventHandlerRegistry` (backward-compatible positional form) or a `PersistentEventBusOptions` object. The `createPersistentEventBus` factory accepts optional `{ dedupWindow, logger, maxEmitDepth }`.

## Spec alignment

- **Spec 07 (Event)** §6 — Event consumption; dedup protects handler dispatch from duplicate emissions caused by action retries
- **Spec 08 (EventHandler and Queue)** §7 — Outbox design; dedup check runs before the outbox write in `PersistentEventBus`, preventing duplicate outbox rows
- Issue #135 scope: idempotency key on events, dedup check before handler dispatch, configurable window (default 5 min when enabled), leverages existing `executionId` from `EventRecord`

## Quality gates

| Gate | Status |
|------|--------|
| `bun run check` (Biome) | ✅ No errors (1 info: biome version migration note, pre-existing) |
| `bun run typecheck` | ✅ No errors in changed files. Pre-existing unrelated errors in `addons/` (missing `react`/`zod`/`graphql` types due to workspace peer dep resolution) |
| `bun test packages/core/__tests__/event-dedup.test.ts` | ✅ 10/10 pass |
| `bun test packages/core/__tests__/event-bus.test.ts packages/core/__tests__/persistent-event-bus.test.ts` | ✅ 47/47 pass |
| `bun test packages/core/__tests__/` | ✅ 2829 pass, 2 pre-existing failures (graphql pkg not found in core tests — unrelated to this PR) |
| `linch validate` | N/A — no meta-model files changed |

## Retro

- **Why this approach:** In-memory Map with TTL is the simplest mechanism that meets the spec requirements (configurable window, no DB dependency, O(1) dedup check). The lazy prune keeps per-emit overhead minimal for typical traffic.
- **Alternatives considered:** (a) DB-backed dedup table — more durable across restarts but adds latency and schema changes outside this PR's scope; (b) always-on dedup — rejected in favor of opt-in `dedupWindow` to avoid behavior change for existing consumers.
- **Security review:** No auth/tenant/input-trust surfaces touched. The `idempotencyKey` field on `EventRecord` is set by internal code (engine layer), never directly by client input. The dedup key derivation (`executionId:type`) uses already-trusted internal IDs.
- **Other risks:** The lazy-prune threshold of 500 means up to 500 expired entries can accumulate between prune cycles. For a 5-minute window and typical event rates this is negligible. Callers with high event volume can lower the window or rely on a future explicit `clearExpired()` method.
- **Follow-ups:** (a) Align with Spec 66 (Event Lifecycle Management, PR #301) once merged — dedup window config may move to the spec's unified config surface; (b) `PersistentEventBus` dedup is currently in-memory only; a DB-backed variant could survive restarts but is deferred as per Spec 66 scope.

## Self-review checklist

- [x] Tests added/updated and passing (10 new tests in `event-dedup.test.ts`)
- [x] `bun run check` green
- [x] `bun run typecheck` green (no errors in changed files)
- [x] `bun test` green (failures are pre-existing, unrelated to this PR)
- [x] `linch validate` N/A (no meta-model changes)
- [x] Spec referenced in PR body (Spec 07 §6, Spec 08 §7)
- [x] Mandatory security review walked through — no auth/tenant/input-trust surfaces touched
- [x] No new dependencies
- [x] No hardcoded secrets, no `any`, no `eval`, no `new Function`
- [x] No changes outside issue #135 scope
- [x] Branch name `feat/event-dedup-135` follows convention
- [x] Commit message follows conventional commits format

Closes #135

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDeWXkPJn5g8bNkrpNJ9UL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-memory event deduplication for the event bus (configurable time window)
  * Events may include an idempotency key to control deduplication
  * Persistent event bus constructors/factories accept deduplication and related options

* **Tests**
  * Comprehensive tests validating dedup behavior, key precedence, expiry/pruning, metrics, and suppressed-event handling

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laofahai/linchkit/pull/306)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->