### PR TITLE
feat(core): OpenTelemetry seam — Tracer/Meter interfaces + noop default (refs #130 Phase 1)

### DIFF
--- a/docs/specs/28_observability.md
+++ b/docs/specs/28_observability.md
@@ -295,3 +295,177 @@ Proposal
 - External monitoring (Grafana / Prometheus)
 - **Log volume budgets per tenant**
 - **Full-stack log search by traceId**
+
+## 10. M3 OpenTelemetry Integration
+
+Tracking issue: **#130** (Spec 28 M3+).
+
+This section defines the OTel surface area LinchKit core exposes and the
+contracts a future `cap-otel` capability must honor. Phase 1 ships the
+**seam only** — interfaces, a noop default, and a single demonstration
+call site — without taking any `@opentelemetry/*` dependency in core.
+Phase 2 ships the adapter capability + dashboards.
+
+### 10.1 Phase 1 deliverables (this release)
+
+- `Tracer` / `Span` / `Meter` / `Counter` / `Histogram` interfaces in
+  `@linchkit/core` that mirror the shape of `@opentelemetry/api` (no
+  hard dependency).
+- `NoopTracer` + `NoopMeter` defaults — zero runtime cost.
+- Module-level singleton: `getObservability()` / `setObservability()` /
+  `resetObservability()` (the latter for tests).
+- One demonstration span emitted from CommandLayer
+  (`linchkit.command.dispatch`) so the seam is exercised by every
+  request, not just in tests.
+
+### 10.2 Phase 2 deliverables (follow-up issue)
+
+- `cap-otel` capability (new addon) wrapping `@opentelemetry/api` +
+  `@opentelemetry/sdk-trace-node` + `@opentelemetry/sdk-metrics` +
+  `@opentelemetry/exporter-trace-otlp-http` and
+  `@opentelemetry/exporter-metrics-otlp-http`.
+- Pre-built Grafana dashboards committed under
+  `docs/observability/grafana/` (JSON exports).
+- Prometheus alert rules under `docs/observability/prometheus/`.
+- A semantic-convention matrix that maps LinchKit attributes to OTel
+  semantic conventions (`http.*`, `db.*`, `messaging.*`).
+- Optional auto-instrumentation hooks for Bun/Elysia HTTP, Drizzle,
+  and Restate.
+
+### 10.3 Architecture sketch
+
+```text
+CommandLayer.execute(command)
+  └─ withTrace(...)                            (already in place — LinchKit trace_id)
+      └─ tracer.startSpan("linchkit.command.dispatch")
+          ├─ middleware: pre                   → no span (Phase 2 adds per-slot spans)
+          ├─ middleware: auth                  → span "linchkit.command.auth"
+          ├─ exposure check
+          ├─ middleware: permission            → span "linchkit.command.permission"
+          ├─ middleware: tenant                → span "linchkit.command.tenant"
+          ├─ middleware: pre-action            → span "linchkit.command.pre_action"
+          ├─ executor.execute()
+          │     └─ span "linchkit.action.<name>"
+          │           ├─ rule evaluation       → child span "linchkit.rule.<name>"
+          │           ├─ data provider write
+          │           └─ event emission        → span "linchkit.event.<name>"
+          │                 └─ EventHandler    → child span "linchkit.event_handler.<name>"
+          │                       └─ may enqueue flow → span "linchkit.flow.<id>.<step>"
+          └─ middleware: post-action           → span "linchkit.command.post_action"
+```
+
+Phase 1 only emits the outer `linchkit.command.dispatch` span. Phase 2
+fills in the inner spans incrementally — each is an additive change at
+its own call site, made possible by the seam.
+
+### 10.4 Span naming convention
+
+| Span | Where emitted |
+|------|---------------|
+| `linchkit.command.dispatch` | `CommandLayer.execute()` entry — **Phase 1** |
+| `linchkit.command.<slot>` | Each pipeline slot (`auth`, `permission`, `tenant`, `pre_action`, `post_action`) — Phase 2 |
+| `linchkit.action.<name>` | `ActionEngine.execute()` per action — Phase 2 |
+| `linchkit.event.<name>` | EventBus emit — Phase 2 |
+| `linchkit.event_handler.<name>` | EventHandler invocation — Phase 2 |
+| `linchkit.flow.<flowId>.<step>` | Restate Flow step entry — Phase 2 |
+| `linchkit.rule.<name>` | Rule evaluation when block/effect runs — Phase 2 |
+
+Naming rules:
+- Lowercase, dot-separated, ASCII only.
+- Domain prefix is always `linchkit.` (avoids collision with auto-
+  instrumentation that uses `http.*` / `db.*`).
+- Action / event / handler / rule names are the user-defined entity
+  identifiers (already validated `verb_noun` for actions, snake_case
+  elsewhere) — safe to use verbatim.
+
+### 10.5 Span attribute schema
+
+Required on every span emitted by core:
+
+| Attribute | Type | Notes |
+|-----------|------|-------|
+| `linchkit.command` | string | The command/action name (`linchkit.command.*` spans). |
+| `linchkit.channel` | string | One of `http`, `mcp`, `cli`, `ui`, `internal`. |
+| `linchkit.trace_id` | string | LinchKit internal trace ID (mirrors `X-Trace-Id`). Distinct from OTel `trace_id`; allows correlation with the existing Execution Log. |
+
+Conditional (set when present on the request):
+
+| Attribute | Type | Notes |
+|-----------|------|-------|
+| `linchkit.tenant_id` | string | Set by tenant middleware. Required for any span emitted after the tenant slot. |
+| `linchkit.capability` | string | The capability that owns the action/entity (resolved via OntologyRegistry). |
+| `linchkit.entity` | string | The target entity name when applicable. |
+| `linchkit.action` | string | The action name (set on `linchkit.action.*` spans even though the prefix already names it — eases cross-span query). |
+| `linchkit.actor.id` | string | Set on auth-completed spans only. |
+| `linchkit.actor.type` | string | `human` / `system` / `agent`. |
+| `linchkit.approval_id` | string | Set when re-executing an approval. |
+| `linchkit.skip_action_slots` | boolean | Set on `onchange` dispatch. |
+
+PII rule: NEVER set raw user input, password, or token fields as
+attributes. Field names of failed validators are allowed (already used
+elsewhere in the codebase for error context).
+
+### 10.6 Trace propagation (HTTP + GraphQL)
+
+| Transport | Inbound | Outbound |
+|-----------|---------|----------|
+| REST | Read W3C `traceparent` + `tracestate` from request headers; restore via `withTraceId` so the `X-Trace-Id` and OTel trace IDs share a parent. | Emit `traceparent` on any outgoing HTTP call from `cap-*` adapters. |
+| GraphQL | Yoga plugin reads `traceparent`. | N/A (server-side only). |
+| MCP | Adapter forwards `_traceparent` system meta when present. | Adapter sets `_traceparent` on tool invocations. |
+| Restate | Phase 2: store `traceparent` in workflow state so resumed steps continue the same trace. | Phase 2. |
+
+LinchKit's internal `X-Trace-Id` (Spec 28 §4.4) and the OTel
+`trace_id` are kept in sync only at request boundaries — internally
+each system uses its own ID for legacy compatibility (the Execution
+Log writes the LinchKit ID; OTel exports its own ID).
+
+### 10.7 OTLP exporter configuration (Phase 2)
+
+Environment variables (standard OTel names):
+
+| Var | Default | Notes |
+|-----|---------|-------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | _unset_ | When unset, the noop tracer/meter stay registered — **no network calls**. |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `http/protobuf` | `grpc` supported when the gRPC SDK is installed. |
+| `OTEL_EXPORTER_OTLP_HEADERS` | _unset_ | Comma-separated `k=v` pairs for auth tokens. |
+| `OTEL_SERVICE_NAME` | `linchkit` | Override per deployment. |
+| `OTEL_SERVICE_VERSION` | package.json `version` | Read at startup. |
+| `OTEL_RESOURCE_ATTRIBUTES` | `linchkit.tenant_mode=multi` | Caller may append. |
+| `OTEL_TRACES_SAMPLER` | `parentbased_traceidratio` | |
+| `OTEL_TRACES_SAMPLER_ARG` | `1.0` (dev) / `0.1` (prod default) | Tunable. |
+| `OTEL_METRIC_EXPORT_INTERVAL` | `60000` (ms) | |
+
+Defaults are designed so a Phase 2 install with **no env vars set**
+behaves like Phase 1: noop only, no exporter, zero network traffic.
+
+### 10.8 Metric set
+
+LinchKit-defined OTel instruments (Phase 2 — names finalize when the
+adapter ships):
+
+| Instrument | Type | Unit | Attributes |
+|------------|------|------|------------|
+| `linchkit.commands.duration` | histogram | `ms` | `command`, `channel`, `status` |
+| `linchkit.actions.invoked` | counter | `1` | `action`, `status`, `tenant_id` |
+| `linchkit.events.processed` | counter | `1` | `event`, `status` (`success` / `error`), `handler` |
+| `linchkit.replay.batch.size` | histogram | `1` | `source` (`outbox` / `worker`) |
+| `linchkit.rules.blocked` | counter | `1` | `rule`, `entity` |
+| `linchkit.flow.active` | gauge (observable) | `1` | `flow_id` |
+
+These overlap with the existing in-process `MetricsCollector` metrics
+on purpose: the adapter subscribes to the in-process collector and
+forwards observations to OTel — one direction of data flow, no double
+counting.
+
+### 10.9 Future Phase 2
+
+- Pre-built Grafana dashboards committed under
+  `docs/observability/grafana/` (JSON exports for: Command Overview,
+  Action Drilldown, Event Pipeline, Tenant Comparison).
+- Prometheus alert rules under `docs/observability/prometheus/` (high
+  error rate, p99 regression, outbox backlog, flow stalled).
+- Semantic conventions matrix mapping LinchKit attributes to OTel
+  `http.*`, `db.*`, `messaging.*` where overlap exists.
+- Auto-instrumentation for Elysia, Drizzle, and Restate.
+- `OTEL_SDK_DISABLED=true` honored by the adapter to fall back to noop
+  without uninstalling.

--- a/packages/core/src/engine/command-layer.ts
+++ b/packages/core/src/engine/command-layer.ts
@@ -29,6 +29,7 @@ import { AuthorizationError, LinchKitError, SystemError } from "../errors";
 import { consoleLogger } from "../observability/console-logger";
 import type { MetricsCollector } from "../observability/metrics";
 import { noopMetricsCollector } from "../observability/metrics";
+import { getObservability } from "../observability/observability-registry";
 import { getCurrentTrace, withTrace, withTraceId } from "../observability/trace-context";
 import type { ActionDefinition, ActionResult, Actor } from "../types/action";
 import type { BatchActionsInput, BatchActionsResult, BatchSucceededItem } from "../types/batch";
@@ -366,6 +367,41 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
     // Capture trace ID from the active trace context
     const trace = getCurrentTrace();
 
+    // OTel seam (Spec 28 M3, issue #130 Phase 1) — emit a single
+    // `linchkit.command.dispatch` span around the pipeline. Defaults to
+    // the noop tracer (zero cost); a future OTel adapter swaps in via
+    // `setObservability(...)` without touching this call site.
+    const dispatchSpan = getObservability().tracer.startSpan("linchkit.command.dispatch", {
+      kind: "internal",
+      attributes: {
+        "linchkit.command": execOptions.command,
+        "linchkit.channel": execOptions.channel ?? "internal",
+        ...(trace?.traceId ? { "linchkit.trace_id": trace.traceId } : {}),
+      },
+    });
+    try {
+      const result = await executeInnerImpl(execOptions, pipelineStart, trace, dispatchSpan);
+      // Authoritative status set here so every early-return failure path
+      // (unknown action, blocked middleware, invalid approval options, …)
+      // exports an accurate span status, not just the late success path.
+      // Inner catch records exception details first; this set is idempotent.
+      dispatchSpan.setStatus({ code: result.success ? "ok" : "error" });
+      return result;
+    } catch (err) {
+      dispatchSpan.recordException(err instanceof Error ? err : new Error(String(err)));
+      dispatchSpan.setStatus({ code: "error" });
+      throw err;
+    } finally {
+      dispatchSpan.end();
+    }
+  }
+
+  async function executeInnerImpl(
+    execOptions: CommandExecuteOptions,
+    pipelineStart: number,
+    trace: ReturnType<typeof getCurrentTrace>,
+    dispatchSpan: ReturnType<ReturnType<typeof getObservability>["tracer"]["startSpan"]>,
+  ): Promise<ActionResult> {
     // Build context with copies to isolate from caller
     const ctx: CommandContext = {
       command: execOptions.command,
@@ -609,6 +645,12 @@ export function createCommandLayer(options: CommandLayerOptions): CommandLayer {
       const run = compose(pipeline);
       await run(ctx);
     } catch (err) {
+      // Record on the OTel dispatch span (noop unless an adapter is wired).
+      dispatchSpan.recordException(err instanceof Error ? err : String(err));
+      dispatchSpan.setStatus({
+        code: "error",
+        message: err instanceof Error ? err.message : String(err),
+      });
       metrics.increment("action.executions", { action: ctx.command, status: "error" });
       metrics.increment("action.errors", { action: ctx.command });
       metrics.timing("action.duration_ms", Date.now() - pipelineStart, {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -322,7 +322,22 @@ export type {
   AlertSeverity,
   SystemAlertDefinition,
 } from "./observability/alert-engine";
+export type {
+  Counter,
+  Histogram,
+  InstrumentOptions,
+  Meter,
+  MetricAttributes,
+  MetricAttributeValue,
+} from "./observability/meter";
+export { NoopMeter, noopMeter } from "./observability/meter";
 export type { MetricSnapshot, MetricsCollector, MetricsSummary } from "./observability/metrics";
+export type { Observability } from "./observability/observability-registry";
+export {
+  getObservability,
+  resetObservability,
+  setObservability,
+} from "./observability/observability-registry";
 export type {
   LogLevel,
   LogSink,
@@ -330,6 +345,17 @@ export type {
   StructuredLoggerOptions,
 } from "./observability/structured-logger";
 export type { TraceState } from "./observability/trace-context";
+export type {
+  Span,
+  SpanAttributes,
+  SpanAttributeValue,
+  SpanKind,
+  SpanStatus,
+  SpanStatusCode,
+  StartSpanOptions,
+  Tracer,
+} from "./observability/tracer";
+export { NoopTracer, noopTracer } from "./observability/tracer";
 export type {
   EntityDescriptor,
   OntologyRegistry,

--- a/packages/core/src/observability/__tests__/observability-registry.test.ts
+++ b/packages/core/src/observability/__tests__/observability-registry.test.ts
@@ -1,0 +1,117 @@
+/**
+ * observability-registry tests (Spec 28 M3 / issue #130 Phase 1).
+ *
+ * Covers the seam contract: noop default, swap-in via
+ * `setObservability`, reset, and that the default noop is safe to
+ * exercise (no throws, no allocations beyond a fresh span object).
+ */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import { type Counter, type Histogram, type Meter, noopMeter } from "../meter";
+import {
+  getObservability,
+  type Observability,
+  resetObservability,
+  setObservability,
+} from "../observability-registry";
+import { NoopTracer, noopTracer, type Span, type StartSpanOptions, type Tracer } from "../tracer";
+
+describe("observability-registry", () => {
+  afterEach(() => {
+    // Always restore the noop default so cross-test leakage is impossible.
+    resetObservability();
+  });
+
+  it("returns the noop default before anything is registered", () => {
+    const obs = getObservability();
+    expect(obs.tracer).toBe(noopTracer);
+    expect(obs.meter).toBe(noopMeter);
+  });
+
+  it("calling noop tracer + meter methods does not throw", () => {
+    const obs = getObservability();
+    const span = obs.tracer.startSpan("noop.span");
+    expect(() => {
+      span.setAttribute("k", "v");
+      span.setAttributes({ a: 1, b: true });
+      span.recordException(new Error("boom"));
+      span.setStatus({ code: "error", message: "boom" });
+      span.end();
+    }).not.toThrow();
+
+    const counter = obs.meter.createCounter("noop.counter");
+    const hist = obs.meter.createHistogram("noop.hist");
+    expect(() => {
+      counter.add(1, { k: "v" });
+      hist.record(42);
+    }).not.toThrow();
+  });
+
+  it("setObservability swaps in a fake tracer + meter and returns the previous bundle", () => {
+    const spanCalls: Array<{ name: string; options?: StartSpanOptions }> = [];
+    const fakeSpan: Span = {
+      setAttribute: () => fakeSpan,
+      setAttributes: () => fakeSpan,
+      recordException: () => fakeSpan,
+      setStatus: () => fakeSpan,
+      end: () => {},
+      isRecording: () => true,
+    };
+    const fakeTracer: Tracer = {
+      startSpan(name, options) {
+        spanCalls.push({ name, options });
+        return fakeSpan;
+      },
+    };
+    const counterAdds: Array<{ name: string; value: number }> = [];
+    const histRecords: Array<{ name: string; value: number }> = [];
+    const fakeMeter: Meter = {
+      createCounter(name): Counter {
+        return {
+          add(value) {
+            counterAdds.push({ name, value });
+          },
+        };
+      },
+      createHistogram(name): Histogram {
+        return {
+          record(value) {
+            histRecords.push({ name, value });
+          },
+        };
+      },
+    };
+
+    const fake: Observability = { tracer: fakeTracer, meter: fakeMeter };
+    const prev = setObservability(fake);
+    expect(prev.tracer).toBe(noopTracer);
+    expect(prev.meter).toBe(noopMeter);
+
+    const obs = getObservability();
+    expect(obs).toBe(fake);
+
+    obs.tracer.startSpan("linchkit.command.dispatch", { attributes: { ok: true } });
+    obs.meter.createCounter("c").add(3);
+    obs.meter.createHistogram("h").record(7);
+
+    expect(spanCalls).toEqual([
+      { name: "linchkit.command.dispatch", options: { attributes: { ok: true } } },
+    ]);
+    expect(counterAdds).toEqual([{ name: "c", value: 3 }]);
+    expect(histRecords).toEqual([{ name: "h", value: 7 }]);
+  });
+
+  it("resetObservability restores the noop default", () => {
+    const fake: Observability = {
+      tracer: new NoopTracer(),
+      meter: noopMeter,
+    };
+    setObservability(fake);
+    expect(getObservability()).toBe(fake);
+
+    resetObservability();
+    const obs = getObservability();
+    expect(obs.tracer).toBe(noopTracer);
+    expect(obs.meter).toBe(noopMeter);
+  });
+});

--- a/packages/core/src/observability/__tests__/tracer.noop.test.ts
+++ b/packages/core/src/observability/__tests__/tracer.noop.test.ts
@@ -1,0 +1,53 @@
+/**
+ * NoopTracer lifecycle tests (Spec 28 M3 / issue #130 Phase 1).
+ *
+ * Verifies the seam's safety contract: every method on a noop span
+ * is chainable, end() is idempotent in effect, and isRecording() flips
+ * after end().
+ */
+
+import { describe, expect, it } from "bun:test";
+import { NoopTracer, noopTracer } from "../tracer";
+
+describe("NoopTracer", () => {
+  it("returns a recording span until end() is called", () => {
+    const span = noopTracer.startSpan("op");
+    expect(span.isRecording()).toBe(true);
+    span.end();
+    expect(span.isRecording()).toBe(false);
+  });
+
+  it("mutator methods are chainable", () => {
+    const span = noopTracer.startSpan("op");
+    const chained = span
+      .setAttribute("a", 1)
+      .setAttributes({ b: "x", c: true })
+      .recordException(new Error("nope"))
+      .recordException("string-error")
+      .setStatus({ code: "ok" });
+    expect(chained).toBe(span);
+    span.end();
+  });
+
+  it("end() can be called with an explicit endTime without throwing", () => {
+    const span = noopTracer.startSpan("op", { kind: "server", startTime: 1 });
+    expect(() => span.end(2)).not.toThrow();
+  });
+
+  it("returns a fresh span per call (no shared mutable state)", () => {
+    const a = noopTracer.startSpan("a");
+    const b = noopTracer.startSpan("b");
+    expect(a).not.toBe(b);
+    a.end();
+    expect(b.isRecording()).toBe(true);
+    b.end();
+  });
+
+  it("a freshly constructed NoopTracer behaves identically to the singleton", () => {
+    const local = new NoopTracer();
+    const span = local.startSpan("local");
+    expect(span.isRecording()).toBe(true);
+    span.end();
+    expect(span.isRecording()).toBe(false);
+  });
+});

--- a/packages/core/src/observability/index.ts
+++ b/packages/core/src/observability/index.ts
@@ -24,12 +24,28 @@ export {
 export { consoleLogger } from "./console-logger";
 export { InMemoryExecutionLogger } from "./execution-logger";
 export {
+  type Counter,
+  type Histogram,
+  type InstrumentOptions,
+  type Meter,
+  type MetricAttributes,
+  type MetricAttributeValue,
+  NoopMeter,
+  noopMeter,
+} from "./meter";
+export {
   InMemoryMetricsCollector,
   type MetricSnapshot,
   type MetricsCollector,
   type MetricsSummary,
   noopMetricsCollector,
 } from "./metrics";
+export {
+  getObservability,
+  type Observability,
+  resetObservability,
+  setObservability,
+} from "./observability-registry";
 export {
   type BuildObservabilitySummaryOptions,
   buildObservabilitySummary,
@@ -52,3 +68,15 @@ export {
   withTrace,
   withTraceId,
 } from "./trace-context";
+export {
+  NoopTracer,
+  noopTracer,
+  type Span,
+  type SpanAttributes,
+  type SpanAttributeValue,
+  type SpanKind,
+  type SpanStatus,
+  type SpanStatusCode,
+  type StartSpanOptions,
+  type Tracer,
+} from "./tracer";

--- a/packages/core/src/observability/meter.ts
+++ b/packages/core/src/observability/meter.ts
@@ -1,0 +1,99 @@
+/**
+ * Meter — OTel-compatible metrics seam (Spec 28 M3 / issue #130).
+ *
+ * Mirrors the shape of `@opentelemetry/api`'s `Meter` + `Counter` +
+ * `Histogram` so a future `cap-otel` adapter can plug in without
+ * touching call sites. Phase 1 ships interfaces + a no-op
+ * implementation only.
+ *
+ * Relationship with the existing `MetricsCollector` (./metrics.ts):
+ * - `MetricsCollector` is LinchKit's own counters/gauges/histograms API
+ *   used by CommandLayer for in-process telemetry and the alert engine.
+ * - `Meter` is the OTel-aligned seam — when the adapter ships, the
+ *   adapter will subscribe to `MetricsCollector` events (or wrap it)
+ *   and forward to OTLP. Two surfaces, one direction of data flow.
+ *   Keeping them separate avoids pinning core's internal API to OTel's
+ *   versioning.
+ */
+
+// ── Attribute bag ────────────────────────────────────────
+
+/** Attribute value types accepted on metric instruments. */
+export type MetricAttributeValue =
+  | string
+  | number
+  | boolean
+  | readonly string[]
+  | readonly number[]
+  | readonly boolean[];
+
+/** Attribute bag attached to a metric observation. */
+export type MetricAttributes = Record<string, MetricAttributeValue>;
+
+// ── Instruments ──────────────────────────────────────────
+
+/** Options accepted when creating an instrument. */
+export interface InstrumentOptions {
+  /** Human-readable description. */
+  description?: string;
+  /**
+   * Unit string following UCUM (e.g. `ms`, `By`, `1`). OTel recommends
+   * `1` for dimensionless instruments.
+   */
+  unit?: string;
+}
+
+/**
+ * Monotonic counter — increments only. Mirrors OTel's `Counter`.
+ */
+export interface Counter {
+  /** Add a positive delta with optional attributes. */
+  add(value: number, attributes?: MetricAttributes): void;
+}
+
+/**
+ * Histogram instrument — records distributions of values. Mirrors
+ * OTel's `Histogram`.
+ */
+export interface Histogram {
+  /** Record an observation with optional attributes. */
+  record(value: number, attributes?: MetricAttributes): void;
+}
+
+// ── Meter ────────────────────────────────────────────────
+
+/**
+ * Meter — factory for counter / histogram instruments. Mirrors the
+ * subset of `@opentelemetry/api`'s `Meter` we plan to use.
+ */
+export interface Meter {
+  createCounter(name: string, options?: InstrumentOptions): Counter;
+  createHistogram(name: string, options?: InstrumentOptions): Histogram;
+}
+
+// ── Noop implementation ──────────────────────────────────
+
+const NOOP_COUNTER: Counter = {
+  add: () => {},
+};
+
+const NOOP_HISTOGRAM: Histogram = {
+  record: () => {},
+};
+
+/**
+ * Default no-op meter — returns shared singleton instruments. Used as
+ * the registry default; replaced via `setObservability(...)` once an
+ * OTel adapter is wired in.
+ */
+export class NoopMeter implements Meter {
+  createCounter(_name: string, _options?: InstrumentOptions): Counter {
+    return NOOP_COUNTER;
+  }
+  createHistogram(_name: string, _options?: InstrumentOptions): Histogram {
+    return NOOP_HISTOGRAM;
+  }
+}
+
+/** Singleton instance to avoid per-call allocation of the meter itself. */
+export const noopMeter: Meter = new NoopMeter();

--- a/packages/core/src/observability/observability-registry.ts
+++ b/packages/core/src/observability/observability-registry.ts
@@ -1,0 +1,90 @@
+/**
+ * Observability registry — module-level singleton holding the active
+ * `Tracer` + `Meter` pair. This is the seam an OTel adapter (or any
+ * other backend) plugs into.
+ *
+ * Defaults: `NoopTracer` + `NoopMeter`. Calls flow through with zero
+ * runtime cost beyond a method call + tiny span object allocation.
+ *
+ * Usage (instrumented call site):
+ * ```ts
+ * import { getObservability } from "@linchkit/core/server";
+ *
+ * const span = getObservability().tracer.startSpan("linchkit.action.submit_request", {
+ *   attributes: { "linchkit.tenant_id": tenantId },
+ * });
+ * try {
+ *   // ... work ...
+ * } finally {
+ *   span.end();
+ * }
+ * ```
+ *
+ * Usage (adapter registration, Phase 2):
+ * ```ts
+ * import { setObservability } from "@linchkit/core/server";
+ * import { createOtelAdapter } from "@linchkit/cap-otel";
+ *
+ * setObservability(createOtelAdapter({ endpoint: process.env.OTEL_EXPORTER_OTLP_ENDPOINT }));
+ * ```
+ */
+
+import { type Meter, noopMeter } from "./meter";
+import { noopTracer, type Tracer } from "./tracer";
+
+// ── Types ────────────────────────────────────────────────
+
+/**
+ * Bundle of observability primitives. Always exposes both `tracer`
+ * and `meter` — adapters that only ship one MUST still provide the
+ * noop for the other (use `noopTracer` / `noopMeter` from this
+ * package).
+ */
+export interface Observability {
+  readonly tracer: Tracer;
+  readonly meter: Meter;
+}
+
+// ── Singleton ────────────────────────────────────────────
+
+const DEFAULT_OBSERVABILITY: Observability = Object.freeze({
+  tracer: noopTracer,
+  meter: noopMeter,
+});
+
+let current: Observability = DEFAULT_OBSERVABILITY;
+
+/**
+ * Get the currently registered observability bundle. Returns the
+ * frozen `{ tracer: noopTracer, meter: noopMeter }` default until
+ * `setObservability` is called.
+ *
+ * Always returns a non-null bundle — call sites never need to
+ * null-check the tracer / meter.
+ */
+export function getObservability(): Observability {
+  return current;
+}
+
+/**
+ * Register a new observability bundle. Typically called once at
+ * startup by a capability (e.g. `cap-otel`). Passing a partial
+ * bundle is intentionally NOT supported — be explicit so missing
+ * fields surface as type errors rather than silent noops.
+ *
+ * Returns the previous bundle so callers can compose / restore in
+ * tests.
+ */
+export function setObservability(next: Observability): Observability {
+  const prev = current;
+  current = next;
+  return prev;
+}
+
+/**
+ * Reset the registry to the noop default. Primarily a test helper so
+ * one test's `setObservability` call cannot leak into the next.
+ */
+export function resetObservability(): Observability {
+  return setObservability(DEFAULT_OBSERVABILITY);
+}

--- a/packages/core/src/observability/tracer.ts
+++ b/packages/core/src/observability/tracer.ts
@@ -1,0 +1,144 @@
+/**
+ * Tracer — OTel-compatible tracing seam (Spec 28 M3 / issue #130).
+ *
+ * Provides a minimal `Tracer` / `Span` interface that mirrors the shape of
+ * `@opentelemetry/api` without taking a dependency on it. A future
+ * `cap-otel` capability can drop in a real OTel adapter that implements
+ * this interface; until then `NoopTracer` is wired in via the
+ * observability registry so call sites can sprinkle `startSpan(...)` /
+ * `span.end()` without any runtime cost.
+ *
+ * Phase 1 (this file): types + no-op implementation only. No exporter,
+ * no protobuf, no transport. The named seam exists so call sites
+ * (CommandLayer, ActionEngine, EventHandlers, Flow steps) can be
+ * instrumented incrementally and the OTel adapter can ship later
+ * without rewriting any call sites.
+ */
+
+// ── Span attribute values ────────────────────────────────
+
+/**
+ * Valid attribute value types — mirrors OTel's
+ * `AttributeValue` union to keep the seam swap-in compatible. Strings,
+ * numbers, booleans, and homogeneous arrays of those are allowed.
+ */
+export type SpanAttributeValue =
+  | string
+  | number
+  | boolean
+  | readonly string[]
+  | readonly number[]
+  | readonly boolean[];
+
+/** Attribute bag attached to a span (OTel `Attributes` shape). */
+export type SpanAttributes = Record<string, SpanAttributeValue>;
+
+// ── Span ─────────────────────────────────────────────────
+
+/** Status code reported on a span when it ends. */
+export type SpanStatusCode = "unset" | "ok" | "error";
+
+/** Status payload reported on a span when it ends. */
+export interface SpanStatus {
+  code: SpanStatusCode;
+  /** Human-readable status message (optional, recommended for `error`). */
+  message?: string;
+}
+
+/**
+ * A live span. Mirrors the operations we expect to use from
+ * `@opentelemetry/api`'s `Span` type without pulling the dependency in.
+ *
+ * Lifecycle: created by `Tracer.startSpan()`, mutated via
+ * `setAttribute(s)` / `recordException` / `setStatus`, finalized via
+ * `end()`. After `end()` no further mutations are permitted (no-op in
+ * the noop impl; OTel adapter will warn).
+ */
+export interface Span {
+  /** Set a single attribute. */
+  setAttribute(key: string, value: SpanAttributeValue): this;
+  /** Bulk-set attributes (overwrites existing keys). */
+  setAttributes(attrs: SpanAttributes): this;
+  /** Record an exception on the span without ending it. */
+  recordException(error: Error | string): this;
+  /** Set the span status; an unset error code is recommended for failures. */
+  setStatus(status: SpanStatus): this;
+  /** Finalize the span. Must be called exactly once per span. */
+  end(endTime?: number): void;
+  /** Returns true after `end()` has been called. */
+  isRecording(): boolean;
+}
+
+// ── Tracer ───────────────────────────────────────────────
+
+/** SpanKind — same five values as OTel. */
+export type SpanKind = "internal" | "server" | "client" | "producer" | "consumer";
+
+/** Options accepted by `Tracer.startSpan`. */
+export interface StartSpanOptions {
+  /** Span kind — defaults to "internal" for in-process work. */
+  kind?: SpanKind;
+  /** Initial attribute bag. */
+  attributes?: SpanAttributes;
+  /** Explicit start time in epoch milliseconds (defaults to now). */
+  startTime?: number;
+}
+
+/**
+ * Tracer — creates spans. Mirrors the subset of `@opentelemetry/api`'s
+ * `Tracer` we plan to use.
+ */
+export interface Tracer {
+  /**
+   * Start a new span. The returned span is "current" only for the
+   * caller's scope — Phase 1 does NOT implement context propagation
+   * (that comes with the OTel adapter). Use the returned `Span` handle
+   * directly and call `end()` when done.
+   */
+  startSpan(name: string, options?: StartSpanOptions): Span;
+}
+
+// ── Noop implementation ──────────────────────────────────
+
+/**
+ * Default no-op span. All mutators return `this` for chainability and
+ * `end()` / `isRecording()` are inert. Allocates one tiny object per
+ * `startSpan()` — acceptable for the seam since callers typically pair
+ * it with a `try { ... } finally { span.end() }` pattern.
+ */
+class NoopSpan implements Span {
+  private ended = false;
+
+  setAttribute(_key: string, _value: SpanAttributeValue): this {
+    return this;
+  }
+  setAttributes(_attrs: SpanAttributes): this {
+    return this;
+  }
+  recordException(_error: Error | string): this {
+    return this;
+  }
+  setStatus(_status: SpanStatus): this {
+    return this;
+  }
+  end(_endTime?: number): void {
+    this.ended = true;
+  }
+  isRecording(): boolean {
+    return !this.ended;
+  }
+}
+
+/**
+ * Default no-op tracer — returns a fresh `NoopSpan` for every call.
+ * Used as the registry default; replaced via `setObservability(...)`
+ * once an OTel adapter is wired in.
+ */
+export class NoopTracer implements Tracer {
+  startSpan(_name: string, _options?: StartSpanOptions): Span {
+    return new NoopSpan();
+  }
+}
+
+/** Singleton instance to avoid per-call allocation of the tracer itself. */
+export const noopTracer: Tracer = new NoopTracer();

--- a/packages/core/src/server-entry.ts
+++ b/packages/core/src/server-entry.ts
@@ -182,6 +182,15 @@ export {
 } from "./observability/alert-engine";
 export { consoleLogger } from "./observability/console-logger";
 export { InMemoryExecutionLogger } from "./observability/execution-logger";
+export type {
+  Counter,
+  Histogram,
+  InstrumentOptions,
+  Meter,
+  MetricAttributes,
+  MetricAttributeValue,
+} from "./observability/meter";
+export { NoopMeter, noopMeter } from "./observability/meter";
 export {
   InMemoryMetricsCollector,
   type MetricSnapshot,
@@ -189,6 +198,12 @@ export {
   type MetricsSummary,
   noopMetricsCollector,
 } from "./observability/metrics";
+export type { Observability } from "./observability/observability-registry";
+export {
+  getObservability,
+  resetObservability,
+  setObservability,
+} from "./observability/observability-registry";
 export {
   createStructuredLogger,
   createTestLogSink,
@@ -203,6 +218,17 @@ export {
   type TraceState,
   withTrace,
 } from "./observability/trace-context";
+export type {
+  Span,
+  SpanAttributes,
+  SpanAttributeValue,
+  SpanKind,
+  SpanStatus,
+  SpanStatusCode,
+  StartSpanOptions,
+  Tracer,
+} from "./observability/tracer";
+export { NoopTracer, noopTracer } from "./observability/tracer";
 
 // === AI service ===
 


### PR DESCRIPTION
## Summary
- Phase 1 of #130 — design + scaffolding for OpenTelemetry integration (Spec 28 M3+). **Adapter implementation in follow-up.**
- Adds `Tracer` / `Span` / `Meter` / `Counter` / `Histogram` interfaces in `@linchkit/core` mirroring `@opentelemetry/api` shape — no `@opentelemetry/*` dependency taken.
- Ships `NoopTracer` + `NoopMeter` + module-level `getObservability()` / `setObservability()` registry. A future `cap-otel` capability plugs in via `setObservability(...)` without touching any call site.
- Wires one demonstration span (`linchkit.command.dispatch`) in `CommandLayer.executeInner` — covers every dispatch. Authoritative status set in the outer wrapper so every early-return failure path is reported correctly.
- Spec 28 §10 documents architecture, naming convention, attribute schema, OTLP env vars, metric set, and Phase 2 deliverables.

## Out of scope (Phase 2)
- Real OTLP exporter (will live in a new `cap-otel` capability)
- Pre-built Grafana / Prometheus dashboard JSON
- Per-slot / per-action / per-event spans (additive, enabled by this seam)
- Auto-instrumentation for Elysia / Drizzle / Restate

## Cross-model review
- codex initial pass found P1 — span status not set on early failure returns; **fixed** by hoisting status set to the outer wrapper based on `result.success`.

## Test plan
- [x] `bun install --force` (clean)
- [x] `bun run check` (no errors)
- [x] `bun run typecheck` (no errors)
- [x] `bun test` — 5029 pass / 3 skip / 0 fail; 9 new tests across `observability-registry.test.ts` + `tracer.noop.test.ts`

Refs #130 (do not close — Phase 1 only; cap-otel adapter is the follow-up).