### PR TITLE
feat(core): formLayout() chain builder for view form layouts (refs #142 Phase 2)

### DIFF
--- a/packages/core/__tests__/view-form-layout-builder.test.ts
+++ b/packages/core/__tests__/view-form-layout-builder.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Tests for the `formLayout()` chain builder — Phase 2 of issue #142.
+ *
+ * Critical invariants:
+ *   1. Chain output deep-equals the helper composition for equivalent input.
+ *   2. `.build()` is idempotent (no mutation, no shared references).
+ *   3. Nesting works end-to-end: notebook > page > group > row > field.
+ *   4. Output is JSON-serializable (no closures, no class instances).
+ */
+
+import { describe, expect, it } from "bun:test";
+// Import via the public barrel — catches export regressions too.
+import { field, formLayout, group, notebook, page, row, separator } from "../src";
+import type { FormLayout, FormLayoutNode } from "../src/types/view";
+
+describe("formLayout() chain builder", () => {
+  it("produces the same FormLayout as the equivalent helper composition", () => {
+    const chain = formLayout()
+      .row(field("title"), field("department"))
+      .group(field("priority"), field("requester"))
+      .notebook(page("Items", field("items")))
+      .build();
+
+    const helpers: FormLayout = {
+      nodes: [
+        row(field("title"), field("department")),
+        group(field("priority"), field("requester")),
+        notebook(page("Items", field("items"))),
+      ],
+    };
+
+    expect(chain).toEqual(helpers);
+  });
+
+  it("matches the exact shape from the issue body example", () => {
+    // formLayout().row(field('a'), field('b')).notebook(...).build()
+    const chain = formLayout()
+      .row(field("a"), field("b"))
+      .notebook(page("Tab", field("c")))
+      .build();
+
+    expect(chain).toEqual({
+      nodes: [
+        {
+          type: "group",
+          columns: 2,
+          children: [
+            { type: "field", field: "a" },
+            { type: "field", field: "b" },
+          ],
+        },
+        {
+          type: "notebook",
+          children: [{ type: "page", title: "Tab", children: [{ type: "field", field: "c" }] }],
+        },
+      ],
+    });
+  });
+
+  describe("top-level append methods", () => {
+    it(".field(name) appends a bare field node", () => {
+      const out = formLayout().field("title").build();
+      expect(out.nodes).toEqual([{ type: "field", field: "title" }]);
+    });
+
+    it(".field(name, opts) forwards options to the helper", () => {
+      const out = formLayout().field("title", { label: "T", readonly: true }).build();
+      expect(out.nodes).toEqual([{ type: "field", field: "title", label: "T", readonly: true }]);
+    });
+
+    it(".row() with no children collapses to a 1-column group", () => {
+      const out = formLayout().row().build();
+      expect(out.nodes).toEqual([{ type: "group", columns: 1, children: [] }]);
+    });
+
+    it(".row() sets columns to child count", () => {
+      const out = formLayout().row(field("a"), field("b"), field("c")).build();
+      expect(out.nodes).toEqual([
+        {
+          type: "group",
+          columns: 3,
+          children: [
+            { type: "field", field: "a" },
+            { type: "field", field: "b" },
+            { type: "field", field: "c" },
+          ],
+        },
+      ]);
+    });
+
+    it(".group() with no children produces an empty group", () => {
+      const out = formLayout().group().build();
+      expect(out.nodes).toEqual([{ type: "group", children: [] }]);
+    });
+
+    it(".group() with a single field accepts the same shape as helper", () => {
+      const out = formLayout().group(field("only")).build();
+      expect(out.nodes).toEqual([{ type: "group", children: [{ type: "field", field: "only" }] }]);
+    });
+
+    it(".notebook() collects pages", () => {
+      const out = formLayout()
+        .notebook(page("Tab 1", field("a")), page("Tab 2", field("b")))
+        .build();
+      expect(out.nodes).toEqual([
+        {
+          type: "notebook",
+          children: [
+            { type: "page", title: "Tab 1", children: [{ type: "field", field: "a" }] },
+            { type: "page", title: "Tab 2", children: [{ type: "field", field: "b" }] },
+          ],
+        },
+      ]);
+    });
+
+    it(".page() at top level appends a page node", () => {
+      const out = formLayout().page("Header", field("a")).build();
+      expect(out.nodes).toEqual([
+        { type: "page", title: "Header", children: [{ type: "field", field: "a" }] },
+      ]);
+    });
+
+    it("multiple calls append in call order", () => {
+      const out = formLayout().field("a").row(field("b"), field("c")).group(field("d")).build();
+      expect(out.nodes).toEqual([
+        { type: "field", field: "a" },
+        {
+          type: "group",
+          columns: 2,
+          children: [
+            { type: "field", field: "b" },
+            { type: "field", field: "c" },
+          ],
+        },
+        { type: "group", children: [{ type: "field", field: "d" }] },
+      ]);
+    });
+  });
+
+  describe(".append()", () => {
+    it("forwards pre-built nodes verbatim (for shapes the chain can't express)", () => {
+      // Group with a title — not expressible via .group(...children) directly.
+      const titled: FormLayoutNode = {
+        type: "group",
+        title: "Customer",
+        columns: 1,
+        children: [{ type: "field", field: "name" }],
+      };
+      const out = formLayout().append(titled, separator("End")).build();
+      expect(out.nodes).toEqual([
+        {
+          type: "group",
+          title: "Customer",
+          columns: 1,
+          children: [{ type: "field", field: "name" }],
+        },
+        { type: "separator", label: "End" },
+      ]);
+    });
+
+    it("deep-clones appended nodes — caller mutation does not leak", () => {
+      const live: FormLayoutNode = {
+        type: "group",
+        title: "Live",
+        children: [{ type: "field", field: "x" }],
+      };
+      const builder = formLayout().append(live);
+      const built = builder.build();
+
+      // Mutate the original
+      (live as { title?: string }).title = "Mutated";
+      (live.children[0] as { field: string }).field = "y";
+
+      expect(built.nodes).toEqual([
+        { type: "group", title: "Live", children: [{ type: "field", field: "x" }] },
+      ]);
+    });
+  });
+
+  describe("nesting end-to-end", () => {
+    it("notebook > page > group > row > field round-trips", () => {
+      const out = formLayout()
+        .notebook(page("Main", group(row(field("a"), field("b")), row(field("c"), field("d")))))
+        .build();
+
+      expect(out).toEqual({
+        nodes: [
+          {
+            type: "notebook",
+            children: [
+              {
+                type: "page",
+                title: "Main",
+                children: [
+                  {
+                    type: "group",
+                    children: [
+                      {
+                        type: "group",
+                        columns: 2,
+                        children: [
+                          { type: "field", field: "a" },
+                          { type: "field", field: "b" },
+                        ],
+                      },
+                      {
+                        type: "group",
+                        columns: 2,
+                        children: [
+                          { type: "field", field: "c" },
+                          { type: "field", field: "d" },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+    });
+  });
+
+  describe(".build() idempotency", () => {
+    it("returns deep-equal but distinct objects on repeated calls", () => {
+      const builder = formLayout()
+        .row(field("a"), field("b"))
+        .notebook(page("Tab", field("c")));
+
+      const a = builder.build();
+      const b = builder.build();
+
+      expect(a).toEqual(b);
+      expect(a).not.toBe(b);
+      expect(a.nodes).not.toBe(b.nodes);
+      expect(a.nodes?.[0]).not.toBe(b.nodes?.[0]);
+      // Children arrays inside nodes must also be cloned.
+      const groupA = a.nodes?.[0];
+      const groupB = b.nodes?.[0];
+      if (groupA?.type === "group" && groupB?.type === "group") {
+        expect(groupA.children).not.toBe(groupB.children);
+        expect(groupA.children[0]).not.toBe(groupB.children[0]);
+      }
+    });
+
+    it("mutating one build() result does not affect the other", () => {
+      const builder = formLayout().row(field("a"));
+
+      const first = builder.build();
+      const second = builder.build();
+
+      // Mutate first's row node
+      const firstRow = first.nodes?.[0];
+      if (firstRow?.type === "group") {
+        firstRow.children.push({ type: "field", field: "leaked" });
+        firstRow.title = "leaked";
+      }
+
+      const secondRow = second.nodes?.[0];
+      if (secondRow?.type === "group") {
+        expect(secondRow.children).toEqual([{ type: "field", field: "a" }]);
+        expect(secondRow.title).toBeUndefined();
+      }
+    });
+
+    it("subsequent builder calls after build() reflect in the next build()", () => {
+      const builder = formLayout().field("a");
+      const first = builder.build();
+      builder.field("b");
+      const second = builder.build();
+
+      expect(first.nodes).toEqual([{ type: "field", field: "a" }]);
+      expect(second.nodes).toEqual([
+        { type: "field", field: "a" },
+        { type: "field", field: "b" },
+      ]);
+    });
+
+    it("mutating field opts after build() does not leak across builds", () => {
+      const condition = { field: "type", operator: "eq" as const, value: "A" };
+      const builder = formLayout().field("name", { visibleWhen: condition });
+      const a = builder.build();
+      const b = builder.build();
+
+      // Mutate the original condition
+      condition.value = "B";
+
+      const fieldA = a.nodes?.[0];
+      const fieldB = b.nodes?.[0];
+      if (fieldA?.type === "field" && fieldB?.type === "field") {
+        expect(fieldA.visibleWhen?.value).toBe("A");
+        expect(fieldB.visibleWhen?.value).toBe("A");
+        expect(fieldA.visibleWhen).not.toBe(fieldB.visibleWhen);
+      }
+    });
+  });
+
+  describe("output shape guarantees", () => {
+    it("output is JSON-serializable (no functions, no cycles)", () => {
+      const out = formLayout()
+        .row(field("a"), field("b"))
+        .notebook(page("Tab", field("c")))
+        .build();
+      const json = JSON.stringify(out);
+      expect(JSON.parse(json)).toEqual(out);
+    });
+
+    it("empty builder yields { nodes: [] }", () => {
+      expect(formLayout().build()).toEqual({ nodes: [] });
+    });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -418,6 +418,8 @@ export { defineSemanticRelation } from "./types/semantic-relation";
 export { resolveEnvVars } from "./utils/env";
 export type { IdentifierValidationResult } from "./utils/identifier";
 export { validateIdentifier } from "./utils/identifier";
+// View layout chain builder — parallel ergonomic API to the helpers above
+export { type FormLayoutBuilder, formLayout } from "./view/form-layout-builder";
 // View layout helpers — syntactic sugar over FormLayoutNode JSON shape
 export {
   type FieldOptions,

--- a/packages/core/src/view/form-layout-builder.ts
+++ b/packages/core/src/view/form-layout-builder.ts
@@ -1,0 +1,179 @@
+/**
+ * formLayout — Chain-style builder for view form layouts.
+ *
+ * Phase 2 of issue #142. Mirrors the dual-entry pattern established by
+ * `permissionGroup()` in cap-permission: provides an IDE-guided chain API
+ * that produces the SAME plain `FormLayout` object as the equivalent
+ * composition of the standalone helpers (`field`, `row`, `group`,
+ * `notebook`, `page`) from `./layout-helpers`.
+ *
+ * Design notes:
+ *   - `.build()` is idempotent: each call returns a fresh deep-clone, the
+ *     internal state is never mutated by `build()`, and the returned object
+ *     shares no references with the builder or with prior builds.
+ *   - Every node appended through chain methods is normalized to the exact
+ *     plain shape produced by the helpers — no closures, no class instances,
+ *     no symbols — keeping the output JSONB-safe.
+ *   - Top-level nodes are collected in order; multiple `.row(...)` /
+ *     `.group(...)` / `.field(...)` / `.notebook(...)` / `.page(...)` calls
+ *     append in call order.
+ *   - Both `.row()` and `.group()` follow the helper semantics exactly:
+ *     `.row(a, b)` becomes `{ type: "group", columns: 2, children: [a, b] }`
+ *     and `.group(a, b)` becomes `{ type: "group", children: [a, b] }`. For
+ *     decorated groups (`title`, `className`, custom `columns`), use the
+ *     verbose JSON form via `.append()` — see below.
+ *
+ * @example
+ *   const layout = formLayout()
+ *     .row(field("title"), field("department"))
+ *     .group(field("priority"), field("requester"))
+ *     .notebook(page("Items", field("items")))
+ *     .build();
+ *
+ *   // Same shape as:
+ *   //   { nodes: [
+ *   //     row(field("title"), field("department")),
+ *   //     group(field("priority"), field("requester")),
+ *   //     notebook(page("Items", field("items"))),
+ *   //   ] }
+ */
+
+import type { FormFieldNode, FormLayout, FormLayoutNode, FormPageNode } from "../types/view";
+import { type FieldOptions, field, group, notebook, page, row } from "./layout-helpers";
+
+// ── Builder interface ───────────────────────────────────────
+
+export interface FormLayoutBuilder {
+  /** Append a bare field node at the top level. */
+  field(name: string, opts?: FieldOptions): FormLayoutBuilder;
+  /** Append a row (group with `columns = children.length`). */
+  row(...children: FormLayoutNode[]): FormLayoutBuilder;
+  /** Append a group (default 2-column container). */
+  group(...children: FormLayoutNode[]): FormLayoutBuilder;
+  /** Append a notebook (tab container) holding the given pages. */
+  notebook(...pages: FormPageNode[]): FormLayoutBuilder;
+  /** Append a page node (typically used as a notebook child; here for parity). */
+  page(title: string, ...children: FormLayoutNode[]): FormLayoutBuilder;
+  /**
+   * Append one or more pre-built layout nodes verbatim. Useful for shapes the
+   * chain methods can't express directly (e.g. groups with `title` /
+   * `className`, separators with labels). Each node is deep-cloned on
+   * `.build()`, so callers may freely reuse the same node object.
+   */
+  append(...nodes: FormLayoutNode[]): FormLayoutBuilder;
+  /** Materialize the layout. Idempotent — each call returns a fresh clone. */
+  build(): FormLayout;
+}
+
+// ── Factory ─────────────────────────────────────────────────
+
+/**
+ * Start building a form layout.
+ *
+ * The returned builder accumulates top-level nodes. `.build()` returns
+ * `{ nodes: FormLayoutNode[] }` — the canonical shape consumed by
+ * `ViewDefinition.layout`.
+ */
+export function formLayout(): FormLayoutBuilder {
+  const nodes: FormLayoutNode[] = [];
+
+  const builder: FormLayoutBuilder = {
+    field(name, opts) {
+      nodes.push(field(name, opts));
+      return builder;
+    },
+
+    row(...children) {
+      nodes.push(row(...children));
+      return builder;
+    },
+
+    group(...children) {
+      nodes.push(group(...children));
+      return builder;
+    },
+
+    notebook(...pages) {
+      nodes.push(notebook(...pages));
+      return builder;
+    },
+
+    page(title, ...children) {
+      nodes.push(page(title, ...children));
+      return builder;
+    },
+
+    append(...incoming) {
+      for (const node of incoming) {
+        nodes.push(node);
+      }
+      return builder;
+    },
+
+    build() {
+      return { nodes: nodes.map(cloneNode) };
+    },
+  };
+
+  return builder;
+}
+
+// ── Deep clone (covers the FormLayoutNode union) ────────────
+
+/**
+ * Deep-clone a layout node. All node payloads are plain JSON, so
+ * `structuredClone` would also work — but we walk the tree by hand to (a)
+ * keep the dependency footprint zero and (b) make it explicit which fields
+ * each node type carries (so a future field addition forces a compile-time
+ * update here).
+ */
+function cloneNode(node: FormLayoutNode): FormLayoutNode {
+  switch (node.type) {
+    case "field":
+      return cloneFieldNode(node);
+    case "group":
+      return {
+        type: "group",
+        ...(node.title !== undefined ? { title: node.title } : {}),
+        ...(node.columns !== undefined ? { columns: node.columns } : {}),
+        ...(node.className !== undefined ? { className: node.className } : {}),
+        children: node.children.map(cloneNode),
+      };
+    case "notebook":
+      return {
+        type: "notebook",
+        ...(node.className !== undefined ? { className: node.className } : {}),
+        children: node.children.map(clonePageNode),
+      };
+    case "page":
+      return clonePageNode(node);
+    case "separator":
+      return node.label !== undefined
+        ? { type: "separator", label: node.label }
+        : { type: "separator" };
+  }
+}
+
+function cloneFieldNode(node: FormFieldNode): FormFieldNode {
+  const out: FormFieldNode = { type: "field", field: node.field };
+  if (node.label !== undefined) out.label = node.label;
+  if (node.readonly !== undefined) out.readonly = node.readonly;
+  if (node.colspan !== undefined) out.colspan = node.colspan;
+  if (node.widget !== undefined) out.widget = node.widget;
+  if (node.nolabel !== undefined) out.nolabel = node.nolabel;
+  if (node.className !== undefined) out.className = node.className;
+  if (node.visibleWhen !== undefined) {
+    // `visibleWhen.value` is `unknown` — structuredClone safely walks it.
+    out.visibleWhen = structuredClone(node.visibleWhen);
+  }
+  return out;
+}
+
+function clonePageNode(node: FormPageNode): FormPageNode {
+  return {
+    type: "page",
+    title: node.title,
+    ...(node.className !== undefined ? { className: node.className } : {}),
+    children: node.children.map(cloneNode),
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `formLayout()` chain builder in `@linchkit/core` — parallel ergonomic API to the existing `field` / `row` / `group` / `notebook` / `page` helpers, mirroring the Phase 1 pattern from `permissionGroup()` (PR #317).
- Chain output deep-equals the helper composition for equivalent input; output is a plain `FormLayout` ready to drop into `ViewDefinition.layout`.
- `.build()` is fully idempotent (deep-cloned, no shared references, no mutation leaks between calls or with caller-owned objects).
- `.append(...)` escape hatch for verbose JSON shapes the chain can't express (titled groups, labeled separators).

## Builder surface
```ts
formLayout()
  .field(name, opts?)
  .row(...children)
  .group(...children)
  .notebook(...pages)
  .page(title, ...children)
  .append(...nodes)
  .build()  // → FormLayout
```

## Test plan
- [x] `bun run check` (clean)
- [x] `bun run typecheck` (clean)
- [x] `bun test` — 5104 pass / 3 skip / 0 fail; 20 new tests in `view-form-layout-builder.test.ts`
- [ ] `defineView()` wiring is intentionally out of scope (Phase 3+)

## Cross-model review
Codex/Gemini unavailable (codex usage limit, gemini classifier blocked); manual orchestrator review verified: deep-clone isolation between consecutive .build() calls, idempotency, output shape matches existing FormLayout type drop-in.

Refs #142 — keeps the issue open since Phase 3 (`defineRule`, etc.) is still pending.