### PR TITLE
feat(cap-ui): migrate cap-audit-ui hardcoded strings to i18n (closes #323)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/ai-resolve-intent.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/ai-resolve-intent.test.ts
@@ -156,7 +156,7 @@ async function postResolveIntent(
 // ── Scenario 1: Happy path ───────────────────────────────────
 
 describe("POST /api/ai/resolve-intent — happy path", () => {
-  const PORT = 31920;
+  const PORT = 31940;
   let server: ReturnType<typeof createServer>;
   const auditLogger = new AIAuditLogger();
   const { ontology } = buildOntology([createPurchaseAction]);
@@ -227,7 +227,7 @@ describe("POST /api/ai/resolve-intent — happy path", () => {
 // ── Scenario 2: AI cannot match ──────────────────────────────
 
 describe("POST /api/ai/resolve-intent — AI cannot match", () => {
-  const PORT = 31921;
+  const PORT = 31941;
   let server: ReturnType<typeof createServer>;
   const auditLogger = new AIAuditLogger();
   const { ontology } = buildOntology([createPurchaseAction]);
@@ -275,7 +275,7 @@ describe("POST /api/ai/resolve-intent — AI cannot match", () => {
 // ── Scenario 3: Empty prompt → 400 (Zod) ─────────────────────
 
 describe("POST /api/ai/resolve-intent — empty prompt", () => {
-  const PORT = 31922;
+  const PORT = 31942;
   let server: ReturnType<typeof createServer>;
   const { ontology } = buildOntology([createPurchaseAction]);
   const ai = fakeAiService({
@@ -315,7 +315,7 @@ describe("POST /api/ai/resolve-intent — empty prompt", () => {
 // ── Scenario 4: AI service unavailable → 503 ─────────────────
 
 describe("POST /api/ai/resolve-intent — AI unavailable", () => {
-  const PORT = 31923;
+  const PORT = 31943;
   let server: ReturnType<typeof createServer>;
   const auditLogger = new AIAuditLogger();
   const { ontology } = buildOntology([createPurchaseAction]);
@@ -373,7 +373,7 @@ describe("POST /api/ai/resolve-intent — AI unavailable", () => {
 // ── Scenario 5: Permission filtering ─────────────────────────
 
 describe("POST /api/ai/resolve-intent — permission filtering", () => {
-  const PORT = 31925;
+  const PORT = 31945;
   let server: ReturnType<typeof createServer>;
   const auditLogger = new AIAuditLogger();
   // Build an ontology with TWO actions; the actor is allowed to execute
@@ -454,7 +454,7 @@ describe("POST /api/ai/resolve-intent — permission filtering", () => {
 // ── Scenario 6: Audit entry shape ────────────────────────────
 
 describe("POST /api/ai/resolve-intent — audit entry shape", () => {
-  const PORT = 31926;
+  const PORT = 31946;
   let server: ReturnType<typeof createServer>;
   const auditLogger = new AIAuditLogger();
   const { ontology } = buildOntology([createPurchaseAction]);

--- a/addons/audit/cap-audit-ui/__tests__/i18n.test.ts
+++ b/addons/audit/cap-audit-ui/__tests__/i18n.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Smoke test for cap-audit-ui's i18n bootstrap module.
+ *
+ * Verifies the side-effect-only `./i18n` import registers the `en` and
+ * `zh-CN` bundles on the shared react-i18next instance so that every
+ * `t("audit.…")` / `t("events.…")` key the views call resolves to a
+ * non-default value.
+ *
+ * Asserting a representative sample of keys per locale catches the
+ * common breakage modes — JSON edit drops a top-level namespace, host
+ * adapter renames the i18n re-export, or a translation row goes empty.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+// Sample of keys exercised by AuditList / AuditDetail / AuditFilters
+// (audit.*) and EventTimeline / EventHandlersPanel / EventReplayDialog
+// (events.*). Local-only common keys live under audit.common.*.
+const SAMPLE_KEYS = [
+  "audit.list.title",
+  "audit.list.totalCount",
+  "audit.detail.title",
+  "audit.detail.stateTransition",
+  "audit.filters.statusAny",
+  "audit.common.previous",
+  "audit.common.next",
+  "events.timeline.title",
+  "events.handlers.title",
+  "events.replay.title",
+  "events.replay.delivered",
+] as const;
+
+describe("cap-audit-ui i18n bootstrap", () => {
+  it("registers en and zh-CN translations for every audit/events key", async () => {
+    const { i18n } = await import("@linchkit/cap-adapter-ui");
+    // Triggers `addResourceBundle(…)` for both locales as a side effect.
+    await import("../src/i18n");
+    // Subsequent imports of any view also re-import the bootstrap;
+    // re-evaluation must be idempotent (addResourceBundle deep=true,
+    // overwrite=true) — assert by re-running the import and re-checking.
+    await import("../src/i18n");
+
+    for (const key of SAMPLE_KEYS) {
+      const enValue = i18n.getResource("en", "translation", key);
+      const zhValue = i18n.getResource("zh-CN", "translation", key);
+      expect(typeof enValue).toBe("string");
+      expect((enValue as string).length).toBeGreaterThan(0);
+      expect(typeof zhValue).toBe("string");
+      expect((zhValue as string).length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/addons/audit/cap-audit-ui/__tests__/i18n.test.ts
+++ b/addons/audit/cap-audit-ui/__tests__/i18n.test.ts
@@ -18,13 +18,15 @@ import { describe, expect, it } from "bun:test";
 // (events.*). Local-only common keys live under audit.common.*.
 const SAMPLE_KEYS = [
   "audit.list.title",
-  "audit.list.totalCount",
+  "audit.list.totalCount_one",
+  "audit.list.totalCount_other",
   "audit.detail.title",
   "audit.detail.stateTransition",
   "audit.filters.statusAny",
   "audit.common.previous",
   "audit.common.next",
   "events.timeline.title",
+  "events.timeline.totalCount_other",
   "events.handlers.title",
   "events.replay.title",
   "events.replay.delivered",
@@ -33,12 +35,12 @@ const SAMPLE_KEYS = [
 describe("cap-audit-ui i18n bootstrap", () => {
   it("registers en and zh-CN translations for every audit/events key", async () => {
     const { i18n } = await import("@linchkit/cap-adapter-ui");
-    // Triggers `addResourceBundle(…)` for both locales as a side effect.
-    await import("../src/i18n");
-    // Subsequent imports of any view also re-import the bootstrap;
-    // re-evaluation must be idempotent (addResourceBundle deep=true,
-    // overwrite=true) — assert by re-running the import and re-checking.
-    await import("../src/i18n");
+    const { registerAuditI18nResources } = await import("../src/i18n");
+
+    // Explicit second call validates the bootstrap is idempotent;
+    // `addResourceBundle(deep=true, overwrite=true)` must merge without
+    // tearing down the host's existing "translation" namespace.
+    registerAuditI18nResources();
 
     for (const key of SAMPLE_KEYS) {
       const enValue = i18n.getResource("en", "translation", key);

--- a/addons/audit/cap-audit-ui/src/i18n/index.ts
+++ b/addons/audit/cap-audit-ui/src/i18n/index.ts
@@ -1,0 +1,37 @@
+/**
+ * Capability-scoped translation bundles for cap-audit-ui.
+ *
+ * Registers `en` and `zh-CN` resources on the shared react-i18next
+ * instance owned by `@linchkit/cap-adapter-ui`. Loading is side-effect-only:
+ * importing the module is enough to make every `t("audit.…")` /
+ * `t("events.…")` key resolve at render time. Importing again
+ * (re-evaluation under HMR / test isolation) is safe —
+ * `addResourceBundle(deep=true, overwrite=true)` merges idempotently.
+ *
+ * Layout matches `linch i18n-check` discovery: one JSON file per locale
+ * under `src/i18n/locales/`, keyed by BCP-47 language tag. The host i18n
+ * runtime in cap-adapter-ui is the single source of truth for the active
+ * language and the fallback chain.
+ *
+ * Mirrors the bootstrap pattern from cap-search-ui to avoid creating a
+ * new shared package — see KISS guideline in CLAUDE.md.
+ */
+
+import { i18n } from "@linchkit/cap-adapter-ui";
+import en from "./locales/en.json";
+import zhCN from "./locales/zh-CN.json";
+
+/** Locale code → resource map, used to seed the shared i18next instance. */
+const RESOURCES = {
+  en,
+  "zh-CN": zhCN,
+} as const;
+
+// `deep=true` so existing bundles (cap-adapter-ui's "translation" namespace)
+// are merged rather than replaced; `overwrite=true` ensures HMR re-imports
+// pick up edits to the JSON without a full reload.
+for (const [locale, resource] of Object.entries(RESOURCES)) {
+  i18n.addResourceBundle(locale, "translation", resource, true, true);
+}
+
+export { RESOURCES };

--- a/addons/audit/cap-audit-ui/src/i18n/index.ts
+++ b/addons/audit/cap-audit-ui/src/i18n/index.ts
@@ -30,8 +30,12 @@ const RESOURCES = {
 // `deep=true` so existing bundles (cap-adapter-ui's "translation" namespace)
 // are merged rather than replaced; `overwrite=true` ensures HMR re-imports
 // pick up edits to the JSON without a full reload.
-for (const [locale, resource] of Object.entries(RESOURCES)) {
-  i18n.addResourceBundle(locale, "translation", resource, true, true);
+export function registerAuditI18nResources(): void {
+  for (const [locale, resource] of Object.entries(RESOURCES)) {
+    i18n.addResourceBundle(locale, "translation", resource, true, true);
+  }
 }
+
+registerAuditI18nResources();
 
 export { RESOURCES };

--- a/addons/audit/cap-audit-ui/src/i18n/locales/en.json
+++ b/addons/audit/cap-audit-ui/src/i18n/locales/en.json
@@ -15,7 +15,8 @@
       "duration": "Duration",
       "empty": "No execution log entries match the current filters.",
       "openDetail": "Open audit detail",
-      "totalCount": "{{count}} entries"
+      "totalCount_one": "{{count}} entry",
+      "totalCount_other": "{{count}} entries"
     },
     "detail": {
       "title": "Execution detail",
@@ -68,8 +69,8 @@
       "summary": "Replay summary",
       "summaryHeading": "Replay result",
       "summaryDryHeading": "Dry run result",
-      "delivered": "{{n}} delivered",
-      "failed": "{{n}} failed",
+      "delivered": "{{count}} delivered",
+      "failed": "{{count}} failed",
       "noHandlers": "No registered handlers matched this event."
     },
     "timeline": {
@@ -79,7 +80,8 @@
       "hideHandlers": "Hide handlers",
       "viewHandlers": "View handlers",
       "replay": "Replay",
-      "totalCount": "{{count}} events"
+      "totalCount_one": "{{count}} event",
+      "totalCount_other": "{{count}} events"
     }
   }
 }

--- a/addons/audit/cap-audit-ui/src/i18n/locales/en.json
+++ b/addons/audit/cap-audit-ui/src/i18n/locales/en.json
@@ -1,0 +1,85 @@
+{
+  "audit": {
+    "common": {
+      "previous": "Previous",
+      "next": "Next"
+    },
+    "list": {
+      "title": "Audit Log",
+      "subtitle": "Every action execution recorded in _linchkit.executions.",
+      "startedAt": "Started",
+      "action": "Action",
+      "entity": "Entity",
+      "actor": "Actor",
+      "status": "Status",
+      "duration": "Duration",
+      "empty": "No execution log entries match the current filters.",
+      "openDetail": "Open audit detail",
+      "totalCount": "{{count}} entries"
+    },
+    "detail": {
+      "title": "Execution detail",
+      "executionId": "Execution ID",
+      "status": "Status",
+      "action": "Action",
+      "duration": "Duration",
+      "actor": "Actor",
+      "entity": "Entity",
+      "channel": "Channel",
+      "capability": "Capability",
+      "startedAt": "Started",
+      "completedAt": "Completed",
+      "error": "Error",
+      "stateTransition": "State transition",
+      "input": "Input",
+      "output": "Output",
+      "meta": "Execution meta (Spec 65)",
+      "notFound": "Execution not found."
+    },
+    "filters": {
+      "action": "Action",
+      "actor": "Actor",
+      "entity": "Entity",
+      "status": "Status",
+      "statusAny": "Any",
+      "apply": "Apply",
+      "reset": "Reset filters"
+    }
+  },
+  "events": {
+    "handlers": {
+      "title": "Handler history",
+      "empty": "No handler invocations recorded.",
+      "handler": "Handler",
+      "status": "Status",
+      "duration": "ms",
+      "aggregate": "(aggregate)"
+    },
+    "replay": {
+      "title": "Replay event",
+      "description": "Re-dispatch the event through its registered handlers. The original event row is never modified.",
+      "targetFallback": "Event",
+      "dryRun": "Dry run",
+      "dryRunHint": "Dry run — resolve candidate handlers without invoking them.",
+      "handlerFilterLabel": "Restrict to handler (optional)",
+      "cancel": "Cancel",
+      "submit": "Replay now",
+      "submitDry": "Run dry replay",
+      "summary": "Replay summary",
+      "summaryHeading": "Replay result",
+      "summaryDryHeading": "Dry run result",
+      "delivered": "{{n}} delivered",
+      "failed": "{{n}} failed",
+      "noHandlers": "No registered handlers matched this event."
+    },
+    "timeline": {
+      "title": "Event Timeline",
+      "subtitle": "Every domain event persisted to _linchkit.events with per-handler delivery state.",
+      "empty": "No events match the current filter.",
+      "hideHandlers": "Hide handlers",
+      "viewHandlers": "View handlers",
+      "replay": "Replay",
+      "totalCount": "{{count}} events"
+    }
+  }
+}

--- a/addons/audit/cap-audit-ui/src/i18n/locales/zh-CN.json
+++ b/addons/audit/cap-audit-ui/src/i18n/locales/zh-CN.json
@@ -15,7 +15,8 @@
       "duration": "耗时",
       "empty": "当前筛选条件下没有匹配的执行日志。",
       "openDetail": "打开执行详情",
-      "totalCount": "共 {{count}} 条"
+      "totalCount_one": "共 {{count}} 条",
+      "totalCount_other": "共 {{count}} 条"
     },
     "detail": {
       "title": "执行详情",
@@ -68,8 +69,8 @@
       "summary": "重放摘要",
       "summaryHeading": "重放结果",
       "summaryDryHeading": "试运行结果",
-      "delivered": "已派发 {{n}} 个",
-      "failed": "失败 {{n}} 个",
+      "delivered": "已派发 {{count}} 个",
+      "failed": "失败 {{count}} 个",
       "noHandlers": "没有已注册的处理器匹配该事件。"
     },
     "timeline": {
@@ -79,7 +80,8 @@
       "hideHandlers": "隐藏处理器",
       "viewHandlers": "查看处理器",
       "replay": "重放",
-      "totalCount": "共 {{count}} 个事件"
+      "totalCount_one": "共 {{count}} 个事件",
+      "totalCount_other": "共 {{count}} 个事件"
     }
   }
 }

--- a/addons/audit/cap-audit-ui/src/i18n/locales/zh-CN.json
+++ b/addons/audit/cap-audit-ui/src/i18n/locales/zh-CN.json
@@ -1,0 +1,85 @@
+{
+  "audit": {
+    "common": {
+      "previous": "上一页",
+      "next": "下一页"
+    },
+    "list": {
+      "title": "审计日志",
+      "subtitle": "_linchkit.executions 中记录的每一次 Action 执行。",
+      "startedAt": "开始时间",
+      "action": "Action",
+      "entity": "实体",
+      "actor": "操作者",
+      "status": "状态",
+      "duration": "耗时",
+      "empty": "当前筛选条件下没有匹配的执行日志。",
+      "openDetail": "打开执行详情",
+      "totalCount": "共 {{count}} 条"
+    },
+    "detail": {
+      "title": "执行详情",
+      "executionId": "执行 ID",
+      "status": "状态",
+      "action": "Action",
+      "duration": "耗时",
+      "actor": "操作者",
+      "entity": "实体",
+      "channel": "通道",
+      "capability": "能力",
+      "startedAt": "开始时间",
+      "completedAt": "完成时间",
+      "error": "错误",
+      "stateTransition": "状态迁移",
+      "input": "输入",
+      "output": "输出",
+      "meta": "执行元数据 (Spec 65)",
+      "notFound": "未找到该执行记录。"
+    },
+    "filters": {
+      "action": "Action",
+      "actor": "操作者",
+      "entity": "实体",
+      "status": "状态",
+      "statusAny": "全部",
+      "apply": "应用",
+      "reset": "重置筛选"
+    }
+  },
+  "events": {
+    "handlers": {
+      "title": "处理器历史",
+      "empty": "没有处理器调用记录。",
+      "handler": "处理器",
+      "status": "状态",
+      "duration": "毫秒",
+      "aggregate": "（聚合）"
+    },
+    "replay": {
+      "title": "重放事件",
+      "description": "通过已注册的处理器重新派发该事件。原始事件行不会被修改。",
+      "targetFallback": "事件",
+      "dryRun": "试运行",
+      "dryRunHint": "试运行 — 仅解析候选处理器而不实际调用。",
+      "handlerFilterLabel": "限定处理器（可选）",
+      "cancel": "取消",
+      "submit": "立即重放",
+      "submitDry": "运行试重放",
+      "summary": "重放摘要",
+      "summaryHeading": "重放结果",
+      "summaryDryHeading": "试运行结果",
+      "delivered": "已派发 {{n}} 个",
+      "failed": "失败 {{n}} 个",
+      "noHandlers": "没有已注册的处理器匹配该事件。"
+    },
+    "timeline": {
+      "title": "事件时间线",
+      "subtitle": "_linchkit.events 中持久化的每一个领域事件，附带每个处理器的派发状态。",
+      "empty": "没有事件匹配当前筛选条件。",
+      "hideHandlers": "隐藏处理器",
+      "viewHandlers": "查看处理器",
+      "replay": "重放",
+      "totalCount": "共 {{count}} 个事件"
+    }
+  }
+}

--- a/addons/audit/cap-audit-ui/src/index.ts
+++ b/addons/audit/cap-audit-ui/src/index.ts
@@ -4,7 +4,15 @@
  * Registers the audit log admin route + the event timeline admin route.
  * Imported by the host UI bundle (cap-adapter-ui) to wire the capability
  * into the admin layout.
+ *
+ * The `./i18n` import is side-effect-only — it adds the capability's
+ * `en` / `zh-CN` bundles to the shared react-i18next instance before
+ * any view is rendered. Keep it ABOVE the route registration so the
+ * `audit.list.title` / `events.timeline.title` labels used below
+ * resolve on first render.
  */
+
+import "./i18n";
 
 import { registerAdminRoute } from "@linchkit/cap-adapter-ui/route-registry";
 

--- a/addons/audit/cap-audit-ui/src/views/AuditList.tsx
+++ b/addons/audit/cap-audit-ui/src/views/AuditList.tsx
@@ -259,7 +259,7 @@ export function AuditList() {
               size="sm"
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={page <= 1 || loading}
-              aria-label={t("common.previous", "Previous")}
+              aria-label={t("audit.common.previous", "Previous")}
             >
               <ChevronLeft className="size-4" />
             </Button>
@@ -271,7 +271,7 @@ export function AuditList() {
               size="sm"
               onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
               disabled={page >= totalPages || loading}
-              aria-label={t("common.next", "Next")}
+              aria-label={t("audit.common.next", "Next")}
             >
               <ChevronRight className="size-4" />
             </Button>

--- a/addons/audit/cap-audit-ui/src/views/EventReplayDialog.tsx
+++ b/addons/audit/cap-audit-ui/src/views/EventReplayDialog.tsx
@@ -209,11 +209,17 @@ function ReplaySummary({ report }: { report: ReplayReport }) {
             : t("events.replay.summaryHeading", "Replay result")}
         </span>
         <Badge variant="default">
-          {t("events.replay.delivered", { defaultValue: "{{n}} delivered", n: report.delivered })}
+          {t("events.replay.delivered", {
+            defaultValue: "{{count}} delivered",
+            count: report.delivered,
+          })}
         </Badge>
         {report.failed > 0 && (
           <Badge variant="destructive">
-            {t("events.replay.failed", { defaultValue: "{{n}} failed", n: report.failed })}
+            {t("events.replay.failed", {
+              defaultValue: "{{count}} failed",
+              count: report.failed,
+            })}
           </Badge>
         )}
       </header>


### PR DESCRIPTION
## Summary
- Wire i18n into `cap-audit-ui` (en + zh-CN bundles, side-effect bootstrap).
- All `audit.*` / `events.*` keys covered; AuditList pagination labels namespaced to `audit.common.*` to avoid colliding with cap-adapter-ui's host bundle.
- Reuse host-owned `common.refresh` / `common.close` as-is.
- cap-search-ui was already migrated in #319; this PR completes #323.

## Verification
- `bun run check` — clean.
- `bun run typecheck` — clean.
- `bun test` — 5157 pass / 3 skip / 0 fail (323 files).
- `linch i18n-check` — `5 clean, 0 skipped, 5 total. cap-audit-ui [en, zh-CN] OK`.

## Test plan
- [x] Bootstrap registers en + zh-CN bundles via `i18n.addResourceBundle`
- [x] Every key referenced from AuditList / AuditDetail / AuditFilters / EventTimeline / EventsPage / EventHandlersPanel / EventReplayDialog resolves in both locales
- [x] No regression in cap-search-ui i18n

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full English and Simplified Chinese translations for the audit UI (listings, details, filters, handler history, replay flows, timelines).
  * Translation bundles are now registered automatically at startup.

* **Bug Fixes / UX**
  * Pagination accessibility labels and replay result count display improved for correct localization and pluralization.

* **Tests**
  * Added a smoke test to validate i18n resource loading.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laofahai/linchkit/pull/326?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->