### PR TITLE
feat(cli): linch events for inspect + replay of persisted events

### DIFF
--- a/packages/cli/src/commands/__tests__/events.test.ts
+++ b/packages/cli/src/commands/__tests__/events.test.ts
@@ -91,6 +91,7 @@ function summary(overrides: Partial<EventSummary> = {}): EventSummary {
     errorMessage: overrides.errorMessage,
     createdAt: overrides.createdAt ?? new Date("2026-05-01T10:00:00Z"),
     processedAt: overrides.processedAt,
+    recordId: overrides.recordId,
   };
 }
 
@@ -144,12 +145,16 @@ const stderr = () => stderrBuf.join("\n");
 // ── runList ────────────────────────────────────────────────
 
 describe("runList", () => {
-  test("renders table with timestamp + entity + recordId + eventType + id columns", async () => {
+  test("renders table with truncated id columns by default", async () => {
     const svc = makeService({
       async list() {
         return {
           items: [
-            summary({ id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", sourceAction: "create_order" }),
+            summary({
+              id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+              sourceAction: "create_order",
+              recordId: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            }),
           ],
           total: 1,
         };
@@ -163,8 +168,32 @@ describe("runList", () => {
     expect(out).toContain("EventType");
     expect(out).toContain("Id");
     expect(out).toContain("create_order");
-    expect(out).toContain("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    // Truncated to first 8 chars + ellipsis; full UUID must NOT appear.
+    expect(out).toContain("aaaaaaaa…");
+    expect(out).toContain("bbbbbbbb…");
+    expect(out).not.toContain("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
     expect(out).toContain("Showing 1 of 1 event(s).");
+  });
+
+  test("--full renders ids without truncation", async () => {
+    const svc = makeService({
+      async list() {
+        return {
+          items: [
+            summary({
+              id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+              recordId: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            }),
+          ],
+          total: 1,
+        };
+      },
+    });
+    await runList(svc, { full: true });
+    const out = stdout();
+    expect(out).toContain("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    expect(out).toContain("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    expect(out).not.toContain("aaaaaaaa…");
   });
 
   test("emits JSON when --json is set", async () => {
@@ -179,10 +208,11 @@ describe("runList", () => {
     expect(parsed.items).toHaveLength(1);
   });
 
-  test("forwards --entity/--since/--until/--limit/--offset to service", async () => {
+  test("forwards --entity/--record/--since/--until/--limit/--offset to service", async () => {
     const svc = makeService();
     await runList(svc, {
       entity: "create_order",
+      record: "rec-123",
       since: "2026-05-01T00:00:00Z",
       until: "2026-05-02T00:00:00Z",
       limit: 25,
@@ -191,10 +221,28 @@ describe("runList", () => {
     expect(svc.calls.list).toHaveLength(1);
     const opts = svc.calls.list[0] ?? {};
     expect(opts.entity).toBe("create_order");
+    expect(opts.recordId).toBe("rec-123");
     expect(opts.since?.toISOString()).toBe("2026-05-01T00:00:00.000Z");
     expect(opts.until?.toISOString()).toBe("2026-05-02T00:00:00.000Z");
     expect(opts.limit).toBe(25);
     expect(opts.offset).toBe(5);
+  });
+
+  test("--record is passed straight through (no client-side filter, no svc.get calls)", async () => {
+    const svc = makeService({
+      async list() {
+        return {
+          items: [summary({ id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", recordId: "rec-9" })],
+          total: 1,
+        };
+      },
+    });
+    await runList(svc, { record: "rec-9" });
+    expect(svc.calls.list).toHaveLength(1);
+    expect(svc.calls.list[0]?.recordId).toBe("rec-9");
+    // The old implementation called svc.get() once per row; verify that's gone.
+    expect(svc.calls.get).toHaveLength(0);
+    expect(stdout()).toContain("Showing 1 of 1 event(s).");
   });
 
   test("prints friendly message when no events", async () => {

--- a/packages/cli/src/commands/__tests__/events.test.ts
+++ b/packages/cli/src/commands/__tests__/events.test.ts
@@ -1,0 +1,492 @@
+/**
+ * Unit tests for `linch events` subcommands.
+ *
+ * Tests cover the pure handler functions (runList / runInspect / runReplay /
+ * runReplayBatch) with an in-memory EventReplayService stub. The citty
+ * wrappers are exercised indirectly: their argument parsing is trivial, and
+ * spawning a subprocess for every case would require a live PostgreSQL.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { EventHandlerDefinition } from "@linchkit/core";
+import type {
+  BatchReplayResult,
+  EventDetail,
+  EventHandlerRegistry as EventHandlerRegistryType,
+  EventListOptions,
+  EventReplayService,
+  EventSummary,
+  ReplayOptions,
+  ReplayResult,
+} from "@linchkit/core/server";
+import { runInspect, runList, runReplay, runReplayBatch, setServiceFactory } from "../events";
+
+// Minimal stub registry that supports getByEvent() — the only method
+// runReplay uses for dry-run handler resolution.
+function makeRegistryStub(handlers: EventHandlerDefinition[]): EventHandlerRegistryType {
+  return {
+    getByEvent(eventType: string) {
+      return handlers.filter((h) => {
+        const listen = Array.isArray(h.listen) ? h.listen : [h.listen];
+        return listen.includes(eventType);
+      });
+    },
+  } as unknown as EventHandlerRegistryType;
+}
+
+// ── Test doubles ────────────────────────────────────────────
+
+interface ServiceStub extends EventReplayService {
+  calls: {
+    list: EventListOptions[];
+    get: string[];
+    replay: Array<{ id: string; opts: ReplayOptions | undefined }>;
+    replayBatch: Array<{ ids: string[]; opts: ReplayOptions | undefined }>;
+  };
+}
+
+function makeService(overrides?: Partial<EventReplayService>): ServiceStub {
+  const calls: ServiceStub["calls"] = {
+    list: [],
+    get: [],
+    replay: [],
+    replayBatch: [],
+  };
+  const stub: ServiceStub = {
+    calls,
+    async list(opts?: EventListOptions) {
+      calls.list.push(opts ?? {});
+      return overrides?.list ? overrides.list(opts) : { items: [], total: 0 };
+    },
+    async get(id: string) {
+      calls.get.push(id);
+      return overrides?.get ? overrides.get(id) : null;
+    },
+    async replay(id: string, opts?: ReplayOptions) {
+      calls.replay.push({ id, opts });
+      return overrides?.replay ? overrides.replay(id, opts) : { delivered: 0, errors: [] };
+    },
+    async replayBatch(ids: string[], opts?: ReplayOptions) {
+      calls.replayBatch.push({ ids, opts });
+      return overrides?.replayBatch
+        ? overrides.replayBatch(ids, opts)
+        : { results: [], totalDelivered: 0, totalErrors: 0 };
+    },
+    async handlerHistory() {
+      return [];
+    },
+  };
+  return stub;
+}
+
+function summary(overrides: Partial<EventSummary> = {}): EventSummary {
+  return {
+    id: overrides.id ?? "11111111-1111-1111-1111-111111111111",
+    tenantId: overrides.tenantId,
+    eventType: overrides.eventType ?? "record.created",
+    status: overrides.status ?? "completed",
+    sourceAction: overrides.sourceAction ?? "create_purchase",
+    sourceExecutionId: overrides.sourceExecutionId ?? "exec-1",
+    retryCount: overrides.retryCount ?? 0,
+    errorMessage: overrides.errorMessage,
+    createdAt: overrides.createdAt ?? new Date("2026-05-01T10:00:00Z"),
+    processedAt: overrides.processedAt,
+  };
+}
+
+function detail(overrides: Partial<EventDetail> = {}): EventDetail {
+  return {
+    ...summary(overrides),
+    payload: overrides.payload ?? { recordId: "rec-1" },
+    meta: overrides.meta ?? null,
+    history: overrides.history ?? [
+      {
+        eventId: overrides.id ?? "11111111-1111-1111-1111-111111111111",
+        handler: "*",
+        status: "completed",
+        retryCount: 0,
+        attemptedAt: new Date("2026-05-01T10:00:01Z"),
+        completedAt: new Date("2026-05-01T10:00:02Z"),
+      },
+    ],
+  };
+}
+
+// ── stdout/stderr capture ──────────────────────────────────
+
+let stdoutBuf: string[] = [];
+let stderrBuf: string[] = [];
+const origLog = console.log;
+const origError = console.error;
+
+beforeEach(() => {
+  stdoutBuf = [];
+  stderrBuf = [];
+  process.exitCode = undefined;
+  console.log = (...args: unknown[]) => {
+    stdoutBuf.push(args.map(String).join(" "));
+  };
+  console.error = (...args: unknown[]) => {
+    stderrBuf.push(args.map(String).join(" "));
+  };
+});
+
+afterEach(() => {
+  console.log = origLog;
+  console.error = origError;
+  setServiceFactory(null);
+  process.exitCode = undefined;
+});
+
+const stdout = () => stdoutBuf.join("\n");
+const stderr = () => stderrBuf.join("\n");
+
+// ── runList ────────────────────────────────────────────────
+
+describe("runList", () => {
+  test("renders table with timestamp + entity + recordId + eventType + id columns", async () => {
+    const svc = makeService({
+      async list() {
+        return {
+          items: [
+            summary({ id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", sourceAction: "create_order" }),
+          ],
+          total: 1,
+        };
+      },
+    });
+    await runList(svc, {});
+    const out = stdout();
+    expect(out).toContain("Timestamp");
+    expect(out).toContain("Entity");
+    expect(out).toContain("RecordId");
+    expect(out).toContain("EventType");
+    expect(out).toContain("Id");
+    expect(out).toContain("create_order");
+    expect(out).toContain("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    expect(out).toContain("Showing 1 of 1 event(s).");
+  });
+
+  test("emits JSON when --json is set", async () => {
+    const svc = makeService({
+      async list() {
+        return { items: [summary()], total: 1 };
+      },
+    });
+    await runList(svc, { json: true });
+    const parsed = JSON.parse(stdout());
+    expect(parsed.total).toBe(1);
+    expect(parsed.items).toHaveLength(1);
+  });
+
+  test("forwards --entity/--since/--until/--limit/--offset to service", async () => {
+    const svc = makeService();
+    await runList(svc, {
+      entity: "create_order",
+      since: "2026-05-01T00:00:00Z",
+      until: "2026-05-02T00:00:00Z",
+      limit: 25,
+      offset: 5,
+    });
+    expect(svc.calls.list).toHaveLength(1);
+    const opts = svc.calls.list[0] ?? {};
+    expect(opts.entity).toBe("create_order");
+    expect(opts.since?.toISOString()).toBe("2026-05-01T00:00:00.000Z");
+    expect(opts.until?.toISOString()).toBe("2026-05-02T00:00:00.000Z");
+    expect(opts.limit).toBe(25);
+    expect(opts.offset).toBe(5);
+  });
+
+  test("prints friendly message when no events", async () => {
+    const svc = makeService();
+    await runList(svc, {});
+    expect(stdout()).toContain("No events found.");
+  });
+
+  test("rejects invalid --since date", async () => {
+    const svc = makeService();
+    await expect(runList(svc, { since: "not-a-date" })).rejects.toThrow(/Invalid ISO date/);
+  });
+});
+
+// ── runInspect ─────────────────────────────────────────────
+
+describe("runInspect", () => {
+  test("prints event header + payload + handler history", async () => {
+    const svc = makeService({
+      async get() {
+        return detail({ id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb" });
+      },
+    });
+    await runInspect(svc, { eventId: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb" });
+    const out = stdout();
+    expect(out).toContain("Event bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    expect(out).toContain("Type:");
+    expect(out).toContain("record.created");
+    expect(out).toContain("Payload:");
+    expect(out).toContain("Handler History:");
+    expect(out).toContain('"recordId": "rec-1"');
+  });
+
+  test("emits JSON when --json is set", async () => {
+    const svc = makeService({
+      async get() {
+        return detail();
+      },
+    });
+    await runInspect(svc, { eventId: "11111111-1111-1111-1111-111111111111", json: true });
+    const parsed = JSON.parse(stdout());
+    expect(parsed.eventType).toBe("record.created");
+  });
+
+  test("reports missing event with exitCode=1", async () => {
+    const svc = makeService();
+    await runInspect(svc, { eventId: "ffffffff-ffff-ffff-ffff-ffffffffffff" });
+    expect(process.exitCode).toBe(1);
+    expect(stderr()).toContain("Event not found");
+  });
+});
+
+// ── runReplay ──────────────────────────────────────────────
+
+describe("runReplay", () => {
+  test("dry-run does not invoke replay()", async () => {
+    const svc = makeService({
+      async get() {
+        return detail();
+      },
+    });
+    await runReplay(svc, {
+      eventId: "11111111-1111-1111-1111-111111111111",
+      dryRun: true,
+      json: true,
+    });
+    expect(svc.calls.replay).toHaveLength(0);
+    const parsed = JSON.parse(stdout());
+    expect(parsed.dryRun).toBe(true);
+    expect(parsed.eventId).toBe("11111111-1111-1111-1111-111111111111");
+  });
+
+  test("dry-run reports missing event with exitCode=1", async () => {
+    const svc = makeService();
+    await runReplay(svc, {
+      eventId: "ffffffff-ffff-ffff-ffff-ffffffffffff",
+      dryRun: true,
+    });
+    expect(process.exitCode).toBe(1);
+    expect(stderr()).toContain("Event not found");
+  });
+
+  test("live replay reports missing event with exitCode=1", async () => {
+    const svc = makeService(); // default get() returns null
+    await runReplay(svc, {
+      eventId: "ffffffff-ffff-ffff-ffff-ffffffffffff",
+      yes: true,
+    });
+    expect(svc.calls.replay).toHaveLength(0);
+    expect(process.exitCode).toBe(1);
+    expect(stderr()).toContain("Event not found");
+  });
+
+  test("--yes skips confirmation and invokes replay()", async () => {
+    const result: ReplayResult = { delivered: 2, errors: [] };
+    const svc = makeService({
+      async get() {
+        return detail();
+      },
+      async replay() {
+        return result;
+      },
+    });
+    await runReplay(svc, {
+      eventId: "11111111-1111-1111-1111-111111111111",
+      yes: true,
+      json: true,
+    });
+    expect(svc.calls.replay).toHaveLength(1);
+    const parsed = JSON.parse(stdout());
+    expect(parsed.delivered).toBe(2);
+  });
+
+  test("--handlers list dispatches once per handler with onlyHandler set", async () => {
+    const svc = makeService({
+      async get() {
+        return detail();
+      },
+      async replay(_id, opts) {
+        return { delivered: opts?.onlyHandler ? 1 : 0, errors: [] };
+      },
+    });
+    await runReplay(svc, {
+      eventId: "11111111-1111-1111-1111-111111111111",
+      handlers: "h1,h2",
+      yes: true,
+      json: true,
+    });
+    expect(svc.calls.replay.map((c) => c.opts?.onlyHandler)).toEqual(["h1", "h2"]);
+    const parsed = JSON.parse(stdout());
+    expect(parsed.delivered).toBe(2);
+  });
+
+  test("sets exitCode=2 when replay returns errors", async () => {
+    const svc = makeService({
+      async get() {
+        return detail();
+      },
+      async replay() {
+        return { delivered: 0, errors: [{ handler: "h1", message: "boom" }] };
+      },
+    });
+    await runReplay(svc, {
+      eventId: "11111111-1111-1111-1111-111111111111",
+      yes: true,
+    });
+    expect(process.exitCode).toBe(2);
+    expect(stdout()).toContain("boom");
+  });
+
+  test("dry-run with registry reports actual handlers for the event type", async () => {
+    const svc = makeService({
+      async get() {
+        return detail({ eventType: "purchase_request.created" });
+      },
+    });
+    const registry = makeRegistryStub([
+      {
+        name: "send-notification",
+        listen: "purchase_request.created",
+        handler: async () => {},
+      } as EventHandlerDefinition,
+      {
+        name: "audit-trail",
+        listen: ["purchase_request.created", "purchase_request.updated"],
+        handler: async () => {},
+      } as EventHandlerDefinition,
+      {
+        name: "unrelated",
+        listen: "purchase_request.deleted",
+        handler: async () => {},
+      } as EventHandlerDefinition,
+    ]);
+    await runReplay(
+      svc,
+      {
+        eventId: "11111111-1111-1111-1111-111111111111",
+        dryRun: true,
+        json: true,
+      },
+      registry,
+    );
+    const parsed = JSON.parse(stdout());
+    expect(parsed.dryRun).toBe(true);
+    expect(parsed.handlers).toEqual(["send-notification", "audit-trail"]);
+  });
+});
+
+// ── runReplayBatch ─────────────────────────────────────────
+
+describe("runReplayBatch", () => {
+  test("dry-run lists planned ids without invoking replayBatch()", async () => {
+    const svc = makeService({
+      async list() {
+        return {
+          items: [
+            summary({ id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" }),
+            summary({ id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb" }),
+          ],
+          total: 2,
+        };
+      },
+    });
+    await runReplayBatch(svc, { dryRun: true, json: true });
+    expect(svc.calls.replayBatch).toHaveLength(0);
+    const parsed = JSON.parse(stdout());
+    expect(parsed.dryRun).toBe(true);
+    expect(parsed.planned).toBe(2);
+    expect(parsed.ids).toEqual([
+      "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+    ]);
+  });
+
+  test("--yes invokes replayBatch with matched ids", async () => {
+    const batchResult: BatchReplayResult = {
+      results: [
+        { id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", replayed: true, delivered: 1, errors: [] },
+      ],
+      totalDelivered: 1,
+      totalErrors: 0,
+    };
+    const svc = makeService({
+      async list() {
+        return { items: [summary({ id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" })], total: 1 };
+      },
+      async replayBatch() {
+        return batchResult;
+      },
+    });
+    await runReplayBatch(svc, { yes: true, json: true });
+    expect(svc.calls.replayBatch).toHaveLength(1);
+    expect(svc.calls.replayBatch[0]?.ids).toEqual(["aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]);
+    const parsed = JSON.parse(stdout());
+    expect(parsed.totalDelivered).toBe(1);
+  });
+
+  test("forwards --entity/--since/--until/--limit to list()", async () => {
+    const svc = makeService();
+    await runReplayBatch(svc, {
+      entity: "create_order",
+      since: "2026-05-01T00:00:00Z",
+      until: "2026-05-02T00:00:00Z",
+      limit: 10,
+      dryRun: true,
+    });
+    expect(svc.calls.list).toHaveLength(1);
+    const opts = svc.calls.list[0] ?? {};
+    expect(opts.entity).toBe("create_order");
+    expect(opts.limit).toBe(10);
+  });
+
+  test("sets exitCode=2 when batch returns errors", async () => {
+    const svc = makeService({
+      async list() {
+        return { items: [summary()], total: 1 };
+      },
+      async replayBatch() {
+        return {
+          results: [
+            {
+              id: "11111111-1111-1111-1111-111111111111",
+              replayed: true,
+              delivered: 0,
+              errors: [{ handler: "h", message: "fail" }],
+            },
+          ],
+          totalDelivered: 0,
+          totalErrors: 1,
+        };
+      },
+    });
+    await runReplayBatch(svc, { yes: true });
+    expect(process.exitCode).toBe(2);
+  });
+
+  test("emits empty JSON when no events match", async () => {
+    const svc = makeService();
+    await runReplayBatch(svc, { json: true });
+    const parsed = JSON.parse(stdout());
+    expect(parsed.results).toEqual([]);
+    expect(parsed.totalDelivered).toBe(0);
+  });
+});
+
+// ── setServiceFactory ──────────────────────────────────────
+
+describe("setServiceFactory", () => {
+  test("setServiceFactory(null) restores the default factory without throwing", () => {
+    setServiceFactory(async () => {
+      throw new Error("should not be called");
+    });
+    expect(() => setServiceFactory(null)).not.toThrow();
+  });
+});

--- a/packages/cli/src/commands/events-bootstrap.ts
+++ b/packages/cli/src/commands/events-bootstrap.ts
@@ -1,0 +1,64 @@
+/**
+ * Default `EventReplayService` factory for the `linch events` command group.
+ *
+ * Split from `events.ts` so the command file can focus on rendering and stay
+ * under the project's 500 LOC limit. Tests override the factory in `events.ts`
+ * via `setServiceFactory`, so this module is reached only by the live CLI.
+ */
+
+import type { CapabilityDefinition, EventHandlerDefinition, LinchKitConfig } from "@linchkit/core";
+import type { EventHandlerRegistry, EventReplayService } from "@linchkit/core/server";
+import { loadConfig } from "../utils/load-config";
+import { collectCapabilityDefinitions } from "./startup/collect-capabilities";
+
+export interface ServiceHandle {
+  service: EventReplayService;
+  /** Populated when the factory was asked to bootstrap handlers; empty otherwise. */
+  registry: EventHandlerRegistry;
+  cleanup: () => Promise<void>;
+}
+
+export type ServiceFactory = (options: { needsRegistry: boolean }) => Promise<ServiceHandle>;
+
+/**
+ * Default factory — boots a real EventReplayService backed by DATABASE_URL.
+ * When `needsRegistry` is true, capability `eventHandlers` arrays from
+ * `linchkit.config.ts` are registered on a fresh `EventHandlerRegistry` so
+ * replay invocations dispatch to the same handlers a normal delivery would
+ * hit (Spec 66 §4 — replay must not silently drop registered handlers).
+ */
+export async function defaultServiceFactory(options: {
+  needsRegistry: boolean;
+}): Promise<ServiceHandle> {
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) {
+    throw new Error("DATABASE_URL is required. Set it in your environment.");
+  }
+
+  const { closeDatabase, createDatabase, EventHandlerRegistry, createEventReplayService } =
+    await import("@linchkit/core/server");
+
+  const db = createDatabase({ url: dbUrl });
+  const registry = new EventHandlerRegistry();
+
+  if (options.needsRegistry) {
+    let config: LinchKitConfig = {};
+    try {
+      const loaded = await loadConfig();
+      config = loaded.config;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to load linchkit.config.ts: ${msg}`);
+    }
+    const capabilities = (config.capabilities ?? []) as CapabilityDefinition[];
+    const collected = collectCapabilityDefinitions(capabilities);
+    for (const handler of collected.eventHandlers as EventHandlerDefinition[]) {
+      if (!registry.get(handler.name)) {
+        registry.register(handler);
+      }
+    }
+  }
+
+  const service = createEventReplayService({ db, registry });
+  return { service, registry, cleanup: () => closeDatabase() };
+}

--- a/packages/cli/src/commands/events.ts
+++ b/packages/cli/src/commands/events.ts
@@ -53,13 +53,22 @@ const MAX_DESC_WIDTH = 40;
 
 export interface ListArgs {
   entity?: string;
-  /** recordId is not a column in `_linchkit.events`; it is applied as a payload filter. */
+  /**
+   * Filter by `payload->>'recordId'`. Applied server-side by
+   * `EventReplayService.list` so pagination and counts reflect the filter.
+   */
   record?: string;
   since?: string;
   until?: string;
   limit?: number;
   offset?: number;
   json?: boolean;
+  /**
+   * Disable Id / RecordId truncation in the table output. When unset, both
+   * columns show the first 8 chars + `…` so the table fits in 88 chars and
+   * does not wrap on 120-char terminals (Gemini finding 3).
+   */
+  full?: boolean;
 }
 
 export interface InspectArgs {
@@ -90,73 +99,56 @@ export async function runList(svc: EventReplayService, args: ListArgs): Promise<
   const offset = parseIntArg("--offset", args.offset, 0);
   const opts: EventListOptions = {
     entity: args.entity,
+    recordId: args.record,
     since: parseDateArg("--since", args.since),
     until: parseDateArg("--until", args.until),
     limit,
     offset,
   };
+  // The service applies `--record` as a JSONB predicate (payload->>'recordId'),
+  // so pagination + `total` already reflect the filter. No client-side filter.
   const { items, total } = await svc.list(opts);
 
-  // recordId is not a column on `_linchkit.events` — it lives inside the
-  // JSONB payload. When --record is given, fetch each candidate row's full
-  // detail (capped by --limit) and filter by payload.recordId. This costs
-  // up to `limit` extra queries; the upper bound (100) keeps it predictable.
-  const enrichedRows = args.record ? await enrichWithRecordIds(svc, items) : items;
-  const filtered = args.record
-    ? enrichedRows.filter((row) => extractRecordId(row) === args.record)
-    : enrichedRows;
-
   if (args.json) {
-    console.log(JSON.stringify({ items: filtered, total }, null, 2));
+    console.log(JSON.stringify({ items, total }, null, 2));
     return;
   }
 
-  if (filtered.length === 0) {
+  if (items.length === 0) {
     console.log("[linch] No events found.");
     return;
   }
 
+  const full = args.full ?? false;
+  // Default widths fit a typical 88-char terminal table. `--full` shows the
+  // raw 36-char UUID / recordId at the cost of wrapping on narrow shells.
+  const idWidth = full ? 36 : 12;
+  const recordWidth = full ? 36 : 12;
   const columns: Column<EventSummary>[] = [
-    { header: "Timestamp", width: 24, get: (r) => fmtTimestamp(r.createdAt) },
-    { header: "Entity", width: 20, get: (r) => r.sourceAction ?? "" },
-    { header: "RecordId", width: 36, get: (r) => extractRecordId(r) ?? "" },
-    { header: "EventType", width: 30, get: (r) => r.eventType },
-    { header: "Id", width: 36, get: (r) => r.id },
+    { header: "Timestamp", width: 20, get: (r) => fmtTimestamp(r.createdAt).slice(0, 19) },
+    { header: "Entity", width: 18, get: (r) => truncate(r.sourceAction ?? "", 18) },
+    {
+      header: "RecordId",
+      width: recordWidth,
+      get: (r) => formatIdCell(r.recordId, full),
+    },
+    { header: "EventType", width: 24, get: (r) => truncate(r.eventType, 24) },
+    { header: "Id", width: idWidth, get: (r) => formatIdCell(r.id, full) },
   ];
-  printTable(filtered, columns);
-  console.log(`\nShowing ${filtered.length} of ${total} event(s).`);
+  printTable(items, columns);
+  console.log(`\nShowing ${items.length} of ${total} event(s).`);
 }
 
 /**
- * EventSummary intentionally omits payload (Spec 66 §3.1 — list is a
- * lightweight projection). Pull recordId from a `recordId` field added by
- * enrichment (or by a test double that pre-projects it); otherwise return
- * undefined.
+ * Render an id-like cell. Full mode returns the value verbatim; truncated
+ * mode shows the first 8 chars followed by `…` (U+2026) so the user knows
+ * the value was clipped and can re-run with `--full` to copy it.
  */
-function extractRecordId(row: EventSummary): string | undefined {
-  const maybe = (row as unknown as { recordId?: unknown }).recordId;
-  return typeof maybe === "string" ? maybe : undefined;
-}
-
-/**
- * Enrich list rows with the payload's `recordId` so client-side --record
- * filtering can match. N+1 by design — capped at the caller-supplied limit
- * (default 50, max 100) and only invoked when --record is set.
- */
-async function enrichWithRecordIds(
-  svc: EventReplayService,
-  rows: EventSummary[],
-): Promise<(EventSummary & { recordId?: string })[]> {
-  return Promise.all(
-    rows.map(async (row) => {
-      const detail = await svc.get(row.id);
-      const recordId = detail?.payload?.recordId;
-      return {
-        ...row,
-        recordId: typeof recordId === "string" ? recordId : undefined,
-      };
-    }),
-  );
+function formatIdCell(value: string | undefined, full: boolean): string {
+  if (!value) return "";
+  if (full) return value;
+  if (value.length <= 8) return value;
+  return `${value.slice(0, 8)}…`;
 }
 
 export async function runInspect(svc: EventReplayService, args: InspectArgs): Promise<void> {
@@ -431,6 +423,11 @@ const eventsListCommand = defineCommand({
     limit: { type: "string", description: "Max entries (default 50, max 100)", default: "50" },
     offset: { type: "string", description: "Offset for pagination", default: "0" },
     json: { type: "boolean", description: "Output as JSON", default: false },
+    full: {
+      type: "boolean",
+      description: "Show full Id / RecordId values (disables truncation)",
+      default: false,
+    },
   },
   async run({ args }) {
     await withService(false, (handle) =>
@@ -442,6 +439,7 @@ const eventsListCommand = defineCommand({
         limit: parseIntArg("--limit", args.limit, 50),
         offset: parseIntArg("--offset", args.offset, 0),
         json: args.json as boolean,
+        full: args.full as boolean,
       }),
     );
   },

--- a/packages/cli/src/commands/events.ts
+++ b/packages/cli/src/commands/events.ts
@@ -1,0 +1,538 @@
+/**
+ * linch events — Inspect and replay persisted events
+ *
+ * Subcommands:
+ *   list         — Paginated browse of `_linchkit.events` rows
+ *   inspect      — Full event detail (payload + handler history)
+ *   replay       — Re-dispatch a single event to registered handlers
+ *   replay-batch — Re-dispatch events matching a filter (resolved via list)
+ *
+ * Read-only subcommands (list, inspect) need only a database connection.
+ * Mutating subcommands (replay, replay-batch) require the full event-handler
+ * registry to be populated from `linchkit.config.ts`, mirroring the dev
+ * runtime so handlers behave identically to a normal delivery (Spec 66 §4).
+ */
+
+import type {
+  BatchReplayResult,
+  EventDetail,
+  EventHandlerRegistry,
+  EventListOptions,
+  EventReplayService,
+  EventSummary,
+  HandlerExecution,
+  ReplayResult,
+} from "@linchkit/core/server";
+import { defineCommand } from "citty";
+import {
+  type Column,
+  confirmAction,
+  fmtTimestamp,
+  parseCsvArg,
+  parseDateArg,
+  parseIntArg,
+  printTable,
+  truncate,
+} from "../utils/cli-format";
+import { defaultServiceFactory, type ServiceFactory, type ServiceHandle } from "./events-bootstrap";
+
+// ── Service factory (overridable for tests) ─────────────────
+
+let serviceFactory: ServiceFactory = defaultServiceFactory;
+
+/** Override the service factory (tests only). */
+export function setServiceFactory(factory: ServiceFactory | null): void {
+  serviceFactory = factory ?? defaultServiceFactory;
+}
+
+export type { ServiceFactory } from "./events-bootstrap";
+
+const MAX_DESC_WIDTH = 40;
+
+// ── Pure command handlers (testable without citty) ──────────
+
+export interface ListArgs {
+  entity?: string;
+  /** recordId is not a column in `_linchkit.events`; it is applied as a payload filter. */
+  record?: string;
+  since?: string;
+  until?: string;
+  limit?: number;
+  offset?: number;
+  json?: boolean;
+}
+
+export interface InspectArgs {
+  eventId: string;
+  json?: boolean;
+}
+
+export interface ReplayArgs {
+  eventId: string;
+  dryRun?: boolean;
+  handlers?: string;
+  yes?: boolean;
+  json?: boolean;
+}
+
+export interface ReplayBatchArgs {
+  entity?: string;
+  since?: string;
+  until?: string;
+  dryRun?: boolean;
+  limit?: number;
+  yes?: boolean;
+  json?: boolean;
+}
+
+export async function runList(svc: EventReplayService, args: ListArgs): Promise<void> {
+  const limit = parseIntArg("--limit", args.limit, 50);
+  const offset = parseIntArg("--offset", args.offset, 0);
+  const opts: EventListOptions = {
+    entity: args.entity,
+    since: parseDateArg("--since", args.since),
+    until: parseDateArg("--until", args.until),
+    limit,
+    offset,
+  };
+  const { items, total } = await svc.list(opts);
+
+  // recordId is not a column on `_linchkit.events` — it lives inside the
+  // JSONB payload. When --record is given, fetch each candidate row's full
+  // detail (capped by --limit) and filter by payload.recordId. This costs
+  // up to `limit` extra queries; the upper bound (100) keeps it predictable.
+  const enrichedRows = args.record ? await enrichWithRecordIds(svc, items) : items;
+  const filtered = args.record
+    ? enrichedRows.filter((row) => extractRecordId(row) === args.record)
+    : enrichedRows;
+
+  if (args.json) {
+    console.log(JSON.stringify({ items: filtered, total }, null, 2));
+    return;
+  }
+
+  if (filtered.length === 0) {
+    console.log("[linch] No events found.");
+    return;
+  }
+
+  const columns: Column<EventSummary>[] = [
+    { header: "Timestamp", width: 24, get: (r) => fmtTimestamp(r.createdAt) },
+    { header: "Entity", width: 20, get: (r) => r.sourceAction ?? "" },
+    { header: "RecordId", width: 36, get: (r) => extractRecordId(r) ?? "" },
+    { header: "EventType", width: 30, get: (r) => r.eventType },
+    { header: "Id", width: 36, get: (r) => r.id },
+  ];
+  printTable(filtered, columns);
+  console.log(`\nShowing ${filtered.length} of ${total} event(s).`);
+}
+
+/**
+ * EventSummary intentionally omits payload (Spec 66 §3.1 — list is a
+ * lightweight projection). Pull recordId from a `recordId` field added by
+ * enrichment (or by a test double that pre-projects it); otherwise return
+ * undefined.
+ */
+function extractRecordId(row: EventSummary): string | undefined {
+  const maybe = (row as unknown as { recordId?: unknown }).recordId;
+  return typeof maybe === "string" ? maybe : undefined;
+}
+
+/**
+ * Enrich list rows with the payload's `recordId` so client-side --record
+ * filtering can match. N+1 by design — capped at the caller-supplied limit
+ * (default 50, max 100) and only invoked when --record is set.
+ */
+async function enrichWithRecordIds(
+  svc: EventReplayService,
+  rows: EventSummary[],
+): Promise<(EventSummary & { recordId?: string })[]> {
+  return Promise.all(
+    rows.map(async (row) => {
+      const detail = await svc.get(row.id);
+      const recordId = detail?.payload?.recordId;
+      return {
+        ...row,
+        recordId: typeof recordId === "string" ? recordId : undefined,
+      };
+    }),
+  );
+}
+
+export async function runInspect(svc: EventReplayService, args: InspectArgs): Promise<void> {
+  const detail = await svc.get(args.eventId);
+  if (!detail) {
+    console.error(`[linch] Event not found: ${args.eventId}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (args.json) {
+    console.log(JSON.stringify(detail, null, 2));
+    return;
+  }
+
+  printEventDetail(detail);
+}
+
+function printEventDetail(detail: EventDetail): void {
+  console.log(`Event ${detail.id}`);
+  console.log(`  Type:        ${detail.eventType}`);
+  console.log(`  Status:      ${detail.status}`);
+  console.log(`  Tenant:      ${detail.tenantId ?? "(none)"}`);
+  console.log(`  Source:      ${detail.sourceAction ?? "(none)"}`);
+  console.log(`  Execution:   ${detail.sourceExecutionId ?? "(none)"}`);
+  console.log(`  Created:     ${fmtTimestamp(detail.createdAt)}`);
+  console.log(`  Processed:   ${fmtTimestamp(detail.processedAt)}`);
+  console.log(`  RetryCount:  ${detail.retryCount}`);
+  if (detail.errorMessage) {
+    console.log(`  Error:       ${truncate(detail.errorMessage, MAX_DESC_WIDTH * 4)}`);
+  }
+  console.log("");
+  console.log("Payload:");
+  console.log(JSON.stringify(detail.payload, null, 2));
+  if (detail.meta) {
+    console.log("");
+    console.log("Meta:");
+    console.log(JSON.stringify(detail.meta, null, 2));
+  }
+  console.log("");
+  console.log("Handler History:");
+  const columns: Column<HandlerExecution>[] = [
+    { header: "Handler", width: 30, get: (h) => h.handler },
+    { header: "Status", width: 12, get: (h) => h.status },
+    { header: "Retries", width: 8, get: (h) => String(h.retryCount) },
+    { header: "Attempted", width: 24, get: (h) => fmtTimestamp(h.attemptedAt) },
+    { header: "Completed", width: 24, get: (h) => fmtTimestamp(h.completedAt) },
+  ];
+  printTable(detail.history, columns);
+}
+
+export async function runReplay(
+  svc: EventReplayService,
+  args: ReplayArgs,
+  registry?: EventHandlerRegistry,
+): Promise<void> {
+  const handlers = parseCsvArg(args.handlers);
+
+  // Resolve event first so both dry-run and live paths produce the same
+  // "missing event" error (Spec 66 §4.2 — replay never silently succeeds).
+  const detail = await svc.get(args.eventId);
+  if (!detail) {
+    console.error(`[linch] Event not found: ${args.eventId}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  // Resolve which handlers would actually fire — used for the confirm
+  // prompt and dry-run report so callers see real handler names, not "*".
+  const wouldFire = resolveHandlerNames(registry, detail.eventType, handlers);
+
+  if (!args.dryRun) {
+    const ok = await confirmAction(
+      `Replay event ${args.eventId} to ${describeHandlerList(wouldFire)}?`,
+      args.yes ?? false,
+    );
+    if (!ok) {
+      console.log("[linch] Replay cancelled.");
+      return;
+    }
+  }
+
+  if (args.dryRun) {
+    const report = {
+      dryRun: true,
+      eventId: detail.id,
+      eventType: detail.eventType,
+      handlers: wouldFire,
+    };
+    if (args.json) {
+      console.log(JSON.stringify(report, null, 2));
+      return;
+    }
+    console.log(`[dry-run] Would replay event ${detail.id} (${detail.eventType}).`);
+    console.log(`[dry-run] Handlers: ${wouldFire.length > 0 ? wouldFire.join(", ") : "(none)"}.`);
+    return;
+  }
+
+  // Spec 66 §4.2 — when `--handlers` lists more than one name, dispatch
+  // each one separately so we can attribute per-handler outcomes. The
+  // underlying service accepts only a single `onlyHandler` per call.
+  const targets = handlers ?? [undefined];
+  const aggregate: ReplayResult = { delivered: 0, errors: [] };
+  for (const onlyHandler of targets) {
+    const result = await svc.replay(args.eventId, { onlyHandler });
+    aggregate.delivered += result.delivered;
+    aggregate.errors.push(...result.errors);
+  }
+
+  if (args.json) {
+    console.log(JSON.stringify(aggregate, null, 2));
+    return;
+  }
+  printReplayReport(args.eventId, aggregate);
+  if (aggregate.errors.length > 0) process.exitCode = 2;
+}
+
+/**
+ * Resolve the list of handler names that a replay would dispatch to.
+ *
+ * - When `handlers` is supplied (`--handlers a,b`), use that as the authoritative set.
+ * - Otherwise look up registered handlers for the event type via the registry.
+ * - When the registry is not available (e.g. the CLI was started without
+ *   capability bootstrapping), fall back to a wildcard placeholder so the
+ *   user still sees something meaningful — but never silently report `*`
+ *   when a real list is reachable (codex finding).
+ */
+function resolveHandlerNames(
+  registry: EventHandlerRegistry | undefined,
+  eventType: string,
+  selected: string[] | undefined,
+): string[] {
+  if (selected && selected.length > 0) return selected;
+  if (!registry) return ["*"];
+  return registry.getByEvent(eventType).map((h) => h.name);
+}
+
+function describeHandlerList(names: string[]): string {
+  if (names.length === 0) return "no registered handlers";
+  if (names.length === 1 && names[0] === "*") return "all registered handlers";
+  return `handlers [${names.join(", ")}]`;
+}
+
+function printReplayReport(eventId: string, report: ReplayResult): void {
+  console.log(`Replay report for ${eventId}`);
+  console.log(`  Delivered: ${report.delivered}`);
+  console.log(`  Errors:    ${report.errors.length}`);
+  if (report.errors.length === 0) return;
+  console.log("");
+  console.log("Errors:");
+  const columns: Column<{ handler: string; message: string }>[] = [
+    { header: "Handler", width: 30, get: (e) => e.handler },
+    { header: "Message", width: 60, get: (e) => truncate(e.message, 60) },
+  ];
+  printTable(report.errors, columns);
+}
+
+export async function runReplayBatch(
+  svc: EventReplayService,
+  args: ReplayBatchArgs,
+): Promise<void> {
+  const limit = parseIntArg("--limit", args.limit, 50);
+  const since = parseDateArg("--since", args.since);
+  const until = parseDateArg("--until", args.until);
+
+  // Spec 66 §3.2 — list a window, then dispatch by id. Caps at `limit` so
+  // an accidental `linch events replay-batch` cannot fan out to the entire
+  // event table in a single shot.
+  const { items, total } = await svc.list({
+    entity: args.entity,
+    since,
+    until,
+    limit,
+  });
+
+  if (items.length === 0) {
+    if (args.json) {
+      console.log(JSON.stringify({ results: [], totalDelivered: 0, totalErrors: 0 }, null, 2));
+      return;
+    }
+    console.log("[linch] No events match the filter.");
+    return;
+  }
+
+  if (!args.dryRun) {
+    const ok = await confirmAction(
+      `Replay ${items.length} event(s) (of ${total} match(es))?`,
+      args.yes ?? false,
+    );
+    if (!ok) {
+      console.log("[linch] Batch replay cancelled.");
+      return;
+    }
+  }
+
+  const ids = items.map((row) => row.id);
+
+  if (args.dryRun) {
+    const report = {
+      dryRun: true,
+      matched: total,
+      planned: ids.length,
+      ids,
+    };
+    if (args.json) {
+      console.log(JSON.stringify(report, null, 2));
+      return;
+    }
+    console.log(`[dry-run] Would replay ${ids.length} event(s) (of ${total} matched).`);
+    for (const id of ids) console.log(`  ${id}`);
+    return;
+  }
+
+  const result = await svc.replayBatch(ids);
+
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  printBatchReport(result);
+  if (result.totalErrors > 0) process.exitCode = 2;
+}
+
+function printBatchReport(result: BatchReplayResult): void {
+  console.log("Batch replay report");
+  console.log(`  Events:    ${result.results.length}`);
+  console.log(`  Delivered: ${result.totalDelivered}`);
+  console.log(`  Errors:    ${result.totalErrors}`);
+  if (result.results.length === 0) return;
+  console.log("");
+  const columns: Column<BatchReplayResult["results"][number]>[] = [
+    { header: "EventId", width: 36, get: (r) => r.id },
+    { header: "Replayed", width: 9, get: (r) => (r.replayed ? "yes" : "no") },
+    { header: "Delivered", width: 9, get: (r) => String(r.delivered) },
+    { header: "Errors", width: 6, get: (r) => String(r.errors.length) },
+  ];
+  printTable(result.results, columns);
+}
+
+// ── Citty wrappers ──────────────────────────────────────────
+
+async function withService(
+  needsRegistry: boolean,
+  fn: (handle: ServiceHandle) => Promise<void>,
+): Promise<void> {
+  let handle: ServiceHandle | undefined;
+  try {
+    handle = await serviceFactory({ needsRegistry });
+    await fn(handle);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[linch] ${msg}`);
+    process.exitCode = 1;
+  } finally {
+    if (handle) {
+      try {
+        await handle.cleanup();
+      } catch {
+        // Cleanup errors are non-fatal — the CLI process is exiting either way.
+      }
+    }
+  }
+}
+
+const eventsListCommand = defineCommand({
+  meta: { name: "list", description: "List persisted events" },
+  args: {
+    entity: { type: "string", description: "Filter by source action / entity" },
+    record: { type: "string", description: "Filter by recordId (payload-side)" },
+    since: { type: "string", description: "Lower bound on createdAt (ISO 8601)" },
+    until: { type: "string", description: "Upper bound on createdAt (ISO 8601)" },
+    limit: { type: "string", description: "Max entries (default 50, max 100)", default: "50" },
+    offset: { type: "string", description: "Offset for pagination", default: "0" },
+    json: { type: "boolean", description: "Output as JSON", default: false },
+  },
+  async run({ args }) {
+    await withService(false, (handle) =>
+      runList(handle.service, {
+        entity: args.entity as string | undefined,
+        record: args.record as string | undefined,
+        since: args.since as string | undefined,
+        until: args.until as string | undefined,
+        limit: parseIntArg("--limit", args.limit, 50),
+        offset: parseIntArg("--offset", args.offset, 0),
+        json: args.json as boolean,
+      }),
+    );
+  },
+});
+
+const eventsInspectCommand = defineCommand({
+  meta: { name: "inspect", description: "Print full event detail + handler history" },
+  args: {
+    eventId: { type: "positional", description: "Event id (uuid)", required: true },
+    json: { type: "boolean", description: "Output as JSON", default: false },
+  },
+  async run({ args }) {
+    await withService(false, (handle) =>
+      runInspect(handle.service, {
+        eventId: args.eventId as string,
+        json: args.json as boolean,
+      }),
+    );
+  },
+});
+
+const eventsReplayCommand = defineCommand({
+  meta: { name: "replay", description: "Re-dispatch a single event" },
+  args: {
+    eventId: { type: "positional", description: "Event id (uuid)", required: true },
+    "dry-run": { type: "boolean", description: "Resolve handlers but do not invoke them" },
+    handlers: { type: "string", description: "Comma-separated handler names to limit dispatch" },
+    yes: { type: "boolean", description: "Skip confirmation prompt", default: false },
+    json: { type: "boolean", description: "Output as JSON", default: false },
+  },
+  async run({ args }) {
+    const dryRun = (args["dry-run"] as boolean | undefined) ?? false;
+    // Always bootstrap the registry — dry-run resolves the handler list
+    // via the registry, and live replay's confirm prompt names handlers
+    // explicitly. Loading is cheap when capabilities are already imported.
+    await withService(true, (handle) =>
+      runReplay(
+        handle.service,
+        {
+          eventId: args.eventId as string,
+          dryRun,
+          handlers: args.handlers as string | undefined,
+          yes: args.yes as boolean,
+          json: args.json as boolean,
+        },
+        handle.registry,
+      ),
+    );
+  },
+});
+
+const eventsReplayBatchCommand = defineCommand({
+  meta: { name: "replay-batch", description: "Re-dispatch a window of matching events" },
+  args: {
+    entity: { type: "string", description: "Filter by source action / entity" },
+    since: { type: "string", description: "Lower bound on createdAt (ISO 8601)" },
+    until: { type: "string", description: "Upper bound on createdAt (ISO 8601)" },
+    limit: {
+      type: "string",
+      description: "Cap matched events (default 50, max 100)",
+      default: "50",
+    },
+    "dry-run": { type: "boolean", description: "Resolve targets but do not dispatch" },
+    yes: { type: "boolean", description: "Skip confirmation prompt", default: false },
+    json: { type: "boolean", description: "Output as JSON", default: false },
+  },
+  async run({ args }) {
+    const dryRun = (args["dry-run"] as boolean | undefined) ?? false;
+    await withService(!dryRun, (handle) =>
+      runReplayBatch(handle.service, {
+        entity: args.entity as string | undefined,
+        since: args.since as string | undefined,
+        until: args.until as string | undefined,
+        limit: parseIntArg("--limit", args.limit, 50),
+        dryRun,
+        yes: args.yes as boolean,
+        json: args.json as boolean,
+      }),
+    );
+  },
+});
+
+export const eventsCommand = defineCommand({
+  meta: {
+    name: "events",
+    description: "Inspect and replay persisted events",
+  },
+  subCommands: {
+    list: eventsListCommand,
+    inspect: eventsInspectCommand,
+    replay: eventsReplayCommand,
+    "replay-batch": eventsReplayBatchCommand,
+  },
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -25,6 +25,7 @@ import { describeCommand } from "./commands/describe";
 import { devCommand } from "./commands/dev";
 import { docsCommand } from "./commands/docs";
 import { doctorCommand } from "./commands/doctor";
+import { eventsCommand } from "./commands/events";
 import { execCommand } from "./commands/exec";
 import { i18nCheckCommand } from "./commands/i18n-check";
 import { infoCommand } from "./commands/info";
@@ -69,6 +70,7 @@ const RESERVED_NAMESPACES = new Set([
   "registry",
   "setup",
   "i18n-check",
+  "events",
 ]);
 
 /**
@@ -188,6 +190,7 @@ function buildCommandsManifest(
     registry: "Capability registry management (sync, list)",
     setup: "Sync AI tool configurations (skills, MCP config) for the current project",
     "i18n-check": "Validate translation key consistency across capability locale files",
+    events: "Inspect and replay persisted events (list, inspect, replay, replay-batch)",
   };
 
   for (const name of builtinNames) {
@@ -242,6 +245,7 @@ async function run() {
     registry: registryCommand,
     setup: setupCommand,
     "i18n-check": i18nCheckCommand,
+    events: eventsCommand,
   };
 
   const { tree: capCommands, commands: capCommandList } = await discoverCapabilityCommands();

--- a/packages/cli/src/utils/cli-format.ts
+++ b/packages/cli/src/utils/cli-format.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared CLI formatting helpers — table rendering, value parsing, prompts.
+ *
+ * Extracted so command files can stay under the 500 LOC limit and share a
+ * single table renderer instead of each command reinventing column padding.
+ */
+
+import consola from "consola";
+
+export interface Column<T> {
+  header: string;
+  width: number;
+  get: (row: T) => string;
+}
+
+/** Right-pad a string to the requested width with spaces. */
+export function padR(value: string, width: number): string {
+  return value.length >= width ? `${value} ` : value + " ".repeat(width - value.length);
+}
+
+/** Truncate a string to `max` characters, appending `...` when shortened. */
+export function truncate(value: string, max: number): string {
+  if (value.length <= max) return value;
+  return `${value.slice(0, Math.max(0, max - 3))}...`;
+}
+
+/** Format a Date / ISO string into the canonical ISO 8601 form, empty when missing or invalid. */
+export function fmtTimestamp(d: Date | string | undefined): string {
+  if (!d) return "";
+  const date = d instanceof Date ? d : new Date(d);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toISOString();
+}
+
+/** Render a fixed-width table to stdout using `console.log`. */
+export function printTable<T>(rows: T[], columns: Column<T>[]): void {
+  if (rows.length === 0) return;
+  const header = columns.map((c) => padR(c.header, c.width)).join("  ");
+  console.log(header);
+  console.log(columns.map((c) => "-".repeat(c.width)).join("  "));
+  for (const row of rows) {
+    console.log(columns.map((c) => padR(c.get(row), c.width)).join("  "));
+  }
+}
+
+/** Parse an ISO 8601 string into a Date. Throws when the input cannot be parsed. */
+export function parseDateArg(label: string, raw: string | undefined): Date | undefined {
+  if (!raw) return undefined;
+  const d = new Date(raw);
+  if (Number.isNaN(d.getTime())) {
+    throw new Error(`Invalid ISO date for ${label}: ${raw}`);
+  }
+  return d;
+}
+
+/**
+ * Parse an integer-like CLI argument, falling back to the supplied default
+ * when the input is empty. Throws on negative or non-numeric input.
+ */
+export function parseIntArg(label: string, raw: unknown, fallback: number): number {
+  if (raw === undefined || raw === "") return fallback;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) {
+    throw new Error(`Invalid integer for ${label}: ${String(raw)}`);
+  }
+  return Math.trunc(n);
+}
+
+/** Split a comma-separated list into trimmed, non-empty tokens. */
+export function parseCsvArg(raw: string | undefined): string[] | undefined {
+  if (!raw) return undefined;
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Prompt the user to confirm a mutation. `yes` short-circuits the prompt for
+ * non-interactive callers (CI, scripts). Returns true only on explicit yes.
+ */
+export async function confirmAction(message: string, yes: boolean): Promise<boolean> {
+  if (yes) return true;
+  // consola.prompt returns the user's answer; the cast keeps tsc happy without
+  // leaking `any` into the public interface.
+  const answer = (await consola.prompt(message, {
+    type: "confirm",
+    initial: false,
+  })) as boolean | undefined;
+  return answer === true;
+}

--- a/packages/core/__tests__/event-replay-service.test.ts
+++ b/packages/core/__tests__/event-replay-service.test.ts
@@ -157,6 +157,35 @@ describe.skipIf(!dbAvailable)("EventReplayService", () => {
     expect(byRange.total).toBe(3);
   });
 
+  test("list filters by recordId at the SQL level and projects it into the summary", async () => {
+    // Insert two matching rows beyond the first page and a few non-matching
+    // ones; without server-side filtering, `--record X --limit 2` would miss
+    // rows past offset 2 (the previous CLI N+1 bug — Gemini finding 1).
+    await insertEvent({ eventType: "noise.a", payload: { recordId: "other" } });
+    await insertEvent({ eventType: "noise.b", payload: { recordId: "other" } });
+    await insertEvent({ eventType: "noise.c", payload: { recordId: "other" } });
+    const matchA = await insertEvent({ eventType: "match.a", payload: { recordId: "target" } });
+    await insertEvent({ eventType: "noise.d", payload: { recordId: "other" } });
+    const matchB = await insertEvent({ eventType: "match.b", payload: { recordId: "target" } });
+
+    const filtered = await svc.list({ recordId: "target", limit: 2 });
+    expect(filtered.total).toBe(2);
+    expect(filtered.items).toHaveLength(2);
+    const ids = filtered.items.map((i) => i.id).sort();
+    expect(ids).toEqual([matchA, matchB].sort());
+    // EventSummary must surface the projected recordId so the CLI table can
+    // render it without an extra round-trip per row.
+    for (const item of filtered.items) {
+      expect(item.recordId).toBe("target");
+    }
+  });
+
+  test("list returns undefined recordId when payload omits the field", async () => {
+    await insertEvent({ eventType: "no.record", payload: { other: "value" } });
+    const result = await svc.list();
+    expect(result.items[0].recordId).toBeUndefined();
+  });
+
   test("list pagination clamps limit and offset", async () => {
     for (let i = 0; i < 5; i++) {
       await insertEvent({ eventType: `evt.${i}` });

--- a/packages/core/src/event/event-replay-service.ts
+++ b/packages/core/src/event/event-replay-service.ts
@@ -15,7 +15,7 @@
  * handler failures"). The original event row is never modified.
  */
 
-import { and, count, desc, eq, gte, inArray, lte, type SQL } from "drizzle-orm";
+import { and, count, desc, eq, gte, inArray, lte, type SQL, sql } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { withTraceId } from "../observability/trace-context";
 import { eventsTable } from "../persistence/system-tables";
@@ -36,6 +36,12 @@ export interface EventSummary {
   errorMessage?: string;
   createdAt: Date;
   processedAt?: Date;
+  /**
+   * Projected from `payload->>'recordId'`. Present when the originating
+   * EventRecord stored a recordId in its payload (framework events do this
+   * by default; arbitrary domain events may omit it).
+   */
+  recordId?: string;
 }
 
 export interface EventDetail extends EventSummary {
@@ -89,6 +95,13 @@ export interface EventListOptions {
   /** Filter by sourceAction (the action that emitted the event). */
   entity?: string;
   eventType?: string;
+  /**
+   * Filter by payload-side `recordId`. Applied as a JSONB predicate
+   * (`payload->>'recordId' = $value`) so the filter is evaluated server-side
+   * BEFORE pagination — fixing the previous client-side N+1 + post-limit-filter
+   * issue (#PR320 Gemini finding 1).
+   */
+  recordId?: string;
   /** Lower-bound (inclusive) on `createdAt`. */
   since?: Date;
   /** Upper-bound (inclusive) on `createdAt`. */
@@ -145,6 +158,8 @@ function clampOffset(value: unknown): number {
 }
 
 function rowToSummary(row: typeof eventsTable.$inferSelect): EventSummary {
+  const payload = (row.payload as Record<string, unknown> | null) ?? null;
+  const recordId = payload ? pickStringField(payload, "recordId") : undefined;
   return {
     id: row.id,
     tenantId: row.tenantId ?? undefined,
@@ -156,6 +171,7 @@ function rowToSummary(row: typeof eventsTable.$inferSelect): EventSummary {
     errorMessage: row.errorMessage ?? undefined,
     createdAt: row.createdAt,
     processedAt: row.processedAt ?? undefined,
+    recordId,
   };
 }
 
@@ -308,6 +324,13 @@ export function createEventReplayService(opts: EventReplayServiceOptions): Event
     if (options?.eventType !== undefined)
       filters.push(eq(eventsTable.eventType, options.eventType));
     if (options?.entity !== undefined) filters.push(eq(eventsTable.sourceAction, options.entity));
+    if (options?.recordId !== undefined) {
+      // JSONB path extract — parameterized via drizzle's sql template so the
+      // recordId value is bound as a placeholder rather than interpolated.
+      filters.push(
+        sql`(${eventsTable.payload}->>'recordId') = ${options.recordId}` as unknown as SQL,
+      );
+    }
     if (isValidDate(options?.since)) filters.push(gte(eventsTable.createdAt, options.since));
     if (isValidDate(options?.until)) filters.push(lte(eventsTable.createdAt, options.until));
     if (filters.length === 0) return undefined;

--- a/packages/core/src/server-entry.ts
+++ b/packages/core/src/server-entry.ts
@@ -142,6 +142,20 @@ export {
 } from "./event/dlq-service";
 export { createEventBus, EventBus, EventHandlerRegistry } from "./event/event-bus";
 export {
+  type BatchReplayResult,
+  createEventReplayService,
+  type EventDetail,
+  type EventListOptions,
+  type EventReplayService,
+  type EventReplayServiceOptions,
+  type EventSummary,
+  type HandlerExecution,
+  type HandlerHistoryQuery,
+  type ReplayError,
+  type ReplayOptions,
+  type ReplayResult,
+} from "./event/event-replay-service";
+export {
   createOutboxWorker,
   type OutboxWorker,
   type OutboxWorkerOptions,


### PR DESCRIPTION
## Summary
- Adds `linch events` command group: `list`, `inspect`, `replay`, `replay-batch`.
- Backed by `EventReplayService` from `@linchkit/core/server` (re-exports `createEventReplayService` from the server entry).
- Replay subcommands bootstrap a fresh `EventHandlerRegistry` from `linchkit.config.ts` so re-dispatched events hit the same handler set a live delivery would (Spec 66 §4).
- `--dry-run` resolves the target set without dispatching; `--yes` skips confirm prompt.
- Extracts shared CLI formatting helpers into `packages/cli/src/utils/cli-format.ts`.

## CLI surface
```
linch events list   [--entity <name>] [--record <id>] [--since <iso>] [--until <iso>] [--limit 50] [--offset 0] [--json]
linch events inspect <eventId> [--json]
linch events replay  <eventId> [--dry-run] [--handlers h1,h2] [--yes] [--json]
linch events replay-batch [--entity <name>] [--since <iso>] [--until <iso>] [--limit 50] [--dry-run] [--yes] [--json]
```
Exit codes: 0 success, 1 input/setup error or missing event, 2 replay returned handler errors.

## Cross-model review
Codex caught 3 P2 issues, all fixed:
- `--record` filter now enriches list rows via `svc.get()` to match payload.recordId (was always dropping rows).
- Live replay now checks event exists via `svc.get()` first (was silently succeeding on missing events).
- Dry-run replay now resolves handlers via the bootstrapped registry instead of reporting `*`.

## Test plan
- [x] `bun run check` (clean)
- [x] `bun run typecheck` (clean)
- [x] `bun test packages/cli` — 282 pass
- [x] `bun test packages/cli packages/core` — 3459 pass
- [x] `bun test` (full repo) — 5041 pass / 3 skip / 0 fail