### PR TITLE
feat(audit-ui): scaffold cap-audit-ui capability (closes #138)

### DIFF
--- a/addons/audit/cap-audit-ui/README.md
+++ b/addons/audit/cap-audit-ui/README.md
@@ -1,0 +1,38 @@
+# @linchkit/cap-audit-ui
+
+Audit log viewer UI for LinchKit. Provides an admin page that lists every
+Action execution recorded in `_linchkit.executions`, with filters
+(action / actor / status / entity / date range) and a side-drawer
+detail view showing the full input, output, execution meta, and state
+transition for a single entry.
+
+Read-only — data is sourced through the existing `executionLogList`
+GraphQL query exposed by `@linchkit/cap-adapter-server` against the
+`execution_log` system entity. This package never writes audit data
+and never queries the `_linchkit.executions` table directly.
+
+## Installation
+
+```bash
+bun add @linchkit/cap-audit-ui
+```
+
+The capability `autoInstall: true` activates whenever
+`@linchkit/cap-adapter-ui` is present.
+
+## Peer dependencies
+
+- `@linchkit/core` ^0.2.0
+- `@linchkit/cap-adapter-ui` ^1.0.0
+- `react` ^19.0.0
+- `react-i18next` >=14.0.0
+
+## Route
+
+Mounted at `/admin/audit` (id: `audit`, order: 110).
+
+## Related
+
+- Spec 11 — Execution Log
+- Spec 14 — System Capabilities
+- Issue #138

--- a/addons/audit/cap-audit-ui/__tests__/views.test.tsx
+++ b/addons/audit/cap-audit-ui/__tests__/views.test.tsx
@@ -82,18 +82,18 @@ describe("buildAuditFilter", () => {
     });
   });
 
-  it("merges date range into a single started_at gte/lte clause", () => {
+  it("drops startedAfter/startedBefore until SystemDataProvider supports range operators", () => {
+    // SystemDataProvider currently uses equality-only filters; emitting a
+    // { gte, lte } clause silently returns zero rows. The UI fields stay so
+    // the layout is stable, but the wire payload must omit them for now.
     const raw = buildAuditFilter({
+      action: "create_order",
       startedAfter: "2026-01-01T00:00:00.000Z",
       startedBefore: "2026-01-02T00:00:00.000Z",
     });
     const parsed = JSON.parse(raw ?? "{}");
-    expect(parsed).toEqual({
-      started_at: {
-        gte: "2026-01-01T00:00:00.000Z",
-        lte: "2026-01-02T00:00:00.000Z",
-      },
-    });
+    expect(parsed).toEqual({ action_name: "create_order" });
+    expect(parsed.started_at).toBeUndefined();
   });
 
   it("drops empty string values", () => {
@@ -200,9 +200,10 @@ describe("queryAuditDetail", () => {
               error_message: null,
               input: JSON.stringify({ amount: 100 }),
               output: JSON.stringify({ ok: true }),
-              meta: JSON.stringify({ _channel: "graphql" }),
-              state_transition_from: "draft",
-              state_transition_to: "submitted",
+              meta: JSON.stringify({
+                _channel: "graphql",
+                stateTransition: { from: "draft", to: "submitted" },
+              }),
               started_at: "2026-05-16T12:00:00.000Z",
               completed_at: "2026-05-16T12:00:00.042Z",
             },
@@ -215,7 +216,10 @@ describe("queryAuditDetail", () => {
     expect(detail).not.toBeNull();
     expect(detail?.input).toEqual({ amount: 100 });
     expect(detail?.output).toEqual({ ok: true });
-    expect(detail?.meta).toEqual({ _channel: "graphql" });
+    expect(detail?.meta).toMatchObject({
+      _channel: "graphql",
+      stateTransition: { from: "draft", to: "submitted" },
+    });
     expect(detail?.stateTransitionFrom).toBe("draft");
     expect(detail?.stateTransitionTo).toBe("submitted");
     expect(detail?.capability).toBe("cap-purchase");

--- a/addons/audit/cap-audit-ui/__tests__/views.test.tsx
+++ b/addons/audit/cap-audit-ui/__tests__/views.test.tsx
@@ -1,0 +1,231 @@
+/**
+ * Smoke tests for cap-audit-ui.
+ *
+ * Bun's default test runner has no DOM, so these tests focus on the
+ * exported surface and the pure helpers (filter serialization, list
+ * mapping, detail JSON parsing) that drive the views. Render-level
+ * tests are deferred until the repo gains a DOM testing harness.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+// Stub the cap-adapter-ui api module BEFORE the audit-api import below
+// so `graphql()` is intercepted. mock.module must be set up before any
+// dynamic imports of the consumer.
+const graphqlMock = mock(async (_query: string, _vars?: Record<string, unknown>) => ({ data: {} }));
+
+mock.module("@linchkit/cap-adapter-ui/lib/api", () => ({
+  graphql: graphqlMock,
+}));
+
+const { AUDIT_STATUSES, buildAuditFilter, queryAuditDetail, queryAuditList } = await import(
+  "../src/lib/audit-api"
+);
+const { capAuditUi } = await import("../src/capability");
+const viewsModule = await import("../src/index");
+
+beforeEach(() => {
+  graphqlMock.mockClear();
+});
+
+afterEach(() => {
+  graphqlMock.mockReset();
+});
+
+// ── Capability metadata ─────────────────────────────────
+
+describe("capAuditUi", () => {
+  it("declares the expected name, type, group, and dependencies", () => {
+    expect(capAuditUi.name).toBe("cap-audit-ui");
+    expect(capAuditUi.type).toBe("standard");
+    expect(capAuditUi.category).toBe("system");
+    expect(capAuditUi.group).toBe("audit");
+    expect(capAuditUi.dependencies).toEqual(["cap-adapter-ui"]);
+    expect(capAuditUi.autoInstall).toBe(true);
+  });
+});
+
+// ── Public exports surface ──────────────────────────────
+
+describe("cap-audit-ui exports", () => {
+  it("exposes the views, capability, and api helpers", () => {
+    expect(viewsModule.capAuditUi).toBe(capAuditUi);
+    expect(typeof viewsModule.AuditList).toBe("function");
+    expect(typeof viewsModule.AuditDetailView).toBe("function");
+    expect(typeof viewsModule.AuditFiltersBar).toBe("function");
+    expect(typeof viewsModule.queryAuditList).toBe("function");
+    expect(typeof viewsModule.queryAuditDetail).toBe("function");
+    expect(viewsModule.AUDIT_STATUSES).toEqual(AUDIT_STATUSES);
+  });
+});
+
+// ── Filter serialization ────────────────────────────────
+
+describe("buildAuditFilter", () => {
+  it("returns undefined when no filter is set", () => {
+    expect(buildAuditFilter({})).toBeUndefined();
+  });
+
+  it("maps filter keys to system schema column names", () => {
+    const raw = buildAuditFilter({
+      action: "create_order",
+      actorId: "user-1",
+      status: "succeeded",
+      entity: "order",
+    });
+    const parsed = JSON.parse(raw ?? "{}");
+    expect(parsed).toEqual({
+      action_name: "create_order",
+      actor_id: "user-1",
+      status: "succeeded",
+      entity_name: "order",
+    });
+  });
+
+  it("merges date range into a single started_at gte/lte clause", () => {
+    const raw = buildAuditFilter({
+      startedAfter: "2026-01-01T00:00:00.000Z",
+      startedBefore: "2026-01-02T00:00:00.000Z",
+    });
+    const parsed = JSON.parse(raw ?? "{}");
+    expect(parsed).toEqual({
+      started_at: {
+        gte: "2026-01-01T00:00:00.000Z",
+        lte: "2026-01-02T00:00:00.000Z",
+      },
+    });
+  });
+
+  it("drops empty string values", () => {
+    const raw = buildAuditFilter({ action: "", actorId: "user-1" });
+    const parsed = JSON.parse(raw ?? "{}");
+    expect(parsed).toEqual({ actor_id: "user-1" });
+    expect(parsed.action_name).toBeUndefined();
+  });
+});
+
+// ── queryAuditList wiring ───────────────────────────────
+
+describe("queryAuditList", () => {
+  it("sends the configured filter, page, and sort to executionLogList", async () => {
+    graphqlMock.mockImplementationOnce(async () => ({
+      data: {
+        executionLogList: {
+          items: [
+            {
+              id: "exec-1",
+              action_name: "create_order",
+              entity_name: "order",
+              record_id: "ord-9",
+              actor_id: "user-1",
+              actor_type: "user",
+              status: "succeeded",
+              duration_ms: 42,
+              error_code: null,
+              error_message: null,
+              started_at: "2026-05-16T12:00:00.000Z",
+              completed_at: "2026-05-16T12:00:00.042Z",
+            },
+          ],
+          total: 1,
+        },
+      },
+    }));
+
+    const result = await queryAuditList({
+      filters: { action: "create_order" },
+      page: 2,
+      pageSize: 25,
+    });
+
+    expect(graphqlMock).toHaveBeenCalledTimes(1);
+    const [, vars] = graphqlMock.mock.calls[0] ?? [];
+    expect(vars).toMatchObject({
+      filter: JSON.stringify({ action_name: "create_order" }),
+      page: 2,
+      pageSize: 25,
+      sortField: "started_at",
+      sortOrder: "desc",
+    });
+
+    expect(result.total).toBe(1);
+    expect(result.items[0]).toMatchObject({
+      id: "exec-1",
+      action: "create_order",
+      entity: "order",
+      recordId: "ord-9",
+      actorId: "user-1",
+      actorType: "user",
+      status: "succeeded",
+      durationMs: 42,
+    });
+  });
+
+  it("throws when the GraphQL response carries errors", async () => {
+    graphqlMock.mockImplementationOnce(async () => ({
+      errors: [{ message: "boom" }],
+    }));
+
+    await expect(queryAuditList()).rejects.toThrow("boom");
+  });
+
+  it("returns an empty result when the server returns no data", async () => {
+    graphqlMock.mockImplementationOnce(async () => ({ data: {} }));
+
+    const result = await queryAuditList();
+    expect(result).toEqual({ items: [], total: 0 });
+  });
+});
+
+// ── queryAuditDetail wiring ─────────────────────────────
+
+describe("queryAuditDetail", () => {
+  it("parses JSON-string input/output/meta payloads", async () => {
+    graphqlMock.mockImplementationOnce(async () => ({
+      data: {
+        executionLogList: {
+          items: [
+            {
+              id: "exec-1",
+              action_name: "create_order",
+              entity_name: "order",
+              record_id: "ord-9",
+              capability: "cap-purchase",
+              channel: "graphql",
+              actor_id: "user-1",
+              actor_type: "user",
+              status: "succeeded",
+              duration_ms: 42,
+              error_code: null,
+              error_message: null,
+              input: JSON.stringify({ amount: 100 }),
+              output: JSON.stringify({ ok: true }),
+              meta: JSON.stringify({ _channel: "graphql" }),
+              state_transition_from: "draft",
+              state_transition_to: "submitted",
+              started_at: "2026-05-16T12:00:00.000Z",
+              completed_at: "2026-05-16T12:00:00.042Z",
+            },
+          ],
+        },
+      },
+    }));
+
+    const detail = await queryAuditDetail("exec-1");
+    expect(detail).not.toBeNull();
+    expect(detail?.input).toEqual({ amount: 100 });
+    expect(detail?.output).toEqual({ ok: true });
+    expect(detail?.meta).toEqual({ _channel: "graphql" });
+    expect(detail?.stateTransitionFrom).toBe("draft");
+    expect(detail?.stateTransitionTo).toBe("submitted");
+    expect(detail?.capability).toBe("cap-purchase");
+  });
+
+  it("returns null when no row matches the id", async () => {
+    graphqlMock.mockImplementationOnce(async () => ({
+      data: { executionLogList: { items: [] } },
+    }));
+
+    expect(await queryAuditDetail("missing")).toBeNull();
+  });
+});

--- a/addons/audit/cap-audit-ui/__tests__/views.test.tsx
+++ b/addons/audit/cap-audit-ui/__tests__/views.test.tsx
@@ -10,11 +10,16 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
 // Stub the cap-adapter-ui api module BEFORE the audit-api import below
-// so `graphql()` is intercepted. mock.module must be set up before any
-// dynamic imports of the consumer.
+// so `graphql()` is intercepted. mock.module is process-wide in bun:test
+// and persists across test files, so we re-export the full module surface
+// (only `graphql` is replaced) — otherwise unrelated test files that import
+// the api module (`isAuthEnabled`, `isAiEnabled`, etc.) would get an
+// undefined for every function we forgot to declare, breaking test isolation.
 const graphqlMock = mock(async (_query: string, _vars?: Record<string, unknown>) => ({ data: {} }));
 
+const apiActual = await import("@linchkit/cap-adapter-ui/lib/api");
 mock.module("@linchkit/cap-adapter-ui/lib/api", () => ({
+  ...apiActual,
   graphql: graphqlMock,
 }));
 

--- a/addons/audit/cap-audit-ui/package.json
+++ b/addons/audit/cap-audit-ui/package.json
@@ -24,7 +24,7 @@
     "@linchkit/cap-adapter-ui": "workspace:*"
   },
   "linchkit": {
-    "minCoreVersion": "^0.1.0",
+    "minCoreVersion": "^0.2.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/audit/cap-audit-ui/package.json
+++ b/addons/audit/cap-audit-ui/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@linchkit/cap-audit-ui",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "files": [
+    "src/",
+    "package.json",
+    "README.md"
+  ],
+  "exports": {
+    ".": "./src/index.ts",
+    "./capability": "./src/capability.ts"
+  },
+  "peerDependencies": {
+    "@linchkit/core": "^0.2.0",
+    "@linchkit/cap-adapter-ui": "^1.0.0",
+    "react": "^19.0.0",
+    "react-i18next": ">=14.0.0"
+  },
+  "devDependencies": {
+    "@linchkit/core": "workspace:*",
+    "@linchkit/cap-adapter-ui": "workspace:*"
+  },
+  "linchkit": {
+    "minCoreVersion": "^0.1.0",
+    "type": "standard",
+    "category": "system"
+  }
+}

--- a/addons/audit/cap-audit-ui/src/capability.ts
+++ b/addons/audit/cap-audit-ui/src/capability.ts
@@ -1,0 +1,31 @@
+/**
+ * Capability definition for cap-audit-ui.
+ *
+ * Provides the Audit Log Viewer admin pages — a list of every Action
+ * execution recorded in `_linchkit.executions`, with filters and a
+ * detail drawer showing input/output/rules/state-transitions for one
+ * execution.
+ *
+ * Backend data source: existing `executionLogList` GraphQL query
+ * (registered by `cap-adapter-server` against the `execution_log`
+ * system entity). This capability is read-only and does NOT query
+ * the `_linchkit.executions` table directly.
+ *
+ * Issue: #138
+ * Spec: 14 (System Capabilities), 11 (Execution Log)
+ */
+
+import { defineCapability } from "@linchkit/core";
+
+export const capAuditUi = defineCapability({
+  name: "cap-audit-ui",
+  label: "Audit Log Viewer UI",
+  description:
+    "Admin UI for browsing the execution log — list, filter (action/actor/status/date/entity), and inspect a single execution's full input/output/rules/state-transitions.",
+  type: "standard",
+  category: "system",
+  version: "0.1.0",
+  group: "audit",
+  dependencies: ["cap-adapter-ui"],
+  autoInstall: true,
+});

--- a/addons/audit/cap-audit-ui/src/index.ts
+++ b/addons/audit/cap-audit-ui/src/index.ts
@@ -1,0 +1,33 @@
+/**
+ * Entry point for cap-audit-ui.
+ *
+ * Registers the audit log admin route. Imported by the host UI bundle
+ * (cap-adapter-ui) to wire the capability into the admin layout.
+ */
+
+import { registerAdminRoute } from "@linchkit/cap-adapter-ui/route-registry";
+
+export { capAuditUi } from "./capability";
+export type {
+  AuditDetail,
+  AuditFilters,
+  AuditListResult,
+  AuditRow,
+  AuditStatus,
+} from "./lib/audit-api";
+export { AUDIT_STATUSES, queryAuditDetail, queryAuditList } from "./lib/audit-api";
+export { default as AuditDetailView } from "./views/AuditDetail";
+export { AuditFiltersBar } from "./views/AuditFilters";
+export { default as AuditList } from "./views/AuditList";
+
+registerAdminRoute({
+  id: "audit",
+  capability: "cap-audit-ui",
+  path: "/admin/audit",
+  label: "audit.list.title",
+  icon: "ScrollText",
+  // Sit just after the placeholder builtin executions route (order 100)
+  // so existing nav order is preserved while we transition.
+  order: 110,
+  component: () => import("./pages/audit-page"),
+});

--- a/addons/audit/cap-audit-ui/src/lib/audit-api.ts
+++ b/addons/audit/cap-audit-ui/src/lib/audit-api.ts
@@ -80,12 +80,18 @@ export interface AuditDetail extends AuditRow {
 /**
  * Build the `filter` JSON string consumed by the auto-generated
  * `executionLogList` query. The server-side filter is conjunctive
- * (AND across keys) and supports `gte`/`lte` operators on datetime
- * fields via Drizzle's between operator.
+ * (AND across keys).
  *
  * Empty / undefined values are dropped so the resulting filter is
  * minimal — this matches how `cap-adapter-ui/lib/api`'s
  * `queryExecutionLogs` builds its filter argument.
+ *
+ * Date-range note: `startedAfter` / `startedBefore` are intentionally
+ * dropped here. `SystemDataProvider` currently applies filters with
+ * equality only (`eq(col, value)`); serializing a `{ gte, lte }` shape
+ * would silently return zero rows. Once the provider gains range-operator
+ * support these branches can be re-enabled (the UI fields stay so the
+ * shape of the page doesn't change when the server side lands).
  */
 export function buildAuditFilter(filters: AuditFilters): string | undefined {
   const filter: Record<string, unknown> = {};
@@ -93,12 +99,6 @@ export function buildAuditFilter(filters: AuditFilters): string | undefined {
   if (filters.actorId) filter.actor_id = filters.actorId;
   if (filters.status) filter.status = filters.status;
   if (filters.entity) filter.entity_name = filters.entity;
-  if (filters.startedAfter) {
-    filter.started_at = { ...((filter.started_at as object) ?? {}), gte: filters.startedAfter };
-  }
-  if (filters.startedBefore) {
-    filter.started_at = { ...((filter.started_at as object) ?? {}), lte: filters.startedBefore };
-  }
   return Object.keys(filter).length > 0 ? JSON.stringify(filter) : undefined;
 }
 
@@ -207,7 +207,6 @@ const DETAIL_QUERY = `
         status duration_ms
         error_code error_message
         input output meta
-        state_transition_from state_transition_to
         started_at completed_at
       }
     }
@@ -220,8 +219,23 @@ interface DetailRow extends ListRow {
   input: unknown;
   output: unknown;
   meta: unknown;
-  state_transition_from: string | null;
-  state_transition_to: string | null;
+}
+
+/**
+ * State transition (from / to action) is persisted inside the executions
+ * `metadata` JSONB under `stateTransition` rather than as top-level columns.
+ * Project the values out of the parsed meta payload.
+ */
+function extractStateTransition(meta: unknown): { from: string | null; to: string | null } {
+  if (meta && typeof meta === "object") {
+    const t = (meta as { stateTransition?: { from?: unknown; to?: unknown } }).stateTransition;
+    if (t && typeof t === "object") {
+      const from = typeof t.from === "string" ? t.from : null;
+      const to = typeof t.to === "string" ? t.to : null;
+      return { from, to };
+    }
+  }
+  return { from: null, to: null };
 }
 
 /**
@@ -262,14 +276,17 @@ export async function queryAuditDetail(id: string): Promise<AuditDetail | null> 
   const row = res.data?.executionLogList?.items.at(0);
   if (!row) return null;
 
+  const meta = parseJsonField(row.meta) as Record<string, unknown> | null;
+  const transition = extractStateTransition(meta);
+
   return {
     ...rowToAudit(row),
     capability: row.capability,
     channel: row.channel,
     input: parseJsonField(row.input),
     output: parseJsonField(row.output),
-    meta: parseJsonField(row.meta) as Record<string, unknown> | null,
-    stateTransitionFrom: row.state_transition_from,
-    stateTransitionTo: row.state_transition_to,
+    meta,
+    stateTransitionFrom: transition.from,
+    stateTransitionTo: transition.to,
   };
 }

--- a/addons/audit/cap-audit-ui/src/lib/audit-api.ts
+++ b/addons/audit/cap-audit-ui/src/lib/audit-api.ts
@@ -1,0 +1,275 @@
+/**
+ * Audit log API client.
+ *
+ * Wraps the existing `executionLogList` GraphQL query with a typed,
+ * filter-aware helper for the audit viewer UI. Reads only — audit data
+ * lives in `_linchkit.executions` and is exposed read-only via the
+ * `execution_log` system entity registered by cap-adapter-server.
+ *
+ * NOTE: list fields here are kept tight (only what the table renders);
+ * detail view issues a second targeted query for the full payload to
+ * avoid shipping JSON blobs in the list payload.
+ */
+
+import { graphql } from "@linchkit/cap-adapter-ui/lib/api";
+
+// ── Status enum ─────────────────────────────────────────
+
+export type AuditStatus = "succeeded" | "failed" | "blocked" | "pending_approval";
+
+export const AUDIT_STATUSES: readonly AuditStatus[] = [
+  "succeeded",
+  "failed",
+  "blocked",
+  "pending_approval",
+] as const;
+
+// ── Filter shape ────────────────────────────────────────
+
+export interface AuditFilters {
+  /** Filter by action name (exact match on action_name). */
+  action?: string;
+  /** Filter by actor id (exact match on actor_id). */
+  actorId?: string;
+  /** Filter by execution status. */
+  status?: AuditStatus;
+  /** Filter by entity name (exact match on entity_name). */
+  entity?: string;
+  /** ISO timestamp — entries started at or after this instant. */
+  startedAfter?: string;
+  /** ISO timestamp — entries started at or before this instant. */
+  startedBefore?: string;
+}
+
+// ── Row shape used by the list view ─────────────────────
+
+export interface AuditRow {
+  id: string;
+  action: string;
+  entity: string | null;
+  recordId: string | null;
+  actorId: string | null;
+  actorType: string | null;
+  status: AuditStatus;
+  durationMs: number;
+  errorCode: string | null;
+  errorMessage: string | null;
+  startedAt: string;
+  completedAt: string | null;
+}
+
+export interface AuditListResult {
+  items: AuditRow[];
+  total: number;
+}
+
+// ── Detail shape ────────────────────────────────────────
+
+export interface AuditDetail extends AuditRow {
+  capability: string | null;
+  channel: string | null;
+  input: unknown;
+  output: unknown;
+  meta: Record<string, unknown> | null;
+  stateTransitionFrom: string | null;
+  stateTransitionTo: string | null;
+}
+
+// ── Filter serialization ───────────────────────────────
+
+/**
+ * Build the `filter` JSON string consumed by the auto-generated
+ * `executionLogList` query. The server-side filter is conjunctive
+ * (AND across keys) and supports `gte`/`lte` operators on datetime
+ * fields via Drizzle's between operator.
+ *
+ * Empty / undefined values are dropped so the resulting filter is
+ * minimal — this matches how `cap-adapter-ui/lib/api`'s
+ * `queryExecutionLogs` builds its filter argument.
+ */
+export function buildAuditFilter(filters: AuditFilters): string | undefined {
+  const filter: Record<string, unknown> = {};
+  if (filters.action) filter.action_name = filters.action;
+  if (filters.actorId) filter.actor_id = filters.actorId;
+  if (filters.status) filter.status = filters.status;
+  if (filters.entity) filter.entity_name = filters.entity;
+  if (filters.startedAfter) {
+    filter.started_at = { ...((filter.started_at as object) ?? {}), gte: filters.startedAfter };
+  }
+  if (filters.startedBefore) {
+    filter.started_at = { ...((filter.started_at as object) ?? {}), lte: filters.startedBefore };
+  }
+  return Object.keys(filter).length > 0 ? JSON.stringify(filter) : undefined;
+}
+
+// ── List query ──────────────────────────────────────────
+
+const LIST_QUERY = `
+  query AuditList($filter: String, $page: Int, $pageSize: Int, $sortField: String, $sortOrder: String) {
+    executionLogList(
+      filter: $filter
+      page: $page
+      pageSize: $pageSize
+      sortField: $sortField
+      sortOrder: $sortOrder
+    ) {
+      items {
+        id action_name entity_name record_id
+        actor_id actor_type
+        status duration_ms
+        error_code error_message
+        started_at completed_at
+      }
+      total
+    }
+  }
+`;
+
+interface ListRow {
+  id: string;
+  action_name: string;
+  entity_name: string | null;
+  record_id: string | null;
+  actor_id: string | null;
+  actor_type: string | null;
+  status: AuditStatus;
+  duration_ms: number | null;
+  error_code: string | null;
+  error_message: string | null;
+  started_at: string;
+  completed_at: string | null;
+}
+
+function rowToAudit(r: ListRow): AuditRow {
+  return {
+    id: r.id,
+    action: r.action_name,
+    entity: r.entity_name,
+    recordId: r.record_id,
+    actorId: r.actor_id,
+    actorType: r.actor_type,
+    status: r.status,
+    durationMs: r.duration_ms ?? 0,
+    errorCode: r.error_code,
+    errorMessage: r.error_message,
+    startedAt: r.started_at,
+    completedAt: r.completed_at,
+  };
+}
+
+export interface QueryAuditListOptions {
+  filters?: AuditFilters;
+  page?: number;
+  pageSize?: number;
+  sortField?: string;
+  sortOrder?: "asc" | "desc";
+}
+
+/**
+ * Fetch a page of audit entries from `executionLogList`.
+ *
+ * Defaults: page 1, pageSize 50, newest-first by `started_at`.
+ */
+export async function queryAuditList(
+  options: QueryAuditListOptions = {},
+): Promise<AuditListResult> {
+  const filter = buildAuditFilter(options.filters ?? {});
+  const res = await graphql<{
+    executionLogList: { items: ListRow[]; total: number };
+  }>(LIST_QUERY, {
+    filter,
+    page: options.page ?? 1,
+    pageSize: options.pageSize ?? 50,
+    sortField: options.sortField ?? "started_at",
+    sortOrder: options.sortOrder ?? "desc",
+  });
+
+  if (res.errors && res.errors.length > 0) {
+    const first = res.errors.at(0);
+    throw new Error(first?.message ?? "Failed to query audit log");
+  }
+
+  const data = res.data?.executionLogList ?? { items: [], total: 0 };
+  return {
+    items: data.items.map(rowToAudit),
+    total: data.total,
+  };
+}
+
+// ── Detail query ────────────────────────────────────────
+
+const DETAIL_QUERY = `
+  query AuditDetail($filter: String) {
+    executionLogList(filter: $filter, page: 1, pageSize: 1) {
+      items {
+        id action_name entity_name record_id capability channel
+        actor_id actor_type
+        status duration_ms
+        error_code error_message
+        input output meta
+        state_transition_from state_transition_to
+        started_at completed_at
+      }
+    }
+  }
+`;
+
+interface DetailRow extends ListRow {
+  capability: string | null;
+  channel: string | null;
+  input: unknown;
+  output: unknown;
+  meta: unknown;
+  state_transition_from: string | null;
+  state_transition_to: string | null;
+}
+
+/**
+ * Parse a JSON-string field returned by the auto-generated entity
+ * GraphQL layer. The `system-data-provider` JSON-encodes the `input`,
+ * `output`, and `meta` fields before returning them so the GraphQL
+ * type can be `String`. This helper safely re-parses them — falling
+ * back to the raw value if it's already an object or unparsable.
+ *
+ * TODO(spec-14): once the audit GraphQL type exposes typed payloads
+ * directly (instead of stringified JSON), drop this helper.
+ */
+function parseJsonField(value: unknown): unknown {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Fetch a single execution by id, including the full input/output/meta
+ * payload and state transition. Returns `null` if not found.
+ */
+export async function queryAuditDetail(id: string): Promise<AuditDetail | null> {
+  const filter = JSON.stringify({ id });
+  const res = await graphql<{
+    executionLogList: { items: DetailRow[] };
+  }>(DETAIL_QUERY, { filter });
+
+  if (res.errors && res.errors.length > 0) {
+    const first = res.errors.at(0);
+    throw new Error(first?.message ?? "Failed to query audit detail");
+  }
+
+  const row = res.data?.executionLogList?.items.at(0);
+  if (!row) return null;
+
+  return {
+    ...rowToAudit(row),
+    capability: row.capability,
+    channel: row.channel,
+    input: parseJsonField(row.input),
+    output: parseJsonField(row.output),
+    meta: parseJsonField(row.meta) as Record<string, unknown> | null,
+    stateTransitionFrom: row.state_transition_from,
+    stateTransitionTo: row.state_transition_to,
+  };
+}

--- a/addons/audit/cap-audit-ui/src/pages/audit-page.tsx
+++ b/addons/audit/cap-audit-ui/src/pages/audit-page.tsx
@@ -1,0 +1,11 @@
+/**
+ * Lazy-loaded admin route component for the audit log viewer.
+ *
+ * Imported indirectly through `registerAdminRoute(...)` in `index.ts`.
+ */
+
+import AuditList from "../views/AuditList";
+
+export default function AuditPage() {
+  return <AuditList />;
+}

--- a/addons/audit/cap-audit-ui/src/views/AuditDetail.tsx
+++ b/addons/audit/cap-audit-ui/src/views/AuditDetail.tsx
@@ -1,0 +1,226 @@
+/**
+ * AuditDetail — full payload view for one execution log entry.
+ *
+ * Renders four sections:
+ *   1. Summary (action, actor, status, duration, channel, error)
+ *   2. Input / Output JSON
+ *   3. State transition (from → to) when present
+ *   4. ExecutionMeta snapshot (Spec 65) when present
+ *
+ * Rules evaluated by the execution are NOT yet exposed by the
+ * `executionLogList` query — see follow-up note in the audit-api
+ * module. When that field becomes available, add a fifth section here.
+ */
+
+import { Badge, Button } from "@linchkit/ui-kit/components";
+import { ArrowRight, ExternalLink, Loader2, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { type AuditDetail, queryAuditDetail } from "../lib/audit-api";
+
+export interface AuditDetailViewProps {
+  /** Execution id (`_linchkit.executions.id`). */
+  executionId: string;
+  /** Called when the user closes the panel. */
+  onClose: () => void;
+}
+
+function statusVariant(status: string): "default" | "secondary" | "destructive" | "outline" {
+  if (status === "succeeded") return "default";
+  if (status === "failed" || status === "blocked") return "destructive";
+  return "secondary";
+}
+
+function JsonBlock({ value }: { value: unknown }) {
+  if (value === null || value === undefined) {
+    return <span className="text-xs text-muted-foreground">—</span>;
+  }
+  const text = typeof value === "string" ? value : JSON.stringify(value, null, 2);
+  return (
+    <pre className="max-h-72 overflow-auto rounded-md border bg-muted/40 p-3 text-xs leading-relaxed">
+      <code>{text}</code>
+    </pre>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-[11px] uppercase tracking-wider text-muted-foreground">{label}</span>
+      <div className="text-sm">{children}</div>
+    </div>
+  );
+}
+
+export function AuditDetailView(props: AuditDetailViewProps) {
+  const { executionId, onClose } = props;
+  const { t } = useTranslation();
+  const [detail, setDetail] = useState<AuditDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    queryAuditDetail(executionId)
+      .then((row) => {
+        if (cancelled) return;
+        setDetail(row);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [executionId]);
+
+  return (
+    <aside
+      className="flex h-full w-full max-w-xl flex-col border-l bg-background"
+      aria-label={t("audit.detail.title", "Execution detail")}
+    >
+      <header className="flex items-center justify-between border-b px-4 py-3">
+        <div className="flex items-center gap-2 min-w-0">
+          <ExternalLink className="size-4 text-muted-foreground shrink-0" />
+          <h2 className="truncate text-sm font-semibold">
+            {detail?.action ?? t("audit.detail.title", "Execution detail")}
+          </h2>
+        </div>
+        <Button variant="ghost" size="sm" onClick={onClose} aria-label={t("common.close", "Close")}>
+          <X className="size-4" />
+        </Button>
+      </header>
+
+      <div className="flex-1 overflow-auto px-4 py-3">
+        {loading ? (
+          <div className="flex h-full items-center justify-center">
+            <Loader2 className="size-5 animate-spin text-muted-foreground" />
+          </div>
+        ) : error ? (
+          <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+            {error}
+          </div>
+        ) : !detail ? (
+          <div className="text-sm text-muted-foreground">
+            {t("audit.detail.notFound", "Execution not found.")}
+          </div>
+        ) : (
+          <div className="flex flex-col gap-5">
+            {/* ── Summary ──────────────────────────────── */}
+            <section className="grid grid-cols-2 gap-3">
+              <Field label={t("audit.detail.executionId", "Execution ID")}>
+                <code className="break-all text-xs">{detail.id}</code>
+              </Field>
+              <Field label={t("audit.detail.status", "Status")}>
+                <Badge variant={statusVariant(detail.status)}>{detail.status}</Badge>
+              </Field>
+              <Field label={t("audit.detail.action", "Action")}>{detail.action}</Field>
+              <Field label={t("audit.detail.duration", "Duration")}>{detail.durationMs} ms</Field>
+              <Field label={t("audit.detail.actor", "Actor")}>
+                {detail.actorId ? (
+                  <span>
+                    <span className="text-muted-foreground">{detail.actorType ?? "?"}:</span>{" "}
+                    <code className="text-xs">{detail.actorId}</code>
+                  </span>
+                ) : (
+                  <span className="text-xs text-muted-foreground">—</span>
+                )}
+              </Field>
+              <Field label={t("audit.detail.entity", "Entity")}>
+                {detail.entity ? (
+                  <span>
+                    <code className="text-xs">{detail.entity}</code>
+                    {detail.recordId && (
+                      <span className="text-muted-foreground"> / {detail.recordId}</span>
+                    )}
+                  </span>
+                ) : (
+                  <span className="text-xs text-muted-foreground">—</span>
+                )}
+              </Field>
+              <Field label={t("audit.detail.channel", "Channel")}>
+                {detail.channel ?? <span className="text-xs text-muted-foreground">—</span>}
+              </Field>
+              <Field label={t("audit.detail.capability", "Capability")}>
+                {detail.capability ?? <span className="text-xs text-muted-foreground">—</span>}
+              </Field>
+              <Field label={t("audit.detail.startedAt", "Started")}>
+                <span className="text-xs">{new Date(detail.startedAt).toLocaleString()}</span>
+              </Field>
+              <Field label={t("audit.detail.completedAt", "Completed")}>
+                <span className="text-xs">
+                  {detail.completedAt ? new Date(detail.completedAt).toLocaleString() : "—"}
+                </span>
+              </Field>
+            </section>
+
+            {/* ── Error ──────────────────────────────────── */}
+            {detail.errorMessage && (
+              <section className="rounded-md border border-destructive/40 bg-destructive/10 p-3">
+                <div className="text-[11px] uppercase tracking-wider text-destructive/80">
+                  {t("audit.detail.error", "Error")}
+                </div>
+                {detail.errorCode && (
+                  <code className="mt-1 block text-xs text-destructive">{detail.errorCode}</code>
+                )}
+                <p className="mt-1 text-sm text-destructive">{detail.errorMessage}</p>
+              </section>
+            )}
+
+            {/* ── State transition ───────────────────────── */}
+            {detail.stateTransitionTo && (
+              <section>
+                <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  {t("audit.detail.stateTransition", "State transition")}
+                </h3>
+                <div className="flex items-center gap-2">
+                  <Badge variant="outline">{detail.stateTransitionFrom ?? "∅"}</Badge>
+                  <ArrowRight className="size-3.5 text-muted-foreground" />
+                  <Badge variant="secondary">{detail.stateTransitionTo}</Badge>
+                </div>
+              </section>
+            )}
+
+            {/* ── Input / output ────────────────────────── */}
+            <section>
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                {t("audit.detail.input", "Input")}
+              </h3>
+              <JsonBlock value={detail.input} />
+            </section>
+            <section>
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                {t("audit.detail.output", "Output")}
+              </h3>
+              <JsonBlock value={detail.output} />
+            </section>
+
+            {/* ── Meta ──────────────────────────────────── */}
+            {detail.meta && Object.keys(detail.meta).length > 0 && (
+              <section>
+                <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  {t("audit.detail.meta", "Execution meta (Spec 65)")}
+                </h3>
+                <JsonBlock value={detail.meta} />
+              </section>
+            )}
+
+            {/* TODO(spec-14, spec-11): show rules_evaluated[] once the
+                executionLogList GraphQL projection exposes that field.
+                See cap-adapter-server/src/system-data-provider.ts:
+                rules_evaluated is captured in the in-memory log entry
+                but not yet projected through the system schema. */}
+          </div>
+        )}
+      </div>
+    </aside>
+  );
+}
+
+export default AuditDetailView;

--- a/addons/audit/cap-audit-ui/src/views/AuditDetail.tsx
+++ b/addons/audit/cap-audit-ui/src/views/AuditDetail.tsx
@@ -43,6 +43,26 @@ function JsonBlock({ value }: { value: unknown }) {
   );
 }
 
+/**
+ * Format an ISO timestamp using the active i18n locale and the user's
+ * timezone. Mirrors the helper in AuditList so list rows and detail rows
+ * render identically and we don't rely on the locale-implicit
+ * `Date.toLocaleString()`.
+ */
+function formatDateTime(iso: string, locale: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return new Intl.DateTimeFormat(locale, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).format(date);
+}
+
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="flex flex-col gap-1">
@@ -54,7 +74,7 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
 
 export function AuditDetailView(props: AuditDetailViewProps) {
   const { executionId, onClose } = props;
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [detail, setDetail] = useState<AuditDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -151,11 +171,11 @@ export function AuditDetailView(props: AuditDetailViewProps) {
                 {detail.capability ?? <span className="text-xs text-muted-foreground">—</span>}
               </Field>
               <Field label={t("audit.detail.startedAt", "Started")}>
-                <span className="text-xs">{new Date(detail.startedAt).toLocaleString()}</span>
+                <span className="text-xs">{formatDateTime(detail.startedAt, i18n.language)}</span>
               </Field>
               <Field label={t("audit.detail.completedAt", "Completed")}>
                 <span className="text-xs">
-                  {detail.completedAt ? new Date(detail.completedAt).toLocaleString() : "—"}
+                  {detail.completedAt ? formatDateTime(detail.completedAt, i18n.language) : "—"}
                 </span>
               </Field>
             </section>

--- a/addons/audit/cap-audit-ui/src/views/AuditFilters.tsx
+++ b/addons/audit/cap-audit-ui/src/views/AuditFilters.tsx
@@ -22,30 +22,6 @@ export interface AuditFiltersProps {
   onReset: () => void;
 }
 
-/**
- * Convert an `<input type="datetime-local">` value (no timezone) into
- * an ISO string. Returns `undefined` for empty input so we don't send
- * empty filter keys to the server.
- */
-function toIso(local: string): string | undefined {
-  if (!local) return undefined;
-  const date = new Date(local);
-  if (Number.isNaN(date.getTime())) return undefined;
-  return date.toISOString();
-}
-
-/**
- * Convert an ISO string back to the `datetime-local` input format
- * (YYYY-MM-DDTHH:mm). Empty / undefined → empty string.
- */
-function fromIso(iso: string | undefined): string {
-  if (!iso) return "";
-  const date = new Date(iso);
-  if (Number.isNaN(date.getTime())) return "";
-  // Drop seconds and timezone — datetime-local accepts YYYY-MM-DDTHH:mm
-  return date.toISOString().slice(0, 16);
-}
-
 export function AuditFiltersBar(props: AuditFiltersProps) {
   const { value, onChange, onApply, onReset } = props;
   const { t } = useTranslation();
@@ -122,31 +98,14 @@ export function AuditFiltersBar(props: AuditFiltersProps) {
         </select>
       </div>
 
-      <div className="flex flex-col gap-1">
-        <Label htmlFor="audit-filter-after" className="text-xs">
-          {t("audit.filters.after", "After")}
-        </Label>
-        <Input
-          id="audit-filter-after"
-          type="datetime-local"
-          value={fromIso(value.startedAfter)}
-          onChange={(e) => patch({ startedAfter: toIso(e.target.value) })}
-          className="h-8 w-52"
-        />
-      </div>
-
-      <div className="flex flex-col gap-1">
-        <Label htmlFor="audit-filter-before" className="text-xs">
-          {t("audit.filters.before", "Before")}
-        </Label>
-        <Input
-          id="audit-filter-before"
-          type="datetime-local"
-          value={fromIso(value.startedBefore)}
-          onChange={(e) => patch({ startedBefore: toIso(e.target.value) })}
-          className="h-8 w-52"
-        />
-      </div>
+      {/*
+        Date range filters (After / Before) are intentionally hidden until
+        SystemDataProvider supports range operators. Showing them while
+        buildAuditFilter drops the values produced an "Apply" that looked
+        successful but didn't change the wire payload — confusing UX. The
+        AuditFilters type retains the fields so the prop shape doesn't break
+        when range support lands and the inputs return.
+      */}
 
       <div className="flex items-center gap-2">
         <Button type="submit" size="sm">

--- a/addons/audit/cap-audit-ui/src/views/AuditFilters.tsx
+++ b/addons/audit/cap-audit-ui/src/views/AuditFilters.tsx
@@ -1,0 +1,170 @@
+/**
+ * AuditFilters — filter toolbar for the audit log list.
+ *
+ * Stateless / controlled — the parent owns the `AuditFilters` value
+ * and decides when to actually re-fetch. This keeps the list page in
+ * full control of debounce / submit semantics.
+ */
+
+import { Button, Input, Label } from "@linchkit/ui-kit/components";
+import { RotateCcw, Search } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import {
+  AUDIT_STATUSES,
+  type AuditFilters as AuditFiltersValue,
+  type AuditStatus,
+} from "../lib/audit-api";
+
+export interface AuditFiltersProps {
+  value: AuditFiltersValue;
+  onChange: (next: AuditFiltersValue) => void;
+  onApply: () => void;
+  onReset: () => void;
+}
+
+/**
+ * Convert an `<input type="datetime-local">` value (no timezone) into
+ * an ISO string. Returns `undefined` for empty input so we don't send
+ * empty filter keys to the server.
+ */
+function toIso(local: string): string | undefined {
+  if (!local) return undefined;
+  const date = new Date(local);
+  if (Number.isNaN(date.getTime())) return undefined;
+  return date.toISOString();
+}
+
+/**
+ * Convert an ISO string back to the `datetime-local` input format
+ * (YYYY-MM-DDTHH:mm). Empty / undefined → empty string.
+ */
+function fromIso(iso: string | undefined): string {
+  if (!iso) return "";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  // Drop seconds and timezone — datetime-local accepts YYYY-MM-DDTHH:mm
+  return date.toISOString().slice(0, 16);
+}
+
+export function AuditFiltersBar(props: AuditFiltersProps) {
+  const { value, onChange, onApply, onReset } = props;
+  const { t } = useTranslation();
+
+  function patch(next: Partial<AuditFiltersValue>) {
+    onChange({ ...value, ...next });
+  }
+
+  return (
+    <form
+      className="flex flex-wrap items-end gap-3 rounded-md border bg-muted/20 p-3"
+      onSubmit={(e) => {
+        e.preventDefault();
+        onApply();
+      }}
+    >
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="audit-filter-action" className="text-xs">
+          {t("audit.filters.action", "Action")}
+        </Label>
+        <Input
+          id="audit-filter-action"
+          value={value.action ?? ""}
+          onChange={(e) => patch({ action: e.target.value || undefined })}
+          placeholder="create_order"
+          className="h-8 w-44"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="audit-filter-actor" className="text-xs">
+          {t("audit.filters.actor", "Actor")}
+        </Label>
+        <Input
+          id="audit-filter-actor"
+          value={value.actorId ?? ""}
+          onChange={(e) => patch({ actorId: e.target.value || undefined })}
+          placeholder="user-id"
+          className="h-8 w-40"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="audit-filter-entity" className="text-xs">
+          {t("audit.filters.entity", "Entity")}
+        </Label>
+        <Input
+          id="audit-filter-entity"
+          value={value.entity ?? ""}
+          onChange={(e) => patch({ entity: e.target.value || undefined })}
+          placeholder="order"
+          className="h-8 w-40"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="audit-filter-status" className="text-xs">
+          {t("audit.filters.status", "Status")}
+        </Label>
+        <select
+          id="audit-filter-status"
+          value={value.status ?? ""}
+          onChange={(e) =>
+            patch({ status: (e.target.value || undefined) as AuditStatus | undefined })
+          }
+          className="h-8 rounded-md border border-input bg-background px-2 text-sm"
+        >
+          <option value="">{t("audit.filters.statusAny", "Any")}</option>
+          {AUDIT_STATUSES.map((status) => (
+            <option key={status} value={status}>
+              {status}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="audit-filter-after" className="text-xs">
+          {t("audit.filters.after", "After")}
+        </Label>
+        <Input
+          id="audit-filter-after"
+          type="datetime-local"
+          value={fromIso(value.startedAfter)}
+          onChange={(e) => patch({ startedAfter: toIso(e.target.value) })}
+          className="h-8 w-52"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <Label htmlFor="audit-filter-before" className="text-xs">
+          {t("audit.filters.before", "Before")}
+        </Label>
+        <Input
+          id="audit-filter-before"
+          type="datetime-local"
+          value={fromIso(value.startedBefore)}
+          onChange={(e) => patch({ startedBefore: toIso(e.target.value) })}
+          className="h-8 w-52"
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button type="submit" size="sm">
+          <Search className="mr-1 size-3.5" />
+          {t("audit.filters.apply", "Apply")}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          onClick={onReset}
+          aria-label={t("audit.filters.reset", "Reset filters")}
+        >
+          <RotateCcw className="size-3.5" />
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+export default AuditFiltersBar;

--- a/addons/audit/cap-audit-ui/src/views/AuditList.tsx
+++ b/addons/audit/cap-audit-ui/src/views/AuditList.tsx
@@ -18,7 +18,7 @@ import {
   TableRow,
 } from "@linchkit/ui-kit/components";
 import { ChevronLeft, ChevronRight, Loader2, RefreshCw } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   type AuditFilters as AuditFiltersValue,
@@ -44,10 +44,30 @@ function formatDuration(ms: number): string {
   return `${(ms / 1000).toFixed(2)}s`;
 }
 
+/**
+ * Format an ISO timestamp using the active i18n locale and the user's
+ * timezone. Centralized so list rows and detail rows render identically
+ * and we don't rely on the locale-implicit `Date.toLocaleString()` (which
+ * gives different output depending on the JS runtime's default locale).
+ */
+function formatDateTime(iso: string, locale: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return new Intl.DateTimeFormat(locale, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).format(date);
+}
+
 // ── Component ───────────────────────────────────────────
 
 export function AuditList() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [filters, setFilters] = useState<AuditFiltersValue>({});
   // Filters that have actually been submitted — separate so typing
   // in a filter input doesn't hammer the server until the user clicks
@@ -59,8 +79,13 @@ export function AuditList() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  // Monotonic request id — guards against an older fetch resolving last
+  // and overwriting the result of a newer fetch (filter switches, manual
+  // refresh, pagination clicks all race the in-flight request).
+  const requestSeqRef = useRef(0);
 
   const refetch = useCallback(async () => {
+    const seq = ++requestSeqRef.current;
     setLoading(true);
     setError(null);
     try {
@@ -69,14 +94,17 @@ export function AuditList() {
         page,
         pageSize: PAGE_SIZE,
       });
+      // Stale response — a newer fetch already started; drop this result.
+      if (seq !== requestSeqRef.current) return;
       setRows(result.items);
       setTotal(result.total);
     } catch (err) {
+      if (seq !== requestSeqRef.current) return;
       setError(err instanceof Error ? err.message : String(err));
       setRows([]);
       setTotal(0);
     } finally {
-      setLoading(false);
+      if (seq === requestSeqRef.current) setLoading(false);
     }
   }, [appliedFilters, page]);
 
@@ -168,11 +196,21 @@ export function AuditList() {
                   <TableRow
                     key={row.id}
                     data-state={selectedId === row.id ? "selected" : undefined}
-                    className="cursor-pointer"
+                    className="cursor-pointer focus:bg-muted focus:outline-none"
+                    role="button"
+                    tabIndex={0}
+                    aria-label={t("audit.list.openDetail", "Open audit detail")}
+                    aria-pressed={selectedId === row.id}
                     onClick={() => setSelectedId(row.id)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        setSelectedId(row.id);
+                      }
+                    }}
                   >
                     <TableCell className="font-mono text-xs">
-                      {new Date(row.startedAt).toLocaleString()}
+                      {formatDateTime(row.startedAt, i18n.language)}
                     </TableCell>
                     <TableCell className="font-medium">{row.action}</TableCell>
                     <TableCell>

--- a/addons/audit/cap-audit-ui/src/views/AuditList.tsx
+++ b/addons/audit/cap-audit-ui/src/views/AuditList.tsx
@@ -1,0 +1,252 @@
+/**
+ * AuditList — paginated table of execution log entries with a filter
+ * toolbar and a side-drawer detail view.
+ *
+ * Wires together AuditFiltersBar + the audit-api list query + a
+ * lightweight pagination footer. Detail view is mounted in a sibling
+ * panel when the user clicks a row.
+ */
+
+import {
+  Badge,
+  Button,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@linchkit/ui-kit/components";
+import { ChevronLeft, ChevronRight, Loader2, RefreshCw } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  type AuditFilters as AuditFiltersValue,
+  type AuditRow,
+  type AuditStatus,
+  queryAuditList,
+} from "../lib/audit-api";
+import AuditDetailView from "./AuditDetail";
+import { AuditFiltersBar } from "./AuditFilters";
+
+// ── Helpers ─────────────────────────────────────────────
+
+const PAGE_SIZE = 50;
+
+function statusVariant(status: AuditStatus): "default" | "secondary" | "destructive" | "outline" {
+  if (status === "succeeded") return "default";
+  if (status === "failed" || status === "blocked") return "destructive";
+  return "secondary";
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+// ── Component ───────────────────────────────────────────
+
+export function AuditList() {
+  const { t } = useTranslation();
+  const [filters, setFilters] = useState<AuditFiltersValue>({});
+  // Filters that have actually been submitted — separate so typing
+  // in a filter input doesn't hammer the server until the user clicks
+  // "Apply" (or presses Enter inside the form).
+  const [appliedFilters, setAppliedFilters] = useState<AuditFiltersValue>({});
+  const [page, setPage] = useState(1);
+  const [rows, setRows] = useState<AuditRow[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const refetch = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await queryAuditList({
+        filters: appliedFilters,
+        page,
+        pageSize: PAGE_SIZE,
+      });
+      setRows(result.items);
+      setTotal(result.total);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setRows([]);
+      setTotal(0);
+    } finally {
+      setLoading(false);
+    }
+  }, [appliedFilters, page]);
+
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  function handleApply() {
+    setAppliedFilters(filters);
+    setPage(1);
+  }
+
+  function handleReset() {
+    setFilters({});
+    setAppliedFilters({});
+    setPage(1);
+  }
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <div className="flex h-full">
+      <div className="flex flex-1 flex-col gap-3 p-4">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-lg font-semibold">{t("audit.list.title", "Audit Log")}</h1>
+            <p className="text-xs text-muted-foreground">
+              {t("audit.list.subtitle", "Every action execution recorded in _linchkit.executions.")}
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={refetch}
+            disabled={loading}
+            aria-label={t("common.refresh", "Refresh")}
+          >
+            <RefreshCw className={`mr-1 size-3.5 ${loading ? "animate-spin" : ""}`} />
+            {t("common.refresh", "Refresh")}
+          </Button>
+        </div>
+
+        {/* Filters */}
+        <AuditFiltersBar
+          value={filters}
+          onChange={setFilters}
+          onApply={handleApply}
+          onReset={handleReset}
+        />
+
+        {/* Error banner */}
+        {error && (
+          <div className="rounded-md border border-destructive/40 bg-destructive/10 p-2 text-sm text-destructive">
+            {error}
+          </div>
+        )}
+
+        {/* Table */}
+        <div className="rounded-md border overflow-hidden">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-44">{t("audit.list.startedAt", "Started")}</TableHead>
+                <TableHead>{t("audit.list.action", "Action")}</TableHead>
+                <TableHead>{t("audit.list.entity", "Entity")}</TableHead>
+                <TableHead>{t("audit.list.actor", "Actor")}</TableHead>
+                <TableHead className="w-28">{t("audit.list.status", "Status")}</TableHead>
+                <TableHead className="w-24 text-right">
+                  {t("audit.list.duration", "Duration")}
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {loading && rows.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={6} className="h-24 text-center">
+                    <Loader2 className="mx-auto size-5 animate-spin text-muted-foreground" />
+                  </TableCell>
+                </TableRow>
+              ) : rows.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={6} className="h-24 text-center text-sm text-muted-foreground">
+                    {t("audit.list.empty", "No execution log entries match the current filters.")}
+                  </TableCell>
+                </TableRow>
+              ) : (
+                rows.map((row) => (
+                  <TableRow
+                    key={row.id}
+                    data-state={selectedId === row.id ? "selected" : undefined}
+                    className="cursor-pointer"
+                    onClick={() => setSelectedId(row.id)}
+                  >
+                    <TableCell className="font-mono text-xs">
+                      {new Date(row.startedAt).toLocaleString()}
+                    </TableCell>
+                    <TableCell className="font-medium">{row.action}</TableCell>
+                    <TableCell>
+                      {row.entity ? (
+                        <span className="text-xs">
+                          <code>{row.entity}</code>
+                          {row.recordId && (
+                            <span className="text-muted-foreground"> / {row.recordId}</span>
+                          )}
+                        </span>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {row.actorId ? (
+                        <span className="text-xs">
+                          <span className="text-muted-foreground">{row.actorType ?? "?"}:</span>{" "}
+                          <code>{row.actorId}</code>
+                        </span>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={statusVariant(row.status)}>{row.status}</Badge>
+                    </TableCell>
+                    <TableCell className="text-right text-xs">
+                      {formatDuration(row.durationMs)}
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+
+        {/* Pagination */}
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
+          <span>
+            {t("audit.list.totalCount", { defaultValue: "{{count}} entries", count: total })}
+          </span>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={page <= 1 || loading}
+              aria-label={t("common.previous", "Previous")}
+            >
+              <ChevronLeft className="size-4" />
+            </Button>
+            <span>
+              {page} / {totalPages}
+            </span>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              disabled={page >= totalPages || loading}
+              aria-label={t("common.next", "Next")}
+            >
+              <ChevronRight className="size-4" />
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* Detail panel */}
+      {selectedId && (
+        <AuditDetailView executionId={selectedId} onClose={() => setSelectedId(null)} />
+      )}
+    </div>
+  );
+}
+
+export default AuditList;

--- a/addons/audit/cap-audit-ui/tsconfig.json
+++ b/addons/audit/cap-audit-ui/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "jsx": "react-jsx",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "composite": true,
+    "baseUrl": ".",
+    "paths": {
+      "@linchkit/core": ["../../../packages/core/src"],
+      "@linchkit/cap-adapter-ui": ["../../adapter-ui/cap-adapter-ui/src"],
+      "@linchkit/cap-adapter-ui/route-registry": [
+        "../../adapter-ui/cap-adapter-ui/src/lib/route-registry.ts"
+      ],
+      "@linchkit/cap-adapter-ui/lib/api": ["../../adapter-ui/cap-adapter-ui/src/lib/api.ts"],
+      "@linchkit/ui-kit": ["../../adapter-ui/cap-adapter-ui/ui-kit/src"],
+      "@linchkit/ui-kit/components": ["../../adapter-ui/cap-adapter-ui/ui-kit/src/components"],
+      "@linchkit/ui-kit/hooks": ["../../adapter-ui/cap-adapter-ui/ui-kit/src/hooks"],
+      "@linchkit/ui-kit/lib/utils": ["../../adapter-ui/cap-adapter-ui/ui-kit/src/lib/utils"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "__tests__/**/*.ts", "__tests__/**/*.tsx"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -163,6 +163,20 @@
         "@linchkit/core": "^0.2.0",
       },
     },
+    "addons/audit/cap-audit-ui": {
+      "name": "@linchkit/cap-audit-ui",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@linchkit/cap-adapter-ui": "workspace:*",
+        "@linchkit/core": "workspace:*",
+      },
+      "peerDependencies": {
+        "@linchkit/cap-adapter-ui": "^1.0.0",
+        "@linchkit/core": "^0.2.0",
+        "react": "^19.0.0",
+        "react-i18next": ">=14.0.0",
+      },
+    },
     "addons/auth/cap-auth": {
       "name": "@linchkit/cap-auth",
       "version": "1.0.0",
@@ -636,6 +650,8 @@
     "@linchkit/cap-adapter-ui": ["@linchkit/cap-adapter-ui@workspace:addons/adapter-ui/cap-adapter-ui"],
 
     "@linchkit/cap-ai-provider": ["@linchkit/cap-ai-provider@workspace:addons/ai-provider/cap-ai-provider"],
+
+    "@linchkit/cap-audit-ui": ["@linchkit/cap-audit-ui@workspace:addons/audit/cap-audit-ui"],
 
     "@linchkit/cap-auth": ["@linchkit/cap-auth@workspace:addons/auth/cap-auth"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@modelcontextprotocol/sdk": "1.29.0",
-        "@restatedev/restate-sdk": "1.13.0",
+        "@restatedev/restate-sdk": "1.14.2",
         "@tanstack/react-table": "^8.21.3",
         "ai": "^6.0.134",
         "dataloader": "^2.2.3",
@@ -271,7 +271,7 @@
       "name": "@linchkit/cap-flow-restate",
       "version": "1.0.0",
       "dependencies": {
-        "@restatedev/restate-sdk": "1.13.0",
+        "@restatedev/restate-sdk": "1.14.2",
       },
       "devDependencies": {
         "@linchkit/core": "workspace:*",
@@ -849,9 +849,9 @@
 
     "@repeaterjs/repeater": ["@repeaterjs/repeater@3.0.6", "https://registry.npmmirror.com/@repeaterjs/repeater/-/repeater-3.0.6.tgz", {}, "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA=="],
 
-    "@restatedev/restate-sdk": ["@restatedev/restate-sdk@1.13.0", "", { "dependencies": { "@restatedev/restate-sdk-core": "1.13.0" } }, "sha512-SAqes+qbpMn1HCRn/275FuNkyhvYsNwoe9BJwT0OjV1ocKC27SR4UGp/d2vO9mV6804VlSapybpGs4H7SM3HMA=="],
+    "@restatedev/restate-sdk": ["@restatedev/restate-sdk@1.14.2", "", { "dependencies": { "@restatedev/restate-sdk-core": "1.14.2" } }, "sha512-qh6g0oTH7wuy9hGm2gdAmsfOO8StYYS1Yy5goQ2dhBk1OsO/GPy4jcMdWwRSgIaql7LvDpXBrj5orQU1+QXC2Q=="],
 
-    "@restatedev/restate-sdk-core": ["@restatedev/restate-sdk-core@1.13.0", "", {}, "sha512-DVmlI3rI8coA0Hcpxd2cLaK5DKUCwKDyXWXqjMorhqd4HBqdJBWtgrS0y0ZGUW+vuzJMeFpFvq3nhQJIvn6U9Q=="],
+    "@restatedev/restate-sdk-core": ["@restatedev/restate-sdk-core@1.14.2", "", {}, "sha512-fJPgdp8ITo0uaCS3zbrAqwv7l7CayF1uA84e1Iz8tqvBTllMdGuio5j/kwDlzXf2Ad7FFFdyKx4CjaSTCpo3PA=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.10", "https://registry.npmmirror.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.10.tgz", { "os": "android", "cpu": "arm64" }, "sha512-jOHxwXhxmFKuXztiu1ORieJeTbx5vrTkcOkkkn2d35726+iwhrY1w/+nYY/AGgF12thg33qC3R1LMBF5tHTZHg=="],
 


### PR DESCRIPTION
## Summary

Scaffolds a new UI capability `cap-audit-ui` that provides an audit log viewer reading from `_linchkit.executions`. Closes #138.

Layout (mirrors `cap-chatter-ui`):

\`\`\`
addons/audit/cap-audit-ui/
  src/
    capability.ts           defineCapability() entry
    views/AuditList.tsx     paginated list with filter sidebar
    views/AuditDetail.tsx   full execution: input/output/meta/state transition
    views/AuditFilters.tsx  filter sidebar: action, actor, status, date, entity
    lib/audit-api.ts        typed GraphQL hooks
    pages/audit-page.tsx    route-mounted composed page
  __tests__/views.test.tsx  smoke tests
  package.json + tsconfig.json + README.md
\`\`\`

Wired into root workspaces via bun.lock.

## Cross-model review (codex)

Codex flagged three issues, all addressed:

| Finding | Resolution |
|---|---|
| **[P2]** approvals schema regression vs main | Resolved by merging main (commit `6a92eb0` brings in PR #302's `actors_snapshot` rename + 0006 migration) |
| **[P2]** date range filter (`gte`/`lte`) silently returns zero rows because `SystemDataProvider` is equality-only | `buildAuditFilter` no longer emits the range clause; UI fields stay so layout is stable. Inline comment documents the gap |
| **[P3]** `state_transition_from`/`_to` are not real columns | `queryAuditDetail` projects from `metadata.stateTransition.{from,to}` via a small `extractStateTransition` helper |

## Known scaffold-stage limitations (server-side gaps)

- **Date range filtering** — needs `SystemDataProvider` (or its replacement) to support `gte`/`lte` operators. The UI fields render today; wire-up is one-line in `buildAuditFilter` once available.
- **Server-side `cap-audit` backend** — this PR ships only the UI; the GraphQL `executionLogList` query already exists, so the UI is functional today, but a dedicated backend may want to project additional fields (capability, channel, error categorization).

## Quality gates

- \`bun run check\` ✅
- \`bun run typecheck\` ✅
- \`bun test\` ✅ (4974/4977 pass, 0 fail, 3 intentional E2E skips)

## Self-review

- [x] Tests added (filter builder + list + detail wiring + state transition projection)
- [x] No new dependencies (uses existing shadcn/radix/lucide/react-i18next from cap-chatter-ui)
- [x] No \`any\`, no \`eval\`, no hardcoded secrets
- [x] No console.log in runtime code (only in CLI / tests if any)
- [x] Cross-model review (codex) — 3 findings, all addressed
- [x] Spec referenced — issue #138 + Spec 14 (system capabilities)
- [x] Comments / docs in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added audit log viewer to the admin interface, accessible at `/admin/audit`
  * View paginated execution history with filtering by action, actor, entity, status, and date range
  * Inspect detailed execution information including status, duration, input/output, and state transitions

* **Documentation**
  * Added README documentation for the audit log viewer capability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laofahai/linchkit/pull/310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->