### PR TITLE
feat(adapter-server): wire EventReplayService into GraphQL (closes #321)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/graphql-events.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/graphql-events.test.ts
@@ -1,0 +1,449 @@
+/**
+ * GraphQL events surface — exercises the three operations registered by
+ * `buildEventsGraphQLExtension` end-to-end through a real GraphQL schema:
+ *
+ *   - `eventList`
+ *   - `eventHandlerHistory`
+ *   - `eventReplay`
+ *
+ * The tests stub `EventReplayService` so the surface can be validated
+ * without a running PostgreSQL — the resolvers' contract with the service
+ * is documented by these expectations.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import type {
+  EventDetail,
+  EventListOptions,
+  EventReplayService,
+  HandlerExecution,
+  HandlerHistoryQuery,
+  ReplayOptions,
+  ReplayResult,
+} from "@linchkit/core";
+import { GraphQLNonNull, GraphQLObjectType, GraphQLSchema, GraphQLString, graphql } from "graphql";
+import { buildEventsGraphQLExtension } from "../src/graphql/events";
+
+// ── Stub service helpers ────────────────────────────────────
+
+interface StubServiceOptions {
+  listImpl?: EventReplayService["list"];
+  getImpl?: EventReplayService["get"];
+  replayImpl?: EventReplayService["replay"];
+  handlerHistoryImpl?: EventReplayService["handlerHistory"];
+}
+
+function createStubService(opts: StubServiceOptions = {}): EventReplayService {
+  return {
+    list: opts.listImpl ?? (async (_o?: EventListOptions) => ({ items: [], total: 0 })),
+    get: opts.getImpl ?? (async (_id: string): Promise<EventDetail | null> => null),
+    replay:
+      opts.replayImpl ??
+      (async (_id: string, _o?: ReplayOptions): Promise<ReplayResult> => ({
+        delivered: 0,
+        errors: [],
+      })),
+    replayBatch: async () => ({ results: [], totalDelivered: 0, totalErrors: 0 }),
+    handlerHistory:
+      opts.handlerHistoryImpl ??
+      (async (_q: HandlerHistoryQuery): Promise<HandlerExecution[]> => []),
+  };
+}
+
+function buildSchema(service: EventReplayService): GraphQLSchema {
+  const ext = buildEventsGraphQLExtension({ service });
+  return new GraphQLSchema({
+    query: new GraphQLObjectType({
+      name: "Query",
+      fields: {
+        ping: { type: new GraphQLNonNull(GraphQLString), resolve: () => "pong" },
+        ...ext.queryFields,
+      },
+    }),
+    mutation: new GraphQLObjectType({
+      name: "Mutation",
+      fields: { ...ext.mutationFields },
+    }),
+  });
+}
+
+// Admin actor used by every test except the explicit forbidden case.
+const ADMIN_CTX = {
+  actor: { id: "u-admin", type: "human", groups: ["admin"] },
+  tenantId: "t1",
+};
+
+// ── eventList ──────────────────────────────────────────────
+
+describe("graphql events / eventList", () => {
+  test("projects EventSummary rows to the wire shape and respects pagination", async () => {
+    const listImpl = mock(async (_opts?: EventListOptions) => ({
+      items: [
+        {
+          id: "11111111-1111-1111-1111-111111111111",
+          tenantId: "t1",
+          eventType: "order.created",
+          status: "completed" as const,
+          sourceAction: "create_order",
+          sourceExecutionId: "exec-1",
+          retryCount: 0,
+          errorMessage: undefined,
+          createdAt: new Date("2026-05-16T08:30:00Z"),
+          processedAt: new Date("2026-05-16T08:30:01Z"),
+        },
+      ],
+      total: 42,
+    }));
+    const schema = buildSchema(createStubService({ listImpl }));
+    const result = await graphql({
+      schema,
+      source: `
+        query {
+          eventList(limit: 5, offset: 10) {
+            total
+            events {
+              id tenantId eventType status
+              sourceAction sourceExecutionId
+              retryCount errorMessage
+              createdAt processedAt
+            }
+          }
+        }
+      `,
+      contextValue: ADMIN_CTX,
+    });
+
+    expect(result.errors).toBeUndefined();
+    const data = result.data?.eventList as {
+      total: number;
+      events: Array<{
+        id: string;
+        tenantId: string | null;
+        eventType: string;
+        status: string;
+        sourceAction: string | null;
+        sourceExecutionId: string | null;
+        retryCount: number;
+        errorMessage: string | null;
+        createdAt: string;
+        processedAt: string | null;
+      }>;
+    };
+
+    expect(data.total).toBe(42);
+    expect(data.events).toHaveLength(1);
+    expect(data.events[0]).toEqual({
+      id: "11111111-1111-1111-1111-111111111111",
+      tenantId: "t1",
+      eventType: "order.created",
+      status: "completed",
+      sourceAction: "create_order",
+      sourceExecutionId: "exec-1",
+      retryCount: 0,
+      errorMessage: null,
+      createdAt: "2026-05-16T08:30:00.000Z",
+      processedAt: "2026-05-16T08:30:01.000Z",
+    });
+
+    expect(listImpl).toHaveBeenCalledTimes(1);
+    const passed = listImpl.mock.calls[0]?.[0];
+    expect(passed?.limit).toBe(5);
+    expect(passed?.offset).toBe(10);
+    expect(passed?.tenantId).toBe("t1");
+  });
+
+  test("forwards tenant scope from context", async () => {
+    const listImpl = mock(async (_opts?: EventListOptions) => ({
+      items: [],
+      total: 0,
+    }));
+    const schema = buildSchema(createStubService({ listImpl }));
+    await graphql({
+      schema,
+      source: `{ eventList { total } }`,
+      contextValue: {
+        actor: { id: "u-admin", type: "human", groups: ["admin"] },
+        tenantId: "tenant-A",
+      },
+    });
+    expect(listImpl.mock.calls[0]?.[0]?.tenantId).toBe("tenant-A");
+  });
+
+  test("rejects unauthenticated callers", async () => {
+    const schema = buildSchema(createStubService());
+    const result = await graphql({
+      schema,
+      source: `{ eventList { total } }`,
+      contextValue: {
+        actor: { id: "anonymous", type: "system", groups: [] },
+        tenantId: "t1",
+      },
+    });
+    expect(result.errors?.[0]?.message).toMatch(/forbidden/i);
+  });
+
+  test("rejects authenticated callers without admin group", async () => {
+    const schema = buildSchema(createStubService());
+    const result = await graphql({
+      schema,
+      source: `{ eventList { total } }`,
+      contextValue: {
+        actor: { id: "u-1", type: "human", groups: ["sales"] },
+        tenantId: "t1",
+      },
+    });
+    expect(result.errors?.[0]?.message).toMatch(/forbidden/i);
+  });
+
+  test("rejects malformed ISO dates", async () => {
+    const schema = buildSchema(createStubService());
+    const result = await graphql({
+      schema,
+      source: `query($s: String) { eventList(since: $s) { total } }`,
+      variableValues: { s: "not-a-date" },
+      contextValue: ADMIN_CTX,
+    });
+    expect(result.errors?.[0]?.message).toMatch(/invalid iso/i);
+  });
+});
+
+// ── eventHandlerHistory ─────────────────────────────────────
+
+describe("graphql events / eventHandlerHistory", () => {
+  test("projects HandlerExecution into the wire shape with derived durationMs", async () => {
+    const getImpl = mock(
+      async (id: string): Promise<EventDetail | null> => ({
+        id,
+        tenantId: "t1",
+        eventType: "order.created",
+        status: "completed",
+        sourceAction: "create_order",
+        sourceExecutionId: "exec-1",
+        retryCount: 0,
+        errorMessage: undefined,
+        createdAt: new Date("2026-05-16T08:30:00Z"),
+        processedAt: new Date("2026-05-16T08:30:01Z"),
+        payload: {},
+        meta: null,
+        history: [],
+      }),
+    );
+    const handlerHistoryImpl = mock(
+      async (_q: HandlerHistoryQuery): Promise<HandlerExecution[]> => [
+        {
+          eventId: "id-1",
+          handler: "*",
+          status: "completed",
+          retryCount: 0,
+          errorMessage: undefined,
+          attemptedAt: new Date("2026-05-16T08:30:00Z"),
+          completedAt: new Date("2026-05-16T08:30:00.250Z"),
+        },
+      ],
+    );
+    const schema = buildSchema(createStubService({ getImpl, handlerHistoryImpl }));
+
+    const result = await graphql({
+      schema,
+      source: `query($id: ID!) {
+        eventHandlerHistory(eventId: $id) {
+          handler status durationMs error
+        }
+      }`,
+      variableValues: { id: "id-1" },
+      contextValue: ADMIN_CTX,
+    });
+
+    expect(result.errors).toBeUndefined();
+    const rows = result.data?.eventHandlerHistory as Array<{
+      handler: string;
+      status: string;
+      durationMs: number | null;
+      error: string | null;
+    }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual({
+      handler: "*",
+      status: "completed",
+      durationMs: 250,
+      error: null,
+    });
+  });
+
+  test("returns an empty list when the event is missing", async () => {
+    const schema = buildSchema(createStubService());
+    const result = await graphql({
+      schema,
+      source: `{ eventHandlerHistory(eventId: "missing") { handler } }`,
+      contextValue: ADMIN_CTX,
+    });
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.eventHandlerHistory).toEqual([]);
+  });
+
+  test("rejects cross-tenant access", async () => {
+    const getImpl = async (id: string): Promise<EventDetail | null> => ({
+      id,
+      tenantId: "OTHER",
+      eventType: "x",
+      status: "completed",
+      retryCount: 0,
+      createdAt: new Date(),
+      payload: {},
+      meta: null,
+      history: [],
+    });
+    const schema = buildSchema(createStubService({ getImpl }));
+    const result = await graphql({
+      schema,
+      source: `{ eventHandlerHistory(eventId: "id-1") { handler } }`,
+      contextValue: ADMIN_CTX,
+    });
+    expect(result.errors?.[0]?.message).toMatch(/different tenant/i);
+  });
+});
+
+// ── eventReplay ─────────────────────────────────────────────
+
+describe("graphql events / eventReplay", () => {
+  function detailFor(id: string, tenantId: string | undefined = "t1"): EventDetail {
+    return {
+      id,
+      tenantId,
+      eventType: "order.created",
+      status: "completed",
+      sourceAction: "create_order",
+      retryCount: 0,
+      errorMessage: undefined,
+      createdAt: new Date("2026-05-16T08:30:00Z"),
+      payload: {},
+      meta: null,
+      history: [],
+    };
+  }
+
+  test("dryRun does NOT invoke replay() and returns a zero-delivery report", async () => {
+    const getImpl = mock(async (id: string) => detailFor(id));
+    const replayImpl = mock(async (_id: string, _opts?: ReplayOptions) => ({
+      delivered: 0,
+      errors: [],
+    }));
+    const schema = buildSchema(createStubService({ getImpl, replayImpl }));
+
+    const result = await graphql({
+      schema,
+      source: `mutation($id: ID!) {
+        eventReplay(eventId: $id, dryRun: true) {
+          eventId dryRun delivered failed
+          handlers { handler status error }
+        }
+      }`,
+      variableValues: { id: "id-1" },
+      contextValue: ADMIN_CTX,
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.eventReplay).toEqual({
+      eventId: "id-1",
+      dryRun: true,
+      delivered: 0,
+      failed: 0,
+      handlers: [],
+    });
+    expect(replayImpl).toHaveBeenCalledTimes(0);
+    expect(getImpl).toHaveBeenCalledTimes(1);
+  });
+
+  test("live replay invokes replay() and surfaces handler errors in the handlers array", async () => {
+    const getImpl = async (id: string) => detailFor(id);
+    const replayImpl = mock(async (_id: string, opts?: ReplayOptions) => {
+      expect(opts?.onlyHandler).toBe("email-handler");
+      return {
+        delivered: 1,
+        errors: [{ handler: "billing-handler", message: "smtp down" }],
+      };
+    });
+    const schema = buildSchema(createStubService({ getImpl, replayImpl }));
+
+    const result = await graphql({
+      schema,
+      source: `mutation($id: ID!, $h: String) {
+        eventReplay(eventId: $id, dryRun: false, handlers: $h) {
+          eventId dryRun delivered failed
+          handlers { handler status error }
+        }
+      }`,
+      variableValues: { id: "id-1", h: "email-handler" },
+      contextValue: ADMIN_CTX,
+    });
+
+    expect(result.errors).toBeUndefined();
+    const report = result.data?.eventReplay as {
+      eventId: string;
+      dryRun: boolean;
+      delivered: number;
+      failed: number;
+      handlers: Array<{ handler: string; status: string; error: string | null }>;
+    };
+    expect(report.eventId).toBe("id-1");
+    expect(report.dryRun).toBe(false);
+    expect(report.delivered).toBe(1);
+    expect(report.failed).toBe(1);
+    expect(report.handlers).toHaveLength(2);
+    const errorEntry = report.handlers.find((h) => h.status === "error");
+    expect(errorEntry?.handler).toBe("billing-handler");
+    expect(errorEntry?.error).toBe("smtp down");
+    const successEntry = report.handlers.find((h) => h.status === "success");
+    expect(successEntry).toBeTruthy();
+    expect(replayImpl).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns a NOT_FOUND GraphQL error when the event is missing", async () => {
+    const schema = buildSchema(createStubService());
+    const result = await graphql({
+      schema,
+      source: `mutation {
+        eventReplay(eventId: "missing") { eventId dryRun delivered failed handlers { handler status } }
+      }`,
+      contextValue: ADMIN_CTX,
+    });
+    expect(result.errors?.[0]?.message).toMatch(/not found/i);
+    expect(result.errors?.[0]?.extensions?.code).toBe("NOT_FOUND");
+  });
+
+  test("rejects cross-tenant replay", async () => {
+    const getImpl = async (id: string) => detailFor(id, "OTHER");
+    const replayImpl = mock(async () => ({ delivered: 0, errors: [] }));
+    const schema = buildSchema(createStubService({ getImpl, replayImpl }));
+    const result = await graphql({
+      schema,
+      source: `mutation { eventReplay(eventId: "id-1") { eventId dryRun delivered failed handlers { handler status } } }`,
+      contextValue: ADMIN_CTX,
+    });
+    expect(result.errors?.[0]?.message).toMatch(/different tenant/i);
+    expect(replayImpl).toHaveBeenCalledTimes(0);
+  });
+});
+
+// ── Wiring through buildGraphQLSchema ───────────────────────
+
+describe("buildGraphQLSchema / eventReplayService wiring", () => {
+  test("registers the three operations when eventReplayService is provided", async () => {
+    const { buildGraphQLSchema } = await import("../src/graphql/build-schema");
+    const svc = createStubService();
+    const schema = buildGraphQLSchema([], { eventReplayService: svc });
+    const typeMap = schema.getTypeMap();
+    expect(schema.getQueryType()?.getFields().eventList).toBeDefined();
+    expect(schema.getQueryType()?.getFields().eventHandlerHistory).toBeDefined();
+    expect(schema.getMutationType()?.getFields().eventReplay).toBeDefined();
+    expect(typeMap.EventSummary).toBeDefined();
+    expect(typeMap.ReplayReport).toBeDefined();
+  });
+
+  test("omits the events surface entirely when eventReplayService is absent", async () => {
+    const { buildGraphQLSchema } = await import("../src/graphql/build-schema");
+    const schema = buildGraphQLSchema([]);
+    expect(schema.getQueryType()?.getFields().eventList).toBeUndefined();
+    expect(schema.getMutationType()).toBeUndefined();
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
@@ -17,6 +17,7 @@ import type {
   DerivedPropertyEngine,
   EntityDefinition,
   EventBus,
+  EventReplayService,
   MaskRecordOptions,
   PermissionGroupDefinition,
   RelationDefinition,
@@ -44,6 +45,7 @@ import {
 import { buildBatchMutationField } from "./build-batch-mutation";
 import { buildOnchangeMutationFields } from "./build-onchange-mutations";
 import { buildSubscriptionFields, createEventBusPubSub } from "./build-subscriptions";
+import { buildEventsGraphQLExtension } from "./events";
 import { safeParseJSON } from "./json-arg";
 import {
   generateActionInputType,
@@ -201,6 +203,18 @@ export interface BuildGraphQLSchemaOptions {
    * here, or set it on `createCommandLayer` so both transports pick it up.
    */
   transactionManager?: TransactionManager;
+  /**
+   * Event replay service. When provided, the schema registers three
+   * admin-only operations consumed by cap-audit-ui:
+   *   - `eventList`               (query)
+   *   - `eventHandlerHistory`     (query)
+   *   - `eventReplay`             (mutation)
+   *
+   * Omit to keep the GraphQL surface free of event introspection — the UI
+   * surfaces a clear "events surface unavailable" error if it tries to
+   * call these operations without the service wired.
+   */
+  eventReplayService?: EventReplayService;
 }
 
 /**
@@ -342,21 +356,29 @@ export function buildGraphQLSchema(
   };
 
   if (entities.length === 0) {
-    // Return a minimal valid schema with a placeholder query (plus any extra fields)
+    // Return a minimal valid schema with a placeholder query (plus any
+    // extra fields and the optional events extension).
+    const eventsExt = options?.eventReplayService
+      ? buildEventsGraphQLExtension({ service: options.eventReplayService })
+      : { queryFields: {}, mutationFields: {} };
     const minimalQueryFields: Record<string, GraphQLFieldConfig<unknown, unknown>> = {
       _empty: {
         type: GraphQLString,
         resolve: () => "No entities registered",
       },
+      ...eventsExt.queryFields,
       ...options?.extraQueryFields,
     };
-    const minimalMutationFields = options?.extraMutationFields;
+    const minimalMutationFields: Record<string, GraphQLFieldConfig<unknown, unknown>> = {
+      ...eventsExt.mutationFields,
+      ...options?.extraMutationFields,
+    };
     return new GraphQLSchema({
       query: new GraphQLObjectType({
         name: "Query",
         fields: minimalQueryFields,
       }),
-      ...(minimalMutationFields && Object.keys(minimalMutationFields).length > 0
+      ...(Object.keys(minimalMutationFields).length > 0
         ? {
             mutation: new GraphQLObjectType({
               name: "Mutation",
@@ -1076,6 +1098,18 @@ export function buildGraphQLSchema(
     internalSchemas,
   });
   Object.assign(mutationFields, onchangeFields);
+
+  // Merge the event-replay GraphQL surface (issue #321) — wired only when
+  // the host passes an `EventReplayService` instance. Registered BEFORE
+  // capability-contributed fields so a capability can override individual
+  // operations if it wants to (mirrors how cap-search composes).
+  if (options?.eventReplayService) {
+    const eventsExt = buildEventsGraphQLExtension({
+      service: options.eventReplayService,
+    });
+    Object.assign(queryFields, eventsExt.queryFields);
+    Object.assign(mutationFields, eventsExt.mutationFields);
+  }
 
   // Merge capability-contributed GraphQL fields (Spec 57 graphqlExtensions)
   if (options?.extraQueryFields) {

--- a/addons/adapter-server/cap-adapter-server/src/graphql/events/event-handler-history-resolver.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/events/event-handler-history-resolver.ts
@@ -1,0 +1,93 @@
+/**
+ * `eventHandlerHistory(eventId: ID!)` GraphQL query — per-event handler
+ * delivery summary.
+ *
+ * Fronts `EventReplayService.handlerHistory({ eventId })`. The service
+ * currently emits a single wildcard entry whose `handler` is `"*"` until
+ * per-handler tracking lands (Spec 66 §2.4) — surface the entry as-is.
+ *
+ * Tenant scoping: the service `handlerHistory` query does not filter by
+ * tenant, so the resolver loads the event via `get(id)` and rejects access
+ * when the row belongs to a different tenant.
+ */
+
+import type { EventReplayService, HandlerExecution } from "@linchkit/core";
+import {
+  GraphQLError,
+  type GraphQLFieldConfig,
+  GraphQLID,
+  GraphQLList,
+  GraphQLNonNull,
+} from "graphql";
+import { HandlerHistoryEntryType } from "./event-types";
+import { isVisibleToTenant, requireAdmin } from "./shared";
+
+interface HandlerHistoryResolverContext {
+  actor?: { id?: string; type?: string; groups?: string[] };
+  tenantId?: string;
+}
+
+interface HandlerHistoryArgs {
+  eventId: string;
+}
+
+interface ProjectedHistoryEntry {
+  handler: string;
+  status: string;
+  durationMs: number | null;
+  error: string | null;
+}
+
+/**
+ * Project the service's `HandlerExecution` onto the UI's wire shape.
+ *
+ * `durationMs` is derived from `attemptedAt`/`completedAt` when both are
+ * set; otherwise null (matches the UI contract: "null when the run never
+ * completed").
+ */
+function projectHistory(entry: HandlerExecution): ProjectedHistoryEntry {
+  const durationMs =
+    entry.completedAt && entry.attemptedAt
+      ? Math.max(0, entry.completedAt.getTime() - entry.attemptedAt.getTime())
+      : null;
+  return {
+    handler: entry.handler,
+    status: entry.status,
+    durationMs,
+    error: entry.errorMessage ?? null,
+  };
+}
+
+export function buildEventHandlerHistoryField(
+  service: EventReplayService,
+): GraphQLFieldConfig<unknown, unknown> {
+  return {
+    type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(HandlerHistoryEntryType))),
+    description: "Per-handler delivery history for a single event. Admin-only; tenant-scoped.",
+    args: {
+      eventId: { type: new GraphQLNonNull(GraphQLID) },
+    },
+    resolve: async (
+      _root: unknown,
+      args: HandlerHistoryArgs,
+      contextValue: unknown,
+    ): Promise<ProjectedHistoryEntry[]> => {
+      const ctx = (contextValue ?? {}) as HandlerHistoryResolverContext;
+      requireAdmin(ctx.actor);
+
+      // Resolve the event first to enforce tenant scoping. `get` returns
+      // null for missing rows or malformed ids — surface both as "no
+      // history" so a UI can render an empty state without a GraphQL error.
+      const detail = await service.get(args.eventId);
+      if (!detail) return [];
+      if (!isVisibleToTenant(detail.tenantId, ctx.tenantId)) {
+        throw new GraphQLError("Forbidden: event belongs to a different tenant.", {
+          extensions: { code: "FORBIDDEN", http: { status: 403 } },
+        });
+      }
+
+      const history = await service.handlerHistory({ eventId: args.eventId });
+      return history.map(projectHistory);
+    },
+  };
+}

--- a/addons/adapter-server/cap-adapter-server/src/graphql/events/event-list-resolver.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/events/event-list-resolver.ts
@@ -1,0 +1,135 @@
+/**
+ * `eventList` GraphQL query — paginated event timeline.
+ *
+ * Fronts `EventReplayService.list(...)`. The service already supports
+ * `entity`/`since`/`until`/`limit`/`offset`/`tenantId` filtering — the
+ * resolver forwards the request context's tenant so cross-tenant leakage
+ * is impossible.
+ *
+ * `recordId` filter:
+ *   The UI passes `recordId` but `EventReplayService.list` does not yet
+ *   accept it. We drop the argument silently (NOT error) so a UI bug
+ *   does not break the list — see the `TODO(recordId)` below.
+ */
+
+import type { EventReplayService, EventSummary } from "@linchkit/core";
+import {
+  GraphQLError,
+  type GraphQLFieldConfig,
+  GraphQLInt,
+  GraphQLNonNull,
+  GraphQLString,
+} from "graphql";
+import { EventListResultType } from "./event-types";
+import { parseIsoDate, requireAdmin } from "./shared";
+
+interface EventListResolverContext {
+  actor?: { id?: string; type?: string; groups?: string[] };
+  tenantId?: string;
+}
+
+interface EventListArgs {
+  entity?: string;
+  // TODO(recordId): drop once EventReplayService.list supports recordId/sourceExecutionId filtering.
+  recordId?: string;
+  since?: string;
+  until?: string;
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * Project a `core` `EventSummary` (`createdAt: Date`) onto the wire-format
+ * shape expected by the UI (`createdAt: string`, ISO 8601).
+ */
+function projectSummary(item: EventSummary): {
+  id: string;
+  tenantId: string | null;
+  eventType: string;
+  status: string;
+  sourceAction: string | null;
+  sourceExecutionId: string | null;
+  retryCount: number;
+  errorMessage: string | null;
+  createdAt: string;
+  processedAt: string | null;
+} {
+  return {
+    id: item.id,
+    tenantId: item.tenantId ?? null,
+    eventType: item.eventType,
+    status: item.status,
+    sourceAction: item.sourceAction ?? null,
+    sourceExecutionId: item.sourceExecutionId ?? null,
+    retryCount: item.retryCount,
+    errorMessage: item.errorMessage ?? null,
+    createdAt: item.createdAt.toISOString(),
+    processedAt: item.processedAt ? item.processedAt.toISOString() : null,
+  };
+}
+
+/** Build the `eventList` query field bound to a specific service instance. */
+export function buildEventListField(
+  service: EventReplayService,
+): GraphQLFieldConfig<unknown, unknown> {
+  return {
+    type: new GraphQLNonNull(EventListResultType),
+    description:
+      "Paginated event timeline. Tenant-scoped via the request context; admin-only. " +
+      "Forwarded to EventReplayService.list — see @linchkit/core/event.",
+    args: {
+      entity: {
+        type: GraphQLString,
+        description: "Filter by sourceAction (the action that emitted the event).",
+      },
+      recordId: {
+        type: GraphQLString,
+        description:
+          "Reserved for future use — accepted for UI forward-compatibility but ignored " +
+          "until EventReplayService supports recordId/sourceExecutionId filtering.",
+      },
+      since: { type: GraphQLString, description: "ISO 8601 timestamp lower bound (inclusive)." },
+      until: { type: GraphQLString, description: "ISO 8601 timestamp upper bound (inclusive)." },
+      limit: {
+        type: GraphQLInt,
+        description: "Max entries to return (server clamps to <=100, default 50).",
+      },
+      offset: { type: GraphQLInt, description: "Number of entries to skip (default 0)." },
+    },
+    resolve: async (
+      _root: unknown,
+      args: EventListArgs,
+      contextValue: unknown,
+    ): Promise<{
+      events: ReturnType<typeof projectSummary>[];
+      total: number;
+    }> => {
+      const ctx = (contextValue ?? {}) as EventListResolverContext;
+      requireAdmin(ctx.actor);
+
+      let since: Date | undefined;
+      let until: Date | undefined;
+      try {
+        since = parseIsoDate(args.since);
+        until = parseIsoDate(args.until);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Invalid ISO date";
+        throw new GraphQLError(message);
+      }
+
+      const result = await service.list({
+        tenantId: ctx.tenantId,
+        entity: args.entity,
+        since,
+        until,
+        limit: args.limit,
+        offset: args.offset,
+      });
+
+      return {
+        events: result.items.map(projectSummary),
+        total: result.total,
+      };
+    },
+  };
+}

--- a/addons/adapter-server/cap-adapter-server/src/graphql/events/event-replay-resolver.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/events/event-replay-resolver.ts
@@ -1,0 +1,162 @@
+/**
+ * `eventReplay(eventId: ID!, dryRun: Boolean, handlers: String)` GraphQL
+ * mutation — re-dispatch a persisted event through its registered handlers.
+ *
+ * Fronts `EventReplayService.replay(id, { onlyHandler })`. The UI's wire
+ * format uses `handlers` (singular handler name accepted today — see
+ * `addons/audit/cap-audit-ui/src/lib/eventsClient.ts`). We forward the
+ * value as-is to `onlyHandler`; multi-handler comma-separated input is a
+ * future enhancement tracked as a TODO.
+ *
+ * `dryRun` semantics:
+ *   The current `EventReplayService.replay` does not have a dry-run mode,
+ *   so the resolver short-circuits BEFORE calling `replay()` when
+ *   `dryRun === true`. It still loads the event (to honor permission
+ *   and tenant checks and to surface "missing event" cleanly) and emits
+ *   an empty `handlers` array with `delivered = failed = 0`. That matches
+ *   the UI's "did not invoke handlers" contract.
+ *
+ * Tenant scoping: `replay` operates on a single row fetched via the
+ * service's internal `fetchRow`, which has no tenant filter. The resolver
+ * loads the event via `get` first to enforce tenant visibility.
+ *
+ * Error handling: any per-handler failures collected by the service are
+ * projected into the `handlers` array as `status: "error"` entries — the
+ * mutation itself does NOT throw when individual handlers fail.
+ */
+
+import type { EventReplayService, ReplayError, ReplayResult } from "@linchkit/core";
+import {
+  GraphQLBoolean,
+  GraphQLError,
+  type GraphQLFieldConfig,
+  GraphQLID,
+  GraphQLNonNull,
+  GraphQLString,
+} from "graphql";
+import { ReplayReportType } from "./event-types";
+import { isVisibleToTenant, requireAdmin } from "./shared";
+
+interface ReplayResolverContext {
+  actor?: { id?: string; type?: string; groups?: string[] };
+  tenantId?: string;
+}
+
+interface ReplayArgs {
+  eventId: string;
+  dryRun?: boolean | null;
+  // TODO(handlers): accept comma-separated handler names once the service
+  // supports a multi-handler filter. Today a single handler name is expected.
+  handlers?: string | null;
+}
+
+interface ProjectedReplayHandler {
+  handler: string;
+  status: "success" | "error";
+  error: string | null;
+}
+
+interface ProjectedReplayReport {
+  eventId: string;
+  dryRun: boolean;
+  delivered: number;
+  failed: number;
+  handlers: ProjectedReplayHandler[];
+}
+
+/**
+ * Project the service's `ReplayResult` onto the UI's `ReplayReport` shape.
+ * Successes get `status: "success"`; the per-handler error list maps to
+ * `status: "error"` entries with the captured message.
+ *
+ * The service's `delivered` is a count, not a per-handler breakdown — we
+ * don't know the handler names that succeeded. To keep the UI's contract
+ * informative we still emit one synthetic success entry per delivered
+ * invocation; without per-handler success identifiers, callers should treat
+ * these as opaque markers (the count is what matters).
+ */
+function projectReplay(
+  eventId: string,
+  dryRun: boolean,
+  result: ReplayResult,
+): ProjectedReplayReport {
+  const errors: ProjectedReplayHandler[] = result.errors.map((err: ReplayError) => ({
+    handler: err.handler,
+    status: "error" as const,
+    error: err.message,
+  }));
+  // Synthesize anonymous success entries so the `handlers` array length
+  // matches `delivered + failed` — the UI uses this as a "what ran" list.
+  const successes: ProjectedReplayHandler[] = Array.from({ length: result.delivered }, (_, i) => ({
+    handler: `delivered[${i}]`,
+    status: "success" as const,
+    error: null,
+  }));
+  return {
+    eventId,
+    dryRun,
+    delivered: result.delivered,
+    failed: result.errors.length,
+    handlers: [...successes, ...errors],
+  };
+}
+
+export function buildEventReplayField(
+  service: EventReplayService,
+): GraphQLFieldConfig<unknown, unknown> {
+  return {
+    type: new GraphQLNonNull(ReplayReportType),
+    description:
+      "Re-dispatch a persisted event through its registered handlers. Admin-only; tenant-scoped. " +
+      "When `dryRun` is true the resolver returns a zero-delivery report WITHOUT invoking handlers.",
+    args: {
+      eventId: { type: new GraphQLNonNull(GraphQLID) },
+      dryRun: { type: GraphQLBoolean },
+      handlers: {
+        type: GraphQLString,
+        description:
+          "Restrict the replay to a single handler name. Multi-handler / comma-separated input is not yet supported.",
+      },
+    },
+    resolve: async (
+      _root: unknown,
+      args: ReplayArgs,
+      contextValue: unknown,
+    ): Promise<ProjectedReplayReport> => {
+      const ctx = (contextValue ?? {}) as ReplayResolverContext;
+      requireAdmin(ctx.actor);
+
+      const dryRun = args.dryRun === true;
+      const onlyHandler =
+        typeof args.handlers === "string" && args.handlers.length > 0 ? args.handlers : undefined;
+
+      // Resolve and tenant-check BEFORE replay so cross-tenant invocation
+      // is impossible. `get` returns null for missing rows or malformed
+      // ids — surface as a GraphQL error so the UI can show a clear message.
+      const detail = await service.get(args.eventId);
+      if (!detail) {
+        throw new GraphQLError(`Event "${args.eventId}" not found.`, {
+          extensions: { code: "NOT_FOUND", http: { status: 404 } },
+        });
+      }
+      if (!isVisibleToTenant(detail.tenantId, ctx.tenantId)) {
+        throw new GraphQLError("Forbidden: event belongs to a different tenant.", {
+          extensions: { code: "FORBIDDEN", http: { status: 403 } },
+        });
+      }
+
+      if (dryRun) {
+        return {
+          eventId: args.eventId,
+          dryRun: true,
+          delivered: 0,
+          failed: 0,
+          handlers: [],
+        };
+      }
+
+      const result = await service.replay(args.eventId, { onlyHandler });
+      return projectReplay(args.eventId, false, result);
+    },
+  };
+}

--- a/addons/adapter-server/cap-adapter-server/src/graphql/events/event-types.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/events/event-types.ts
@@ -1,0 +1,116 @@
+/**
+ * Shared GraphQL output types for the event-replay surface.
+ *
+ * Wire shape is locked by the cap-audit-ui `eventsClient` (see
+ * `addons/audit/cap-audit-ui/src/lib/eventsClient.ts`). Field names
+ * and nullability MUST stay aligned so the UI can render the timeline
+ * end-to-end without translation.
+ */
+
+import {
+  GraphQLBoolean,
+  GraphQLID,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql";
+
+// ── EventSummary ────────────────────────────────────────────
+
+/**
+ * Single persisted event row, projected to the camelCase shape used by the
+ * UI. Mirrors `EventSummary` in `@linchkit/core/event` but with `createdAt`
+ * and `processedAt` serialized as ISO strings (GraphQL String).
+ */
+export const EventSummaryType = new GraphQLObjectType({
+  name: "EventSummary",
+  description: "Persisted event summary as projected for the events timeline UI.",
+  fields: () => ({
+    id: { type: new GraphQLNonNull(GraphQLID) },
+    tenantId: { type: GraphQLString },
+    eventType: { type: new GraphQLNonNull(GraphQLString) },
+    status: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "pending | processing | completed | failed | dead_letter",
+    },
+    sourceAction: { type: GraphQLString },
+    sourceExecutionId: { type: GraphQLString },
+    retryCount: { type: new GraphQLNonNull(GraphQLInt) },
+    errorMessage: { type: GraphQLString },
+    createdAt: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "ISO 8601 timestamp",
+    },
+    processedAt: {
+      type: GraphQLString,
+      description: "ISO 8601 timestamp; absent when the event has not been processed",
+    },
+  }),
+});
+
+// ── EventListResult ─────────────────────────────────────────
+
+export const EventListResultType = new GraphQLObjectType({
+  name: "EventListResult",
+  description: "Paginated event list result.",
+  fields: () => ({
+    events: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(EventSummaryType))),
+    },
+    total: { type: new GraphQLNonNull(GraphQLInt) },
+  }),
+});
+
+// ── HandlerHistoryEntry ─────────────────────────────────────
+
+/**
+ * Per-handler delivery summary. Until per-handler completion tracking exists
+ * (Spec 66 §2.4) the service emits a single wildcard entry whose `handler`
+ * is `"*"` — surface as-is so the UI can render an aggregate row.
+ */
+export const HandlerHistoryEntryType = new GraphQLObjectType({
+  name: "HandlerHistoryEntry",
+  description: "Per-handler delivery summary for a single event.",
+  fields: () => ({
+    handler: { type: new GraphQLNonNull(GraphQLString) },
+    status: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "pending | processing | completed | failed | dead_letter",
+    },
+    durationMs: { type: GraphQLInt },
+    error: { type: GraphQLString },
+  }),
+});
+
+// ── ReplayHandlerOutcome ────────────────────────────────────
+
+export const ReplayHandlerOutcomeType = new GraphQLObjectType({
+  name: "ReplayHandlerOutcome",
+  description: "Outcome of replaying an event through a single handler.",
+  fields: () => ({
+    handler: { type: new GraphQLNonNull(GraphQLString) },
+    status: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: `"success" when the handler ran without throwing; "error" otherwise`,
+    },
+    error: { type: GraphQLString },
+  }),
+});
+
+// ── ReplayReport ────────────────────────────────────────────
+
+export const ReplayReportType = new GraphQLObjectType({
+  name: "ReplayReport",
+  description: "Aggregate report for a single eventReplay invocation.",
+  fields: () => ({
+    eventId: { type: new GraphQLNonNull(GraphQLID) },
+    dryRun: { type: new GraphQLNonNull(GraphQLBoolean) },
+    delivered: { type: new GraphQLNonNull(GraphQLInt) },
+    failed: { type: new GraphQLNonNull(GraphQLInt) },
+    handlers: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ReplayHandlerOutcomeType))),
+    },
+  }),
+});

--- a/addons/adapter-server/cap-adapter-server/src/graphql/events/index.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/events/index.ts
@@ -1,0 +1,64 @@
+/**
+ * Events GraphQL extension — wires `EventReplayService` into the served
+ * schema as three operations expected by cap-audit-ui:
+ *
+ *   - `eventList(...)` query → paginated timeline
+ *   - `eventHandlerHistory(eventId)` query → per-event handler summary
+ *   - `eventReplay(eventId, dryRun, handlers)` mutation → re-dispatch
+ *
+ * Field names and arg names mirror
+ * `addons/audit/cap-audit-ui/src/lib/eventsClient.ts` exactly — the UI
+ * shape is authoritative.
+ *
+ * Registration pattern matches `cap-search` (see
+ * `addons/search/cap-search/src/graphql.ts`): the build function returns
+ * `{ queryFields, mutationFields }` so the host (build-schema or a
+ * capability `graphqlExtensions` slot) can merge them into the schema.
+ */
+
+import type { EventReplayService } from "@linchkit/core";
+import type { GraphQLFieldConfig } from "graphql";
+import { buildEventHandlerHistoryField } from "./event-handler-history-resolver";
+import { buildEventListField } from "./event-list-resolver";
+import { buildEventReplayField } from "./event-replay-resolver";
+
+export interface EventsGraphQLExtensionOptions {
+  service: EventReplayService;
+}
+
+export interface EventsGraphQLExtension {
+  queryFields: Record<string, GraphQLFieldConfig<unknown, unknown>>;
+  mutationFields: Record<string, GraphQLFieldConfig<unknown, unknown>>;
+}
+
+/**
+ * Build the events GraphQL extension. Returns the queries and mutation as
+ * separate maps so callers can splice them into `Query`/`Mutation` types or
+ * pass them as `extraQueryFields`/`extraMutationFields` to
+ * `buildGraphQLSchema`.
+ */
+export function buildEventsGraphQLExtension(
+  options: EventsGraphQLExtensionOptions,
+): EventsGraphQLExtension {
+  const { service } = options;
+  return {
+    queryFields: {
+      eventList: buildEventListField(service),
+      eventHandlerHistory: buildEventHandlerHistoryField(service),
+    },
+    mutationFields: {
+      eventReplay: buildEventReplayField(service),
+    },
+  };
+}
+
+export { buildEventHandlerHistoryField } from "./event-handler-history-resolver";
+export { buildEventListField } from "./event-list-resolver";
+export { buildEventReplayField } from "./event-replay-resolver";
+export {
+  EventListResultType,
+  EventSummaryType,
+  HandlerHistoryEntryType,
+  ReplayHandlerOutcomeType,
+  ReplayReportType,
+} from "./event-types";

--- a/addons/adapter-server/cap-adapter-server/src/graphql/events/shared.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/events/shared.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared helpers for the event-replay GraphQL resolvers.
+ *
+ * Permission gate
+ * ───────────────
+ * `requireAdmin` is the lowest-friction admin check that still rejects the
+ * default anonymous actor wired by CommandLayer (`{ type: "system", id:
+ * "anonymous", groups: [] }`). It allows any actor that:
+ *   - is not the anonymous fallback AND
+ *   - either has the `"admin"` group OR is a system/worker process.
+ *
+ * This is intentionally simple — proper admin gating belongs in
+ * cap-permission. Once that capability is wired into the GraphQL transport
+ * via a permission slot middleware, this resolver-local check can be
+ * dropped. Tracked as a follow-up.
+ *
+ * Date parsing
+ * ────────────
+ * `parseIsoDate` rejects strings that fail to produce a finite
+ * `Date.getTime()`. The service layer already silently drops invalid
+ * dates from the SQL filter, but failing fast at the boundary keeps the
+ * caller honest about what window was actually applied.
+ */
+
+import { GraphQLError } from "graphql";
+
+interface ActorLike {
+  id?: string;
+  type?: string;
+  groups?: string[];
+}
+
+const ADMIN_GROUP = "admin";
+const ANONYMOUS_ID = "anonymous";
+const TRUSTED_ACTOR_TYPES: ReadonlySet<string> = new Set(["system", "worker"]);
+
+/**
+ * Throw a Forbidden GraphQL error when the actor cannot run an admin-only
+ * operation. Accepts the actor in its loosest shape so the helper composes
+ * with multiple resolver context types.
+ */
+export function requireAdmin(actor?: ActorLike | null): void {
+  if (!actor || typeof actor !== "object") {
+    throw new GraphQLError("Forbidden: events surface requires an authenticated actor.", {
+      extensions: { code: "FORBIDDEN", http: { status: 403 } },
+    });
+  }
+  if (!actor.id || actor.id === ANONYMOUS_ID) {
+    throw new GraphQLError("Forbidden: events surface requires an authenticated actor.", {
+      extensions: { code: "FORBIDDEN", http: { status: 403 } },
+    });
+  }
+  const groups = Array.isArray(actor.groups) ? actor.groups : [];
+  const hasAdminGroup = groups.includes(ADMIN_GROUP);
+  const isTrustedType = typeof actor.type === "string" && TRUSTED_ACTOR_TYPES.has(actor.type);
+  if (!hasAdminGroup && !isTrustedType) {
+    throw new GraphQLError("Forbidden: events surface is admin-only.", {
+      extensions: { code: "FORBIDDEN", http: { status: 403 } },
+    });
+  }
+}
+
+/**
+ * Parse an ISO 8601 string into a `Date`. Returns `undefined` for empty input.
+ * Throws when the input is a non-empty string that does not parse to a finite
+ * date — the SQL layer ignores invalid dates silently and we want to fail loud.
+ */
+export function parseIsoDate(value: string | undefined): Date | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  const dt = new Date(value);
+  if (Number.isNaN(dt.getTime())) {
+    throw new Error(`Invalid ISO 8601 timestamp: ${value}`);
+  }
+  return dt;
+}
+
+/**
+ * Post-filter helper: return true when the row's `tenantId` is visible to the
+ * caller's tenant scope. The service's `get`/`fetchRow` does NOT filter by
+ * tenant, so resolvers calling those paths must apply this guard.
+ *
+ * Rules:
+ *   - When `ctxTenantId` is undefined, the caller is acting in the
+ *     untenanted (global) scope and may see ALL rows.
+ *   - When `ctxTenantId` is set, the row must either match or be unscoped
+ *     (`tenantId === undefined`) — unscoped rows are framework-emitted
+ *     events the operator should still see.
+ */
+export function isVisibleToTenant(
+  rowTenantId: string | undefined,
+  ctxTenantId: string | undefined,
+): boolean {
+  if (ctxTenantId === undefined) return true;
+  if (rowTenantId === undefined) return true;
+  return rowTenantId === ctxTenantId;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -238,6 +238,19 @@ export {
 } from "./errors";
 export type { EventBus, EventHandlerRegistry } from "./event/event-bus";
 export type {
+  BatchReplayResult,
+  EventDetail,
+  EventListOptions,
+  EventReplayService,
+  EventReplayServiceOptions,
+  EventSummary,
+  HandlerExecution,
+  HandlerHistoryQuery,
+  ReplayError,
+  ReplayOptions,
+  ReplayResult,
+} from "./event/event-replay-service";
+export type {
   FlowEngine,
   FlowRegistry,
   FlowStepContext,

--- a/packages/core/src/server-entry.ts
+++ b/packages/core/src/server-entry.ts
@@ -142,6 +142,20 @@ export {
 } from "./event/dlq-service";
 export { createEventBus, EventBus, EventHandlerRegistry } from "./event/event-bus";
 export {
+  type BatchReplayResult,
+  createEventReplayService,
+  type EventDetail,
+  type EventListOptions,
+  type EventReplayService,
+  type EventReplayServiceOptions,
+  type EventSummary,
+  type HandlerExecution,
+  type HandlerHistoryQuery,
+  type ReplayError,
+  type ReplayOptions,
+  type ReplayResult,
+} from "./event/event-replay-service";
+export {
   createOutboxWorker,
   type OutboxWorker,
   type OutboxWorkerOptions,


### PR DESCRIPTION
## Summary
- Registers three admin-only GraphQL operations that front `EventReplayService` from `@linchkit/core`: `eventList`, `eventHandlerHistory`, `eventReplay`.
- Field names, arg names and shapes match `addons/audit/cap-audit-ui/src/lib/eventsClient.ts` exactly so the audit-UI events timeline (shipped in #322) now works end-to-end.
- Resolvers are tenant-scoped (via `context.tenantId`, with post-filter fallback for `get`-based reads) and admin-gated (`requireAdmin` helper).
- `dryRun` short-circuits before invoking `replay()`; missing events surface as `NOT_FOUND` GraphQL errors; per-handler failures land in the `handlers[]` array as `status: "error"` entries.
- `EventReplayService` and related types are now re-exported from `@linchkit/core` and `@linchkit/core/server` so adapters can consume them.

## Test plan
- [x] `bun run check` (clean)
- [x] `bun run typecheck` (clean)
- [x] `bun test` — 5098 pass / 3 skip / 0 fail; 14 new tests in `graphql-events.test.ts` cover list/history/replay incl. tenant scoping, dry-run, error projection, missing event, and the wiring branch of `buildGraphQLSchema`.

## Follow-ups
- Wire a real `EventReplayService` instance into `dev.ts` (needs db plumbing).
- Move admin gate to a CommandLayer permission slot once cap-permission is on the GraphQL transport.

## Cross-model review
Codex/Gemini unavailable (codex usage limit, gemini classifier blocked); manual orchestrator review covered: tenant-scoping fallback on get-based reads, dry-run short-circuit ordering, per-handler error mapping, GraphQL type name uniqueness vs existing schema.

Closes #321.