### PR TITLE
feat(core/ai): proposal validation Phase 3 + Phase 4 (closes #128)

### DIFF
--- a/packages/core/__tests__/ai-proposal-compatibility-checker.test.ts
+++ b/packages/core/__tests__/ai-proposal-compatibility-checker.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, it } from "bun:test";
+import {
+  buildCompatibilitySnapshot,
+  type CompatibilityRegistrySnapshot,
+  compatibilityCheck,
+} from "../src/ai/proposal-compatibility-checker";
+import type { EntityDefinition } from "../src/types/entity";
+
+// ── Fixtures ──────────────────────────────────────────────────
+
+function makeOrderEntity(): EntityDefinition {
+  return {
+    name: "order",
+    fields: {
+      id: { type: "string", required: true },
+      status: {
+        type: "enum",
+        options: [{ value: "draft" }, { value: "submitted" }, { value: "approved" }],
+      },
+      amount: { type: "number", min: 0, max: 10000 },
+      note: { type: "string" },
+    },
+  };
+}
+
+function makeLineItemEntity(): EntityDefinition {
+  return {
+    name: "line_item",
+    fields: {
+      id: { type: "string", required: true },
+      order_id: { type: "string", required: true },
+      qty: { type: "number" },
+    },
+  };
+}
+
+function makeSnapshot(): CompatibilityRegistrySnapshot {
+  return buildCompatibilitySnapshot(
+    [makeOrderEntity(), makeLineItemEntity()],
+    [
+      // line_item.order_id → order.id
+      { fromEntity: "line_item", fromField: "order_id", toEntity: "order", toField: "id" },
+    ],
+  );
+}
+
+// ── Phase 3 — happy path ─────────────────────────────────────
+
+describe("compatibilityCheck — happy path", () => {
+  it("flags an entity create as info only", () => {
+    const snapshot = makeSnapshot();
+    const result = compatibilityCheck(
+      [
+        {
+          kind: "entity_create",
+          entity: "audit_log",
+          definition: {
+            name: "audit_log",
+            fields: { id: { type: "string", required: true } },
+          },
+        },
+      ],
+      snapshot,
+    );
+    expect(result.compatible).toBe(true);
+    expect(result.breaking).toHaveLength(0);
+    expect(result.info.some((i) => i.rule === "entity_added")).toBe(true);
+  });
+
+  it("flags an optional field add as info only", () => {
+    const snapshot = makeSnapshot();
+    const result = compatibilityCheck(
+      [
+        {
+          kind: "field_add",
+          entity: "order",
+          field: "tags",
+          definition: { type: "string" },
+        },
+      ],
+      snapshot,
+    );
+    expect(result.compatible).toBe(true);
+    expect(result.info.some((i) => i.rule === "field_added")).toBe(true);
+  });
+
+  it("allows compatible type widening (string → text, date → datetime)", () => {
+    const snapshot = makeSnapshot();
+    const result = compatibilityCheck(
+      [{ kind: "field_type_change", entity: "order", field: "note", newType: "text" }],
+      snapshot,
+    );
+    expect(result.compatible).toBe(true);
+    expect(result.breaking).toHaveLength(0);
+  });
+});
+
+// ── Phase 3 — breaking-change rules (one per rule) ───────────
+
+describe("compatibilityCheck — breaking-change rules", () => {
+  it("detects dropping a field that has live FK references (drop_field_with_references)", () => {
+    const snapshot = makeSnapshot();
+    const result = compatibilityCheck(
+      [{ kind: "field_drop", entity: "order", field: "id" }],
+      snapshot,
+    );
+    expect(result.compatible).toBe(false);
+    expect(result.breaking[0].rule).toBe("drop_field_with_references");
+    expect(result.breaking[0].reason).toContain("FK references");
+  });
+
+  it("detects incompatible field type change (incompatible_field_type_change)", () => {
+    const snapshot = makeSnapshot();
+    const result = compatibilityCheck(
+      [{ kind: "field_type_change", entity: "order", field: "amount", newType: "boolean" }],
+      snapshot,
+    );
+    expect(result.compatible).toBe(false);
+    expect(result.breaking[0].rule).toBe("incompatible_field_type_change");
+  });
+
+  it("detects deleting an entity that has FK references (delete_entity_with_references)", () => {
+    const snapshot = makeSnapshot();
+    const result = compatibilityCheck([{ kind: "entity_delete", entity: "order" }], snapshot);
+    expect(result.compatible).toBe(false);
+    expect(result.breaking[0].rule).toBe("delete_entity_with_references");
+  });
+
+  it("detects renaming an entity that has FK references (rename_entity_with_references)", () => {
+    const snapshot = makeSnapshot();
+    const result = compatibilityCheck(
+      [{ kind: "entity_rename", entity: "order", newName: "purchase_order" }],
+      snapshot,
+    );
+    expect(result.compatible).toBe(false);
+    expect(result.breaking[0].rule).toBe("rename_entity_with_references");
+  });
+
+  it("detects tightening nullable → required (tighten_constraint_nullable_to_required)", () => {
+    const snapshot = makeSnapshot();
+    const result = compatibilityCheck(
+      [
+        {
+          kind: "field_constraint_change",
+          entity: "order",
+          field: "note",
+          patch: { required: true },
+        },
+      ],
+      snapshot,
+    );
+    expect(result.compatible).toBe(false);
+    expect(result.breaking[0].rule).toBe("tighten_constraint_nullable_to_required");
+  });
+
+  it("detects adding a unique constraint (tighten_constraint_add_unique)", () => {
+    const snapshot = makeSnapshot();
+    const result = compatibilityCheck(
+      [
+        {
+          kind: "field_constraint_change",
+          entity: "order",
+          field: "note",
+          patch: { unique: true },
+        },
+      ],
+      snapshot,
+    );
+    expect(result.compatible).toBe(false);
+    expect(result.breaking[0].rule).toBe("tighten_constraint_add_unique");
+  });
+
+  it("detects narrowing min upward (tighten_constraint_narrow_min)", () => {
+    const snapshot = makeSnapshot();
+    const result = compatibilityCheck(
+      [
+        {
+          kind: "field_constraint_change",
+          entity: "order",
+          field: "amount",
+          patch: { min: 100 },
+        },
+      ],
+      snapshot,
+    );
+    expect(result.compatible).toBe(false);
+    expect(result.breaking[0].rule).toBe("tighten_constraint_narrow_min");
+  });
+
+  it("detects narrowing max downward (tighten_constraint_narrow_max)", () => {
+    const snapshot = makeSnapshot();
+    const result = compatibilityCheck(
+      [
+        {
+          kind: "field_constraint_change",
+          entity: "order",
+          field: "amount",
+          patch: { max: 100 },
+        },
+      ],
+      snapshot,
+    );
+    expect(result.compatible).toBe(false);
+    expect(result.breaking[0].rule).toBe("tighten_constraint_narrow_max");
+  });
+
+  it("detects narrowing an enum (tighten_constraint_narrow_enum)", () => {
+    const snapshot = makeSnapshot();
+    const result = compatibilityCheck(
+      [
+        {
+          kind: "enum_options_change",
+          entity: "order",
+          field: "status",
+          newOptions: ["draft", "submitted"], // removed "approved"
+        },
+      ],
+      snapshot,
+    );
+    expect(result.compatible).toBe(false);
+    expect(result.breaking[0].rule).toBe("tighten_constraint_narrow_enum");
+    expect(result.breaking[0].reason).toContain("approved");
+  });
+
+  it("detects adding a required field without default (add_required_field_without_default)", () => {
+    const snapshot = makeSnapshot();
+    const result = compatibilityCheck(
+      [
+        {
+          kind: "field_add",
+          entity: "order",
+          field: "currency",
+          definition: { type: "string", required: true },
+        },
+      ],
+      snapshot,
+    );
+    expect(result.compatible).toBe(false);
+    expect(result.breaking[0].rule).toBe("add_required_field_without_default");
+  });
+});
+
+// ── Phase 3 — warnings and info ──────────────────────────────
+
+describe("compatibilityCheck — warnings", () => {
+  it("warns on dropping a field that has no FK references (data loss warning)", () => {
+    const snapshot = makeSnapshot();
+    const result = compatibilityCheck(
+      [{ kind: "field_drop", entity: "order", field: "note" }],
+      snapshot,
+    );
+    expect(result.compatible).toBe(true);
+    expect(result.warnings.some((w) => w.rule === "drop_field_data_loss")).toBe(true);
+  });
+
+  it("warns on deleting an entity that has no incoming references", () => {
+    const snapshot = makeSnapshot();
+    // Remove the line_item → order ref so deleting order is non-breaking
+    snapshot.references = [];
+    const result = compatibilityCheck([{ kind: "entity_delete", entity: "order" }], snapshot);
+    expect(result.compatible).toBe(true);
+    expect(result.warnings.some((w) => w.rule === "delete_entity_data_loss")).toBe(true);
+  });
+
+  it("emits an info note when a field is dropped and re-added (replacement)", () => {
+    const snapshot = makeSnapshot();
+    snapshot.references = [];
+    const result = compatibilityCheck(
+      [
+        { kind: "field_drop", entity: "order", field: "note" },
+        {
+          kind: "field_add",
+          entity: "order",
+          field: "note",
+          definition: { type: "text" },
+        },
+      ],
+      snapshot,
+    );
+    expect(result.info.some((i) => i.rule === "field_drop_and_readd")).toBe(true);
+  });
+});
+
+// ── Phase 3 — adding a required field with a default is OK ───
+
+describe("compatibilityCheck — required field with default", () => {
+  it("does not flag a required field that has a default", () => {
+    const snapshot = makeSnapshot();
+    const result = compatibilityCheck(
+      [
+        {
+          kind: "field_add",
+          entity: "order",
+          field: "currency",
+          definition: { type: "string", required: true, default: "USD" },
+        },
+      ],
+      snapshot,
+    );
+    expect(result.compatible).toBe(true);
+    expect(result.breaking).toHaveLength(0);
+    expect(result.info.some((i) => i.rule === "field_added")).toBe(true);
+  });
+});
+
+// ── Phase 3 — multiple changes ───────────────────────────────
+
+describe("compatibilityCheck — aggregation", () => {
+  it("reports multiple breaking issues from a multi-change proposal", () => {
+    const snapshot = makeSnapshot();
+    const result = compatibilityCheck(
+      [
+        { kind: "field_drop", entity: "order", field: "id" }, // breaking
+        {
+          kind: "enum_options_change",
+          entity: "order",
+          field: "status",
+          newOptions: ["draft"], // narrowing
+        },
+      ],
+      snapshot,
+    );
+    expect(result.compatible).toBe(false);
+    expect(result.breaking.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/core/__tests__/ai-proposal-compatibility-checker.test.ts
+++ b/packages/core/__tests__/ai-proposal-compatibility-checker.test.ts
@@ -187,6 +187,25 @@ describe("compatibilityCheck — breaking-change rules", () => {
     expect(result.breaking[0].rule).toBe("tighten_constraint_narrow_min");
   });
 
+  it("detects introducing a min where none existed (tighten_constraint_narrow_min)", () => {
+    // `qty` on line_item has no min/max — adding a min must be breaking
+    const snapshot = makeSnapshot();
+    const result = compatibilityCheck(
+      [
+        {
+          kind: "field_constraint_change",
+          entity: "line_item",
+          field: "qty",
+          patch: { min: 1 },
+        },
+      ],
+      snapshot,
+    );
+    expect(result.compatible).toBe(false);
+    expect(result.breaking[0].rule).toBe("tighten_constraint_narrow_min");
+    expect(result.breaking[0].reason).toContain("Adding a min");
+  });
+
   it("detects narrowing max downward (tighten_constraint_narrow_max)", () => {
     const snapshot = makeSnapshot();
     const result = compatibilityCheck(
@@ -202,6 +221,25 @@ describe("compatibilityCheck — breaking-change rules", () => {
     );
     expect(result.compatible).toBe(false);
     expect(result.breaking[0].rule).toBe("tighten_constraint_narrow_max");
+  });
+
+  it("detects introducing a max where none existed (tighten_constraint_narrow_max)", () => {
+    // `qty` on line_item has no min/max — adding a max must be breaking
+    const snapshot = makeSnapshot();
+    const result = compatibilityCheck(
+      [
+        {
+          kind: "field_constraint_change",
+          entity: "line_item",
+          field: "qty",
+          patch: { max: 1000 },
+        },
+      ],
+      snapshot,
+    );
+    expect(result.compatible).toBe(false);
+    expect(result.breaking[0].rule).toBe("tighten_constraint_narrow_max");
+    expect(result.breaking[0].reason).toContain("Adding a max");
   });
 
   it("detects narrowing an enum (tighten_constraint_narrow_enum)", () => {
@@ -278,6 +316,42 @@ describe("compatibilityCheck — warnings", () => {
       snapshot,
     );
     expect(result.info.some((i) => i.rule === "field_drop_and_readd")).toBe(true);
+  });
+
+  it("matches each drop/re-add pair exactly once across many changes", () => {
+    // Exercises the two-pass Map index — three drop/add pairs should yield
+    // exactly three `field_drop_and_readd` notes (one per pair), proving the
+    // index does not double-count when many changes are present.
+    const snapshot = makeSnapshot();
+    snapshot.references = [];
+    const result = compatibilityCheck(
+      [
+        { kind: "field_drop", entity: "order", field: "note" },
+        { kind: "field_drop", entity: "order", field: "amount" },
+        { kind: "field_drop", entity: "line_item", field: "qty" },
+        {
+          kind: "field_add",
+          entity: "order",
+          field: "note",
+          definition: { type: "text" },
+        },
+        {
+          kind: "field_add",
+          entity: "order",
+          field: "amount",
+          definition: { type: "number" },
+        },
+        {
+          kind: "field_add",
+          entity: "line_item",
+          field: "qty",
+          definition: { type: "number" },
+        },
+      ],
+      snapshot,
+    );
+    const replacements = result.info.filter((i) => i.rule === "field_drop_and_readd");
+    expect(replacements).toHaveLength(3);
   });
 });
 

--- a/packages/core/__tests__/ai-proposal-dry-run.test.ts
+++ b/packages/core/__tests__/ai-proposal-dry-run.test.ts
@@ -163,6 +163,45 @@ describe("dryRunProposal — drift / error detection", () => {
     expect(result.modelErrors[0].code).toBe("duplicate_entity");
   });
 
+  it("detects dangling reference when target entity has no implicit id field", () => {
+    // The reference omits `toField`, which defaults to "id". But the target
+    // entity ("note_doc") deliberately has no `id` field — the dry-run must
+    // still flag this as a dangling reference rather than silently allowing it.
+    const snapshot: CompatibilityRegistrySnapshot = {
+      entities: {
+        product: {
+          name: "product",
+          fields: {
+            id: { type: "string", required: true },
+            note_ref: { type: "string" },
+          },
+        },
+        note_doc: {
+          name: "note_doc",
+          fields: {
+            // intentionally no "id" field
+            content: { type: "text" },
+          },
+        },
+      },
+      references: [
+        {
+          fromEntity: "product",
+          fromField: "note_ref",
+          toEntity: "note_doc",
+          // toField omitted → previously assumed "id" existed implicitly
+        },
+      ],
+    };
+    const result = dryRunProposal([], snapshot);
+    expect(result.ok).toBe(false);
+    const danglers = result.modelErrors.filter((e) => e.code === "dangling_reference_to_field");
+    expect(danglers).toHaveLength(1);
+    expect(danglers[0].message).toContain('assumes target field "id"');
+    expect(danglers[0].entity).toBe("note_doc");
+    expect(danglers[0].field).toBe("id");
+  });
+
   it("detects dangling reference target after a field drop", () => {
     // Reference to category.label which we then drop
     const snapshot: CompatibilityRegistrySnapshot = {

--- a/packages/core/__tests__/ai-proposal-dry-run.test.ts
+++ b/packages/core/__tests__/ai-proposal-dry-run.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it } from "bun:test";
+import {
+  buildCompatibilitySnapshot,
+  type CompatibilityRegistrySnapshot,
+} from "../src/ai/proposal-compatibility-checker";
+import { dryRunProposal } from "../src/ai/proposal-dry-run";
+import type { EntityDefinition } from "../src/types/entity";
+
+// ── Fixtures ──────────────────────────────────────────────────
+
+function makeProductEntity(): EntityDefinition {
+  return {
+    name: "product",
+    fields: {
+      id: { type: "string", required: true },
+      sku: { type: "string" },
+      price: { type: "number" },
+    },
+  };
+}
+
+function makeCategoryEntity(): EntityDefinition {
+  return {
+    name: "category",
+    fields: {
+      id: { type: "string", required: true },
+      name: { type: "string" },
+    },
+  };
+}
+
+function makeSnapshot(): CompatibilityRegistrySnapshot {
+  return buildCompatibilitySnapshot([makeProductEntity(), makeCategoryEntity()], []);
+}
+
+// ── Happy path ───────────────────────────────────────────────
+
+describe("dryRunProposal — happy path", () => {
+  it("applies a clean add-field change and reports ok=true", () => {
+    const snapshot = makeSnapshot();
+    const result = dryRunProposal(
+      [
+        {
+          kind: "field_add",
+          entity: "product",
+          field: "currency",
+          definition: { type: "string" },
+        },
+      ],
+      snapshot,
+    );
+    expect(result.ok).toBe(true);
+    expect(result.modelErrors).toHaveLength(0);
+    expect(result.sideEffects.fieldsAdded).toBe(1);
+    expect(result.sideEffects.entitiesModified).toBe(1);
+  });
+
+  it("counts add/remove/modify side effects accurately", () => {
+    const snapshot = makeSnapshot();
+    const result = dryRunProposal(
+      [
+        {
+          kind: "entity_create",
+          entity: "warehouse",
+          definition: {
+            name: "warehouse",
+            fields: { id: { type: "string", required: true } },
+          },
+        },
+        { kind: "entity_delete", entity: "category" },
+        {
+          kind: "field_add",
+          entity: "product",
+          field: "weight",
+          definition: { type: "number" },
+        },
+        { kind: "field_drop", entity: "product", field: "sku" },
+        {
+          kind: "field_type_change",
+          entity: "product",
+          field: "price",
+          newType: "number",
+        },
+      ],
+      snapshot,
+    );
+    expect(result.sideEffects.entitiesAdded).toBe(1);
+    expect(result.sideEffects.entitiesRemoved).toBe(1);
+    expect(result.sideEffects.entitiesModified).toBe(1); // only product was field-modified
+    expect(result.sideEffects.fieldsAdded).toBe(1);
+    expect(result.sideEffects.fieldsRemoved).toBe(1);
+    expect(result.sideEffects.fieldsModified).toBe(1);
+    expect(result.postStateEntityCount).toBe(2); // product + warehouse
+  });
+
+  it("renames an entity and rewrites references", () => {
+    const snapshot = buildCompatibilitySnapshot(
+      [makeProductEntity(), makeCategoryEntity()],
+      [
+        {
+          fromEntity: "product",
+          fromField: "id",
+          toEntity: "category",
+          toField: "id",
+        },
+      ],
+    );
+    const result = dryRunProposal(
+      [{ kind: "entity_rename", entity: "category", newName: "product_group" }],
+      snapshot,
+    );
+    expect(result.ok).toBe(true);
+    expect(result.sideEffects.entitiesRenamed).toBe(1);
+  });
+});
+
+// ── Drift detection ──────────────────────────────────────────
+
+describe("dryRunProposal — drift / error detection", () => {
+  it("flags duplicate entity creation as a model error", () => {
+    const snapshot = makeSnapshot();
+    const result = dryRunProposal(
+      [
+        {
+          kind: "entity_create",
+          entity: "product", // already exists
+          definition: {
+            name: "product",
+            fields: { id: { type: "string", required: true } },
+          },
+        },
+      ],
+      snapshot,
+    );
+    expect(result.ok).toBe(false);
+    expect(result.modelErrors[0].code).toBe("duplicate_entity");
+  });
+
+  it("flags missing entity on delete as a model error", () => {
+    const snapshot = makeSnapshot();
+    const result = dryRunProposal([{ kind: "entity_delete", entity: "nonexistent" }], snapshot);
+    expect(result.ok).toBe(false);
+    expect(result.modelErrors[0].code).toBe("missing_entity");
+  });
+
+  it("flags missing field on drop as a model error", () => {
+    const snapshot = makeSnapshot();
+    const result = dryRunProposal(
+      [{ kind: "field_drop", entity: "product", field: "ghost" }],
+      snapshot,
+    );
+    expect(result.ok).toBe(false);
+    expect(result.modelErrors[0].code).toBe("missing_field");
+  });
+
+  it("detects dangling references after entity rename target collision", () => {
+    const snapshot = buildCompatibilitySnapshot([makeProductEntity(), makeCategoryEntity()], []);
+    const result = dryRunProposal(
+      [{ kind: "entity_rename", entity: "product", newName: "category" }],
+      snapshot,
+    );
+    expect(result.ok).toBe(false);
+    expect(result.modelErrors[0].code).toBe("duplicate_entity");
+  });
+
+  it("detects dangling reference target after a field drop", () => {
+    // Reference to category.label which we then drop
+    const snapshot: CompatibilityRegistrySnapshot = {
+      entities: {
+        product: {
+          name: "product",
+          fields: {
+            id: { type: "string", required: true },
+            cat_label: { type: "string" },
+          },
+        },
+        category: {
+          name: "category",
+          fields: {
+            id: { type: "string", required: true },
+            label: { type: "string" },
+          },
+        },
+      },
+      references: [
+        {
+          fromEntity: "product",
+          fromField: "cat_label",
+          toEntity: "category",
+          toField: "label",
+        },
+      ],
+    };
+    const result = dryRunProposal(
+      [{ kind: "field_drop", entity: "category", field: "label" }],
+      snapshot,
+    );
+    expect(result.ok).toBe(false);
+    expect(result.modelErrors.some((e) => e.code === "dangling_reference_to_field")).toBe(true);
+  });
+});
+
+// ── Snapshot isolation ────────────────────────────────────────
+
+describe("dryRunProposal — snapshot isolation", () => {
+  it("does not mutate the caller's snapshot after a destructive change", () => {
+    const snapshot = makeSnapshot();
+    const before = JSON.stringify(snapshot);
+    dryRunProposal(
+      [
+        { kind: "entity_delete", entity: "category" },
+        { kind: "field_drop", entity: "product", field: "sku" },
+      ],
+      snapshot,
+    );
+    const after = JSON.stringify(snapshot);
+    expect(after).toBe(before);
+  });
+
+  it("does not mutate field options when enum is changed", () => {
+    const snapshot: CompatibilityRegistrySnapshot = {
+      entities: {
+        product: {
+          name: "product",
+          fields: {
+            id: { type: "string", required: true },
+            status: {
+              type: "enum",
+              options: [{ value: "active" }, { value: "archived" }],
+            },
+          },
+        },
+      },
+    };
+    const before = JSON.stringify(snapshot);
+    dryRunProposal(
+      [
+        {
+          kind: "enum_options_change",
+          entity: "product",
+          field: "status",
+          newOptions: ["active"],
+        },
+      ],
+      snapshot,
+    );
+    expect(JSON.stringify(snapshot)).toBe(before);
+  });
+
+  it("reports snapshotPreserved=true on success", () => {
+    const snapshot = makeSnapshot();
+    const result = dryRunProposal(
+      [
+        {
+          kind: "field_add",
+          entity: "product",
+          field: "tax",
+          definition: { type: "number" },
+        },
+      ],
+      snapshot,
+    );
+    expect(result.snapshotPreserved).toBe(true);
+  });
+});

--- a/packages/core/__tests__/ai-proposal-validator-extended.test.ts
+++ b/packages/core/__tests__/ai-proposal-validator-extended.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from "bun:test";
+import {
+  buildCompatibilitySnapshot,
+  type CompatibilityRegistrySnapshot,
+} from "../src/ai/proposal-compatibility-checker";
+import { ProposalEngine } from "../src/ai/proposal-engine";
+import {
+  createExtendedProposalValidator,
+  validateProposalExtended,
+} from "../src/ai/proposal-validator-extended";
+import type { EntityDefinition } from "../src/types/entity";
+
+// ── Fixtures ──────────────────────────────────────────────────
+
+function makeEntity(): EntityDefinition {
+  return {
+    name: "invoice",
+    fields: {
+      id: { type: "string", required: true },
+      amount: { type: "number" },
+      note: { type: "string" },
+    },
+  };
+}
+
+function makeSnapshot(): CompatibilityRegistrySnapshot {
+  return buildCompatibilitySnapshot([makeEntity()], []);
+}
+
+// ── Pipeline composition ─────────────────────────────────────
+
+describe("validateProposalExtended — pipeline composition", () => {
+  it("runs all 4 phases when compatibility input is provided", () => {
+    const snapshot = makeSnapshot();
+    const result = validateProposalExtended({
+      securityChanges: [{ type: "create_action", target: "submit_invoice" }],
+      compatibilityChanges: [
+        {
+          kind: "field_add",
+          entity: "invoice",
+          field: "currency",
+          definition: { type: "string" },
+        },
+      ],
+      snapshot,
+    });
+    expect(result.passed).toBe(true);
+    expect(result.phases.map((p) => p.name)).toEqual([
+      "static",
+      "build",
+      "compatibility",
+      "dry_run",
+    ]);
+    expect(result.phases.every((p) => p.status === "passed")).toBe(true);
+    expect(result.compatibility).toBeDefined();
+    expect(result.dryRun).toBeDefined();
+  });
+
+  it("skips Phase 3+4 when no compatibility input supplied", () => {
+    const result = validateProposalExtended({
+      securityChanges: [{ type: "create_action", target: "submit_invoice" }],
+    });
+    expect(result.passed).toBe(true);
+    expect(result.phases[2].status).toBe("skipped");
+    expect(result.phases[3].status).toBe("skipped");
+    expect(result.compatibility).toBeUndefined();
+    expect(result.dryRun).toBeUndefined();
+  });
+
+  it("fails the pipeline when Phase 3 reports breaking changes", () => {
+    const snapshot = makeSnapshot();
+    const result = validateProposalExtended({
+      securityChanges: [{ type: "modify_schema", target: "invoice" }],
+      compatibilityChanges: [
+        {
+          kind: "field_constraint_change",
+          entity: "invoice",
+          field: "note",
+          patch: { required: true }, // nullable → required = breaking
+        },
+      ],
+      snapshot,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.phases.find((p) => p.name === "compatibility")?.status).toBe("failed");
+    expect(result.compatibility?.compatible).toBe(false);
+  });
+
+  it("fails the pipeline when Phase 4 reports model errors", () => {
+    const snapshot = makeSnapshot();
+    const result = validateProposalExtended({
+      securityChanges: [{ type: "modify_schema", target: "invoice" }],
+      compatibilityChanges: [{ kind: "field_drop", entity: "invoice", field: "ghost_field" }],
+      snapshot,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.phases.find((p) => p.name === "dry_run")?.status).toBe("failed");
+    expect(result.dryRun?.ok).toBe(false);
+  });
+
+  it("fails Phase 1+2 when security validation rejects the change", () => {
+    const snapshot = makeSnapshot();
+    const result = validateProposalExtended({
+      securityChanges: [{ type: "delete_rule", target: "any_rule" }], // forbidden by default
+      compatibilityChanges: [
+        {
+          kind: "field_add",
+          entity: "invoice",
+          field: "tags",
+          definition: { type: "string" },
+        },
+      ],
+      snapshot,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.phases.find((p) => p.name === "static")?.status).toBe("failed");
+    expect(result.security.valid).toBe(false);
+  });
+
+  it("honours skipCompatibility / skipDryRun config flags", () => {
+    const snapshot = makeSnapshot();
+    const result = validateProposalExtended(
+      {
+        securityChanges: [{ type: "create_action", target: "x" }],
+        compatibilityChanges: [
+          {
+            kind: "field_add",
+            entity: "invoice",
+            field: "tags",
+            definition: { type: "string" },
+          },
+        ],
+        snapshot,
+      },
+      { skipCompatibility: true, skipDryRun: true },
+    );
+    expect(result.phases.find((p) => p.name === "compatibility")?.status).toBe("skipped");
+    expect(result.phases.find((p) => p.name === "dry_run")?.status).toBe("skipped");
+  });
+});
+
+// ── createExtendedProposalValidator ───────────────────────────
+
+describe("createExtendedProposalValidator", () => {
+  it("creates a reusable validator preserving config", () => {
+    const validator = createExtendedProposalValidator({
+      security: { maxChangesPerProposal: 3 },
+    });
+    expect(validator.config.security?.maxChangesPerProposal).toBe(3);
+
+    const result = validator.validate({
+      securityChanges: [
+        { type: "create_action", target: "a" },
+        { type: "create_action", target: "b" },
+        { type: "create_action", target: "c" },
+        { type: "create_action", target: "d" }, // exceeds 3
+      ],
+    });
+    expect(result.passed).toBe(false);
+  });
+});
+
+// ── ProposalEngine.validateExtended ───────────────────────────
+
+describe("ProposalEngine.validateExtended", () => {
+  it("runs the full pipeline through the engine and returns combined report", () => {
+    const engine = new ProposalEngine();
+    const proposal = engine.createProposal({
+      type: "modify_schema",
+      description: "Add currency field",
+      reasoning: "Multi-currency support",
+      confidence: 0.9,
+      diff: {
+        target: "entity",
+        operation: "update",
+        definition: { entity: "invoice", name: "invoice" },
+        summary: "Add currency",
+      },
+    });
+
+    const snapshot = makeSnapshot();
+    const result = engine.validateExtended(proposal.id, {
+      compatibilityChanges: [
+        {
+          kind: "field_add",
+          entity: "invoice",
+          field: "currency",
+          definition: { type: "string" },
+        },
+      ],
+      snapshot,
+    });
+
+    expect(result.passed).toBe(true);
+    expect(result.phases).toHaveLength(4);
+    expect(result.compatibility).toBeDefined();
+    expect(result.dryRun).toBeDefined();
+    expect(result.dryRun?.sideEffects.fieldsAdded).toBe(1);
+  });
+
+  it("returns combined failure when Phase 3 detects a breaking change via the engine", () => {
+    const engine = new ProposalEngine();
+    const proposal = engine.createProposal({
+      type: "modify_schema",
+      description: "Drop note",
+      reasoning: "Cleanup",
+      confidence: 0.5,
+      diff: {
+        target: "entity",
+        operation: "update",
+        definition: { entity: "invoice", name: "invoice" },
+        summary: "Drop note",
+      },
+    });
+
+    const snapshot = buildCompatibilitySnapshot(
+      [makeEntity()],
+      [
+        // someone references invoice.id
+        {
+          fromEntity: "invoice",
+          fromField: "id",
+          toEntity: "invoice",
+          toField: "id",
+        },
+      ],
+    );
+    const result = engine.validateExtended(proposal.id, {
+      compatibilityChanges: [{ kind: "field_drop", entity: "invoice", field: "id" }],
+      snapshot,
+    });
+
+    expect(result.passed).toBe(false);
+    expect(result.compatibility?.compatible).toBe(false);
+    expect(result.compatibility?.breaking[0].rule).toBe("drop_field_with_references");
+  });
+
+  it("does not change proposal status when validateExtended is invoked", () => {
+    const engine = new ProposalEngine();
+    const proposal = engine.createProposal({
+      type: "add_rule",
+      description: "test",
+      reasoning: "test",
+      confidence: 0.9,
+      diff: { target: "rule", operation: "create", summary: "x" },
+    });
+    engine.validateExtended(proposal.id);
+    expect(engine.get(proposal.id)?.status).toBe("draft");
+  });
+});

--- a/packages/core/src/ai/index.ts
+++ b/packages/core/src/ai/index.ts
@@ -91,6 +91,34 @@ export {
   ProposalCodeGenerator,
   type QualityGateRunner,
 } from "./proposal-code-generator";
+// Proposal Compatibility Checker (Spec 09 Phase 3)
+export {
+  buildCompatibilitySnapshot,
+  compatibilityCheck,
+} from "./proposal-compatibility-checker";
+export type {
+  CompatibilityChange,
+  CompatibilityIssue,
+  CompatibilityRegistrySnapshot,
+  CompatibilityResult,
+  CompatibilitySeverity,
+  EntityCreateChange,
+  EntityDeleteChange,
+  EntityReference,
+  EntityRenameChange,
+  EnumOptionsChange,
+  FieldAddChange,
+  FieldConstraintChange,
+  FieldDropChange,
+  FieldTypeChange,
+} from "./proposal-compatibility-types";
+// Proposal Dry-Run (Spec 09 Phase 4)
+export type {
+  DryRunModelError,
+  DryRunResult,
+  DryRunSideEffects,
+} from "./proposal-dry-run";
+export { dryRunProposal } from "./proposal-dry-run";
 // Proposal Engine
 export type {
   AIProposalStatus,
@@ -112,6 +140,18 @@ export type {
   ProposalViolation,
 } from "./proposal-validator";
 export { createProposalValidator, validateProposal } from "./proposal-validator";
+// Extended Proposal Validator (Spec 09 4-phase pipeline)
+export type {
+  ExtendedPhaseStatus,
+  ExtendedPhaseSummary,
+  ExtendedValidationResult,
+  ExtendedValidatorConfig,
+  ExtendedValidatorInput,
+} from "./proposal-validator-extended";
+export {
+  createExtendedProposalValidator,
+  validateProposalExtended,
+} from "./proposal-validator-extended";
 // Record Analyzer
 export type {
   RecordAnalysis,

--- a/packages/core/src/ai/proposal-compatibility-checker.ts
+++ b/packages/core/src/ai/proposal-compatibility-checker.ts
@@ -1,0 +1,434 @@
+/**
+ * AI Proposal Compatibility Checker (Phase 3)
+ *
+ * Detects breaking changes in a proposal against the currently registered
+ * entity registry. Implements Spec 09 §4.5 (Phase 3: Compatibility Check).
+ *
+ * Breaking-change rules implemented:
+ *  1. Drop a field that still has live FK references.
+ *  2. Change a field type to an incompatible primitive type.
+ *  3. Drop or rename an Entity that has FK references from other entities.
+ *  4. Tighten a constraint (nullable → not-null, enum narrowing).
+ *
+ * The checker is intentionally **pure** — it never touches the live registry.
+ * The caller passes in a `CompatibilityRegistrySnapshot` representing current
+ * state; the checker returns a structured `CompatibilityResult`.
+ */
+
+import type { EntityDefinition, EnumField, FieldDefinition } from "../types/entity";
+import type {
+  CompatibilityChange,
+  CompatibilityIssue,
+  CompatibilityRegistrySnapshot,
+  CompatibilityResult,
+  EntityDeleteChange,
+  EntityReference,
+  EntityRenameChange,
+  EnumOptionsChange,
+  FieldConstraintChange,
+  FieldDropChange,
+  FieldTypeChange,
+} from "./proposal-compatibility-types";
+
+// Re-export types so consumers can import them from this module too
+export type * from "./proposal-compatibility-types";
+
+// ── Type compatibility matrix ────────────────────────────────
+
+/**
+ * Per Spec 09 §4.5, "changing a field type to an incompatible one" is breaking.
+ * We treat type changes as compatible only if the new type is a strict superset
+ * of the old, or identical. All other changes are flagged as breaking.
+ *
+ * The matrix lists *new types* that are compatible for a given *old type*.
+ */
+const TYPE_UPGRADE_MATRIX: Record<FieldDefinition["type"], readonly FieldDefinition["type"][]> = {
+  string: ["string", "text"], // text is wider than string
+  text: ["text"],
+  number: ["number"],
+  boolean: ["boolean"],
+  date: ["date", "datetime"], // datetime is wider than date
+  datetime: ["datetime"],
+  enum: ["enum"],
+  json: ["json"],
+  state: ["state"],
+  computed: ["computed"],
+};
+
+function isTypeCompatible(
+  oldType: FieldDefinition["type"],
+  newType: FieldDefinition["type"],
+): boolean {
+  return TYPE_UPGRADE_MATRIX[oldType]?.includes(newType) ?? false;
+}
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function getField(
+  snapshot: CompatibilityRegistrySnapshot,
+  entity: string,
+  field: string,
+): FieldDefinition | undefined {
+  return snapshot.entities[entity]?.fields[field];
+}
+
+function fieldHasReferences(
+  snapshot: CompatibilityRegistrySnapshot,
+  entity: string,
+  field: string,
+): EntityReference[] {
+  const refs = snapshot.references ?? [];
+  // Either we own a field that's pointed at, OR we point at someone else
+  return refs.filter(
+    (r) =>
+      (r.toEntity === entity && (r.toField ?? "id") === field) ||
+      (r.fromEntity === entity && r.fromField === field),
+  );
+}
+
+function entityHasIncomingReferences(
+  snapshot: CompatibilityRegistrySnapshot,
+  entity: string,
+): EntityReference[] {
+  const refs = snapshot.references ?? [];
+  return refs.filter((r) => r.toEntity === entity);
+}
+
+// ── Per-change checkers ──────────────────────────────────────
+
+function checkFieldDrop(
+  change: FieldDropChange,
+  snapshot: CompatibilityRegistrySnapshot,
+): CompatibilityIssue | undefined {
+  const refs = fieldHasReferences(snapshot, change.entity, change.field);
+  if (refs.length > 0) {
+    const refDesc = refs
+      .map((r) => `${r.fromEntity}.${r.fromField} → ${r.toEntity}.${r.toField ?? "id"}`)
+      .join(", ");
+    return {
+      rule: "drop_field_with_references",
+      severity: "breaking",
+      change,
+      reason:
+        `Field "${change.entity}.${change.field}" still has live FK references and ` +
+        `cannot be dropped (references: ${refDesc})`,
+    };
+  }
+  // Always warn on field drop — even without references it's a data loss event
+  return undefined;
+}
+
+function checkFieldTypeChange(
+  change: FieldTypeChange,
+  snapshot: CompatibilityRegistrySnapshot,
+): CompatibilityIssue | undefined {
+  const current = getField(snapshot, change.entity, change.field);
+  if (!current) {
+    return undefined;
+  }
+  if (current.type === change.newType) {
+    return undefined;
+  }
+  if (!isTypeCompatible(current.type, change.newType)) {
+    return {
+      rule: "incompatible_field_type_change",
+      severity: "breaking",
+      change,
+      reason:
+        `Cannot change field "${change.entity}.${change.field}" from "${current.type}" ` +
+        `to "${change.newType}" — types are not compatible`,
+    };
+  }
+  return undefined;
+}
+
+function checkEntityDelete(
+  change: EntityDeleteChange,
+  snapshot: CompatibilityRegistrySnapshot,
+): CompatibilityIssue | undefined {
+  const refs = entityHasIncomingReferences(snapshot, change.entity);
+  if (refs.length > 0) {
+    const refDesc = refs.map((r) => `${r.fromEntity}.${r.fromField}`).join(", ");
+    return {
+      rule: "delete_entity_with_references",
+      severity: "breaking",
+      change,
+      reason:
+        `Entity "${change.entity}" cannot be deleted — it has incoming FK references ` +
+        `from: ${refDesc}`,
+    };
+  }
+  return undefined;
+}
+
+function checkEntityRename(
+  change: EntityRenameChange,
+  snapshot: CompatibilityRegistrySnapshot,
+): CompatibilityIssue | undefined {
+  const refs = entityHasIncomingReferences(snapshot, change.entity);
+  if (refs.length > 0) {
+    const refDesc = refs.map((r) => `${r.fromEntity}.${r.fromField}`).join(", ");
+    return {
+      rule: "rename_entity_with_references",
+      severity: "breaking",
+      change,
+      reason:
+        `Entity "${change.entity}" cannot be renamed to "${change.newName}" — ` +
+        `it has incoming FK references from: ${refDesc}`,
+    };
+  }
+  return undefined;
+}
+
+function checkConstraintTightening(
+  change: FieldConstraintChange,
+  snapshot: CompatibilityRegistrySnapshot,
+): CompatibilityIssue | undefined {
+  const current = getField(snapshot, change.entity, change.field);
+  if (!current) {
+    return undefined;
+  }
+  const { patch } = change;
+
+  // nullable → not-null
+  if (patch.required === true && current.required !== true) {
+    return {
+      rule: "tighten_constraint_nullable_to_required",
+      severity: "breaking",
+      change,
+      reason:
+        `Tightening "${change.entity}.${change.field}" from nullable to required is ` +
+        `breaking — existing rows with null values will violate the new constraint`,
+    };
+  }
+
+  // adding unique constraint
+  if (patch.unique === true && current.unique !== true) {
+    return {
+      rule: "tighten_constraint_add_unique",
+      severity: "breaking",
+      change,
+      reason:
+        `Adding a unique constraint to "${change.entity}.${change.field}" is breaking — ` +
+        `existing duplicate values will violate the new constraint`,
+    };
+  }
+
+  // narrowing min (raising the floor)
+  if (typeof patch.min === "number" && typeof current.min === "number" && patch.min > current.min) {
+    return {
+      rule: "tighten_constraint_narrow_min",
+      severity: "breaking",
+      change,
+      reason:
+        `Raising min from ${current.min} to ${patch.min} on "${change.entity}.${change.field}" ` +
+        `is breaking — existing values below ${patch.min} will violate the new constraint`,
+    };
+  }
+
+  // narrowing max (lowering the ceiling)
+  if (typeof patch.max === "number" && typeof current.max === "number" && patch.max < current.max) {
+    return {
+      rule: "tighten_constraint_narrow_max",
+      severity: "breaking",
+      change,
+      reason:
+        `Lowering max from ${current.max} to ${patch.max} on "${change.entity}.${change.field}" ` +
+        `is breaking — existing values above ${patch.max} will violate the new constraint`,
+    };
+  }
+
+  return undefined;
+}
+
+function checkEnumOptionsChange(
+  change: EnumOptionsChange,
+  snapshot: CompatibilityRegistrySnapshot,
+): CompatibilityIssue | undefined {
+  const current = getField(snapshot, change.entity, change.field);
+  if (!current || current.type !== "enum") {
+    return undefined;
+  }
+  const oldOptions = new Set((current as EnumField).options.map((o) => o.value));
+  const newOptions = new Set(change.newOptions);
+  const removed: string[] = [];
+  for (const opt of oldOptions) {
+    if (!newOptions.has(opt)) {
+      removed.push(opt);
+    }
+  }
+  if (removed.length > 0) {
+    return {
+      rule: "tighten_constraint_narrow_enum",
+      severity: "breaking",
+      change,
+      reason:
+        `Narrowing enum "${change.entity}.${change.field}" by removing options ` +
+        `[${removed.join(", ")}] is breaking — existing rows with these values become invalid`,
+    };
+  }
+  return undefined;
+}
+
+// ── Public API ───────────────────────────────────────────────
+
+/**
+ * Run a compatibility check over the given changes against a registry snapshot.
+ *
+ * @param changes - The proposed changes (semantically rich, field-level)
+ * @param snapshot - Read-only snapshot of the current registry state
+ * @returns Structured compatibility result with breaking issues / warnings
+ */
+export function compatibilityCheck(
+  changes: CompatibilityChange[],
+  snapshot: CompatibilityRegistrySnapshot,
+): CompatibilityResult {
+  const breaking: CompatibilityIssue[] = [];
+  const warnings: CompatibilityIssue[] = [];
+  const info: CompatibilityIssue[] = [];
+
+  for (const change of changes) {
+    let issue: CompatibilityIssue | undefined;
+
+    switch (change.kind) {
+      case "field_drop":
+        issue = checkFieldDrop(change, snapshot);
+        if (!issue) {
+          // Data-loss warning even without FK references
+          warnings.push({
+            rule: "drop_field_data_loss",
+            severity: "warning",
+            change,
+            reason:
+              `Dropping field "${change.entity}.${change.field}" will discard ` +
+              `existing data — prefer mark-deprecated then remove in next major`,
+          });
+        }
+        break;
+
+      case "field_type_change":
+        issue = checkFieldTypeChange(change, snapshot);
+        break;
+
+      case "entity_delete":
+        issue = checkEntityDelete(change, snapshot);
+        if (!issue) {
+          warnings.push({
+            rule: "delete_entity_data_loss",
+            severity: "warning",
+            change,
+            reason:
+              `Deleting entity "${change.entity}" will discard all stored records — ` +
+              `prefer mark-deprecated then remove in next major`,
+          });
+        }
+        break;
+
+      case "entity_rename":
+        issue = checkEntityRename(change, snapshot);
+        break;
+
+      case "field_constraint_change":
+        issue = checkConstraintTightening(change, snapshot);
+        break;
+
+      case "enum_options_change":
+        issue = checkEnumOptionsChange(change, snapshot);
+        break;
+
+      case "entity_create":
+        // Adding a new entity is always backward-compatible
+        info.push({
+          rule: "entity_added",
+          severity: "info",
+          change,
+          reason: `New entity "${change.entity}" added`,
+        });
+        break;
+
+      case "field_add":
+        // Adding a required field without a default is breaking against existing rows
+        if (change.definition.required && change.definition.default === undefined) {
+          breaking.push({
+            rule: "add_required_field_without_default",
+            severity: "breaking",
+            change,
+            reason:
+              `Adding required field "${change.entity}.${change.field}" without a default ` +
+              `is breaking — existing rows have no value for the new column`,
+          });
+        } else {
+          info.push({
+            rule: "field_added",
+            severity: "info",
+            change,
+            reason: `New field "${change.entity}.${change.field}" added`,
+          });
+        }
+        break;
+
+      default: {
+        // Exhaustiveness check — TS will error if a new kind is added
+        const _exhaustive: never = change;
+        void _exhaustive;
+      }
+    }
+
+    if (issue) {
+      if (issue.severity === "breaking") {
+        breaking.push(issue);
+      } else if (issue.severity === "warning") {
+        warnings.push(issue);
+      } else {
+        info.push(issue);
+      }
+    }
+  }
+
+  // Cross-change consistency: if the same field is dropped and then re-added
+  // with a new type, surface that as an info note rather than a clean drop.
+  for (let i = 0; i < changes.length; i++) {
+    const dropCandidate = changes[i];
+    if (!dropCandidate || dropCandidate.kind !== "field_drop") continue;
+    for (let j = i + 1; j < changes.length; j++) {
+      const nextCandidate = changes[j];
+      if (!nextCandidate) continue;
+      if (
+        nextCandidate.kind === "field_add" &&
+        nextCandidate.entity === dropCandidate.entity &&
+        nextCandidate.field === dropCandidate.field
+      ) {
+        info.push({
+          rule: "field_drop_and_readd",
+          severity: "info",
+          change: nextCandidate,
+          reason:
+            `Field "${dropCandidate.entity}.${dropCandidate.field}" is dropped and re-added — ` +
+            `treat as a destructive replacement`,
+        });
+      }
+    }
+  }
+
+  return {
+    compatible: breaking.length === 0,
+    breaking,
+    warnings,
+    info,
+  };
+}
+
+/**
+ * Build a snapshot from a flat list of entity definitions and references.
+ * Convenience helper for callers that hold their state as arrays.
+ */
+export function buildCompatibilitySnapshot(
+  entities: EntityDefinition[],
+  references: EntityReference[] = [],
+): CompatibilityRegistrySnapshot {
+  const map: Record<string, EntityDefinition> = {};
+  for (const e of entities) {
+    map[e.name] = e;
+  }
+  return { entities: map, references };
+}

--- a/packages/core/src/ai/proposal-compatibility-checker.ts
+++ b/packages/core/src/ai/proposal-compatibility-checker.ts
@@ -214,28 +214,56 @@ function checkConstraintTightening(
     };
   }
 
-  // narrowing min (raising the floor)
-  if (typeof patch.min === "number" && typeof current.min === "number" && patch.min > current.min) {
-    return {
-      rule: "tighten_constraint_narrow_min",
-      severity: "breaking",
-      change,
-      reason:
-        `Raising min from ${current.min} to ${patch.min} on "${change.entity}.${change.field}" ` +
-        `is breaking — existing values below ${patch.min} will violate the new constraint`,
-    };
+  // narrowing min: raising the floor OR introducing one where none existed.
+  // Adding `min` to a previously-unconstrained field rejects rows that were
+  // valid before, so it is just as breaking as raising an existing floor.
+  if (typeof patch.min === "number") {
+    if (current.min === undefined) {
+      return {
+        rule: "tighten_constraint_narrow_min",
+        severity: "breaking",
+        change,
+        reason:
+          `Adding a min of ${patch.min} to "${change.entity}.${change.field}" is breaking — ` +
+          `existing values below ${patch.min} will violate the new constraint`,
+      };
+    }
+    if (typeof current.min === "number" && patch.min > current.min) {
+      return {
+        rule: "tighten_constraint_narrow_min",
+        severity: "breaking",
+        change,
+        reason:
+          `Raising min from ${current.min} to ${patch.min} on "${change.entity}.${change.field}" ` +
+          `is breaking — existing values below ${patch.min} will violate the new constraint`,
+      };
+    }
   }
 
-  // narrowing max (lowering the ceiling)
-  if (typeof patch.max === "number" && typeof current.max === "number" && patch.max < current.max) {
-    return {
-      rule: "tighten_constraint_narrow_max",
-      severity: "breaking",
-      change,
-      reason:
-        `Lowering max from ${current.max} to ${patch.max} on "${change.entity}.${change.field}" ` +
-        `is breaking — existing values above ${patch.max} will violate the new constraint`,
-    };
+  // narrowing max: lowering the ceiling OR introducing one where none existed.
+  // Adding `max` to a previously-unconstrained field rejects rows that were
+  // valid before, so it is just as breaking as lowering an existing ceiling.
+  if (typeof patch.max === "number") {
+    if (current.max === undefined) {
+      return {
+        rule: "tighten_constraint_narrow_max",
+        severity: "breaking",
+        change,
+        reason:
+          `Adding a max of ${patch.max} to "${change.entity}.${change.field}" is breaking — ` +
+          `existing values above ${patch.max} will violate the new constraint`,
+      };
+    }
+    if (typeof current.max === "number" && patch.max < current.max) {
+      return {
+        rule: "tighten_constraint_narrow_max",
+        severity: "breaking",
+        change,
+        reason:
+          `Lowering max from ${current.max} to ${patch.max} on "${change.entity}.${change.field}" ` +
+          `is breaking — existing values above ${patch.max} will violate the new constraint`,
+      };
+    }
   }
 
   return undefined;
@@ -387,26 +415,27 @@ export function compatibilityCheck(
 
   // Cross-change consistency: if the same field is dropped and then re-added
   // with a new type, surface that as an info note rather than a clean drop.
-  for (let i = 0; i < changes.length; i++) {
-    const dropCandidate = changes[i];
-    if (!dropCandidate || dropCandidate.kind !== "field_drop") continue;
-    for (let j = i + 1; j < changes.length; j++) {
-      const nextCandidate = changes[j];
-      if (!nextCandidate) continue;
-      if (
-        nextCandidate.kind === "field_add" &&
-        nextCandidate.entity === dropCandidate.entity &&
-        nextCandidate.field === dropCandidate.field
-      ) {
-        info.push({
-          rule: "field_drop_and_readd",
-          severity: "info",
-          change: nextCandidate,
-          reason:
-            `Field "${dropCandidate.entity}.${dropCandidate.field}" is dropped and re-added — ` +
-            `treat as a destructive replacement`,
-        });
-      }
+  // Two passes (O(N)) keyed by "entity.field" instead of O(N²) nested loops:
+  //   pass 1 → index all field_add changes by their target key
+  //   pass 2 → for every field_drop, look the matching add up in the index
+  const addIndex = new Map<string, CompatibilityChange & { kind: "field_add" }>();
+  for (const change of changes) {
+    if (change.kind === "field_add") {
+      addIndex.set(`${change.entity}.${change.field}`, change);
+    }
+  }
+  for (const change of changes) {
+    if (change.kind !== "field_drop") continue;
+    const match = addIndex.get(`${change.entity}.${change.field}`);
+    if (match) {
+      info.push({
+        rule: "field_drop_and_readd",
+        severity: "info",
+        change: match,
+        reason:
+          `Field "${change.entity}.${change.field}" is dropped and re-added — ` +
+          `treat as a destructive replacement`,
+      });
     }
   }
 

--- a/packages/core/src/ai/proposal-compatibility-types.ts
+++ b/packages/core/src/ai/proposal-compatibility-types.ts
@@ -1,0 +1,139 @@
+/**
+ * AI Proposal Compatibility — shared types (Spec 09 Phase 3)
+ *
+ * Pure type-only module so both the checker (`proposal-compatibility-checker.ts`)
+ * and the dry-run (`proposal-dry-run.ts`) can consume the same vocabulary
+ * without circular imports or oversized files.
+ */
+
+import type { EntityDefinition, FieldDefinition } from "../types/entity";
+
+// ── Snapshot types ────────────────────────────────────────────
+
+/**
+ * A reference from one entity field to another entity. Used to detect
+ * "drop field with data references" and "drop entity with FK references".
+ */
+export interface EntityReference {
+  /** Entity that owns the referencing field */
+  fromEntity: string;
+  /** Field on that entity that points to the target entity */
+  fromField: string;
+  /** Target entity name */
+  toEntity: string;
+  /** Target field on the referenced entity (defaults to "id") */
+  toField?: string;
+}
+
+/**
+ * Snapshot of the registry state used as a baseline for compatibility checks.
+ * The snapshot is immutable from the checker's perspective — it is only read.
+ */
+export interface CompatibilityRegistrySnapshot {
+  /** Currently registered entities, keyed by entity name */
+  entities: Record<string, EntityDefinition>;
+  /** Cross-entity FK references */
+  references?: EntityReference[];
+}
+
+// ── Change types ──────────────────────────────────────────────
+
+/**
+ * A semantically rich change description used by the compatibility checker
+ * and the dry-run runner. Distinct from the security `ProposalChange` in
+ * `proposal-validator.ts` — that one only carries a coarse change type +
+ * target name, which is not enough to reason about field-level breakage.
+ */
+export type CompatibilityChange =
+  | EntityCreateChange
+  | EntityDeleteChange
+  | EntityRenameChange
+  | FieldAddChange
+  | FieldDropChange
+  | FieldTypeChange
+  | FieldConstraintChange
+  | EnumOptionsChange;
+
+export interface EntityCreateChange {
+  kind: "entity_create";
+  entity: string;
+  definition: EntityDefinition;
+}
+
+export interface EntityDeleteChange {
+  kind: "entity_delete";
+  entity: string;
+}
+
+export interface EntityRenameChange {
+  kind: "entity_rename";
+  entity: string;
+  newName: string;
+}
+
+export interface FieldAddChange {
+  kind: "field_add";
+  entity: string;
+  field: string;
+  definition: FieldDefinition;
+}
+
+export interface FieldDropChange {
+  kind: "field_drop";
+  entity: string;
+  field: string;
+}
+
+export interface FieldTypeChange {
+  kind: "field_type_change";
+  entity: string;
+  field: string;
+  newType: FieldDefinition["type"];
+}
+
+export interface FieldConstraintChange {
+  kind: "field_constraint_change";
+  entity: string;
+  field: string;
+  /** New constraint patch (only the fields being changed) */
+  patch: {
+    required?: boolean;
+    unique?: boolean;
+    min?: number;
+    max?: number;
+    pattern?: string;
+  };
+}
+
+export interface EnumOptionsChange {
+  kind: "enum_options_change";
+  entity: string;
+  field: string;
+  /** New set of enum option values */
+  newOptions: string[];
+}
+
+// ── Result types ──────────────────────────────────────────────
+
+export type CompatibilitySeverity = "breaking" | "warning" | "info";
+
+export interface CompatibilityIssue {
+  /** Rule identifier (stable string, suitable for grep/log) */
+  rule: string;
+  severity: CompatibilitySeverity;
+  /** The change that triggered this issue */
+  change: CompatibilityChange;
+  /** Human-readable reason */
+  reason: string;
+}
+
+export interface CompatibilityResult {
+  /** True if no breaking-change issues were found */
+  compatible: boolean;
+  /** All breaking issues */
+  breaking: CompatibilityIssue[];
+  /** Non-breaking warnings (e.g. adding required field with default) */
+  warnings: CompatibilityIssue[];
+  /** Informational notes */
+  info: CompatibilityIssue[];
+}

--- a/packages/core/src/ai/proposal-dry-run.ts
+++ b/packages/core/src/ai/proposal-dry-run.ts
@@ -375,11 +375,19 @@ function validatePostState(snapshot: CompatibilityRegistrySnapshot): DryRunModel
       });
       continue;
     }
+    // Always verify that the target field literally exists. Even when
+    // `toField` is omitted (implicit "id"), we must confirm the target
+    // entity actually defines an "id" field — otherwise the reference is
+    // dangling. Skipping the check for "id" was a silent escape hatch.
     const toField = ref.toField ?? "id";
-    if (toField !== "id" && !to.fields[toField]) {
+    if (!to.fields[toField]) {
       errors.push({
         code: "dangling_reference_to_field",
-        message: `Reference target field "${ref.toEntity}.${toField}" does not exist`,
+        message:
+          ref.toField === undefined
+            ? `Reference "${ref.fromEntity}.${ref.fromField} → ${ref.toEntity}" assumes ` +
+              `target field "id" which does not exist on entity "${ref.toEntity}"`
+            : `Reference target field "${ref.toEntity}.${toField}" does not exist`,
         entity: ref.toEntity,
         field: toField,
       });

--- a/packages/core/src/ai/proposal-dry-run.ts
+++ b/packages/core/src/ai/proposal-dry-run.ts
@@ -1,0 +1,473 @@
+/**
+ * AI Proposal Dry-Run (Phase 4)
+ *
+ * Simulates applying a proposal against an in-memory snapshot of registry
+ * state. Implements Spec 09 §4.6 (Phase 4: Test / Dry Run).
+ *
+ * Goals:
+ *  - Confirm the post-application model still loads cleanly
+ *  - Surface predicted side effects (counts of entities/fields added/removed/modified)
+ *  - Never mutate the caller's snapshot — all mutations happen on a deep clone
+ *
+ * The dry-run is intentionally **synthetic**. It does not touch the live
+ * registry, write to disk, or run user code. It applies the changes to a
+ * cloned snapshot, then runs lightweight meta-model validation against the
+ * post-state.
+ */
+
+import type { EntityDefinition, FieldDefinition } from "../types/entity";
+import type {
+  CompatibilityChange,
+  CompatibilityRegistrySnapshot,
+} from "./proposal-compatibility-types";
+
+// ── Result types ──────────────────────────────────────────────
+
+export interface DryRunSideEffects {
+  entitiesAdded: number;
+  entitiesRemoved: number;
+  entitiesModified: number;
+  entitiesRenamed: number;
+  fieldsAdded: number;
+  fieldsRemoved: number;
+  fieldsModified: number;
+}
+
+export interface DryRunModelError {
+  /** Error code (e.g. "missing_field", "duplicate_entity") */
+  code: string;
+  /** Human-readable message */
+  message: string;
+  /** Affected entity (if applicable) */
+  entity?: string;
+  /** Affected field (if applicable) */
+  field?: string;
+}
+
+export interface DryRunResult {
+  /** True if the post-state passes meta-model validation */
+  ok: boolean;
+  /** Predicted side effects from applying the changes */
+  sideEffects: DryRunSideEffects;
+  /** Validation errors found in the post-state model */
+  modelErrors: DryRunModelError[];
+  /** Number of entities in the post-state */
+  postStateEntityCount: number;
+  /** Whether the original snapshot was preserved (sanity flag — always true) */
+  snapshotPreserved: true;
+}
+
+// ── Snapshot cloning ─────────────────────────────────────────
+
+/**
+ * Deep clone a registry snapshot. We do this manually rather than using
+ * `structuredClone` because entity definitions may carry function values
+ * (e.g. `ComputedField.compute`), which `structuredClone` cannot handle.
+ */
+function cloneSnapshot(snapshot: CompatibilityRegistrySnapshot): CompatibilityRegistrySnapshot {
+  const entities: Record<string, EntityDefinition> = {};
+  for (const [name, def] of Object.entries(snapshot.entities)) {
+    entities[name] = cloneEntity(def);
+  }
+  return {
+    entities,
+    references: snapshot.references ? snapshot.references.map((r) => ({ ...r })) : [],
+  };
+}
+
+function cloneEntity(def: EntityDefinition): EntityDefinition {
+  const fields: Record<string, FieldDefinition> = {};
+  for (const [name, field] of Object.entries(def.fields)) {
+    fields[name] = cloneField(field);
+  }
+  return {
+    ...def,
+    fields,
+    // shallow-clone optional nested objects we care about
+    presentation: def.presentation ? { ...def.presentation } : undefined,
+    exposure: def.exposure ? { ...def.exposure } : undefined,
+    fieldExposure: def.fieldExposure ? { ...def.fieldExposure } : undefined,
+    ai: def.ai ? { ...def.ai } : undefined,
+    i18n: def.i18n ? { ...def.i18n } : undefined,
+  };
+}
+
+function cloneField(field: FieldDefinition): FieldDefinition {
+  // Spread covers all field shapes; for enums we also clone the options array
+  if (field.type === "enum") {
+    return {
+      ...field,
+      options: field.options.map((o) => ({ ...o })),
+    };
+  }
+  return { ...field };
+}
+
+// ── Apply changes to a cloned snapshot ───────────────────────
+
+function applyChanges(
+  snapshot: CompatibilityRegistrySnapshot,
+  changes: CompatibilityChange[],
+  effects: DryRunSideEffects,
+): DryRunModelError[] {
+  const errors: DryRunModelError[] = [];
+
+  for (const change of changes) {
+    switch (change.kind) {
+      case "entity_create": {
+        if (snapshot.entities[change.entity]) {
+          errors.push({
+            code: "duplicate_entity",
+            message: `Cannot create entity "${change.entity}" — already exists`,
+            entity: change.entity,
+          });
+          break;
+        }
+        snapshot.entities[change.entity] = cloneEntity(change.definition);
+        effects.entitiesAdded++;
+        break;
+      }
+
+      case "entity_delete": {
+        if (!snapshot.entities[change.entity]) {
+          errors.push({
+            code: "missing_entity",
+            message: `Cannot delete entity "${change.entity}" — does not exist`,
+            entity: change.entity,
+          });
+          break;
+        }
+        delete snapshot.entities[change.entity];
+        effects.entitiesRemoved++;
+        // Remove references that point at the deleted entity
+        snapshot.references = (snapshot.references ?? []).filter(
+          (r) => r.toEntity !== change.entity && r.fromEntity !== change.entity,
+        );
+        break;
+      }
+
+      case "entity_rename": {
+        const existing = snapshot.entities[change.entity];
+        if (!existing) {
+          errors.push({
+            code: "missing_entity",
+            message: `Cannot rename entity "${change.entity}" — does not exist`,
+            entity: change.entity,
+          });
+          break;
+        }
+        if (snapshot.entities[change.newName]) {
+          errors.push({
+            code: "duplicate_entity",
+            message: `Cannot rename "${change.entity}" → "${change.newName}" — target name exists`,
+            entity: change.newName,
+          });
+          break;
+        }
+        delete snapshot.entities[change.entity];
+        snapshot.entities[change.newName] = { ...existing, name: change.newName };
+        effects.entitiesRenamed++;
+        // Rewrite references
+        snapshot.references = (snapshot.references ?? []).map((r) => ({
+          ...r,
+          fromEntity: r.fromEntity === change.entity ? change.newName : r.fromEntity,
+          toEntity: r.toEntity === change.entity ? change.newName : r.toEntity,
+        }));
+        break;
+      }
+
+      case "field_add": {
+        const entity = snapshot.entities[change.entity];
+        if (!entity) {
+          errors.push({
+            code: "missing_entity",
+            message: `Cannot add field "${change.field}" — entity "${change.entity}" missing`,
+            entity: change.entity,
+            field: change.field,
+          });
+          break;
+        }
+        if (entity.fields[change.field]) {
+          errors.push({
+            code: "duplicate_field",
+            message: `Cannot add field "${change.entity}.${change.field}" — already exists`,
+            entity: change.entity,
+            field: change.field,
+          });
+          break;
+        }
+        entity.fields[change.field] = cloneField(change.definition);
+        effects.fieldsAdded++;
+        break;
+      }
+
+      case "field_drop": {
+        const entity = snapshot.entities[change.entity];
+        if (!entity) {
+          errors.push({
+            code: "missing_entity",
+            message: `Cannot drop field "${change.field}" — entity "${change.entity}" missing`,
+            entity: change.entity,
+            field: change.field,
+          });
+          break;
+        }
+        if (!entity.fields[change.field]) {
+          errors.push({
+            code: "missing_field",
+            message: `Cannot drop field "${change.entity}.${change.field}" — does not exist`,
+            entity: change.entity,
+            field: change.field,
+          });
+          break;
+        }
+        delete entity.fields[change.field];
+        effects.fieldsRemoved++;
+        break;
+      }
+
+      case "field_type_change": {
+        const entity = snapshot.entities[change.entity];
+        const field = entity?.fields[change.field];
+        if (!entity || !field) {
+          errors.push({
+            code: "missing_field",
+            message:
+              `Cannot change type of "${change.entity}.${change.field}" — ` +
+              `entity or field missing`,
+            entity: change.entity,
+            field: change.field,
+          });
+          break;
+        }
+        // Replace with a minimal stub of the new type, preserving label/desc
+        const next = {
+          ...field,
+          type: change.newType,
+        } as FieldDefinition;
+        entity.fields[change.field] = next;
+        effects.fieldsModified++;
+        break;
+      }
+
+      case "field_constraint_change": {
+        const entity = snapshot.entities[change.entity];
+        const field = entity?.fields[change.field];
+        if (!entity || !field) {
+          errors.push({
+            code: "missing_field",
+            message:
+              `Cannot tighten constraint on "${change.entity}.${change.field}" — ` +
+              `entity or field missing`,
+            entity: change.entity,
+            field: change.field,
+          });
+          break;
+        }
+        entity.fields[change.field] = { ...field, ...change.patch };
+        effects.fieldsModified++;
+        break;
+      }
+
+      case "enum_options_change": {
+        const entity = snapshot.entities[change.entity];
+        const field = entity?.fields[change.field];
+        if (!entity || !field || field.type !== "enum") {
+          errors.push({
+            code: "missing_enum_field",
+            message:
+              `Cannot change enum options on "${change.entity}.${change.field}" — ` +
+              `entity or enum field missing`,
+            entity: change.entity,
+            field: change.field,
+          });
+          break;
+        }
+        entity.fields[change.field] = {
+          ...field,
+          options: change.newOptions.map((value) => ({ value })),
+        };
+        effects.fieldsModified++;
+        break;
+      }
+
+      default: {
+        const _exhaustive: never = change;
+        void _exhaustive;
+      }
+    }
+  }
+
+  return errors;
+}
+
+// ── Meta-model validation on the post-state ──────────────────
+
+/**
+ * Lightweight model validation — checks the kinds of invariants a real
+ * registry load would enforce, without actually running the full Registry
+ * pipeline (which has heavy server-side deps).
+ *
+ * Currently checks:
+ *  - Every entity has a non-empty name
+ *  - Every entity has at least one field
+ *  - All references resolve to existing entities/fields
+ *  - No duplicate field names within an entity (impossible via apply, but
+ *    we double-check for create-time supplied entities)
+ */
+function validatePostState(snapshot: CompatibilityRegistrySnapshot): DryRunModelError[] {
+  const errors: DryRunModelError[] = [];
+
+  for (const [name, entity] of Object.entries(snapshot.entities)) {
+    if (!entity.name || entity.name.trim() === "") {
+      errors.push({
+        code: "entity_missing_name",
+        message: `Entity registered as "${name}" has empty name`,
+        entity: name,
+      });
+    }
+    if (entity.name !== name) {
+      errors.push({
+        code: "entity_name_mismatch",
+        message: `Entity registered under "${name}" but declares name "${entity.name}"`,
+        entity: name,
+      });
+    }
+    const fieldNames = Object.keys(entity.fields);
+    if (fieldNames.length === 0) {
+      errors.push({
+        code: "entity_no_fields",
+        message: `Entity "${name}" has no fields after dry-run`,
+        entity: name,
+      });
+    }
+  }
+
+  for (const ref of snapshot.references ?? []) {
+    const from = snapshot.entities[ref.fromEntity];
+    const to = snapshot.entities[ref.toEntity];
+    if (!from) {
+      errors.push({
+        code: "dangling_reference_from",
+        message:
+          `Reference "${ref.fromEntity}.${ref.fromField} → ${ref.toEntity}" has missing ` +
+          `source entity`,
+        entity: ref.fromEntity,
+        field: ref.fromField,
+      });
+      continue;
+    }
+    if (!from.fields[ref.fromField]) {
+      errors.push({
+        code: "dangling_reference_from_field",
+        message: `Reference source field "${ref.fromEntity}.${ref.fromField}" no longer exists`,
+        entity: ref.fromEntity,
+        field: ref.fromField,
+      });
+    }
+    if (!to) {
+      errors.push({
+        code: "dangling_reference_to",
+        message:
+          `Reference "${ref.fromEntity}.${ref.fromField} → ${ref.toEntity}" has missing ` +
+          `target entity`,
+        entity: ref.toEntity,
+      });
+      continue;
+    }
+    const toField = ref.toField ?? "id";
+    if (toField !== "id" && !to.fields[toField]) {
+      errors.push({
+        code: "dangling_reference_to_field",
+        message: `Reference target field "${ref.toEntity}.${toField}" does not exist`,
+        entity: ref.toEntity,
+        field: toField,
+      });
+    }
+  }
+
+  return errors;
+}
+
+// ── Public API ───────────────────────────────────────────────
+
+/**
+ * Dry-run a proposal against an in-memory snapshot.
+ *
+ * The caller's `snapshot` is never mutated — all operations happen on a
+ * deep clone. The returned `DryRunResult` reports predicted side effects
+ * and any meta-model validation errors that would prevent the post-state
+ * from loading cleanly.
+ *
+ * @param changes - The proposed changes
+ * @param snapshot - Current registry state (will be cloned, not mutated)
+ */
+export function dryRunProposal(
+  changes: CompatibilityChange[],
+  snapshot: CompatibilityRegistrySnapshot,
+): DryRunResult {
+  // Snapshot of caller's state for the preservation sanity-check
+  const originalKeys = Object.keys(snapshot.entities).sort();
+  const originalFieldCounts: Record<string, number> = {};
+  for (const [name, def] of Object.entries(snapshot.entities)) {
+    originalFieldCounts[name] = Object.keys(def.fields).length;
+  }
+  const originalRefCount = snapshot.references?.length ?? 0;
+
+  // Work on a deep clone — caller's snapshot must stay intact
+  const working = cloneSnapshot(snapshot);
+
+  const sideEffects: DryRunSideEffects = {
+    entitiesAdded: 0,
+    entitiesRemoved: 0,
+    entitiesModified: 0,
+    entitiesRenamed: 0,
+    fieldsAdded: 0,
+    fieldsRemoved: 0,
+    fieldsModified: 0,
+  };
+
+  // Track which entities were modified (vs added/removed) for the count
+  const modifiedEntities = new Set<string>();
+  for (const change of changes) {
+    if (
+      change.kind === "field_add" ||
+      change.kind === "field_drop" ||
+      change.kind === "field_type_change" ||
+      change.kind === "field_constraint_change" ||
+      change.kind === "enum_options_change"
+    ) {
+      modifiedEntities.add(change.entity);
+    }
+  }
+  sideEffects.entitiesModified = modifiedEntities.size;
+
+  const applyErrors = applyChanges(working, changes, sideEffects);
+  const modelErrors = applyErrors.length > 0 ? applyErrors : validatePostState(working);
+
+  // Sanity: confirm caller's snapshot is untouched
+  const postKeys = Object.keys(snapshot.entities).sort();
+  if (postKeys.length !== originalKeys.length || postKeys.some((k, i) => k !== originalKeys[i])) {
+    // This indicates a bug in cloneSnapshot — surface it loudly
+    throw new Error("dryRunProposal mutated the caller's snapshot (entity keys differ)");
+  }
+  for (const [name, count] of Object.entries(originalFieldCounts)) {
+    const stillThere = snapshot.entities[name];
+    if (!stillThere || Object.keys(stillThere.fields).length !== count) {
+      throw new Error(
+        `dryRunProposal mutated the caller's snapshot (entity "${name}" field count differs)`,
+      );
+    }
+  }
+  if ((snapshot.references?.length ?? 0) !== originalRefCount) {
+    throw new Error("dryRunProposal mutated the caller's snapshot (reference count differs)");
+  }
+
+  return {
+    ok: modelErrors.length === 0,
+    sideEffects,
+    modelErrors,
+    postStateEntityCount: Object.keys(working.entities).length,
+    snapshotPreserved: true,
+  };
+}

--- a/packages/core/src/ai/proposal-engine.ts
+++ b/packages/core/src/ai/proposal-engine.ts
@@ -14,11 +14,20 @@ import type { EventHandlerDefinition } from "../types/event";
 import type { RuleDefinition } from "../types/rule";
 import type { PatternInsight } from "./pattern-insight";
 import type {
+  CompatibilityChange,
+  CompatibilityRegistrySnapshot,
+} from "./proposal-compatibility-types";
+import type {
   ProposalValidatorConfig,
   ProposalChange as SecurityProposalChange,
   ProposalValidationResult as SecurityValidationResult,
 } from "./proposal-validator";
 import { validateProposal as validateProposalSecurity } from "./proposal-validator";
+import type {
+  ExtendedValidationResult,
+  ExtendedValidatorConfig,
+} from "./proposal-validator-extended";
+import { validateProposalExtended } from "./proposal-validator-extended";
 
 // ── Proposal types ───────────────────────────────────────
 
@@ -265,6 +274,41 @@ export class ProposalEngine {
     proposal.status = "rolled_back";
     proposal.rolledBackAt = new Date();
     return proposal;
+  }
+
+  // ── Extended validation (Spec 09 Phase 1–4) ─────────────
+
+  /**
+   * Run the full Spec-09 4-phase validation pipeline on a proposal.
+   * Returns the combined result without changing the proposal's status.
+   * Use this to preview a submission before calling {@link submit}.
+   *
+   * Phases 3 (compatibility) and 4 (dry-run) are only executed when the
+   * caller supplies field-level changes + a registry snapshot. The security
+   * pipeline (Phase 1+2) always runs.
+   */
+  validateExtended(
+    proposalId: string,
+    options?: {
+      compatibilityChanges?: CompatibilityChange[];
+      snapshot?: CompatibilityRegistrySnapshot;
+      extendedConfig?: ExtendedValidatorConfig;
+    },
+  ): ExtendedValidationResult {
+    const proposal = this.getOrThrow(proposalId);
+    const securityChanges = this.toSecurityChanges(proposal);
+    const cfg: ExtendedValidatorConfig = {
+      ...(options?.extendedConfig ?? {}),
+      security: options?.extendedConfig?.security ?? this.validatorConfig,
+    };
+    return validateProposalExtended(
+      {
+        securityChanges,
+        compatibilityChanges: options?.compatibilityChanges,
+        snapshot: options?.snapshot,
+      },
+      cfg,
+    );
   }
 
   // ── Queries ────────────────────────────────────────────

--- a/packages/core/src/ai/proposal-validator-extended.ts
+++ b/packages/core/src/ai/proposal-validator-extended.ts
@@ -1,0 +1,151 @@
+/**
+ * Extended AI Proposal Validator
+ *
+ * Composes the four validation phases described in Spec 09 §4.2:
+ *   Phase 1 — Static check (security / change-type policy)
+ *   Phase 2 — Build check (risk classification)
+ *   Phase 3 — Compatibility check (this module wires it in)
+ *   Phase 4 — Dry-run (this module wires it in)
+ *
+ * Phases 1 & 2 are delegated to the existing `validateProposal()` (see
+ * `proposal-validator.ts`). Phases 3 & 4 are delegated to the new modules.
+ *
+ * Existing callers that only need the security pipeline can continue to call
+ * `validateProposal()` directly. Callers that want the full Spec-09 pipeline
+ * call `validateProposalExtended()` instead.
+ */
+
+import { compatibilityCheck } from "./proposal-compatibility-checker";
+import type {
+  CompatibilityChange,
+  CompatibilityRegistrySnapshot,
+  CompatibilityResult,
+} from "./proposal-compatibility-types";
+import { type DryRunResult, dryRunProposal } from "./proposal-dry-run";
+import {
+  type ProposalChange,
+  type ProposalValidationResult,
+  type ProposalValidatorConfig,
+  validateProposal,
+} from "./proposal-validator";
+
+// ── Extended config & result types ───────────────────────────
+
+export interface ExtendedValidatorInput {
+  /** Security-level changes for Phase 1+2 */
+  securityChanges: ProposalChange[];
+  /** Field-level changes for Phase 3+4 (optional — pipeline skips phases without input) */
+  compatibilityChanges?: CompatibilityChange[];
+  /** Registry snapshot used for Phase 3+4 (required when compatibilityChanges supplied) */
+  snapshot?: CompatibilityRegistrySnapshot;
+}
+
+export interface ExtendedValidatorConfig {
+  /** Forwarded to the security validator */
+  security?: ProposalValidatorConfig;
+  /** When true, skip Phase 3 even if compatibilityChanges are supplied */
+  skipCompatibility?: boolean;
+  /** When true, skip Phase 4 even if compatibilityChanges are supplied */
+  skipDryRun?: boolean;
+}
+
+export type ExtendedPhaseStatus = "passed" | "failed" | "skipped";
+
+export interface ExtendedPhaseSummary {
+  phase: 1 | 2 | 3 | 4;
+  name: "static" | "build" | "compatibility" | "dry_run";
+  status: ExtendedPhaseStatus;
+}
+
+export interface ExtendedValidationResult {
+  /** True if every executed phase passed */
+  passed: boolean;
+  /** Phase-by-phase summary */
+  phases: ExtendedPhaseSummary[];
+  /** Phase 1 + 2 detail (security validator result) */
+  security: ProposalValidationResult;
+  /** Phase 3 detail (undefined if skipped) */
+  compatibility?: CompatibilityResult;
+  /** Phase 4 detail (undefined if skipped) */
+  dryRun?: DryRunResult;
+}
+
+// ── Pipeline ────────────────────────────────────────────────
+
+/**
+ * Run the full Spec-09 4-phase validation pipeline on a proposal.
+ *
+ * Phases 3 and 4 are skipped when either the input does not supply
+ * `compatibilityChanges` + `snapshot`, or the config opts out.
+ */
+export function validateProposalExtended(
+  input: ExtendedValidatorInput,
+  config?: ExtendedValidatorConfig,
+): ExtendedValidationResult {
+  // Phase 1+2 — security / static / risk
+  const security = validateProposal(input.securityChanges, config?.security);
+
+  const phases: ExtendedPhaseSummary[] = [
+    { phase: 1, name: "static", status: security.valid ? "passed" : "failed" },
+    {
+      phase: 2,
+      // Spec 09 Phase 2 here is mapped to the risk classification, which is
+      // produced as part of the same call. It is "passed" iff Phase 1 passed.
+      name: "build",
+      status: security.valid ? "passed" : "failed",
+    },
+  ];
+
+  let compatibility: CompatibilityResult | undefined;
+  let dryRun: DryRunResult | undefined;
+
+  // Narrow once so subsequent uses don't need non-null assertions
+  const compatChanges = input.compatibilityChanges;
+  const snapshot = input.snapshot;
+  const hasPhase34Input =
+    compatChanges !== undefined && compatChanges.length > 0 && snapshot !== undefined;
+
+  // Phase 3 — compatibility
+  if (hasPhase34Input && !config?.skipCompatibility) {
+    compatibility = compatibilityCheck(compatChanges, snapshot);
+    phases.push({
+      phase: 3,
+      name: "compatibility",
+      status: compatibility.compatible ? "passed" : "failed",
+    });
+  } else {
+    phases.push({ phase: 3, name: "compatibility", status: "skipped" });
+  }
+
+  // Phase 4 — dry-run
+  if (hasPhase34Input && !config?.skipDryRun) {
+    dryRun = dryRunProposal(compatChanges, snapshot);
+    phases.push({
+      phase: 4,
+      name: "dry_run",
+      status: dryRun.ok ? "passed" : "failed",
+    });
+  } else {
+    phases.push({ phase: 4, name: "dry_run", status: "skipped" });
+  }
+
+  const passed = phases.every((p) => p.status !== "failed");
+
+  return {
+    passed,
+    phases,
+    security,
+    compatibility,
+    dryRun,
+  };
+}
+
+/**
+ * Create a reusable extended validator with preset config.
+ */
+export function createExtendedProposalValidator(config: ExtendedValidatorConfig) {
+  return {
+    validate: (input: ExtendedValidatorInput) => validateProposalExtended(input, config),
+    config,
+  };
+}

--- a/packages/core/src/server-entry.ts
+++ b/packages/core/src/server-entry.ts
@@ -303,7 +303,33 @@ export {
 // === AI Proposal Validator (server-only — proposal security checks) ===
 
 export {
+  buildCompatibilitySnapshot,
+  type CompatibilityChange,
+  type CompatibilityIssue,
+  type CompatibilityRegistrySnapshot,
+  type CompatibilityResult,
+  type CompatibilitySeverity,
+  compatibilityCheck,
+  createExtendedProposalValidator,
   createProposalValidator,
+  type DryRunModelError,
+  type DryRunResult,
+  type DryRunSideEffects,
+  dryRunProposal,
+  type EntityCreateChange,
+  type EntityDeleteChange,
+  type EntityReference,
+  type EntityRenameChange,
+  type EnumOptionsChange,
+  type ExtendedPhaseStatus,
+  type ExtendedPhaseSummary,
+  type ExtendedValidationResult,
+  type ExtendedValidatorConfig,
+  type ExtendedValidatorInput,
+  type FieldAddChange,
+  type FieldConstraintChange,
+  type FieldDropChange,
+  type FieldTypeChange,
   type ProposalChange,
   type ProposalChangeType,
   type ProposalCustomRule,
@@ -312,6 +338,7 @@ export {
   type ProposalValidatorConfig,
   type ProposalViolation,
   validateProposal as validateAIProposal,
+  validateProposalExtended,
 } from "./ai";
 
 // === AI Anomaly Detector ===


### PR DESCRIPTION
## Summary
Spec 09 §4.5 + §5.5. Adds compatibility check (Phase 3) and dry-run against an in-memory snapshot (Phase 4) on top of the existing Phase 1+2 security validation.

## Phase 3 — `compatibilityCheck()` breaking-change rules
1. `drop_field_with_references`
2. `incompatible_field_type_change` (only `string→text`, `date→datetime` widening-safe)
3. `delete_entity_with_references`
4. `rename_entity_with_references`
5. `tighten_constraint_nullable_to_required`
6. `tighten_constraint_add_unique`
7. `tighten_constraint_narrow_min` / `narrow_max`
8. `tighten_constraint_narrow_enum`
9. `add_required_field_without_default`

Warnings on data-loss drops with no FK refs; info notes on safe adds.

## Phase 4 — `dryRunProposal()` state isolation
- `cloneSnapshot()` does a manual recursive copy (`structuredClone` can't serialize `ComputedField.compute`).
- All mutations applied to the clone; post-run drift check verifies the caller's snapshot is untouched; `snapshotPreserved: true` returned for caller verification.
- Side-effect counts tracked: `entitiesAdded/Removed/Modified/Renamed`, `fieldsAdded/Removed/Modified`.
- Meta-model validation is lightweight (entity-name, non-empty fields, dangling refs); deeper Registry pipeline integration layers on later via optional `ModelValidator` injection.

## Integration
- New `ProposalEngine.validateExtended()` returns combined Phase 1-4 report **without mutating proposal status** (preview).
- Existing `validateProposal()` callers unchanged — pure additive change.

## Verification
- `bun run check` — clean (1147 files)
- `bun run typecheck` — clean
- `bun test` — 5195 pass / 3 skip / 0 fail (325 files)
- 39 new tests / 97 assertions across 3 files

## File layout
- `packages/core/src/ai/proposal-compatibility-types.ts` (shared vocabulary)
- `packages/core/src/ai/proposal-compatibility-checker.ts` (Phase 3)
- `packages/core/src/ai/proposal-dry-run.ts` (Phase 4)
- `packages/core/src/ai/proposal-validator-extended.ts` (orchestrator)
- Tests under `packages/core/__tests__/ai-proposal-*.test.ts`

## Test plan
- [x] Phase 3 happy + each breaking-change rule (one test per rule)
- [x] Phase 4 happy path, simulated drift detection, registry untouched after dry-run
- [x] Engine integration: validateExtended runs Phase 1-4 and returns combined report

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)