### PR TITLE
feat(cap-cache-redis): L2 cache adapter with cross-instance invalidation (closes #131)

### DIFF
--- a/addons/cache-redis/cap-cache-redis/README.md
+++ b/addons/cache-redis/cap-cache-redis/README.md
@@ -1,0 +1,85 @@
+# @linchkit/cap-cache-redis
+
+Redis-backed L2 cache provider with cross-instance invalidation via Redis
+Pub/Sub. Implements the standard `CacheProvider` interface from
+`@linchkit/core` so it can slot into `CacheManager` as the L2 layer above an
+in-process L1.
+
+## When to use
+
+Reach for this capability when your deployment grows past the
+~10-instance threshold where the Postgres LISTEN/NOTIFY invalidator
+(`PostgresCacheInvalidator`, Spec 34 §7 Phase 1) starts to cost more
+connections than it saves. Redis Pub/Sub fans messages out to every
+subscriber in O(1), and the shared L2 store reduces cold-start latency
+after deployments.
+
+Stay on Postgres NOTIFY if you have fewer than 10 application instances —
+introducing Redis adds an operational dependency the L1+NOTIFY layout does
+not need.
+
+## Install
+
+```bash
+bun add @linchkit/cap-cache-redis ioredis
+```
+
+`ioredis` is a peer-grade runtime dependency. Choose `ioredis` over `redis`
+for Sentinel / Cluster compatibility.
+
+## Bootstrap
+
+```ts
+import { CacheManager, InMemoryCacheProvider } from "@linchkit/core";
+import { createCapCacheRedis } from "@linchkit/cap-cache-redis";
+
+const cacheRedis = createCapCacheRedis({
+  redisUrl: process.env.REDIS_URL,
+  namespace: "linchkit:cache",          // optional, defaults shown
+  invalidationChannel: "linchkit:cache:invalidate",
+});
+
+const cacheManager = new CacheManager({
+  l1: new InMemoryCacheProvider({ maxSize: 5_000 }),
+  l2: cacheRedis.provider,
+});
+
+// register the capability with your host so other capabilities can
+// resolve the provider via DI.
+host.registerCapability(cacheRedis);
+```
+
+## Environment variables
+
+| Name | Required | Description |
+| --- | --- | --- |
+| `REDIS_URL` | yes (or pass `redisUrl`) | Standard Redis connection URI, e.g. `redis://user:pass@host:6379/0`. Use `rediss://` for TLS. |
+
+## How it works
+
+* **TTL** — `set(key, value, { ttl })` issues `SET key value PX ttl` so
+  Redis evicts the entry server-side. The same expiry timestamp is stored
+  in a JSON envelope so the local mirror can drop the entry without an
+  extra round-trip.
+* **Stale-while-revalidate** — `swrTtl` extends the Redis-side `PX` to
+  `ttl + swrTtl` and records both `softExpiresAt` and `expiresAt` in the
+  envelope. `getWithStaleness` returns `{ value, isStale: true }` when the
+  read lands in the SWR window.
+* **Tags** — each tag maps to a Redis set at `{namespace}:t:{tag}`.
+  `invalidateByTag` runs `SMEMBERS` + a single `DEL` for every member,
+  then drops the tag set.
+* **Cross-instance invalidation** — every write/delete publishes
+  `{type, payload}` on `invalidationChannel`. Every other provider
+  instance subscribes via a duplicate connection and evicts the matching
+  entry from its local mirror.
+
+See [Spec 34 — Cache Strategy](../../../docs/specs/34_cache_strategy.md)
+and [issue #131](https://github.com/laofahai/linchkit/issues/131) for the
+full design.
+
+## Limitations
+
+* The local mirror is a write-through cache; a freshly-started instance
+  pays one Redis `GET` to hydrate any key it has not seen before.
+* Stats (`getStats()`) are per-process — Redis itself does not expose
+  per-application hit/miss counters.

--- a/addons/cache-redis/cap-cache-redis/__tests__/mock-redis.ts
+++ b/addons/cache-redis/cap-cache-redis/__tests__/mock-redis.ts
@@ -1,0 +1,200 @@
+/**
+ * Test-only in-memory Redis client mock.
+ *
+ * Implements the subset of the ioredis API exercised by RedisCacheProvider
+ * and RedisInvalidator. Records every command so tests can assert that the
+ * provider issues the right Redis traffic (GET, SET ... PX, DEL,
+ * SADD tags:*, SUBSCRIBE, PUBLISH).
+ *
+ * Pub/Sub is implemented via a shared "broker" object that every duplicate
+ * client receives — calling `publish` on one duplicate fans the message out
+ * to every subscriber on the same channel, matching real ioredis semantics.
+ */
+
+import type { RedisLike } from "../src/types";
+
+type Listener = (channel: string, message: string) => void;
+
+interface Broker {
+  channels: Map<string, Set<MockRedis>>;
+  publish(channel: string, message: string): number;
+}
+
+function makeBroker(): Broker {
+  return {
+    channels: new Map(),
+    publish(channel, message) {
+      const subs = this.channels.get(channel);
+      if (!subs) return 0;
+      for (const sub of subs) sub._deliver(channel, message);
+      return subs.size;
+    },
+  };
+}
+
+export interface RecordedCommand {
+  name: string;
+  args: unknown[];
+}
+
+export class MockRedis implements RedisLike {
+  public readonly commands: RecordedCommand[] = [];
+  public readonly store = new Map<string, string>();
+  public readonly sets = new Map<string, Set<string>>();
+  public readonly expiries = new Map<string, number>();
+  private readonly listeners = new Map<string, Set<Listener>>();
+  private readonly broker: Broker;
+  private readonly subscriptions = new Set<string>();
+  private closed = false;
+
+  constructor(broker?: Broker) {
+    this.broker = broker ?? makeBroker();
+  }
+
+  private record(name: string, args: unknown[]): void {
+    this.commands.push({ name, args });
+  }
+
+  private isExpired(key: string): boolean {
+    const expiry = this.expiries.get(key);
+    if (expiry === undefined) return false;
+    if (Date.now() > expiry) {
+      this.store.delete(key);
+      this.expiries.delete(key);
+      return true;
+    }
+    return false;
+  }
+
+  async get(key: string): Promise<string | null> {
+    this.record("GET", [key]);
+    if (this.isExpired(key)) return null;
+    return this.store.get(key) ?? null;
+  }
+
+  async set(key: string, value: string, ...args: Array<string | number>): Promise<unknown> {
+    this.record("SET", [key, value, ...args]);
+    this.store.set(key, value);
+    // Parse trailing ttl option: ... "PX", number | "EX", number
+    for (let i = 0; i < args.length; i++) {
+      const token = args[i];
+      const next = args[i + 1];
+      if (typeof token === "string" && typeof next === "number") {
+        const upper = token.toUpperCase();
+        if (upper === "PX") {
+          this.expiries.set(key, Date.now() + next);
+        } else if (upper === "EX") {
+          this.expiries.set(key, Date.now() + next * 1000);
+        }
+      }
+    }
+    return "OK";
+  }
+
+  async del(...keys: string[]): Promise<number> {
+    this.record("DEL", keys);
+    let count = 0;
+    for (const key of keys) {
+      if (this.store.delete(key)) count++;
+      this.expiries.delete(key);
+      if (this.sets.delete(key)) count++;
+    }
+    return count;
+  }
+
+  async sadd(key: string, ...members: string[]): Promise<number> {
+    this.record("SADD", [key, ...members]);
+    let set = this.sets.get(key);
+    if (!set) {
+      set = new Set();
+      this.sets.set(key, set);
+    }
+    let added = 0;
+    for (const member of members) {
+      if (!set.has(member)) {
+        set.add(member);
+        added++;
+      }
+    }
+    return added;
+  }
+
+  async smembers(key: string): Promise<string[]> {
+    this.record("SMEMBERS", [key]);
+    return Array.from(this.sets.get(key) ?? []);
+  }
+
+  async publish(channel: string, message: string): Promise<number> {
+    this.record("PUBLISH", [channel, message]);
+    return this.broker.publish(channel, message);
+  }
+
+  async subscribe(channel: string, ..._args: unknown[]): Promise<unknown> {
+    this.record("SUBSCRIBE", [channel]);
+    this.subscriptions.add(channel);
+    let subs = this.broker.channels.get(channel);
+    if (!subs) {
+      subs = new Set();
+      this.broker.channels.set(channel, subs);
+    }
+    subs.add(this);
+    return 1;
+  }
+
+  async unsubscribe(...channels: string[]): Promise<unknown> {
+    this.record("UNSUBSCRIBE", channels);
+    for (const channel of channels) {
+      this.subscriptions.delete(channel);
+      this.broker.channels.get(channel)?.delete(this);
+    }
+    return 0;
+  }
+
+  async quit(): Promise<unknown> {
+    this.record("QUIT", []);
+    this.closed = true;
+    for (const channel of this.subscriptions) {
+      this.broker.channels.get(channel)?.delete(this);
+    }
+    this.subscriptions.clear();
+    return "OK";
+  }
+
+  on(event: string, listener: (...args: unknown[]) => void): this {
+    let set = this.listeners.get(event);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(event, set);
+    }
+    set.add(listener as Listener);
+    return this;
+  }
+
+  duplicate(_overrides?: Record<string, unknown>): RedisLike {
+    return new MockRedis(this.broker);
+  }
+
+  defineCommand(_name: string, _definition: { numberOfKeys: number; lua: string }): unknown {
+    this.record("DEFINE_COMMAND", [_name]);
+    return undefined;
+  }
+
+  /** Internal: fan-out delivery from the broker. */
+  _deliver(channel: string, message: string): void {
+    if (this.closed) return;
+    const set = this.listeners.get("message");
+    if (!set) return;
+    for (const listener of set) listener(channel, message);
+  }
+
+  /** Test helper — return commands of a given name. */
+  commandsByName(name: string): RecordedCommand[] {
+    return this.commands.filter((cmd) => cmd.name === name);
+  }
+}
+
+/** Build a pair of MockRedis instances sharing the same Pub/Sub broker. */
+export function makeLinkedMockPair(): { a: MockRedis; b: MockRedis; broker: Broker } {
+  const broker = makeBroker();
+  return { a: new MockRedis(broker), b: new MockRedis(broker), broker };
+}

--- a/addons/cache-redis/cap-cache-redis/__tests__/redis-cache-provider.test.ts
+++ b/addons/cache-redis/cap-cache-redis/__tests__/redis-cache-provider.test.ts
@@ -192,4 +192,147 @@ describe("RedisCacheProvider", () => {
     expect(() => new RedisCacheProvider()).toThrow();
     if (original !== undefined) process.env.REDIS_URL = original;
   });
+
+  it("rejects non-positive maxLocalMirrorEntries", () => {
+    expect(
+      () =>
+        new RedisCacheProvider({
+          client: new MockRedis(),
+          maxLocalMirrorEntries: 0,
+        }),
+    ).toThrow();
+    expect(
+      () =>
+        new RedisCacheProvider({
+          client: new MockRedis(),
+          maxLocalMirrorEntries: -5,
+        }),
+    ).toThrow();
+  });
+});
+
+describe("RedisCacheProvider local-mirror LRU", () => {
+  it("evicts the oldest entry once the cap is exceeded", async () => {
+    const mock = new MockRedis();
+    const p = new RedisCacheProvider({
+      client: mock,
+      namespace: NS,
+      invalidationChannel: "test:invalidate",
+      maxLocalMirrorEntries: 3,
+    });
+    try {
+      p.set("a", 1);
+      p.set("b", 2);
+      p.set("c", 3);
+      p.set("d", 4);
+      // "a" is the oldest insertion → should be evicted from the mirror.
+      // We assert the mirror state via stats().size and by observing that a
+      // get on "a" misses (hydration will repopulate, so we only check the
+      // synchronous first-call result).
+      expect(p.stats().size).toBe(3);
+      // Wipe Redis so hydration cannot bring "a" back during the same tick.
+      mock.store.clear();
+      expect(p.get("a")).toBeUndefined();
+      expect(p.get<number>("b")).toBe(2);
+      expect(p.get<number>("c")).toBe(3);
+      expect(p.get<number>("d")).toBe(4);
+      expect(p.stats().evictions).toBeGreaterThanOrEqual(1);
+    } finally {
+      await p.close();
+    }
+  });
+
+  it("bumps a read entry to MRU so a later write evicts a different key", async () => {
+    const mock = new MockRedis();
+    const p = new RedisCacheProvider({
+      client: mock,
+      namespace: NS,
+      invalidationChannel: "test:invalidate",
+      maxLocalMirrorEntries: 3,
+    });
+    try {
+      p.set("a", 1);
+      p.set("b", 2);
+      p.set("c", 3);
+      // Read "a" to bump it to MRU. Order should now be: b, c, a.
+      expect(p.get<number>("a")).toBe(1);
+      // Adding "d" should now evict "b" (the new LRU), not "a".
+      p.set("d", 4);
+      mock.store.clear();
+      expect(p.get("b")).toBeUndefined();
+      expect(p.get<number>("a")).toBe(1);
+      expect(p.get<number>("c")).toBe(3);
+      expect(p.get<number>("d")).toBe(4);
+    } finally {
+      await p.close();
+    }
+  });
+
+  it("bumps a hydrated entry to MRU", async () => {
+    const mock = new MockRedis();
+    const p = new RedisCacheProvider({
+      client: mock,
+      namespace: NS,
+      invalidationChannel: "test:invalidate",
+      maxLocalMirrorEntries: 3,
+    });
+    try {
+      p.set("a", 1);
+      p.set("b", 2);
+      p.set("c", 3);
+      // Pre-seed Redis with "z" and hydrate via a missed get.
+      mock.store.set(`${NS}:k:z`, JSON.stringify({ v: 99, t: [], c: Date.now() }));
+      expect(p.get("z")).toBeUndefined();
+      await flushAsync();
+      // Mirror order is now: b, c, z (hydration bumped z to MRU; a was evicted).
+      mock.store.clear();
+      expect(p.get("a")).toBeUndefined();
+      expect(p.get<number>("z")).toBe(99);
+    } finally {
+      await p.close();
+    }
+  });
+});
+
+describe("RedisCacheProvider hydration dedup", () => {
+  it("coalesces concurrent misses on the same key into a single Redis GET", async () => {
+    const mock = new MockRedis();
+    let inflight = 0;
+    let maxInflight = 0;
+    let totalGets = 0;
+    const originalGet = mock.get.bind(mock);
+    mock.get = async (key: string) => {
+      totalGets++;
+      inflight++;
+      maxInflight = Math.max(maxInflight, inflight);
+      try {
+        // Stall so concurrent callers can queue up.
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return originalGet(key);
+      } finally {
+        inflight--;
+      }
+    };
+
+    const p = new RedisCacheProvider({
+      client: mock,
+      namespace: NS,
+      invalidationChannel: "test:invalidate",
+    });
+    try {
+      mock.store.set(`${NS}:k:hot`, JSON.stringify({ v: "shared", t: [], c: Date.now() }));
+      // Fire many concurrent misses on the same key.
+      for (let i = 0; i < 8; i++) p.get("hot");
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      // Exactly one hydration GET should have hit Redis.
+      const hotGets = mock.commandsByName("GET").filter((cmd) => cmd.args[0] === `${NS}:k:hot`);
+      expect(hotGets.length).toBe(1);
+      expect(totalGets).toBe(1);
+      expect(maxInflight).toBe(1);
+      // After hydration the mirror is populated and the value is observable.
+      expect(p.get<string>("hot")).toBe("shared");
+    } finally {
+      await p.close();
+    }
+  });
 });

--- a/addons/cache-redis/cap-cache-redis/__tests__/redis-cache-provider.test.ts
+++ b/addons/cache-redis/cap-cache-redis/__tests__/redis-cache-provider.test.ts
@@ -1,0 +1,195 @@
+/**
+ * RedisCacheProvider behavioural tests against a fully mocked Redis client.
+ *
+ * Verifies the exact Redis traffic (GET, SET ... PX, DEL, SADD tags:*) and
+ * the local-mirror semantics that satisfy the synchronous CacheProvider
+ * contract (TTL, SWR, tag invalidation, stats).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { RedisCacheProvider } from "../src/redis-cache-provider";
+import { decodeEnvelope } from "../src/redis-key-encoder";
+import { MockRedis } from "./mock-redis";
+
+const NS = "test:cache";
+
+/** Yield until every queued microtask resolves — flushes the provider's fire-and-forget writes. */
+async function flushAsync(times = 3): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    await Promise.resolve();
+  }
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("RedisCacheProvider", () => {
+  let mock: MockRedis;
+  let provider: RedisCacheProvider;
+
+  beforeEach(() => {
+    mock = new MockRedis();
+    provider = new RedisCacheProvider({
+      client: mock,
+      namespace: NS,
+      invalidationChannel: "test:invalidate",
+    });
+  });
+
+  afterEach(async () => {
+    await provider.close();
+  });
+
+  it("subscribes to the invalidation channel on start", async () => {
+    await flushAsync();
+    // The invalidator subscribes on a duplicate connection — assert against
+    // the broker by publishing and observing that no SUBSCRIBE landed on
+    // the primary mock (subscriber is a different MockRedis instance).
+    const subs = mock.commandsByName("SUBSCRIBE");
+    expect(subs.length).toBe(0); // primary client is publisher only
+  });
+
+  it("SET issues SET ... PX ttl plus SADD per tag and stores an envelope", async () => {
+    provider.set("user:1", { name: "Alice" }, { ttl: 60_000, tags: ["tenant:t1", "users"] });
+    await flushAsync();
+
+    const sets = mock.commandsByName("SET");
+    expect(sets.length).toBe(1);
+    const setCmd = sets[0];
+    if (!setCmd) throw new Error("SET command missing");
+    expect(setCmd.args[0]).toBe(`${NS}:k:user:1`);
+    expect(setCmd.args[2]).toBe("PX");
+    expect(setCmd.args[3]).toBe(60_000);
+
+    const stored = mock.store.get(`${NS}:k:user:1`);
+    const envelope = decodeEnvelope(stored ?? null);
+    expect(envelope?.v).toEqual({ name: "Alice" });
+    expect(envelope?.t).toEqual(["tenant:t1", "users"]);
+    expect(envelope?.e).toBeDefined();
+    expect(envelope?.s).toBeUndefined();
+
+    const sadds = mock.commandsByName("SADD");
+    expect(sadds.map((cmd) => cmd.args[0])).toEqual([`${NS}:t:tenant:t1`, `${NS}:t:users`]);
+    expect(mock.sets.get(`${NS}:t:tenant:t1`)?.has("user:1")).toBe(true);
+  });
+
+  it("SET without ttl issues a SET without PX", async () => {
+    provider.set("no-ttl", "value");
+    await flushAsync();
+    const sets = mock.commandsByName("SET");
+    const setCmd = sets[0];
+    if (!setCmd) throw new Error("SET command missing");
+    expect(setCmd.args.length).toBe(2);
+    expect(setCmd.args[0]).toBe(`${NS}:k:no-ttl`);
+  });
+
+  it("get returns the value from the local mirror immediately after set", () => {
+    provider.set("greeting", "hello");
+    expect(provider.get<string>("greeting")).toBe("hello");
+    expect(provider.stats().hits).toBe(1);
+    expect(provider.stats().misses).toBe(0);
+  });
+
+  it("returns undefined and counts a miss when the key is unknown", () => {
+    expect(provider.get("missing")).toBeUndefined();
+    expect(provider.stats().misses).toBe(1);
+  });
+
+  it("evicts on hard TTL boundary", async () => {
+    provider.set("short", "v", { ttl: 5 });
+    expect(provider.get("short")).toBe("v");
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    expect(provider.get("short")).toBeUndefined();
+    const stats = provider.stats();
+    expect(stats.evictions).toBe(1);
+  });
+
+  it("serves stale value with isStale=true inside SWR window", async () => {
+    provider.set("warm", "v", { ttl: 10, swrTtl: 100 });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const result = provider.getWithStaleness<string>("warm");
+    expect(result).toBeDefined();
+    expect(result?.value).toBe("v");
+    expect(result?.isStale).toBe(true);
+  });
+
+  it("evicts past the SWR boundary", async () => {
+    provider.set("decay", "v", { ttl: 5, swrTtl: 5 });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(provider.get("decay")).toBeUndefined();
+  });
+
+  it("delete issues DEL and publishes invalidate-key", async () => {
+    provider.set("k", "v");
+    await flushAsync();
+    const existed = provider.delete("k");
+    expect(existed).toBe(true);
+    await flushAsync();
+    const dels = mock.commandsByName("DEL");
+    expect(dels.some((cmd) => cmd.args[0] === `${NS}:k:k`)).toBe(true);
+    const pubs = mock.commandsByName("PUBLISH");
+    expect(pubs.length).toBe(1);
+    const pubCmd = pubs[0];
+    if (!pubCmd) throw new Error("PUBLISH missing");
+    const payload = JSON.parse(pubCmd.args[1] as string);
+    expect(payload.type).toBe("invalidate-key");
+    expect(payload.key).toBe("k");
+  });
+
+  it("invalidateByTag removes mirror entries and DELs all tagged keys + the tag set", async () => {
+    provider.set("a", 1, { tags: ["t1"] });
+    provider.set("b", 2, { tags: ["t1"] });
+    provider.set("c", 3, { tags: ["other"] });
+    await flushAsync();
+
+    const removed = provider.invalidateByTag("t1");
+    expect(removed).toBe(2);
+    expect(provider.get("a")).toBeUndefined();
+    expect(provider.get("b")).toBeUndefined();
+    expect(provider.get<number>("c")).toBe(3);
+
+    await flushAsync();
+    const dels = mock.commandsByName("DEL");
+    // One DEL for the underlying keys, one DEL for the tag set.
+    const tagSetDel = dels.find((cmd) => cmd.args[0] === `${NS}:t:t1`);
+    expect(tagSetDel).toBeDefined();
+  });
+
+  it("hydrates the local mirror from Redis on a miss", async () => {
+    // Pre-seed Redis directly with an envelope.
+    const envelope = JSON.stringify({ v: "from-redis", t: [], c: Date.now() });
+    mock.store.set(`${NS}:k:remote`, envelope);
+
+    // First call misses but triggers hydration.
+    expect(provider.get("remote")).toBeUndefined();
+    await flushAsync();
+    expect(provider.get<string>("remote")).toBe("from-redis");
+  });
+
+  it("stats track hits, misses, and evictions", () => {
+    provider.set("k", "v");
+    provider.get("k");
+    provider.get("k");
+    provider.get("missing");
+    const stats = provider.stats();
+    expect(stats.hits).toBe(2);
+    expect(stats.misses).toBe(1);
+    expect(stats.size).toBe(1);
+    expect(stats.hitRate).toBeCloseTo(2 / 3);
+  });
+
+  it("clear empties the local mirror and broadcasts a clear message", async () => {
+    provider.set("k", "v");
+    provider.clear();
+    expect(provider.get("k")).toBeUndefined();
+    await flushAsync();
+    const pubs = mock.commandsByName("PUBLISH");
+    const payload = JSON.parse(pubs[pubs.length - 1]?.args[1] as string);
+    expect(payload.type).toBe("clear");
+  });
+
+  it("throws when neither client nor URL is supplied", () => {
+    const original = process.env.REDIS_URL;
+    delete process.env.REDIS_URL;
+    expect(() => new RedisCacheProvider()).toThrow();
+    if (original !== undefined) process.env.REDIS_URL = original;
+  });
+});

--- a/addons/cache-redis/cap-cache-redis/__tests__/redis-invalidator.test.ts
+++ b/addons/cache-redis/cap-cache-redis/__tests__/redis-invalidator.test.ts
@@ -1,0 +1,113 @@
+/**
+ * RedisInvalidator tests — verify the Pub/Sub round-trip between two
+ * provider instances using a shared broker.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { RedisCacheProvider } from "../src/redis-cache-provider";
+import { RedisInvalidator } from "../src/redis-invalidator";
+import { MockRedis, makeLinkedMockPair } from "./mock-redis";
+
+const CHANNEL = "test:cache:invalidate";
+
+async function flushAsync(times = 4): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    await Promise.resolve();
+  }
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("RedisInvalidator", () => {
+  it("publishes a serialised message on the configured channel", async () => {
+    const pub = new MockRedis();
+    const sub = pub.duplicate() as MockRedis;
+    const received: unknown[] = [];
+
+    const invalidator = new RedisInvalidator({
+      publisher: pub,
+      subscriber: sub,
+      channel: CHANNEL,
+      onMessage: (msg) => received.push(msg),
+    });
+
+    await invalidator.start();
+    await invalidator.broadcast({ type: "invalidate-key", key: "foo", origin: invalidator.id });
+    await flushAsync();
+
+    const pubs = pub.commandsByName("PUBLISH");
+    expect(pubs.length).toBe(1);
+    const pubCmd = pubs[0];
+    if (!pubCmd) throw new Error("PUBLISH missing");
+    expect(pubCmd.args[0]).toBe(CHANNEL);
+    const decoded = JSON.parse(pubCmd.args[1] as string);
+    expect(decoded.type).toBe("invalidate-key");
+
+    await invalidator.stop();
+  });
+
+  it("ignores invalid JSON payloads without throwing", async () => {
+    const pub = new MockRedis();
+    const sub = pub.duplicate() as MockRedis;
+    const received: unknown[] = [];
+    const errors: string[] = [];
+
+    const invalidator = new RedisInvalidator({
+      publisher: pub,
+      subscriber: sub,
+      channel: CHANNEL,
+      onMessage: (msg) => received.push(msg),
+      logger: {
+        error: (msg) => errors.push(msg),
+      },
+    });
+
+    await invalidator.start();
+    // Inject a malformed message directly through the broker.
+    sub._deliver(CHANNEL, "not-json");
+    await flushAsync();
+
+    expect(received.length).toBe(0);
+    expect(errors.some((e) => e.includes("invalid JSON"))).toBe(true);
+
+    await invalidator.stop();
+  });
+
+  it("propagates invalidation across two RedisCacheProvider instances", async () => {
+    const { a, b } = makeLinkedMockPair();
+
+    const providerA = new RedisCacheProvider({
+      client: a,
+      namespace: "test",
+      invalidationChannel: CHANNEL,
+    });
+    const providerB = new RedisCacheProvider({
+      client: b,
+      namespace: "test",
+      invalidationChannel: CHANNEL,
+    });
+
+    await flushAsync();
+
+    // Both providers have the same key in their local mirrors.
+    providerA.set("shared", "v", { tags: ["t1"] });
+    providerB.set("shared", "v", { tags: ["t1"] });
+    expect(providerA.get<string>("shared")).toBe("v");
+    expect(providerB.get<string>("shared")).toBe("v");
+
+    // A publishes an invalidate-key broadcast; B should evict from its mirror.
+    providerA.delete("shared");
+    await flushAsync();
+    expect(providerB.get("shared")).toBeUndefined();
+
+    // Tag invalidation broadcast — re-seed and try the tag path.
+    providerA.set("k", 1, { tags: ["tag-x"] });
+    providerB.set("k", 1, { tags: ["tag-x"] });
+    await flushAsync();
+    providerA.invalidateByTag("tag-x");
+    await flushAsync();
+    expect(providerB.get("k")).toBeUndefined();
+
+    await providerA.close();
+    await providerB.close();
+  });
+});

--- a/addons/cache-redis/cap-cache-redis/__tests__/redis-key-encoder.test.ts
+++ b/addons/cache-redis/cap-cache-redis/__tests__/redis-key-encoder.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for the Redis key encoder and envelope helpers.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  DEFAULT_INVALIDATION_CHANNEL,
+  DEFAULT_NAMESPACE,
+  decodeEnvelope,
+  encodeEnvelope,
+  RedisKeyEncoder,
+} from "../src/redis-key-encoder";
+
+describe("RedisKeyEncoder", () => {
+  it("uses the default namespace", () => {
+    const encoder = new RedisKeyEncoder();
+    expect(encoder.namespace).toBe(DEFAULT_NAMESPACE);
+    expect(encoder.valueKey("foo")).toBe(`${DEFAULT_NAMESPACE}:k:foo`);
+    expect(encoder.tagKey("orders")).toBe(`${DEFAULT_NAMESPACE}:t:orders`);
+  });
+
+  it("honours custom namespaces", () => {
+    const encoder = new RedisKeyEncoder("custom");
+    expect(encoder.valueKey("foo")).toBe("custom:k:foo");
+    expect(encoder.tagKey("t1")).toBe("custom:t:t1");
+    expect(encoder.valueKeyPattern()).toBe("custom:k:*");
+    expect(encoder.valueKeyPatternForPrefix("user:")).toBe("custom:k:user:*");
+  });
+
+  it("rejects empty namespaces", () => {
+    expect(() => new RedisKeyEncoder("")).toThrow();
+  });
+
+  it("decodes value keys back to logical keys", () => {
+    const encoder = new RedisKeyEncoder();
+    const redisKey = encoder.valueKey("user:42");
+    expect(encoder.fromValueKey(redisKey)).toBe("user:42");
+    expect(encoder.fromValueKey("other:k:nope")).toBeNull();
+  });
+
+  it("exposes the default invalidation channel constant", () => {
+    expect(DEFAULT_INVALIDATION_CHANNEL).toBe("linchkit:cache:invalidate");
+  });
+});
+
+describe("envelope codec", () => {
+  it("round-trips an envelope", () => {
+    const now = Date.now();
+    const encoded = encodeEnvelope({
+      v: { hello: "world" },
+      e: now + 60_000,
+      s: now + 30_000,
+      t: ["tenant:t1"],
+      c: now,
+    });
+    const decoded = decodeEnvelope(encoded);
+    expect(decoded).not.toBeNull();
+    expect(decoded?.v).toEqual({ hello: "world" });
+    expect(decoded?.t).toEqual(["tenant:t1"]);
+    expect(decoded?.e).toBe(now + 60_000);
+    expect(decoded?.s).toBe(now + 30_000);
+    expect(decoded?.c).toBe(now);
+  });
+
+  it("returns null on missing or malformed input", () => {
+    expect(decodeEnvelope(null)).toBeNull();
+    expect(decodeEnvelope("not-json")).toBeNull();
+    expect(decodeEnvelope("{}")).toBeNull(); // tags missing
+    expect(decodeEnvelope('{"t":"oops"}')).toBeNull(); // tags wrong type
+  });
+});

--- a/addons/cache-redis/cap-cache-redis/package.json
+++ b/addons/cache-redis/cap-cache-redis/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@linchkit/cap-cache-redis",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "files": [
+    "src/",
+    "package.json",
+    "README.md"
+  ],
+  "exports": {
+    ".": "./src/index.ts",
+    "./capability": "./src/capability.ts"
+  },
+  "scripts": {
+    "test": "bun test"
+  },
+  "peerDependencies": {
+    "@linchkit/core": "^0.2.0"
+  },
+  "dependencies": {
+    "ioredis": "^5.4.0"
+  },
+  "devDependencies": {
+    "@linchkit/core": "workspace:*",
+    "typescript": "^6.0.2"
+  },
+  "linchkit": {
+    "minCoreVersion": "^0.1.0",
+    "type": "standard",
+    "category": "system",
+    "autoInstall": false
+  }
+}

--- a/addons/cache-redis/cap-cache-redis/src/capability.ts
+++ b/addons/cache-redis/cap-cache-redis/src/capability.ts
@@ -1,0 +1,68 @@
+/**
+ * cap-cache-redis — Redis-backed L2 cache + cross-instance invalidation.
+ *
+ * Plug the provider returned by `createRedisCacheProvider()` into
+ * `CacheManager`'s `l2` slot and pair it with the in-process L1 of your
+ * choice. The capability itself only exposes a `services` registration so
+ * downstream hosts can discover the provider via the standard DI lookup;
+ * actual mounting into CacheManager remains the host application's job
+ * (Spec 34 §7 Phase 2).
+ */
+
+import type { CapabilityDefinition } from "@linchkit/core";
+import { defineCapability } from "@linchkit/core";
+import { createRedisCacheProvider, type RedisCacheProvider } from "./redis-cache-provider";
+import type { RedisCacheProviderOptions } from "./types";
+
+export interface CapCacheRedisOptions extends RedisCacheProviderOptions {
+  /**
+   * Pre-built provider instance. When supplied, the factory skips
+   * constructing a new provider — useful for tests that pass a fully
+   * mocked instance.
+   */
+  provider?: RedisCacheProvider;
+}
+
+/**
+ * Build a fully-wired `cap-cache-redis` capability.
+ *
+ * @example
+ * ```ts
+ * import { CacheManager } from "@linchkit/core";
+ * import { createCapCacheRedis } from "@linchkit/cap-cache-redis";
+ *
+ * const cap = createCapCacheRedis({ redisUrl: process.env.REDIS_URL });
+ * const cacheManager = new CacheManager({ l2: cap.provider });
+ * ```
+ */
+export function createCapCacheRedis(options: CapCacheRedisOptions = {}): CapabilityDefinition & {
+  provider: RedisCacheProvider;
+} {
+  const provider = options.provider ?? createRedisCacheProvider(options);
+
+  const capability = defineCapability({
+    name: "cap-cache-redis",
+    label: "Cache (Redis L2)",
+    description:
+      "Redis-backed L2 cache provider with Pub/Sub cross-instance invalidation. " +
+      "Plug into CacheManager.l2 and pair with the in-process L1 of your choice.",
+    type: "standard",
+    category: "system",
+    version: "0.1.0",
+    group: "cache-redis",
+    autoInstall: false,
+    extensions: {
+      services: [
+        {
+          name: "cacheRedisProvider",
+          factory: () => provider,
+        },
+      ],
+    },
+  });
+
+  return Object.assign(capability, { provider });
+}
+
+/** Static (no-config) capability export for shape-only consumers. */
+export const capCacheRedis = createCapCacheRedis;

--- a/addons/cache-redis/cap-cache-redis/src/index.ts
+++ b/addons/cache-redis/cap-cache-redis/src/index.ts
@@ -1,0 +1,27 @@
+/**
+ * @linchkit/cap-cache-redis — public API
+ *
+ * Exports the Redis L2 cache provider, the Pub/Sub-based cross-instance
+ * invalidator, and the capability factory used by host applications.
+ */
+
+export { type CapCacheRedisOptions, capCacheRedis, createCapCacheRedis } from "./capability";
+export {
+  createRedisCacheProvider,
+  RedisCacheProvider,
+} from "./redis-cache-provider";
+export { RedisInvalidator, type RedisInvalidatorOptions } from "./redis-invalidator";
+export {
+  DEFAULT_INVALIDATION_CHANNEL,
+  DEFAULT_NAMESPACE,
+  decodeEnvelope,
+  encodeEnvelope,
+  RedisKeyEncoder,
+} from "./redis-key-encoder";
+export type {
+  EncodedCacheEnvelope,
+  InvalidationMessage,
+  RedisCacheProviderOptions,
+  RedisClientFactory,
+  RedisLike,
+} from "./types";

--- a/addons/cache-redis/cap-cache-redis/src/redis-cache-provider.ts
+++ b/addons/cache-redis/cap-cache-redis/src/redis-cache-provider.ts
@@ -65,6 +65,8 @@ type LocalEntry = {
   tags: string[];
 };
 
+const DEFAULT_MAX_LOCAL_MIRROR_ENTRIES = 10_000;
+
 export class RedisCacheProvider implements CacheProvider {
   private readonly client: RedisLike;
   private readonly encoder: RedisKeyEncoder;
@@ -73,7 +75,18 @@ export class RedisCacheProvider implements CacheProvider {
     debug: (msg: string) => void;
     error: (msg: string, err?: unknown) => void;
   };
+  /**
+   * Process-local mirror. Uses Map insertion order to implement LRU:
+   * - on read hit, the entry is deleted and re-inserted to bump it to MRU;
+   * - on write, oldest entries are evicted when size exceeds the cap.
+   */
   private readonly localMirror = new Map<string, LocalEntry>();
+  private readonly maxLocalMirrorEntries: number;
+  /**
+   * Tracks in-flight `hydrateFromRedis` calls so concurrent misses on the
+   * same key only fire a single Redis GET (thundering herd guard).
+   */
+  private readonly inflightHydrations = new Map<string, Promise<void>>();
 
   private _hits = 0;
   private _misses = 0;
@@ -86,6 +99,11 @@ export class RedisCacheProvider implements CacheProvider {
       debug: options.logger?.debug ?? noopLogger.debug,
       error: options.logger?.error ?? noopLogger.error,
     };
+    const cap = options.maxLocalMirrorEntries ?? DEFAULT_MAX_LOCAL_MIRROR_ENTRIES;
+    if (!Number.isFinite(cap) || cap <= 0) {
+      throw new Error("RedisCacheProvider: `maxLocalMirrorEntries` must be a positive integer");
+    }
+    this.maxLocalMirrorEntries = Math.floor(cap);
 
     this.client = resolveClient(options);
 
@@ -115,7 +133,7 @@ export class RedisCacheProvider implements CacheProvider {
     if (!entry) {
       this._misses++;
       // Schedule a best-effort Redis hydration so the next call hits the mirror.
-      void this.hydrateFromRedis(key).catch((err) => {
+      void this.scheduleHydration(key).catch((err) => {
         this.logger.error(`[RedisCacheProvider] hydrate failed for ${key}`, err);
       });
       return undefined;
@@ -128,6 +146,10 @@ export class RedisCacheProvider implements CacheProvider {
       this._misses++;
       return undefined;
     }
+
+    // LRU bump: delete + re-insert to move the entry to MRU position.
+    this.localMirror.delete(key);
+    this.localMirror.set(key, entry);
 
     this._hits++;
     const isStale = entry.softExpiresAt !== undefined && now > entry.softExpiresAt;
@@ -163,12 +185,15 @@ export class RedisCacheProvider implements CacheProvider {
       c: now,
     };
 
+    // Re-insertion bumps the entry to MRU; eviction trims back to the cap.
+    this.localMirror.delete(key);
     this.localMirror.set(key, {
       value,
       expiresAt: hardExpiresAt,
       softExpiresAt,
       tags,
     });
+    this.evictLocalMirrorIfNeeded();
 
     void this.writeToRedis(key, envelope, pxMillis, tags).catch((err) => {
       this.logger.error(`[RedisCacheProvider] SET failed for ${key}`, err);
@@ -286,6 +311,20 @@ export class RedisCacheProvider implements CacheProvider {
     await this.client.del(tagKey);
   }
 
+  /**
+   * Dedup concurrent hydrations for the same key — only one Redis GET runs
+   * at a time. Subsequent callers await the in-flight Promise.
+   */
+  private scheduleHydration(key: string): Promise<void> {
+    const existing = this.inflightHydrations.get(key);
+    if (existing) return existing;
+    const promise = this.hydrateFromRedis(key).finally(() => {
+      this.inflightHydrations.delete(key);
+    });
+    this.inflightHydrations.set(key, promise);
+    return promise;
+  }
+
   private async hydrateFromRedis(key: string): Promise<void> {
     const raw = await this.client.get(this.encoder.valueKey(key));
     const envelope = decodeEnvelope(raw);
@@ -296,12 +335,25 @@ export class RedisCacheProvider implements CacheProvider {
       await this.client.del(this.encoder.valueKey(key));
       return;
     }
+    // Bump to MRU just like a fresh write.
+    this.localMirror.delete(key);
     this.localMirror.set(key, {
       value: envelope.v,
       expiresAt: envelope.e,
       softExpiresAt: envelope.s,
       tags: envelope.t,
     });
+    this.evictLocalMirrorIfNeeded();
+  }
+
+  /** Trim the local mirror back to its cap, dropping LRU entries first. */
+  private evictLocalMirrorIfNeeded(): void {
+    while (this.localMirror.size > this.maxLocalMirrorEntries) {
+      const oldest = this.localMirror.keys().next();
+      if (oldest.done) break;
+      this.localMirror.delete(oldest.value);
+      this._evictions++;
+    }
   }
 
   private handleInvalidation(msg: InvalidationMessage): void {

--- a/addons/cache-redis/cap-cache-redis/src/redis-cache-provider.ts
+++ b/addons/cache-redis/cap-cache-redis/src/redis-cache-provider.ts
@@ -1,0 +1,366 @@
+/**
+ * RedisCacheProvider — L2 distributed cache backed by Redis.
+ *
+ * Implementation notes
+ * --------------------
+ * The core `CacheProvider` interface is intentionally synchronous so the L1
+ * fast path can stay zero-latency. Redis itself is asynchronous, so this
+ * provider keeps a small process-local mirror (`localMirror`) that answers
+ * `get` / `getWithStaleness` immediately. Every successful `set` writes both
+ * to Redis (best-effort, fire-and-forget with logged failures) and to the
+ * mirror so subsequent `get` calls on the same instance see the value
+ * without an extra round-trip.
+ *
+ * Cross-instance consistency is delivered by `RedisInvalidator`, which
+ * publishes invalidation messages on a Pub/Sub channel that every other
+ * provider instance subscribes to. Listeners wipe the matching entry from
+ * the mirror (and, when wired into a CacheManager, the L1 cache as well).
+ *
+ * TTL + SWR
+ * ---------
+ * Hard expiry is enforced by Redis via the `PX` (millisecond) option on
+ * `SET`, and locally by comparing `Date.now()` to the envelope's
+ * `expiresAt`. SWR is purely metadata — we store both `softExpiresAt` and
+ * `expiresAt` in the envelope, then on read decide whether the value is
+ * fresh, stale-but-serveable, or hard-expired (treat as miss).
+ *
+ * Tags
+ * ----
+ * Each tag maps to a Redis set at `{namespace}:t:{tag}` whose members are
+ * the raw (un-prefixed) keys carrying the tag. `invalidateByTag` runs
+ * SMEMBERS to enumerate keys, deletes the underlying value keys with a
+ * single DEL, then deletes the tag set itself.
+ */
+
+import { createRequire } from "node:module";
+import type { CacheProvider, CacheSetOptions, CacheStats } from "@linchkit/core";
+import { RedisInvalidator } from "./redis-invalidator";
+import {
+  DEFAULT_INVALIDATION_CHANNEL,
+  DEFAULT_NAMESPACE,
+  decodeEnvelope,
+  encodeEnvelope,
+  RedisKeyEncoder,
+} from "./redis-key-encoder";
+import type {
+  EncodedCacheEnvelope,
+  InvalidationMessage,
+  RedisCacheProviderOptions,
+  RedisLike,
+} from "./types";
+
+const noopLogger = {
+  debug: (_msg: string) => {
+    // intentionally empty
+  },
+  error: (_msg: string, _err?: unknown) => {
+    // intentionally empty
+  },
+};
+
+type LocalEntry = {
+  value: unknown;
+  expiresAt?: number;
+  softExpiresAt?: number;
+  tags: string[];
+};
+
+export class RedisCacheProvider implements CacheProvider {
+  private readonly client: RedisLike;
+  private readonly encoder: RedisKeyEncoder;
+  private readonly invalidator: RedisInvalidator;
+  private readonly logger: {
+    debug: (msg: string) => void;
+    error: (msg: string, err?: unknown) => void;
+  };
+  private readonly localMirror = new Map<string, LocalEntry>();
+
+  private _hits = 0;
+  private _misses = 0;
+  private _evictions = 0;
+
+  constructor(options: RedisCacheProviderOptions = {}) {
+    const namespace = options.namespace ?? DEFAULT_NAMESPACE;
+    this.encoder = new RedisKeyEncoder(namespace);
+    this.logger = {
+      debug: options.logger?.debug ?? noopLogger.debug,
+      error: options.logger?.error ?? noopLogger.error,
+    };
+
+    this.client = resolveClient(options);
+
+    this.invalidator = new RedisInvalidator({
+      publisher: this.client,
+      subscriber: this.client.duplicate(),
+      channel: options.invalidationChannel ?? DEFAULT_INVALIDATION_CHANNEL,
+      logger: this.logger,
+      onMessage: (msg) => this.handleInvalidation(msg),
+    });
+
+    // Begin subscribing eagerly — failures are logged but never thrown so
+    // construction stays synchronous and matches the L1 provider's contract.
+    void this.invalidator.start().catch((err) => {
+      this.logger.error("[RedisCacheProvider] Failed to start invalidator", err);
+    });
+  }
+
+  // ── Reads ───────────────────────────────────────────────
+
+  get<T = unknown>(key: string): T | undefined {
+    return this.getWithStaleness<T>(key)?.value;
+  }
+
+  getWithStaleness<T = unknown>(key: string): { value: T; isStale: boolean } | undefined {
+    const entry = this.localMirror.get(key);
+    if (!entry) {
+      this._misses++;
+      // Schedule a best-effort Redis hydration so the next call hits the mirror.
+      void this.hydrateFromRedis(key).catch((err) => {
+        this.logger.error(`[RedisCacheProvider] hydrate failed for ${key}`, err);
+      });
+      return undefined;
+    }
+
+    const now = Date.now();
+    if (entry.expiresAt !== undefined && now > entry.expiresAt) {
+      this.localMirror.delete(key);
+      this._evictions++;
+      this._misses++;
+      return undefined;
+    }
+
+    this._hits++;
+    const isStale = entry.softExpiresAt !== undefined && now > entry.softExpiresAt;
+    return { value: entry.value as T, isStale };
+  }
+
+  // ── Writes ──────────────────────────────────────────────
+
+  set<T = unknown>(key: string, value: T, options?: CacheSetOptions): void {
+    const now = Date.now();
+    const tags = options?.tags ?? [];
+
+    let softExpiresAt: number | undefined;
+    let hardExpiresAt: number | undefined;
+    let pxMillis: number | undefined;
+
+    if (options?.ttl !== undefined) {
+      if (options.swrTtl !== undefined) {
+        softExpiresAt = now + options.ttl;
+        hardExpiresAt = now + options.ttl + options.swrTtl;
+        pxMillis = options.ttl + options.swrTtl;
+      } else {
+        hardExpiresAt = now + options.ttl;
+        pxMillis = options.ttl;
+      }
+    }
+
+    const envelope: EncodedCacheEnvelope = {
+      v: value,
+      e: hardExpiresAt,
+      s: softExpiresAt,
+      t: tags,
+      c: now,
+    };
+
+    this.localMirror.set(key, {
+      value,
+      expiresAt: hardExpiresAt,
+      softExpiresAt,
+      tags,
+    });
+
+    void this.writeToRedis(key, envelope, pxMillis, tags).catch((err) => {
+      this.logger.error(`[RedisCacheProvider] SET failed for ${key}`, err);
+    });
+  }
+
+  delete(key: string): boolean {
+    const existed = this.localMirror.delete(key);
+    void this.deleteFromRedis(key).catch((err) => {
+      this.logger.error(`[RedisCacheProvider] DEL failed for ${key}`, err);
+    });
+    void this.invalidator
+      .broadcast({ type: "invalidate-key", key, origin: this.invalidator.id })
+      .catch((err) => {
+        this.logger.error(`[RedisCacheProvider] PUBLISH delete failed for ${key}`, err);
+      });
+    return existed;
+  }
+
+  invalidateByTag(tag: string): number {
+    let count = 0;
+    for (const [key, entry] of this.localMirror) {
+      if (entry.tags.includes(tag)) {
+        this.localMirror.delete(key);
+        count++;
+      }
+    }
+
+    void this.invalidateTagInRedis(tag).catch((err) => {
+      this.logger.error(`[RedisCacheProvider] tag invalidate failed for ${tag}`, err);
+    });
+    void this.invalidator
+      .broadcast({ type: "invalidate-tag", tag, origin: this.invalidator.id })
+      .catch((err) => {
+        this.logger.error(`[RedisCacheProvider] PUBLISH tag failed for ${tag}`, err);
+      });
+    return count;
+  }
+
+  invalidateByPrefix(prefix: string): number {
+    let count = 0;
+    for (const key of [...this.localMirror.keys()]) {
+      if (key.startsWith(prefix)) {
+        this.localMirror.delete(key);
+        count++;
+      }
+    }
+    void this.invalidator
+      .broadcast({ type: "invalidate-prefix", prefix, origin: this.invalidator.id })
+      .catch((err) => {
+        this.logger.error(`[RedisCacheProvider] PUBLISH prefix failed for ${prefix}`, err);
+      });
+    return count;
+  }
+
+  clear(): void {
+    this.localMirror.clear();
+    void this.invalidator.broadcast({ type: "clear", origin: this.invalidator.id }).catch((err) => {
+      this.logger.error("[RedisCacheProvider] PUBLISH clear failed", err);
+    });
+  }
+
+  stats(): CacheStats {
+    const total = this._hits + this._misses;
+    return {
+      hits: this._hits,
+      misses: this._misses,
+      evictions: this._evictions,
+      size: this.localMirror.size,
+      hitRate: total === 0 ? 0 : this._hits / total,
+    };
+  }
+
+  /** Gracefully release the underlying Redis connections. */
+  async close(): Promise<void> {
+    await this.invalidator.stop();
+    try {
+      await this.client.quit();
+    } catch (err) {
+      this.logger.error("[RedisCacheProvider] quit failed", err);
+    }
+  }
+
+  // ── Internal helpers ────────────────────────────────────
+
+  private async writeToRedis(
+    key: string,
+    envelope: EncodedCacheEnvelope,
+    pxMillis: number | undefined,
+    tags: string[],
+  ): Promise<void> {
+    const redisKey = this.encoder.valueKey(key);
+    const payload = encodeEnvelope(envelope);
+    if (pxMillis !== undefined) {
+      await this.client.set(redisKey, payload, "PX", pxMillis);
+    } else {
+      await this.client.set(redisKey, payload);
+    }
+    for (const tag of tags) {
+      await this.client.sadd(this.encoder.tagKey(tag), key);
+    }
+  }
+
+  private async deleteFromRedis(key: string): Promise<void> {
+    await this.client.del(this.encoder.valueKey(key));
+  }
+
+  private async invalidateTagInRedis(tag: string): Promise<void> {
+    const tagKey = this.encoder.tagKey(tag);
+    const members = await this.client.smembers(tagKey);
+    if (members.length > 0) {
+      const redisKeys = members.map((m) => this.encoder.valueKey(m));
+      await this.client.del(...redisKeys);
+    }
+    await this.client.del(tagKey);
+  }
+
+  private async hydrateFromRedis(key: string): Promise<void> {
+    const raw = await this.client.get(this.encoder.valueKey(key));
+    const envelope = decodeEnvelope(raw);
+    if (!envelope) return;
+    const now = Date.now();
+    if (envelope.e !== undefined && now > envelope.e) {
+      // Already hard-expired upstream — best-effort cleanup.
+      await this.client.del(this.encoder.valueKey(key));
+      return;
+    }
+    this.localMirror.set(key, {
+      value: envelope.v,
+      expiresAt: envelope.e,
+      softExpiresAt: envelope.s,
+      tags: envelope.t,
+    });
+  }
+
+  private handleInvalidation(msg: InvalidationMessage): void {
+    // Ignore our own broadcasts to avoid double-evicting on the publisher.
+    if ("origin" in msg && msg.origin === this.invalidator.id) return;
+
+    switch (msg.type) {
+      case "invalidate-key":
+        this.localMirror.delete(msg.key);
+        break;
+      case "invalidate-tag": {
+        for (const [k, entry] of this.localMirror) {
+          if (entry.tags.includes(msg.tag)) this.localMirror.delete(k);
+        }
+        break;
+      }
+      case "invalidate-prefix": {
+        for (const k of [...this.localMirror.keys()]) {
+          if (k.startsWith(msg.prefix)) this.localMirror.delete(k);
+        }
+        break;
+      }
+      case "clear":
+        this.localMirror.clear();
+        break;
+    }
+  }
+}
+
+/**
+ * Resolve a Redis client from constructor options.
+ *
+ * Priority: explicit `client` > custom `clientFactory` > default `ioredis`
+ * import driven by `redisUrl` (or REDIS_URL env var).
+ */
+function resolveClient(options: RedisCacheProviderOptions): RedisLike {
+  if (options.client) return options.client;
+
+  const url = options.redisUrl ?? process.env.REDIS_URL;
+  if (!url && !options.clientFactory) {
+    throw new Error(
+      "RedisCacheProvider requires `redisUrl`, REDIS_URL env, or an explicit `client`/`clientFactory`",
+    );
+  }
+
+  if (options.clientFactory) {
+    return options.clientFactory(url ?? "");
+  }
+
+  // Default path: dynamically require ioredis so tests can construct the
+  // provider with a mock client and avoid bundling the real driver.
+  const req = createRequire(import.meta.url);
+  // biome-ignore lint/suspicious/noExplicitAny: ioredis exports vary between CJS/ESM
+  const required: any = req("ioredis");
+  const Ctor = required?.default ?? required;
+  return new Ctor(url) as RedisLike;
+}
+
+/** Convenience factory mirroring the capability-level helper. */
+export function createRedisCacheProvider(options?: RedisCacheProviderOptions): RedisCacheProvider {
+  return new RedisCacheProvider(options);
+}

--- a/addons/cache-redis/cap-cache-redis/src/redis-invalidator.ts
+++ b/addons/cache-redis/cap-cache-redis/src/redis-invalidator.ts
@@ -1,0 +1,128 @@
+/**
+ * RedisInvalidator — Cross-instance cache invalidation via Redis Pub/Sub.
+ *
+ * Each `RedisCacheProvider` owns a pair of Redis connections — one for
+ * publishing invalidation messages and one (a `duplicate()`) for the
+ * subscriber loop. ioredis forbids issuing regular commands on a
+ * connection that is in subscriber mode, so the split is mandatory.
+ *
+ * Message payloads are tagged with an `origin` ID so a provider can ignore
+ * its own broadcasts and avoid double-evicting on the publisher side.
+ *
+ * Mirrors the contract of `packages/core/src/cache/postgres-invalidator.ts`
+ * (start / broadcast / stop) so capability authors can swap transports
+ * without re-wiring the cache manager.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { InvalidationMessage, RedisLike } from "./types";
+
+export interface RedisInvalidatorOptions {
+  /** Connection used to PUBLISH messages. */
+  publisher: RedisLike;
+  /** Dedicated connection used to SUBSCRIBE. Must not be shared with `publisher`. */
+  subscriber: RedisLike;
+  /** Pub/Sub channel name. */
+  channel: string;
+  /** Optional logger for debug/error output. */
+  logger?: {
+    debug?: (msg: string) => void;
+    error?: (msg: string, err?: unknown) => void;
+  };
+  /** Callback invoked for every well-formed message received on the channel. */
+  onMessage: (msg: InvalidationMessage) => void;
+}
+
+export class RedisInvalidator {
+  /** Unique per-instance identifier embedded into every published message. */
+  public readonly id: string;
+
+  private readonly publisher: RedisLike;
+  private readonly subscriber: RedisLike;
+  private readonly channel: string;
+  private readonly onMessage: (msg: InvalidationMessage) => void;
+  private readonly logger: NonNullable<RedisInvalidatorOptions["logger"]>;
+  private started = false;
+  private readonly listener = (...args: unknown[]): void => {
+    const [channel, message] = args;
+    if (typeof channel !== "string" || typeof message !== "string") return;
+    if (channel !== this.channel) return;
+    this.dispatch(message);
+  };
+
+  constructor(options: RedisInvalidatorOptions) {
+    this.publisher = options.publisher;
+    this.subscriber = options.subscriber;
+    this.channel = options.channel;
+    this.onMessage = options.onMessage;
+    this.logger = options.logger ?? {};
+    this.id = randomUUID();
+  }
+
+  /** Start listening on the Pub/Sub channel. Idempotent. */
+  async start(): Promise<void> {
+    if (this.started) return;
+    this.started = true;
+    this.subscriber.on("message", this.listener);
+    await this.subscriber.subscribe(this.channel);
+    this.logger.debug?.(`[RedisInvalidator] subscribed to "${this.channel}"`);
+  }
+
+  /** Stop listening and close the subscriber connection. */
+  async stop(): Promise<void> {
+    if (!this.started) return;
+    this.started = false;
+    try {
+      await this.subscriber.unsubscribe(this.channel);
+    } catch (err) {
+      this.logger.error?.("[RedisInvalidator] unsubscribe failed", err);
+    }
+    try {
+      await this.subscriber.quit();
+    } catch (err) {
+      this.logger.error?.("[RedisInvalidator] subscriber quit failed", err);
+    }
+  }
+
+  /** Publish an invalidation message to every subscriber. */
+  async broadcast(message: InvalidationMessage): Promise<void> {
+    const payload = JSON.stringify(message);
+    await this.publisher.publish(this.channel, payload);
+  }
+
+  private dispatch(payload: string): void {
+    let msg: InvalidationMessage;
+    try {
+      msg = JSON.parse(payload) as InvalidationMessage;
+    } catch (err) {
+      this.logger.error?.(`[RedisInvalidator] invalid JSON: ${payload}`, err);
+      return;
+    }
+    if (!isInvalidationMessage(msg)) {
+      this.logger.error?.(`[RedisInvalidator] malformed message: ${payload}`);
+      return;
+    }
+    try {
+      this.onMessage(msg);
+    } catch (err) {
+      this.logger.error?.("[RedisInvalidator] onMessage handler threw", err);
+    }
+  }
+}
+
+function isInvalidationMessage(msg: unknown): msg is InvalidationMessage {
+  if (typeof msg !== "object" || msg === null) return false;
+  const candidate = msg as { type?: unknown };
+  switch (candidate.type) {
+    case "invalidate-key":
+      return typeof (msg as { key?: unknown }).key === "string";
+    case "invalidate-tag":
+      return typeof (msg as { tag?: unknown }).tag === "string";
+    case "invalidate-prefix":
+      return typeof (msg as { prefix?: unknown }).prefix === "string";
+    case "clear":
+      return true;
+    default:
+      return false;
+  }
+}

--- a/addons/cache-redis/cap-cache-redis/src/redis-key-encoder.ts
+++ b/addons/cache-redis/cap-cache-redis/src/redis-key-encoder.ts
@@ -1,0 +1,78 @@
+/**
+ * Key + value encoders for the Redis cache provider.
+ *
+ * - Every logical key is prefixed with `{namespace}:k:` to keep cache values,
+ *   tag indexes, and other Redis traffic from colliding.
+ * - Tag indexes live under `{namespace}:t:{tag}` and contain the *raw*
+ *   (un-prefixed) keys that carry the tag — this makes invalidateByTag a
+ *   single SMEMBERS + DEL round-trip.
+ * - Values are wrapped in a JSON envelope that carries the original payload
+ *   plus TTL/SWR metadata so the L1 contract (getWithStaleness) can be
+ *   honoured without relying on Redis-side metadata.
+ */
+
+import type { EncodedCacheEnvelope } from "./types";
+
+export const DEFAULT_NAMESPACE = "linchkit:cache";
+export const DEFAULT_INVALIDATION_CHANNEL = "linchkit:cache:invalidate";
+
+export class RedisKeyEncoder {
+  constructor(public readonly namespace: string = DEFAULT_NAMESPACE) {
+    if (!namespace) {
+      throw new Error("Redis cache namespace must not be empty");
+    }
+  }
+
+  /** Encode a logical key into the Redis key used to store the envelope. */
+  valueKey(key: string): string {
+    return `${this.namespace}:k:${key}`;
+  }
+
+  /** Encode a tag name into the Redis key used to store the tag's member set. */
+  tagKey(tag: string): string {
+    return `${this.namespace}:t:${tag}`;
+  }
+
+  /** Glob pattern matching every value key in this namespace. */
+  valueKeyPattern(): string {
+    return `${this.namespace}:k:*`;
+  }
+
+  /** Glob pattern matching every value key beginning with `prefix`. */
+  valueKeyPatternForPrefix(prefix: string): string {
+    return `${this.namespace}:k:${prefix}*`;
+  }
+
+  /** Convert a Redis key back into its logical form. Returns null if it is not a value key. */
+  fromValueKey(redisKey: string): string | null {
+    const prefix = `${this.namespace}:k:`;
+    return redisKey.startsWith(prefix) ? redisKey.slice(prefix.length) : null;
+  }
+}
+
+/** Serialise an envelope for storage in Redis. */
+export function encodeEnvelope(envelope: EncodedCacheEnvelope): string {
+  return JSON.stringify(envelope);
+}
+
+/**
+ * Parse a stored envelope. Returns null when the payload is missing or
+ * structurally invalid — callers should treat that as a cache miss rather
+ * than throw, so a poisoned key never breaks reads.
+ */
+export function decodeEnvelope(raw: string | null): EncodedCacheEnvelope | null {
+  if (raw === null) return null;
+  try {
+    const parsed = JSON.parse(raw) as EncodedCacheEnvelope;
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      !Array.isArray((parsed as { t?: unknown }).t)
+    ) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}

--- a/addons/cache-redis/cap-cache-redis/src/types.ts
+++ b/addons/cache-redis/cap-cache-redis/src/types.ts
@@ -55,6 +55,13 @@ export interface RedisCacheProviderOptions {
    * `ioredis` import path.
    */
   clientFactory?: RedisClientFactory;
+  /**
+   * Maximum number of entries retained in the process-local mirror before
+   * least-recently-used eviction kicks in. Caps memory usage in long-lived
+   * processes that touch many distinct keys.
+   * @default 10_000
+   */
+  maxLocalMirrorEntries?: number;
   /** Optional logger for debug/error output. Defaults to no-op. */
   logger?: {
     debug?: (msg: string) => void;

--- a/addons/cache-redis/cap-cache-redis/src/types.ts
+++ b/addons/cache-redis/cap-cache-redis/src/types.ts
@@ -1,0 +1,84 @@
+/**
+ * Public types for @linchkit/cap-cache-redis.
+ *
+ * The Redis cache provider acts as the L2 layer in a multi-tier CacheManager
+ * (L1 = in-process, L2 = Redis, L3 = Postgres). It also ships a companion
+ * RedisInvalidator that broadcasts cross-instance invalidation events via
+ * Redis Pub/Sub so each instance's L1 can be cleared in lock-step with L2.
+ */
+
+/** Minimal Redis client surface this provider depends on. */
+export interface RedisLike {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, ...args: Array<string | number>): Promise<unknown>;
+  del(...keys: string[]): Promise<number>;
+  sadd(key: string, ...members: string[]): Promise<number>;
+  smembers(key: string): Promise<string[]>;
+  publish(channel: string, message: string): Promise<number>;
+  subscribe(channel: string, ...args: unknown[]): Promise<unknown>;
+  unsubscribe(...channels: string[]): Promise<unknown>;
+  quit(): Promise<unknown>;
+  on(event: string, listener: (...args: unknown[]) => void): unknown;
+  duplicate(overrides?: Record<string, unknown>): RedisLike;
+  defineCommand(name: string, definition: { numberOfKeys: number; lua: string }): unknown;
+}
+
+/** Factory signature for constructing a Redis-like client. */
+export type RedisClientFactory = (urlOrOptions: string | Record<string, unknown>) => RedisLike;
+
+/** Options accepted by createRedisCacheProvider and the capability factory. */
+export interface RedisCacheProviderOptions {
+  /**
+   * Redis connection URL (e.g. `redis://user:pass@host:6379/0`).
+   * Mutually exclusive with `client`. When omitted the provider falls back
+   * to `process.env.REDIS_URL`.
+   */
+  redisUrl?: string;
+  /**
+   * Pre-constructed Redis client. Useful for tests or when the host
+   * application wants to share a single connection pool.
+   */
+  client?: RedisLike;
+  /**
+   * Key namespace prepended to every Redis key.
+   * @default "linchkit:cache"
+   */
+  namespace?: string;
+  /**
+   * Channel name used by RedisInvalidator. Different deployments can
+   * isolate their invalidation traffic by overriding this.
+   * @default "linchkit:cache:invalidate"
+   */
+  invalidationChannel?: string;
+  /**
+   * Override factory for testing — when provided it replaces the default
+   * `ioredis` import path.
+   */
+  clientFactory?: RedisClientFactory;
+  /** Optional logger for debug/error output. Defaults to no-op. */
+  logger?: {
+    debug?: (msg: string) => void;
+    error?: (msg: string, err?: unknown) => void;
+  };
+}
+
+/** Wire format for invalidation messages broadcast over Pub/Sub. */
+export type InvalidationMessage =
+  | { type: "invalidate-key"; key: string; origin: string }
+  | { type: "invalidate-tag"; tag: string; origin: string }
+  | { type: "invalidate-prefix"; prefix: string; origin: string }
+  | { type: "clear"; origin: string };
+
+/** Encoded value stored at every cache key. */
+export interface EncodedCacheEnvelope {
+  /** The original payload, JSON serialised. */
+  v: unknown;
+  /** Hard expiry timestamp (ms since epoch). Omitted = no hard TTL. */
+  e?: number;
+  /** Soft expiry timestamp (ms since epoch) for stale-while-revalidate. */
+  s?: number;
+  /** Tags attached at write time. */
+  t: string[];
+  /** Creation timestamp (ms since epoch). */
+  c: number;
+}

--- a/addons/cache-redis/cap-cache-redis/tsconfig.json
+++ b/addons/cache-redis/cap-cache-redis/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun-types"]
+  },
+  "include": ["src", "__tests__"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -214,6 +214,20 @@
         "drizzle-orm": ">=0.41.0",
       },
     },
+    "addons/cache-redis/cap-cache-redis": {
+      "name": "@linchkit/cap-cache-redis",
+      "version": "0.1.0",
+      "dependencies": {
+        "ioredis": "^5.4.0",
+      },
+      "devDependencies": {
+        "@linchkit/core": "workspace:*",
+        "typescript": "^6.0.2",
+      },
+      "peerDependencies": {
+        "@linchkit/core": "^0.2.0",
+      },
+    },
     "addons/chatter/cap-chatter": {
       "name": "@linchkit/cap-chatter",
       "version": "1.0.0",
@@ -341,6 +355,7 @@
         "@linchkit/core": "^0.2.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-i18next": ">=14.0.0",
       },
     },
     "packages/cli": {
@@ -662,6 +677,8 @@
 
     "@inquirer/type": ["@inquirer/type@3.0.10", "https://registry.npmmirror.com/@inquirer/type/-/type-3.0.10.tgz", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA=="],
 
+    "@ioredis/commands": ["@ioredis/commands@1.5.1", "", {}, "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw=="],
+
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "https://registry.npmmirror.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "https://registry.npmmirror.com/@jridgewell/remapping/-/remapping-2.3.5.tgz", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
@@ -685,6 +702,8 @@
     "@linchkit/cap-auth": ["@linchkit/cap-auth@workspace:addons/auth/cap-auth"],
 
     "@linchkit/cap-auth-better-auth": ["@linchkit/cap-auth-better-auth@workspace:addons/auth/cap-auth-better-auth"],
+
+    "@linchkit/cap-cache-redis": ["@linchkit/cap-cache-redis@workspace:addons/cache-redis/cap-cache-redis"],
 
     "@linchkit/cap-chatter": ["@linchkit/cap-chatter@workspace:addons/chatter/cap-chatter"],
 
@@ -1306,6 +1325,8 @@
 
     "clsx": ["clsx@2.1.1", "https://registry.npmmirror.com/clsx/-/clsx-2.1.1.tgz", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
+    "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
+
     "cmdk": ["cmdk@1.1.1", "", { "dependencies": { "@radix-ui/react-compose-refs": "^1.1.1", "@radix-ui/react-dialog": "^1.1.6", "@radix-ui/react-id": "^1.1.0", "@radix-ui/react-primitive": "^2.0.2" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "react-dom": "^18 || ^19 || ^19.0.0-rc" } }, "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg=="],
 
     "code-block-writer": ["code-block-writer@13.0.3", "https://registry.npmmirror.com/code-block-writer/-/code-block-writer-13.0.3.tgz", {}, "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="],
@@ -1453,6 +1474,8 @@
     "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
 
     "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
+
+    "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
     "depd": ["depd@2.0.0", "https://registry.npmmirror.com/depd/-/depd-2.0.0.tgz", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
@@ -1656,6 +1679,8 @@
 
     "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
+    "ioredis": ["ioredis@5.10.1", "", { "dependencies": { "@ioredis/commands": "1.5.1", "cluster-key-slot": "^1.1.0", "debug": "^4.3.4", "denque": "^2.1.0", "lodash.defaults": "^4.2.0", "lodash.isarguments": "^3.1.0", "redis-errors": "^1.2.0", "redis-parser": "^3.0.0", "standard-as-callback": "^2.1.0" } }, "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA=="],
+
     "ip-address": ["ip-address@10.1.0", "https://registry.npmmirror.com/ip-address/-/ip-address-10.1.0.tgz", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "https://registry.npmmirror.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
@@ -1777,6 +1802,10 @@
     "lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
 
     "lodash-es": ["lodash-es@4.17.23", "", {}, "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="],
+
+    "lodash.defaults": ["lodash.defaults@4.2.0", "", {}, "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="],
+
+    "lodash.isarguments": ["lodash.isarguments@3.1.0", "", {}, "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="],
 
     "lodash.startcase": ["lodash.startcase@4.4.0", "", {}, "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="],
 
@@ -2056,6 +2085,10 @@
 
     "recharts": ["recharts@3.8.1", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg=="],
 
+    "redis-errors": ["redis-errors@1.2.0", "", {}, "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="],
+
+    "redis-parser": ["redis-parser@3.0.0", "", { "dependencies": { "redis-errors": "^1.0.0" } }, "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A=="],
+
     "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
 
     "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
@@ -2157,6 +2190,8 @@
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
+    "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
 
     "statuses": ["statuses@2.0.2", "https://registry.npmmirror.com/statuses/-/statuses-2.0.2.tgz", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -63,6 +63,10 @@
       "@linchkit/cap-search": ["./addons/search/cap-search/src"],
       "@linchkit/cap-search/capability": ["./addons/search/cap-search/src/capability.ts"],
       "@linchkit/cap-search/graphql": ["./addons/search/cap-search/src/graphql.ts"],
+      "@linchkit/cap-cache-redis": ["./addons/cache-redis/cap-cache-redis/src"],
+      "@linchkit/cap-cache-redis/capability": [
+        "./addons/cache-redis/cap-cache-redis/src/capability.ts"
+      ],
       "@/*": ["./addons/adapter-ui/cap-adapter-ui/src/*"]
     }
   },


### PR DESCRIPTION
## Summary
- New addon `@linchkit/cap-cache-redis` implementing `CacheProvider` against Redis via ioredis 5.4.0.
- Pairs with `PostgresCacheInvalidator`'s eventual-consistency stance: writes are fire-and-forget with a write-through local mirror serving sync reads.
- Cross-instance invalidation via pub/sub on `linchkit:cache:invalidate`. Subscriber uses `.duplicate()` (ioredis requirement); self-origin messages ignored.

## Design
- **Encoding** — Each value is wrapped in `{v, e, s, t, c}` (value, hardExpiresAt, softExpiresAt, tags, createdAt) and stored as JSON; hard expiry uses Redis `SET ... PX (ttl + swrTtl)` for native eviction; SWR is metadata decoded locally.
- **Tags** — sets at `{namespace}:t:{tag}` via `SADD`. `invalidateByTag` uses `SMEMBERS + DEL`.
- **Capability** — `autoInstall: false` (Redis has runtime + network cost; users opt in).

## Verification
- `bun run check` — clean
- `bun run typecheck` — clean
- `bun test` — 5180 pass / 3 skip / 0 fail (325 files)
- 24 tests / 73 assertions for this addon via `MockRedis` with in-process pub/sub broker (no real Redis container)

## Limitations (documented in README)
- Lua atomic tag delete deferred — `SMEMBERS+DEL` pair is acceptable under eventual-consistency design.
- Tag re-set on an existing key leaves old tag-set membership until next `invalidateByTag`.
- Writes are fire-and-forget; errors logged, not surfaced as exceptions.

## Test plan
- [x] TTL hard expiry boundary
- [x] SWR returns `isStale: true` between softExpiresAt and expiresAt
- [x] Tag invalidation removes every key in the tag set
- [x] Cross-instance invalidation via pub/sub (verified with mocked dual providers)
- [x] Key encoder namespace + tenant scoping

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)