### PR TITLE
feat(core): event-replay service for re-dispatch + handler history (closes #137)

### DIFF
--- a/packages/core/__tests__/event-replay-service.test.ts
+++ b/packages/core/__tests__/event-replay-service.test.ts
@@ -1,0 +1,376 @@
+/**
+ * EventReplayService integration tests
+ *
+ * Tests require a running PostgreSQL instance on the test database URL.
+ * Skips gracefully when the database is not available.
+ *
+ * Mirrors dlq-service.test.ts shape: real PostgreSQL on port 5434, raw DDL
+ * fixture matching the events table schema.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { eq, sql } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import {
+  createEventReplayService,
+  EventHandlerRegistry,
+  type EventReplayService,
+} from "../src/event";
+import { eventsTable } from "../src/persistence/system-tables";
+import { closeDatabase, createDatabase } from "../src/server-entry";
+
+const TEST_DB_URL =
+  process.env.DATABASE_TEST_URL ??
+  "postgres://linchkit_test:linchkit_test@localhost:5434/linchkit_test";
+
+let db: PostgresJsDatabase;
+let registry: EventHandlerRegistry;
+let svc: EventReplayService;
+let dbAvailable = false;
+
+async function canConnect(): Promise<boolean> {
+  try {
+    const testDb = createDatabase({ url: TEST_DB_URL });
+    await testDb.execute(sql`SELECT 1`);
+    await closeDatabase();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+dbAvailable = await canConnect();
+if (!dbAvailable) {
+  console.warn("PostgreSQL not available — skipping EventReplayService tests");
+}
+
+interface InsertOpts {
+  tenantId?: string;
+  eventType?: string;
+  payload?: Record<string, unknown>;
+  sourceAction?: string;
+  sourceExecutionId?: string;
+  status?: "pending" | "processing" | "completed" | "failed" | "dead_letter";
+  errorMessage?: string;
+  retryCount?: number;
+  meta?: Record<string, unknown>;
+}
+
+async function insertEvent(opts?: InsertOpts): Promise<string> {
+  const [row] = await db
+    .insert(eventsTable)
+    .values({
+      eventType: opts?.eventType ?? "test.event",
+      tenantId: opts?.tenantId,
+      payload: opts?.payload ?? { test: true },
+      sourceAction: opts?.sourceAction ?? null,
+      sourceExecutionId: opts?.sourceExecutionId ?? null,
+      status: opts?.status ?? "completed",
+      errorMessage: opts?.errorMessage,
+      retryCount: opts?.retryCount ?? 0,
+      meta: opts?.meta,
+    })
+    .returning({ id: eventsTable.id });
+  return row.id;
+}
+
+describe.skipIf(!dbAvailable)("EventReplayService", () => {
+  beforeAll(async () => {
+    db = createDatabase({ url: TEST_DB_URL });
+
+    await db.execute(sql.raw('DROP TABLE IF EXISTS "_linchkit"."events" CASCADE'));
+    await db.execute(sql.raw('DROP TYPE IF EXISTS "_linchkit"."event_status" CASCADE'));
+    await db.execute(sql.raw('CREATE SCHEMA IF NOT EXISTS "_linchkit"'));
+    await db.execute(
+      sql.raw(`
+        CREATE TYPE "_linchkit"."event_status" AS ENUM('pending', 'processing', 'completed', 'failed', 'dead_letter')
+      `),
+    );
+    await db.execute(
+      sql.raw(`
+        CREATE TABLE IF NOT EXISTS "_linchkit"."events" (
+          "id"                  uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+          "tenant_id"           varchar(255),
+          "event_type"          varchar(255) NOT NULL,
+          "payload"             jsonb,
+          "source_action"       varchar(255),
+          "source_execution_id" text,
+          "created_at"          timestamp DEFAULT now() NOT NULL,
+          "processed_at"        timestamp,
+          "status"              "_linchkit"."event_status" DEFAULT 'pending' NOT NULL,
+          "error_message"       text,
+          "retry_count"         integer DEFAULT 0 NOT NULL,
+          "next_retry_at"       timestamp,
+          "meta"                jsonb
+        )
+      `),
+    );
+  });
+
+  afterAll(async () => {
+    await closeDatabase();
+  });
+
+  beforeEach(async () => {
+    await db.delete(eventsTable);
+    registry = new EventHandlerRegistry();
+    svc = createEventReplayService({ db, registry });
+  });
+
+  // ── list ───────────────────────────────────────────
+
+  test("list returns empty result when table is empty", async () => {
+    const result = await svc.list();
+    expect(result.items).toHaveLength(0);
+    expect(result.total).toBe(0);
+  });
+
+  test("list returns events in descending creation order", async () => {
+    const idFirst = await insertEvent({ eventType: "order.created" });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const idSecond = await insertEvent({ eventType: "payment.captured" });
+
+    const result = await svc.list();
+    expect(result.total).toBe(2);
+    expect(result.items[0].id).toBe(idSecond);
+    expect(result.items[1].id).toBe(idFirst);
+  });
+
+  test("list filters by tenantId, eventType, entity, and time range", async () => {
+    const now = new Date();
+    const earlier = new Date(now.getTime() - 60_000);
+
+    await insertEvent({ tenantId: "t-a", eventType: "order.created", sourceAction: "create" });
+    await insertEvent({ tenantId: "t-b", eventType: "order.created", sourceAction: "create" });
+    await insertEvent({ tenantId: "t-a", eventType: "payment.failed", sourceAction: "pay" });
+
+    const tenantA = await svc.list({ tenantId: "t-a" });
+    expect(tenantA.total).toBe(2);
+
+    const byType = await svc.list({ eventType: "order.created" });
+    expect(byType.total).toBe(2);
+
+    const byEntity = await svc.list({ entity: "pay" });
+    expect(byEntity.total).toBe(1);
+
+    const byRange = await svc.list({ since: earlier, until: new Date(now.getTime() + 60_000) });
+    expect(byRange.total).toBe(3);
+  });
+
+  test("list pagination clamps limit and offset", async () => {
+    for (let i = 0; i < 5; i++) {
+      await insertEvent({ eventType: `evt.${i}` });
+    }
+
+    const page1 = await svc.list({ limit: 2, offset: 0 });
+    expect(page1.items).toHaveLength(2);
+    expect(page1.total).toBe(5);
+
+    const page2 = await svc.list({ limit: 2, offset: 2 });
+    expect(page2.items).toHaveLength(2);
+
+    // Out-of-range pagination input is clamped, not rejected.
+    const clamped = await svc.list({ limit: 9999, offset: -10 });
+    expect(clamped.items.length).toBeLessThanOrEqual(100);
+  });
+
+  // ── get ────────────────────────────────────────────
+
+  test("get returns full detail with payload, meta, and history", async () => {
+    const id = await insertEvent({
+      eventType: "order.created",
+      payload: { orderId: "ord-1", total: 100 },
+      meta: { _tenant_scope: "t-a" },
+      status: "failed",
+      errorMessage: "boom",
+      retryCount: 2,
+    });
+
+    const detail = await svc.get(id);
+    expect(detail).not.toBeNull();
+    expect(detail?.id).toBe(id);
+    expect(detail?.payload).toEqual({ orderId: "ord-1", total: 100 });
+    expect(detail?.meta).toEqual({ _tenant_scope: "t-a" });
+    expect(detail?.status).toBe("failed");
+    expect(detail?.errorMessage).toBe("boom");
+    expect(detail?.history).toHaveLength(1);
+    expect(detail?.history[0].handler).toBe("*");
+    expect(detail?.history[0].status).toBe("failed");
+    expect(detail?.history[0].retryCount).toBe(2);
+  });
+
+  test("get returns null for missing id", async () => {
+    const detail = await svc.get("00000000-0000-0000-0000-000000000000");
+    expect(detail).toBeNull();
+  });
+
+  test("get returns null for non-UUID id", async () => {
+    const detail = await svc.get("not-a-uuid");
+    expect(detail).toBeNull();
+  });
+
+  // ── replay ─────────────────────────────────────────
+
+  test("replay re-dispatches event to all matching handlers", async () => {
+    const seen: Array<{ name: string; payload: unknown }> = [];
+    registry.register({
+      name: "h1",
+      listen: "user.created",
+      handler: async (e) => {
+        seen.push({ name: "h1", payload: e.payload });
+      },
+    });
+    registry.register({
+      name: "h2",
+      listen: "user.created",
+      handler: async (e) => {
+        seen.push({ name: "h2", payload: e.payload });
+      },
+    });
+
+    const id = await insertEvent({
+      eventType: "user.created",
+      payload: { userId: "u-1" },
+    });
+
+    const result = await svc.replay(id);
+    expect(result.delivered).toBe(2);
+    expect(result.errors).toHaveLength(0);
+    expect(seen.map((s) => s.name).sort()).toEqual(["h1", "h2"]);
+    expect(seen[0].payload).toEqual({ userId: "u-1" });
+
+    // Original event row is NOT mutated.
+    const [row] = await db.select().from(eventsTable).where(eq(eventsTable.id, id));
+    expect(row.status).toBe("completed");
+  });
+
+  test("replay collects handler errors instead of throwing", async () => {
+    registry.register({
+      name: "ok-handler",
+      listen: "order.failed",
+      handler: async () => {
+        // success
+      },
+    });
+    registry.register({
+      name: "bad-handler",
+      listen: "order.failed",
+      handler: async () => {
+        throw new Error("downstream timeout");
+      },
+    });
+
+    const id = await insertEvent({ eventType: "order.failed" });
+    const result = await svc.replay(id);
+
+    expect(result.delivered).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toEqual({ handler: "bad-handler", message: "downstream timeout" });
+  });
+
+  test("replay onlyHandler restricts dispatch to a single handler", async () => {
+    const fired: string[] = [];
+    registry.register({
+      name: "h1",
+      listen: "wide.event",
+      handler: async () => {
+        fired.push("h1");
+      },
+    });
+    registry.register({
+      name: "h2",
+      listen: "wide.event",
+      handler: async () => {
+        fired.push("h2");
+      },
+    });
+
+    const id = await insertEvent({ eventType: "wide.event" });
+    const result = await svc.replay(id, { onlyHandler: "h2" });
+
+    expect(result.delivered).toBe(1);
+    expect(fired).toEqual(["h2"]);
+  });
+
+  test("replay returns zero delivered when event is missing", async () => {
+    const result = await svc.replay("00000000-0000-0000-0000-000000000000");
+    expect(result.delivered).toBe(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("replay returns zero delivered when no handlers are registered", async () => {
+    const id = await insertEvent({ eventType: "no.listeners" });
+    const result = await svc.replay(id);
+    expect(result.delivered).toBe(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  // ── replayBatch ────────────────────────────────────
+
+  test("replayBatch processes multiple ids and aggregates totals", async () => {
+    const fired: string[] = [];
+    registry.register({
+      name: "batch-handler",
+      listen: "batch.event",
+      handler: async (e) => {
+        fired.push(String(e.payload.k));
+      },
+    });
+
+    const id1 = await insertEvent({ eventType: "batch.event", payload: { k: "a" } });
+    const id2 = await insertEvent({ eventType: "batch.event", payload: { k: "b" } });
+    const id3 = await insertEvent({ eventType: "batch.event", payload: { k: "c" } });
+    const missing = "00000000-0000-0000-0000-000000000000";
+
+    const result = await svc.replayBatch([id1, id2, missing, id3]);
+
+    expect(result.results).toHaveLength(4);
+    expect(result.totalDelivered).toBe(3);
+    expect(result.totalErrors).toBe(0);
+    expect(result.results[2].replayed).toBe(false);
+    expect(fired.sort()).toEqual(["a", "b", "c"]);
+  });
+
+  test("replayBatch empty input returns zeroed result", async () => {
+    const result = await svc.replayBatch([]);
+    expect(result.results).toEqual([]);
+    expect(result.totalDelivered).toBe(0);
+    expect(result.totalErrors).toBe(0);
+  });
+
+  test("replayBatch rejects oversized batches", async () => {
+    const ids = Array.from({ length: 101 }, () => "00000000-0000-0000-0000-000000000000");
+    await expect(svc.replayBatch(ids)).rejects.toThrow(/exceeds maximum/);
+  });
+
+  // ── handlerHistory ─────────────────────────────────
+
+  test("handlerHistory returns the per-event delivery summary", async () => {
+    const id = await insertEvent({
+      eventType: "audit.applied",
+      status: "completed",
+      retryCount: 1,
+    });
+
+    const history = await svc.handlerHistory({ eventId: id });
+    expect(history).toHaveLength(1);
+    expect(history[0].eventId).toBe(id);
+    expect(history[0].handler).toBe("*");
+    expect(history[0].status).toBe("completed");
+    expect(history[0].retryCount).toBe(1);
+  });
+
+  test("handlerHistory filtered by handler name still returns the wildcard summary", async () => {
+    const id = await insertEvent({ eventType: "filterable.event" });
+    const history = await svc.handlerHistory({ eventId: id, handler: "any-name" });
+    expect(history).toHaveLength(1);
+    expect(history[0].handler).toBe("*");
+  });
+
+  test("handlerHistory returns empty array for missing or invalid id", async () => {
+    expect(await svc.handlerHistory({ eventId: "not-uuid" })).toEqual([]);
+    expect(await svc.handlerHistory({ eventId: "00000000-0000-0000-0000-000000000000" })).toEqual(
+      [],
+    );
+  });
+});

--- a/packages/core/src/event/event-replay-service.ts
+++ b/packages/core/src/event/event-replay-service.ts
@@ -1,0 +1,398 @@
+/**
+ * EventReplayService — Re-dispatch past events and inspect handler delivery
+ *
+ * Operates on the existing `_linchkit.events` table — does NOT introduce a new
+ * system table. Provides:
+ *   - `list` / `get` for browsing persisted events
+ *   - `replay` / `replayBatch` for re-dispatching events through registered
+ *     handlers WITHOUT mutating the original row (no new outbox entry, no
+ *     status change on the source event)
+ *   - `handlerHistory` for the per-event delivery summary
+ *
+ * Replay re-runs handlers in the registry for the event type, collecting
+ * per-handler results so the caller can surface failures rather than have
+ * them silently swallowed (cf. Spec 66 §4 "replay must not silently ignore
+ * handler failures"). The original event row is never modified.
+ */
+
+import { and, count, desc, eq, gte, lte, type SQL } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import { withTraceId } from "../observability/trace-context";
+import { eventsTable } from "../persistence/system-tables";
+import type { EventHandlerContext, EventHandlerDefinition, EventRecord } from "../types/event";
+import { ExecutionMetaImpl } from "../types/execution-meta";
+import { type EventHandlerRegistry, matchesFilter } from "./event-bus";
+
+// ── Public types ────────────────────────────────────────────
+
+export interface EventSummary {
+  id: string;
+  tenantId?: string;
+  eventType: string;
+  status: "pending" | "processing" | "completed" | "failed" | "dead_letter";
+  sourceAction?: string;
+  sourceExecutionId?: string;
+  retryCount: number;
+  errorMessage?: string;
+  createdAt: Date;
+  processedAt?: Date;
+}
+
+export interface EventDetail extends EventSummary {
+  payload: Record<string, unknown>;
+  meta: Record<string, unknown> | null;
+  /** Per-event delivery history (current schema records the latest aggregate result). */
+  history: HandlerExecution[];
+}
+
+/**
+ * Handler execution summary derived from the events row.
+ *
+ * The current schema stores a single aggregate status per event row, not per
+ * (event, handler) pair. Each event therefore produces exactly one
+ * `HandlerExecution` whose `handler` is the wildcard sentinel `"*"`. Once
+ * outbox_completions (Spec 66 §2.4) lands this becomes per-handler.
+ */
+export interface HandlerExecution {
+  eventId: string;
+  /** `"*"` until per-handler completion tracking exists (Spec 66 §2.4). */
+  handler: string;
+  status: "pending" | "processing" | "completed" | "failed" | "dead_letter";
+  retryCount: number;
+  errorMessage?: string;
+  attemptedAt: Date;
+  completedAt?: Date;
+}
+
+export interface ReplayError {
+  handler: string;
+  message: string;
+}
+
+export interface ReplayResult {
+  /** Number of (handler, event) pairs successfully invoked */
+  delivered: number;
+  errors: ReplayError[];
+}
+
+export interface BatchReplayResult {
+  /** Per-event replay outcome, keyed by event id (in input order) */
+  results: Array<{ id: string; replayed: boolean; delivered: number; errors: ReplayError[] }>;
+  /** Total handler invocations succeeded across all events */
+  totalDelivered: number;
+  /** Total handler errors collected across all events */
+  totalErrors: number;
+}
+
+export interface EventListOptions {
+  tenantId?: string;
+  /** Filter by sourceAction (the action that emitted the event). */
+  entity?: string;
+  eventType?: string;
+  /** Lower-bound (inclusive) on `createdAt`. */
+  since?: Date;
+  /** Upper-bound (inclusive) on `createdAt`. */
+  until?: Date;
+  /** Max entries to return (default: 50, max: 100) */
+  limit?: number;
+  /** Number of entries to skip (default: 0) */
+  offset?: number;
+}
+
+export interface ReplayOptions {
+  /** When set, only the named handler is invoked (bypassing other listeners). */
+  onlyHandler?: string;
+}
+
+export interface HandlerHistoryQuery {
+  eventId: string;
+  /** When set, restrict history to the named handler. */
+  handler?: string;
+}
+
+export interface EventReplayService {
+  /** Paginated list of persisted events with optional filtering. */
+  list(options?: EventListOptions): Promise<{ items: EventSummary[]; total: number }>;
+  /** Full event detail (payload + delivery history) by id; null if missing. */
+  get(id: string): Promise<EventDetail | null>;
+  /** Re-dispatch a single event to its registered handlers. */
+  replay(id: string, opts?: ReplayOptions): Promise<ReplayResult>;
+  /** Bulk replay; processes ids sequentially. */
+  replayBatch(ids: string[], opts?: ReplayOptions): Promise<BatchReplayResult>;
+  /** Per-event handler delivery history; empty when event missing. */
+  handlerHistory(query: HandlerHistoryQuery): Promise<HandlerExecution[]>;
+}
+
+export interface EventReplayServiceOptions {
+  db: PostgresJsDatabase;
+  registry: EventHandlerRegistry;
+}
+
+// ── Internal helpers ────────────────────────────────────────
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const DEFAULT_PRIORITY = 100;
+const MAX_BATCH_SIZE = 100;
+
+function clampLimit(value: unknown, fallback: number, max: number): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? Math.max(1, Math.min(Math.trunc(n), max)) : fallback;
+}
+
+function clampOffset(value: unknown): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? Math.max(0, Math.trunc(n)) : 0;
+}
+
+function rowToSummary(row: typeof eventsTable.$inferSelect): EventSummary {
+  return {
+    id: row.id,
+    tenantId: row.tenantId ?? undefined,
+    eventType: row.eventType,
+    status: row.status,
+    sourceAction: row.sourceAction ?? undefined,
+    sourceExecutionId: row.sourceExecutionId ?? undefined,
+    retryCount: row.retryCount,
+    errorMessage: row.errorMessage ?? undefined,
+    createdAt: row.createdAt,
+    processedAt: row.processedAt ?? undefined,
+  };
+}
+
+function rowToDetail(row: typeof eventsTable.$inferSelect): EventDetail {
+  return {
+    ...rowToSummary(row),
+    payload: (row.payload as Record<string, unknown>) ?? {},
+    meta: (row.meta as Record<string, unknown> | null) ?? null,
+    history: [rowToHistory(row)],
+  };
+}
+
+function rowToHistory(row: typeof eventsTable.$inferSelect): HandlerExecution {
+  return {
+    eventId: row.id,
+    handler: "*",
+    status: row.status,
+    retryCount: row.retryCount,
+    errorMessage: row.errorMessage ?? undefined,
+    attemptedAt: row.processedAt ?? row.createdAt,
+    completedAt: row.processedAt ?? undefined,
+  };
+}
+
+/**
+ * Reconstruct an EventRecord from a persisted row. Mirrors OutboxWorker's
+ * rowToEventRecord — keep the two shapes in sync if either changes.
+ */
+function rowToEventRecord(row: typeof eventsTable.$inferSelect): EventRecord {
+  const payload = (row.payload as Record<string, unknown>) ?? {};
+  const metaJson = (row.meta as Record<string, unknown> | null | undefined) ?? undefined;
+  let meta: ExecutionMetaImpl | undefined;
+  if (metaJson) {
+    try {
+      meta = new ExecutionMetaImpl(metaJson);
+    } catch {
+      // Persisted meta failed validation — fall back to empty so replay still
+      // proceeds. OutboxWorker logs this case; the replay path leaves
+      // observability to the caller (which sees `errors` per-handler if
+      // anything downstream throws).
+      meta = undefined;
+    }
+  }
+  return {
+    id: row.id,
+    type: row.eventType,
+    category: "runtime",
+    timestamp: row.createdAt,
+    actor: { type: "system", id: "event-replay" },
+    executionId: row.sourceExecutionId ?? "",
+    tenantId: row.tenantId ?? undefined,
+    payload,
+    meta,
+  };
+}
+
+/** Handler context for replay — emits are swallowed to avoid cascading replays. */
+function createReplayContext(meta: ExecutionMetaImpl | undefined): EventHandlerContext {
+  return {
+    emit: () => {
+      // Replay does not propagate chained emits; downstream events are out of
+      // scope for a single-event re-dispatch (Spec 66 §4.3 safety guards).
+    },
+    meta: meta ?? new ExecutionMetaImpl({}),
+  };
+}
+
+function selectHandlers(
+  registry: EventHandlerRegistry,
+  eventType: string,
+  payload: Record<string, unknown>,
+  onlyHandler: string | undefined,
+): EventHandlerDefinition[] {
+  const all = registry.getByEvent(eventType);
+  const filtered = all.filter((h) => {
+    if (onlyHandler && h.name !== onlyHandler) return false;
+    if (!h.filter) return true;
+    return matchesFilter(payload, h.filter);
+  });
+  filtered.sort((a, b) => (a.priority ?? DEFAULT_PRIORITY) - (b.priority ?? DEFAULT_PRIORITY));
+  return filtered;
+}
+
+// ── Factory ─────────────────────────────────────────────────
+
+export function createEventReplayService(opts: EventReplayServiceOptions): EventReplayService {
+  const { db, registry } = opts;
+
+  function buildWhere(options?: EventListOptions): SQL | undefined {
+    const filters: SQL[] = [];
+    if (options?.tenantId !== undefined) filters.push(eq(eventsTable.tenantId, options.tenantId));
+    if (options?.eventType !== undefined)
+      filters.push(eq(eventsTable.eventType, options.eventType));
+    if (options?.entity !== undefined) filters.push(eq(eventsTable.sourceAction, options.entity));
+    if (options?.since instanceof Date) filters.push(gte(eventsTable.createdAt, options.since));
+    if (options?.until instanceof Date) filters.push(lte(eventsTable.createdAt, options.until));
+    if (filters.length === 0) return undefined;
+    if (filters.length === 1) return filters[0];
+    return and(...filters);
+  }
+
+  async function list(
+    options?: EventListOptions,
+  ): Promise<{ items: EventSummary[]; total: number }> {
+    const limit = clampLimit(options?.limit, 50, 100);
+    const offset = clampOffset(options?.offset);
+    const where = buildWhere(options);
+
+    const [rows, totals] = await Promise.all([
+      where
+        ? db
+            .select()
+            .from(eventsTable)
+            .where(where)
+            .orderBy(desc(eventsTable.createdAt))
+            .limit(limit)
+            .offset(offset)
+        : db
+            .select()
+            .from(eventsTable)
+            .orderBy(desc(eventsTable.createdAt))
+            .limit(limit)
+            .offset(offset),
+      where
+        ? db.select({ total: count() }).from(eventsTable).where(where)
+        : db.select({ total: count() }).from(eventsTable),
+    ]);
+
+    return {
+      items: rows.map(rowToSummary),
+      total: Number(totals[0]?.total ?? 0),
+    };
+  }
+
+  async function get(id: string): Promise<EventDetail | null> {
+    if (!UUID_RE.test(id)) return null;
+    const rows = await db.select().from(eventsTable).where(eq(eventsTable.id, id)).limit(1);
+    return rows[0] ? rowToDetail(rows[0]) : null;
+  }
+
+  async function fetchRow(id: string): Promise<typeof eventsTable.$inferSelect | null> {
+    if (!UUID_RE.test(id)) return null;
+    const rows = await db.select().from(eventsTable).where(eq(eventsTable.id, id)).limit(1);
+    return rows[0] ?? null;
+  }
+
+  async function replay(id: string, options?: ReplayOptions): Promise<ReplayResult> {
+    const row = await fetchRow(id);
+    if (!row) return { delivered: 0, errors: [] };
+    return dispatchRow(row, options?.onlyHandler);
+  }
+
+  async function dispatchRow(
+    row: typeof eventsTable.$inferSelect,
+    onlyHandler: string | undefined,
+  ): Promise<ReplayResult> {
+    const event = rowToEventRecord(row);
+    const handlers = selectHandlers(registry, event.type, event.payload, onlyHandler);
+    if (handlers.length === 0) return { delivered: 0, errors: [] };
+
+    const ctx = createReplayContext(event.meta as ExecutionMetaImpl | undefined);
+    const traceId = (event.payload as Record<string, unknown>)?._traceId as string | undefined;
+
+    let delivered = 0;
+    const errors: ReplayError[] = [];
+
+    for (const handler of handlers) {
+      // Shallow copy so handler mutations cannot leak to siblings/replays.
+      const eventCopy: EventRecord = { ...event, payload: { ...event.payload } };
+      try {
+        const exec = () => handler.handler(eventCopy, ctx);
+        if (traceId) {
+          await withTraceId(traceId, exec);
+        } else {
+          await exec();
+        }
+        delivered++;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        errors.push({ handler: handler.name, message });
+      }
+    }
+
+    return { delivered, errors };
+  }
+
+  async function replayBatch(ids: string[], options?: ReplayOptions): Promise<BatchReplayResult> {
+    if (!Array.isArray(ids) || ids.length === 0) {
+      return { results: [], totalDelivered: 0, totalErrors: 0 };
+    }
+    if (ids.length > MAX_BATCH_SIZE) {
+      throw new Error(`replayBatch: batch size ${ids.length} exceeds maximum of ${MAX_BATCH_SIZE}`);
+    }
+
+    const results: BatchReplayResult["results"] = [];
+    let totalDelivered = 0;
+    let totalErrors = 0;
+
+    for (const id of ids) {
+      if (!UUID_RE.test(id)) {
+        results.push({ id, replayed: false, delivered: 0, errors: [] });
+        continue;
+      }
+      const row = await fetchRow(id);
+      if (!row) {
+        results.push({ id, replayed: false, delivered: 0, errors: [] });
+        continue;
+      }
+      const outcome = await dispatchRow(row, options?.onlyHandler);
+      results.push({
+        id,
+        replayed: true,
+        delivered: outcome.delivered,
+        errors: outcome.errors,
+      });
+      totalDelivered += outcome.delivered;
+      totalErrors += outcome.errors.length;
+    }
+
+    return { results, totalDelivered, totalErrors };
+  }
+
+  async function handlerHistory(query: HandlerHistoryQuery): Promise<HandlerExecution[]> {
+    if (!UUID_RE.test(query.eventId)) return [];
+    const rows = await db
+      .select()
+      .from(eventsTable)
+      .where(eq(eventsTable.id, query.eventId))
+      .limit(1);
+    if (rows.length === 0) return [];
+
+    const history = rows.map(rowToHistory);
+    if (query.handler === undefined) return history;
+    // Wildcard sentinel `"*"` represents "all handlers"; until per-handler
+    // tracking exists, only the wildcard matches an explicit name filter.
+    return history.filter((h) => h.handler === query.handler || h.handler === "*");
+  }
+
+  return { list, get, replay, replayBatch, handlerHistory };
+}

--- a/packages/core/src/event/event-replay-service.ts
+++ b/packages/core/src/event/event-replay-service.ts
@@ -15,7 +15,7 @@
  * handler failures"). The original event row is never modified.
  */
 
-import { and, count, desc, eq, gte, lte, type SQL } from "drizzle-orm";
+import { and, count, desc, eq, gte, inArray, lte, type SQL } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { withTraceId } from "../observability/trace-context";
 import { eventsTable } from "../persistence/system-tables";
@@ -255,12 +255,15 @@ function createReplayContext(
   };
 }
 
-function selectHandlers(
-  registry: EventHandlerRegistry,
-  eventType: string,
-  payload: Record<string, unknown>,
-  onlyHandler: string | undefined,
-): EventHandlerDefinition[] {
+interface SelectHandlersOptions {
+  registry: EventHandlerRegistry;
+  eventType: string;
+  payload: Record<string, unknown>;
+  onlyHandler?: string;
+}
+
+function selectHandlers(options: SelectHandlersOptions): EventHandlerDefinition[] {
+  const { registry, eventType, payload, onlyHandler } = options;
   const all = registry.getByEvent(eventType);
   const filtered = all.filter((h) => {
     if (onlyHandler && h.name !== onlyHandler) return false;
@@ -269,6 +272,29 @@ function selectHandlers(
   });
   filtered.sort((a, b) => (a.priority ?? DEFAULT_PRIORITY) - (b.priority ?? DEFAULT_PRIORITY));
   return filtered;
+}
+
+/**
+ * `instanceof Date` matches `new Date("not-a-date")` (an "Invalid Date"
+ * whose getTime() is NaN). Treat those as missing so the SQL filter
+ * never carries an invalid timestamp.
+ */
+function isValidDate(value: unknown): value is Date {
+  return value instanceof Date && !Number.isNaN(value.getTime());
+}
+
+/**
+ * Deep clone via `structuredClone` so handler mutations on nested objects
+ * (e.g. `event.payload.user.name = "x"`) cannot leak to subsequent
+ * handlers in the same replay or to a later replay of the same row.
+ * Falls back to `JSON.parse(JSON.stringify(...))` if structuredClone is
+ * unavailable in the runtime (older bun versions).
+ */
+function deepClonePayload(payload: Record<string, unknown>): Record<string, unknown> {
+  if (typeof structuredClone === "function") {
+    return structuredClone(payload);
+  }
+  return JSON.parse(JSON.stringify(payload));
 }
 
 // ── Factory ─────────────────────────────────────────────────
@@ -282,8 +308,8 @@ export function createEventReplayService(opts: EventReplayServiceOptions): Event
     if (options?.eventType !== undefined)
       filters.push(eq(eventsTable.eventType, options.eventType));
     if (options?.entity !== undefined) filters.push(eq(eventsTable.sourceAction, options.entity));
-    if (options?.since instanceof Date) filters.push(gte(eventsTable.createdAt, options.since));
-    if (options?.until instanceof Date) filters.push(lte(eventsTable.createdAt, options.until));
+    if (isValidDate(options?.since)) filters.push(gte(eventsTable.createdAt, options.since));
+    if (isValidDate(options?.until)) filters.push(lte(eventsTable.createdAt, options.until));
     if (filters.length === 0) return undefined;
     if (filters.length === 1) return filters[0];
     return and(...filters);
@@ -296,24 +322,17 @@ export function createEventReplayService(opts: EventReplayServiceOptions): Event
     const offset = clampOffset(options?.offset);
     const where = buildWhere(options);
 
+    // Drizzle's `.where(undefined)` is a no-op, so we can pass `where`
+    // directly and skip the redundant ternary branches.
     const [rows, totals] = await Promise.all([
-      where
-        ? db
-            .select()
-            .from(eventsTable)
-            .where(where)
-            .orderBy(desc(eventsTable.createdAt))
-            .limit(limit)
-            .offset(offset)
-        : db
-            .select()
-            .from(eventsTable)
-            .orderBy(desc(eventsTable.createdAt))
-            .limit(limit)
-            .offset(offset),
-      where
-        ? db.select({ total: count() }).from(eventsTable).where(where)
-        : db.select({ total: count() }).from(eventsTable),
+      db
+        .select()
+        .from(eventsTable)
+        .where(where)
+        .orderBy(desc(eventsTable.createdAt))
+        .limit(limit)
+        .offset(offset),
+      db.select({ total: count() }).from(eventsTable).where(where),
     ]);
 
     return {
@@ -345,7 +364,12 @@ export function createEventReplayService(opts: EventReplayServiceOptions): Event
     onlyHandler: string | undefined,
   ): Promise<ReplayResult> {
     const event = rowToEventRecord(row);
-    const handlers = selectHandlers(registry, event.type, event.payload, onlyHandler);
+    const handlers = selectHandlers({
+      registry,
+      eventType: event.type,
+      payload: event.payload,
+      onlyHandler,
+    });
     if (handlers.length === 0) return { delivered: 0, errors: [] };
 
     const ctx = createReplayContext(event.meta as ExecutionMetaImpl | undefined, event.id);
@@ -355,8 +379,9 @@ export function createEventReplayService(opts: EventReplayServiceOptions): Event
     const errors: ReplayError[] = [];
 
     for (const handler of handlers) {
-      // Shallow copy so handler mutations cannot leak to siblings/replays.
-      const eventCopy: EventRecord = { ...event, payload: { ...event.payload } };
+      // Deep clone via structuredClone so nested-object mutations from one
+      // handler cannot leak to siblings or to a later replay of the same row.
+      const eventCopy: EventRecord = { ...event, payload: deepClonePayload(event.payload) };
       try {
         const exec = () => handler.handler(eventCopy, ctx);
         if (traceId) {
@@ -382,17 +407,27 @@ export function createEventReplayService(opts: EventReplayServiceOptions): Event
       throw new Error(`replayBatch: batch size ${ids.length} exceeds maximum of ${MAX_BATCH_SIZE}`);
     }
 
+    // Partition once: keep the original order so the caller's `ids` line up
+    // with `results`, but bulk-fetch the valid UUIDs in a single query
+    // instead of issuing one round-trip per id.
+    const validIds = ids.filter((id) => UUID_RE.test(id));
+    const rowsById = new Map<string, typeof eventsTable.$inferSelect>();
+    if (validIds.length > 0) {
+      const rows = await db.select().from(eventsTable).where(inArray(eventsTable.id, validIds));
+      for (const row of rows) {
+        rowsById.set(row.id, row);
+      }
+    }
+
     const results: BatchReplayResult["results"] = [];
     let totalDelivered = 0;
     let totalErrors = 0;
 
     for (const id of ids) {
-      if (!UUID_RE.test(id)) {
-        results.push({ id, replayed: false, delivered: 0, errors: [] });
-        continue;
-      }
-      const row = await fetchRow(id);
+      const row = rowsById.get(id);
       if (!row) {
+        // Either the id was malformed (filtered out above) or no row
+        // matched it in the bulk fetch.
         results.push({ id, replayed: false, delivered: 0, errors: [] });
         continue;
       }

--- a/packages/core/src/event/event-replay-service.ts
+++ b/packages/core/src/event/event-replay-service.ts
@@ -199,6 +199,17 @@ function rowToEventRecord(row: typeof eventsTable.$inferSelect): EventRecord {
       meta = undefined;
     }
   }
+  // Re-hydrate top-level EventRecord fields from the persisted payload so
+  // the dispatched record matches the original shape. For framework events
+  // (record.created/updated/deleted, state.changed, ...) the producer puts
+  // entity/recordId/action inside the payload jsonb; the EventRecord type
+  // also exposes them at the top level. Handlers like cache invalidation
+  // read the top-level fields, so dropping them silently no-ops the replay.
+  const entity = pickStringField(payload, "entity");
+  const recordId = pickStringField(payload, "recordId");
+  const action = pickStringField(payload, "action") ?? row.sourceAction ?? undefined;
+  const capability = pickStringField(payload, "capability");
+
   return {
     id: row.id,
     type: row.eventType,
@@ -207,19 +218,40 @@ function rowToEventRecord(row: typeof eventsTable.$inferSelect): EventRecord {
     actor: { type: "system", id: "event-replay" },
     executionId: row.sourceExecutionId ?? "",
     tenantId: row.tenantId ?? undefined,
+    entity,
+    recordId,
+    action,
+    capability,
     payload,
     meta,
   };
 }
 
-/** Handler context for replay — emits are swallowed to avoid cascading replays. */
-function createReplayContext(meta: ExecutionMetaImpl | undefined): EventHandlerContext {
+function pickStringField(payload: Record<string, unknown>, key: string): string | undefined {
+  const v = payload[key];
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+/**
+ * Handler context for replay — emits are swallowed to avoid cascading
+ * replays, and the meta is tagged with `_replay`/`_replay_origin_id`
+ * (Spec 66 §4.3 safety markers) so handlers can short-circuit
+ * non-idempotent side effects (sending email, billing, calling
+ * external APIs) when invoked from a replay rather than the
+ * original delivery.
+ */
+function createReplayContext(
+  meta: ExecutionMetaImpl | undefined,
+  originEventId: string,
+): EventHandlerContext {
+  const base = meta ?? new ExecutionMetaImpl({});
+  const tagged = base.extend({}, { _replay: true, _replay_origin_id: originEventId });
   return {
     emit: () => {
       // Replay does not propagate chained emits; downstream events are out of
       // scope for a single-event re-dispatch (Spec 66 §4.3 safety guards).
     },
-    meta: meta ?? new ExecutionMetaImpl({}),
+    meta: tagged,
   };
 }
 
@@ -316,7 +348,7 @@ export function createEventReplayService(opts: EventReplayServiceOptions): Event
     const handlers = selectHandlers(registry, event.type, event.payload, onlyHandler);
     if (handlers.length === 0) return { delivered: 0, errors: [] };
 
-    const ctx = createReplayContext(event.meta as ExecutionMetaImpl | undefined);
+    const ctx = createReplayContext(event.meta as ExecutionMetaImpl | undefined, event.id);
     const traceId = (event.payload as Record<string, unknown>)?._traceId as string | undefined;
 
     let delivered = 0;

--- a/packages/core/src/event/index.ts
+++ b/packages/core/src/event/index.ts
@@ -17,6 +17,20 @@ export {
   matchesFilter,
 } from "./event-bus";
 export {
+  type BatchReplayResult,
+  createEventReplayService,
+  type EventDetail,
+  type EventListOptions,
+  type EventReplayService,
+  type EventReplayServiceOptions,
+  type EventSummary,
+  type HandlerExecution,
+  type HandlerHistoryQuery,
+  type ReplayError,
+  type ReplayOptions,
+  type ReplayResult,
+} from "./event-replay-service";
+export {
   createOutboxWorker,
   type OutboxMetrics,
   type OutboxWorker,


### PR DESCRIPTION
## Summary

Adds \`createEventReplayService({ db, registry })\` to \`@linchkit/core\` for backend event re-dispatch and inspection. Closes #137 and ships Spec 66 §7 M7 "ReplayService" backend (UI deferred to a follow-up).

## API

\`\`\`typescript
list(filters)            // paginated event listing
get(id)                  // full payload + delivery history
replay(id, opts)         // re-dispatch one event to handlers
replayBatch(ids, opts)   // bulk variant (100-id cap)
handlerHistory(query)    // past delivery results per (event, handler)
\`\`\`

All UUID-validated at the boundary; pagination clamped via \`Number.isFinite\` + \`Math.trunc\` + \`Math.max\`/\`min\` (mirrors PR #307 DLQ hardening).

## Spec 66 §4.3 safety guards

- Re-dispatch goes through the \`EventHandlerRegistry\` directly **without** mutating the original \`_linchkit.events\` row or persisting a duplicate event.
- Reconstructed \`EventRecord\` includes top-level \`entity\` / \`recordId\` / \`action\` / \`capability\` (rehydrated from payload) so handlers like cache invalidation see the same shape as the original delivery.
- The handler context's \`ExecutionMeta\` is extended with framework-only \`_replay: true\` + \`_replay_origin_id: <event id>\` so handlers can short-circuit non-idempotent side effects (sending email, billing, external API calls).
- \`emit()\` is a no-op during replay — chained downstream events are out of scope for a single-event re-dispatch.
- Handler failures surface via \`ReplayError[]\` rather than being swallowed.
- \`onlyHandler\` scopes a replay to a single handler name.

## Cross-model review (codex)

| Finding | Resolution |
|---|---|
| **[P2]** Reconstructed event dropped top-level entity/recordId/action — cache-invalidation handlers would silently no-op | Added \`pickStringField\` helper, rehydrated entity/recordId/action/capability from payload (action falls back to \`row.sourceAction\`) |
| **[P2]** Replay handler context indistinguishable from original delivery — non-idempotent handlers re-fire | \`createReplayContext\` extends meta with \`_replay\` + \`_replay_origin_id\` framework system overrides |

## Test plan

- [x] \`bun run check\` — clean
- [x] \`bun run typecheck\` — clean
- [x] \`bun test\` — 4995/4998 pass, 0 fail
- [x] \`bun test packages/core/__tests__/event-replay-service.test.ts\` — 18/18 pass / 57 expects (list filters / pagination clamp / get null / replay multi-handler / replay collects errors / replay onlyHandler / replayBatch + cap / handlerHistory ordering)

## Follow-ups

- **Issue #137 also asks for "Event timeline view in admin UI"** — backend exposes everything the UI needs; recommend filing once this lands.
- Spec 66 §4.4 "linch event inspect/replay" CLI commands wrap this service in a separate PR.
- Per-handler completion tracking once Spec 66 §2.4 \`outbox_completions\` ships in M5 — \`HandlerExecution.handler\` is already shaped for that (currently returns wildcard \`"*"\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event replay functionality to retrieve and re-dispatch persisted events to registered handlers.
  * Enabled event listing with filtering by tenant, event type, entity, and time window, plus pagination support.
  * Introduced batch replay processing to handle multiple events sequentially with error aggregation.
  * Added handler execution history tracking per event for audit and troubleshooting purposes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laofahai/linchkit/pull/315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->