### PR TITLE
feat(cap-observability-otel): OpenTelemetry adapter for core seam (closes #130)

### DIFF
--- a/addons/observability/cap-observability-otel/README.md
+++ b/addons/observability/cap-observability-otel/README.md
@@ -63,11 +63,14 @@ sdk.start();
 //    uses `getObservability().tracer / .meter` flows through OTel.
 setObservability(createOtelAdapter({ serviceName: "linchkit-server" }));
 
-// 3. Graceful shutdown — keep this so spans + metrics flush.
-process.on("SIGTERM", async () => {
-  await sdk.shutdown();
-  process.exit(0);
-});
+// 3. Graceful shutdown — handle both SIGTERM (orchestrators) and
+//    SIGINT (Ctrl-C) so spans + metrics flush before exit.
+for (const signal of ["SIGTERM", "SIGINT"] as const) {
+  process.on(signal, async () => {
+    await sdk.shutdown();
+    process.exit(0);
+  });
+}
 ```
 
 ## Environment variables
@@ -77,7 +80,9 @@ variables. The most relevant ones:
 
 | Variable | Purpose | Default |
 | --- | --- | --- |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | Base OTLP/HTTP endpoint. Used when `bootstrapNodeSdk({ endpoint })` is omitted. | `http://localhost:4318` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Base OTLP/HTTP endpoint. Used when `bootstrapNodeSdk({ endpoint })` is omitted; `v1/traces` and `v1/metrics` are appended automatically. | `http://localhost:4318` |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Per-signal trace endpoint. Used verbatim — overrides both the base env var and the `endpoint` option. | unset |
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Per-signal metric endpoint. Used verbatim — overrides both the base env var and the `endpoint` option. | unset |
 | `OTEL_EXPORTER_OTLP_HEADERS` | Comma-separated `k=v` request headers (e.g. auth tokens). | unset |
 | `OTEL_SERVICE_NAME` | Used by the SDK as a fallback `service.name`. The `serviceName` option in this package takes precedence. | unset |
 | `OTEL_LOG_LEVEL` | Internal SDK log level (`debug`, `info`, `warn`, `error`). | `info` |

--- a/addons/observability/cap-observability-otel/README.md
+++ b/addons/observability/cap-observability-otel/README.md
@@ -1,0 +1,112 @@
+# @linchkit/cap-observability-otel
+
+OpenTelemetry adapter for LinchKit's observability seam (Spec 28 M3, issue
+[#130](https://github.com/laofahai/linchkit/issues/130)).
+
+## What it is
+
+`@linchkit/core` ships a vendor-neutral observability seam — `Tracer`,
+`Span`, `Meter`, `Counter`, `Histogram`, and an `Observability` registry
+in `packages/core/src/observability/`. By default the registry is a
+no-op so instrumented call sites pay zero runtime cost.
+
+This capability provides:
+
+1. **`createOtelAdapter()`** — wraps `@opentelemetry/api`'s tracer +
+   meter so they satisfy the LinchKit interface.
+2. **`bootstrapNodeSdk()`** — convenience helper that constructs a
+   `NodeSDK` with the OTLP/HTTP trace + metric exporters wired up.
+
+The two helpers are decoupled on purpose: the adapter has no Node-SDK
+dependency at the type level, and the bootstrap helper never auto-runs.
+The host application calls both explicitly.
+
+## When to use
+
+Use this capability when you want LinchKit's instrumented call sites
+(CommandLayer, ActionEngine, EventHandlers, Flow steps) to emit OTLP
+traces and metrics to your collector. Skip it in development /
+single-tenant deployments where the no-op default is enough.
+
+## Install
+
+```bash
+bun add @linchkit/cap-observability-otel
+```
+
+Peer dependencies you must also install in the host:
+
+- `@linchkit/core` `^0.2.0`
+- `@opentelemetry/api` `^1.9.0`
+
+## Bootstrap example
+
+```ts
+import { setObservability } from "@linchkit/core/server";
+import {
+  bootstrapNodeSdk,
+  createOtelAdapter,
+} from "@linchkit/cap-observability-otel";
+
+// 1. Construct + start the NodeSDK. This registers global providers
+//    so `trace.getTracer(...)` / `metrics.getMeter(...)` resolve to
+//    the real exporters instead of OTel's built-in no-ops.
+const sdk = bootstrapNodeSdk({
+  serviceName: "linchkit-server",
+  serviceVersion: "0.2.0",
+  // Optional — falls back to OTEL_EXPORTER_OTLP_ENDPOINT env var
+  endpoint: "http://localhost:4318",
+});
+sdk.start();
+
+// 2. Swap LinchKit's observability registry so every call site that
+//    uses `getObservability().tracer / .meter` flows through OTel.
+setObservability(createOtelAdapter({ serviceName: "linchkit-server" }));
+
+// 3. Graceful shutdown — keep this so spans + metrics flush.
+process.on("SIGTERM", async () => {
+  await sdk.shutdown();
+  process.exit(0);
+});
+```
+
+## Environment variables
+
+The OTLP/HTTP exporters honour the standard OpenTelemetry environment
+variables. The most relevant ones:
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Base OTLP/HTTP endpoint. Used when `bootstrapNodeSdk({ endpoint })` is omitted. | `http://localhost:4318` |
+| `OTEL_EXPORTER_OTLP_HEADERS` | Comma-separated `k=v` request headers (e.g. auth tokens). | unset |
+| `OTEL_SERVICE_NAME` | Used by the SDK as a fallback `service.name`. The `serviceName` option in this package takes precedence. | unset |
+| `OTEL_LOG_LEVEL` | Internal SDK log level (`debug`, `info`, `warn`, `error`). | `info` |
+
+See the [OpenTelemetry environment variable
+spec](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/)
+for the full list.
+
+## What ships in Phase 1 (this release)
+
+- [x] `Tracer` + `Span` adapter (`startSpan`, `setAttribute(s)`,
+      `recordException`, `setStatus`, `end`)
+- [x] `Meter` + `Counter` + `Histogram` adapter
+- [x] `bootstrapNodeSdk()` with OTLP/HTTP trace + metric exporters
+- [x] Capability descriptor (`autoInstall: false` — explicit opt-in)
+
+## Out of scope for Phase 1
+
+- OTel `Context` propagation — call sites use the returned `Span`
+  handle directly with `try { ... } finally { span.end() }`.
+- Auto-instrumentation of HTTP / fs / pg / redis libraries — install
+  `@opentelemetry/auto-instrumentations-node` separately if needed.
+- Logs exporter — Spec 28 ships logs through the existing
+  `StructuredLogger` interface; OTLP logs export is a follow-up.
+
+## Related
+
+- Spec 28 — Observability seam
+- Issue [#130](https://github.com/laofahai/linchkit/issues/130) — OTel
+  adapter delivery
+- `packages/core/src/observability/observability-registry.ts` — the
+  registry this adapter plugs into

--- a/addons/observability/cap-observability-otel/__tests__/create-otel-adapter.test.ts
+++ b/addons/observability/cap-observability-otel/__tests__/create-otel-adapter.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Tests for createOtelAdapter — verifies the factory wires a fake OTel
+ * tracer / meter into an Observability bundle without ever touching
+ * the global OTel provider registry.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type {
+  Attributes as OtelAttributes,
+  Counter as OtelCounter,
+  Histogram as OtelHistogram,
+  Meter as OtelMeter,
+  MetricOptions as OtelMetricOptions,
+  Span as OtelSpan,
+  SpanContext as OtelSpanContext,
+  SpanOptions as OtelSpanOptions,
+  SpanStatus as OtelSpanStatus,
+  Tracer as OtelTracer,
+  TimeInput,
+} from "@opentelemetry/api";
+import { SpanStatusCode as OtelSpanStatusCode } from "@opentelemetry/api";
+import { capObservabilityOtel } from "../src/capability";
+import { createOtelAdapter } from "../src/create-otel-adapter";
+
+// ── Minimal fakes (same shape as the dedicated adapter tests) ────
+
+class FakeOtelSpan implements OtelSpan {
+  attributes: OtelAttributes = {};
+  status: OtelSpanStatus = { code: OtelSpanStatusCode.UNSET };
+  ended = false;
+
+  setAttribute(key: string, value: OtelAttributes[string]): this {
+    this.attributes[key] = value;
+    return this;
+  }
+  setAttributes(attrs: OtelAttributes): this {
+    Object.assign(this.attributes, attrs);
+    return this;
+  }
+  addEvent(): this {
+    return this;
+  }
+  addLink(): this {
+    return this;
+  }
+  addLinks(): this {
+    return this;
+  }
+  setStatus(status: OtelSpanStatus): this {
+    this.status = status;
+    return this;
+  }
+  updateName(): this {
+    return this;
+  }
+  end(_endTime?: TimeInput): void {
+    this.ended = true;
+  }
+  isRecording(): boolean {
+    return !this.ended;
+  }
+  recordException(): void {}
+  spanContext(): OtelSpanContext {
+    return {
+      traceId: "00000000000000000000000000000000",
+      spanId: "0000000000000000",
+      traceFlags: 0,
+    };
+  }
+}
+
+class FakeOtelTracer implements OtelTracer {
+  resolvedAs: { name: string; version?: string } | undefined;
+  lastSpanName: string | undefined;
+  lastOptions: OtelSpanOptions | undefined;
+
+  startSpan(name: string, options?: OtelSpanOptions): OtelSpan {
+    this.lastSpanName = name;
+    this.lastOptions = options;
+    return new FakeOtelSpan();
+  }
+  startActiveSpan(): never {
+    throw new Error("unused");
+  }
+}
+
+class FakeCounter implements OtelCounter {
+  calls: Array<{ value: number; attributes?: OtelAttributes }> = [];
+  add(value: number, attributes?: OtelAttributes): void {
+    this.calls.push({ value, attributes });
+  }
+}
+
+class FakeHistogram implements OtelHistogram {
+  calls: Array<{ value: number; attributes?: OtelAttributes }> = [];
+  record(value: number, attributes?: OtelAttributes): void {
+    this.calls.push({ value, attributes });
+  }
+}
+
+class FakeOtelMeter implements OtelMeter {
+  resolvedAs: { name: string; version?: string } | undefined;
+  counter = new FakeCounter();
+  histogram = new FakeHistogram();
+  lastCounterOptions: OtelMetricOptions | undefined;
+  lastHistogramOptions: OtelMetricOptions | undefined;
+
+  createCounter(_name: string, options?: OtelMetricOptions): OtelCounter {
+    this.lastCounterOptions = options;
+    return this.counter;
+  }
+  createHistogram(_name: string, options?: OtelMetricOptions): OtelHistogram {
+    this.lastHistogramOptions = options;
+    return this.histogram;
+  }
+  createUpDownCounter(): never {
+    throw new Error("unused");
+  }
+  createGauge(): never {
+    throw new Error("unused");
+  }
+  createObservableCounter(): never {
+    throw new Error("unused");
+  }
+  createObservableGauge(): never {
+    throw new Error("unused");
+  }
+  createObservableUpDownCounter(): never {
+    throw new Error("unused");
+  }
+  addBatchObservableCallback(): void {}
+  removeBatchObservableCallback(): void {}
+}
+
+// ── Tests ────────────────────────────────────────────────
+
+describe("createOtelAdapter", () => {
+  it("returns a frozen Observability bundle with tracer + meter", () => {
+    const tracer = new FakeOtelTracer();
+    const meter = new FakeOtelMeter();
+
+    const bundle = createOtelAdapter({
+      serviceName: "test-service",
+      tracerProvider: () => tracer,
+      meterProvider: () => meter,
+    });
+
+    expect(bundle.tracer).toBeDefined();
+    expect(bundle.meter).toBeDefined();
+    expect(Object.isFrozen(bundle)).toBe(true);
+  });
+
+  it("passes serviceName + serviceVersion to the resolvers", () => {
+    let tracerArgs: { name: string; version?: string } | undefined;
+    let meterArgs: { name: string; version?: string } | undefined;
+
+    createOtelAdapter({
+      serviceName: "linchkit-server",
+      serviceVersion: "0.2.0",
+      tracerProvider: (name, version) => {
+        tracerArgs = { name, version };
+        return new FakeOtelTracer();
+      },
+      meterProvider: (name, version) => {
+        meterArgs = { name, version };
+        return new FakeOtelMeter();
+      },
+    });
+
+    expect(tracerArgs).toEqual({ name: "linchkit-server", version: "0.2.0" });
+    expect(meterArgs).toEqual({ name: "linchkit-server", version: "0.2.0" });
+  });
+
+  it("defaults serviceName to 'linchkit' when not provided", () => {
+    let resolvedName: string | undefined;
+
+    createOtelAdapter({
+      tracerProvider: (name) => {
+        resolvedName = name;
+        return new FakeOtelTracer();
+      },
+      meterProvider: () => new FakeOtelMeter(),
+    });
+
+    expect(resolvedName).toBe("linchkit");
+  });
+
+  it("tracer.startSpan reaches the underlying OTel tracer", () => {
+    const tracer = new FakeOtelTracer();
+    const bundle = createOtelAdapter({
+      tracerProvider: () => tracer,
+      meterProvider: () => new FakeOtelMeter(),
+    });
+
+    bundle.tracer.startSpan("linchkit.test", {
+      attributes: { "linchkit.kind": "unit" },
+    });
+
+    expect(tracer.lastSpanName).toBe("linchkit.test");
+    expect(tracer.lastOptions?.attributes).toEqual({ "linchkit.kind": "unit" });
+  });
+
+  it("counter and histogram reach the underlying OTel meter", () => {
+    const meter = new FakeOtelMeter();
+    const bundle = createOtelAdapter({
+      tracerProvider: () => new FakeOtelTracer(),
+      meterProvider: () => meter,
+    });
+
+    const counter = bundle.meter.createCounter("c", { description: "d", unit: "1" });
+    counter.add(5, { tenant: "t-1" });
+
+    const histogram = bundle.meter.createHistogram("h", { unit: "ms" });
+    histogram.record(42);
+
+    expect(meter.lastCounterOptions).toEqual({ description: "d", unit: "1" });
+    expect(meter.lastHistogramOptions).toEqual({ description: undefined, unit: "ms" });
+    expect(meter.counter.calls).toEqual([{ value: 5, attributes: { tenant: "t-1" } }]);
+    expect(meter.histogram.calls).toEqual([{ value: 42, attributes: undefined }]);
+  });
+});
+
+describe("capObservabilityOtel descriptor", () => {
+  it("declares the expected identity fields", () => {
+    expect(capObservabilityOtel.name).toBe("cap-observability-otel");
+    expect(capObservabilityOtel.type).toBe("standard");
+    expect(capObservabilityOtel.category).toBe("system");
+    expect(capObservabilityOtel.version).toBe("0.1.0");
+    expect(capObservabilityOtel.group).toBe("observability");
+  });
+
+  it("does NOT auto-install (opt-in only because of runtime cost)", () => {
+    expect(capObservabilityOtel.autoInstall).toBe(false);
+  });
+});

--- a/addons/observability/cap-observability-otel/__tests__/otel-meter-adapter.test.ts
+++ b/addons/observability/cap-observability-otel/__tests__/otel-meter-adapter.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for OtelMeterAdapter / OtelCounterAdapter / OtelHistogramAdapter.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type {
+  Attributes as OtelAttributes,
+  Counter as OtelCounter,
+  Histogram as OtelHistogram,
+  Meter as OtelMeter,
+  MetricOptions as OtelMetricOptions,
+} from "@opentelemetry/api";
+import { OtelMeterAdapter } from "../src/otel-meter-adapter";
+
+// ── Fakes ────────────────────────────────────────────────
+
+interface CounterCall {
+  value: number;
+  attributes?: OtelAttributes;
+}
+interface HistogramCall {
+  value: number;
+  attributes?: OtelAttributes;
+}
+
+class FakeOtelCounter implements OtelCounter {
+  calls: CounterCall[] = [];
+  add(value: number, attributes?: OtelAttributes): void {
+    this.calls.push({ value, attributes });
+  }
+}
+
+class FakeOtelHistogram implements OtelHistogram {
+  calls: HistogramCall[] = [];
+  record(value: number, attributes?: OtelAttributes): void {
+    this.calls.push({ value, attributes });
+  }
+}
+
+class FakeOtelMeter implements OtelMeter {
+  lastCounterName: string | undefined;
+  lastCounterOptions: OtelMetricOptions | undefined;
+  lastHistogramName: string | undefined;
+  lastHistogramOptions: OtelMetricOptions | undefined;
+  counter = new FakeOtelCounter();
+  histogram = new FakeOtelHistogram();
+
+  createCounter(name: string, options?: OtelMetricOptions): OtelCounter {
+    this.lastCounterName = name;
+    this.lastCounterOptions = options;
+    return this.counter;
+  }
+  createHistogram(name: string, options?: OtelMetricOptions): OtelHistogram {
+    this.lastHistogramName = name;
+    this.lastHistogramOptions = options;
+    return this.histogram;
+  }
+  // The rest of the OtelMeter interface (UpDownCounter / Gauge / Observable*)
+  // is unused by the adapter — throw if accidentally called.
+  createUpDownCounter(): never {
+    throw new Error("createUpDownCounter not used by OtelMeterAdapter");
+  }
+  createGauge(): never {
+    throw new Error("createGauge not used by OtelMeterAdapter");
+  }
+  createObservableCounter(): never {
+    throw new Error("createObservableCounter not used by OtelMeterAdapter");
+  }
+  createObservableGauge(): never {
+    throw new Error("createObservableGauge not used by OtelMeterAdapter");
+  }
+  createObservableUpDownCounter(): never {
+    throw new Error("createObservableUpDownCounter not used by OtelMeterAdapter");
+  }
+  addBatchObservableCallback(): void {}
+  removeBatchObservableCallback(): void {}
+}
+
+// ── Tests ────────────────────────────────────────────────
+
+describe("OtelMeterAdapter.createCounter", () => {
+  it("forwards name, description and unit", () => {
+    const inner = new FakeOtelMeter();
+    const meter = new OtelMeterAdapter(inner);
+
+    meter.createCounter("linchkit.action.invocations", {
+      description: "Number of action invocations",
+      unit: "1",
+    });
+
+    expect(inner.lastCounterName).toBe("linchkit.action.invocations");
+    expect(inner.lastCounterOptions).toEqual({
+      description: "Number of action invocations",
+      unit: "1",
+    });
+  });
+
+  it("delegates add() to the underlying counter with attributes", () => {
+    const inner = new FakeOtelMeter();
+    const meter = new OtelMeterAdapter(inner);
+    const counter = meter.createCounter("c");
+
+    counter.add(3, { "linchkit.tenant_id": "t-1" });
+    counter.add(1);
+
+    expect(inner.counter.calls).toEqual([
+      { value: 3, attributes: { "linchkit.tenant_id": "t-1" } },
+      { value: 1, attributes: undefined },
+    ]);
+  });
+});
+
+describe("OtelMeterAdapter.createHistogram", () => {
+  it("forwards name, description and unit", () => {
+    const inner = new FakeOtelMeter();
+    const meter = new OtelMeterAdapter(inner);
+
+    meter.createHistogram("linchkit.action.duration_ms", {
+      description: "Action duration distribution",
+      unit: "ms",
+    });
+
+    expect(inner.lastHistogramName).toBe("linchkit.action.duration_ms");
+    expect(inner.lastHistogramOptions).toEqual({
+      description: "Action duration distribution",
+      unit: "ms",
+    });
+  });
+
+  it("delegates record() to the underlying histogram with attributes", () => {
+    const inner = new FakeOtelMeter();
+    const meter = new OtelMeterAdapter(inner);
+    const histogram = meter.createHistogram("h", { unit: "ms" });
+
+    histogram.record(12.5, { "linchkit.action": "submit_request" });
+    histogram.record(7);
+
+    expect(inner.histogram.calls).toEqual([
+      { value: 12.5, attributes: { "linchkit.action": "submit_request" } },
+      { value: 7, attributes: undefined },
+    ]);
+  });
+});

--- a/addons/observability/cap-observability-otel/__tests__/otel-tracer-adapter.test.ts
+++ b/addons/observability/cap-observability-otel/__tests__/otel-tracer-adapter.test.ts
@@ -222,6 +222,17 @@ describe("OtelSpanAdapter", () => {
     expect(span.isRecording()).toBe(false);
   });
 
+  it("isRecording mirrors a NonRecordingSpan (inner returns false)", () => {
+    const inner = new FakeOtelSpan();
+    inner.ended = true; // simulate a NonRecordingSpan / dropped span
+    const span = new OtelSpanAdapter(inner);
+
+    // The wrapper hasn't been ended yet, but the inner span reports
+    // not-recording — we must propagate that signal so callers can skip
+    // expensive attribute computation.
+    expect(span.isRecording()).toBe(false);
+  });
+
   it("end() is idempotent — second call is a no-op", () => {
     const inner = new FakeOtelSpan();
     const span = new OtelSpanAdapter(inner);

--- a/addons/observability/cap-observability-otel/__tests__/otel-tracer-adapter.test.ts
+++ b/addons/observability/cap-observability-otel/__tests__/otel-tracer-adapter.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Tests for OtelTracerAdapter / OtelSpanAdapter.
+ *
+ * Uses hand-rolled fakes (not bun mock.module) because `mock.module`
+ * leaks across files in the project's shared bun:test process.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  type Attributes as OtelAttributes,
+  type Exception as OtelException,
+  type Link as OtelLink,
+  type Span as OtelSpan,
+  type SpanContext as OtelSpanContext,
+  SpanKind as OtelSpanKind,
+  type SpanOptions as OtelSpanOptions,
+  type SpanStatus as OtelSpanStatus,
+  SpanStatusCode as OtelSpanStatusCode,
+  type Tracer as OtelTracer,
+  type TimeInput,
+} from "@opentelemetry/api";
+import { OtelSpanAdapter, OtelTracerAdapter } from "../src/otel-tracer-adapter";
+
+// ── Fake OTel span ───────────────────────────────────────
+
+interface RecordedException {
+  exception: OtelException;
+  time?: TimeInput;
+}
+
+class FakeOtelSpan implements OtelSpan {
+  attributes: OtelAttributes = {};
+  status: OtelSpanStatus = { code: OtelSpanStatusCode.UNSET };
+  exceptions: RecordedException[] = [];
+  ended = false;
+  endTime: TimeInput | undefined;
+
+  setAttribute(key: string, value: OtelAttributes[string]): this {
+    this.attributes[key] = value;
+    return this;
+  }
+  setAttributes(attrs: OtelAttributes): this {
+    Object.assign(this.attributes, attrs);
+    return this;
+  }
+  addEvent(): this {
+    return this;
+  }
+  addLink(_link: OtelLink): this {
+    return this;
+  }
+  addLinks(_links: OtelLink[]): this {
+    return this;
+  }
+  setStatus(status: OtelSpanStatus): this {
+    this.status = status;
+    return this;
+  }
+  updateName(): this {
+    return this;
+  }
+  end(endTime?: TimeInput): void {
+    this.ended = true;
+    this.endTime = endTime;
+  }
+  isRecording(): boolean {
+    return !this.ended;
+  }
+  recordException(exception: OtelException, time?: TimeInput): void {
+    this.exceptions.push({ exception, time });
+  }
+  spanContext(): OtelSpanContext {
+    return {
+      traceId: "00000000000000000000000000000000",
+      spanId: "0000000000000000",
+      traceFlags: 0,
+    };
+  }
+}
+
+// ── Fake OTel tracer ─────────────────────────────────────
+
+class FakeOtelTracer implements OtelTracer {
+  lastName: string | undefined;
+  lastOptions: OtelSpanOptions | undefined;
+  span = new FakeOtelSpan();
+
+  startSpan(name: string, options?: OtelSpanOptions): OtelSpan {
+    this.lastName = name;
+    this.lastOptions = options;
+    return this.span;
+  }
+  // The full Tracer interface also requires startActiveSpan; the
+  // adapter never calls it so we throw to surface accidental usage.
+  startActiveSpan(): never {
+    throw new Error("startActiveSpan is not used by OtelTracerAdapter");
+  }
+}
+
+// ── Tests ────────────────────────────────────────────────
+
+describe("OtelTracerAdapter", () => {
+  it("forwards span name and translates SpanKind", () => {
+    const tracer = new FakeOtelTracer();
+    const adapter = new OtelTracerAdapter(tracer);
+
+    adapter.startSpan("linchkit.action.submit_request", { kind: "server" });
+
+    expect(tracer.lastName).toBe("linchkit.action.submit_request");
+    expect(tracer.lastOptions?.kind).toBe(OtelSpanKind.SERVER);
+  });
+
+  it("defaults span kind to INTERNAL when not provided", () => {
+    const tracer = new FakeOtelTracer();
+    const adapter = new OtelTracerAdapter(tracer);
+
+    adapter.startSpan("noop");
+
+    expect(tracer.lastOptions?.kind).toBe(OtelSpanKind.INTERNAL);
+  });
+
+  it("forwards initial attributes and startTime", () => {
+    const tracer = new FakeOtelTracer();
+    const adapter = new OtelTracerAdapter(tracer);
+
+    adapter.startSpan("with-attrs", {
+      attributes: { "linchkit.tenant_id": "t-1", "linchkit.size": 42 },
+      startTime: 123,
+    });
+
+    expect(tracer.lastOptions?.attributes).toEqual({
+      "linchkit.tenant_id": "t-1",
+      "linchkit.size": 42,
+    });
+    expect(tracer.lastOptions?.startTime).toBe(123);
+  });
+
+  it("translates every SpanKind value", () => {
+    const tracer = new FakeOtelTracer();
+    const adapter = new OtelTracerAdapter(tracer);
+
+    const mappings: Array<[Parameters<typeof adapter.startSpan>[1] & object, OtelSpanKind]> = [
+      [{ kind: "internal" }, OtelSpanKind.INTERNAL],
+      [{ kind: "server" }, OtelSpanKind.SERVER],
+      [{ kind: "client" }, OtelSpanKind.CLIENT],
+      [{ kind: "producer" }, OtelSpanKind.PRODUCER],
+      [{ kind: "consumer" }, OtelSpanKind.CONSUMER],
+    ];
+
+    for (const [opts, expected] of mappings) {
+      adapter.startSpan("k", opts);
+      expect(tracer.lastOptions?.kind).toBe(expected);
+    }
+  });
+});
+
+describe("OtelSpanAdapter", () => {
+  it("forwards setAttribute to the underlying span", () => {
+    const inner = new FakeOtelSpan();
+    const span = new OtelSpanAdapter(inner);
+
+    const result = span.setAttribute("linchkit.action", "submit_request");
+
+    expect(result).toBe(span);
+    expect(inner.attributes["linchkit.action"]).toBe("submit_request");
+  });
+
+  it("forwards setAttributes (bulk)", () => {
+    const inner = new FakeOtelSpan();
+    const span = new OtelSpanAdapter(inner);
+
+    span.setAttributes({ a: 1, b: "two", c: true });
+
+    expect(inner.attributes).toEqual({ a: 1, b: "two", c: true });
+  });
+
+  it("forwards recordException for Error instances", () => {
+    const inner = new FakeOtelSpan();
+    const span = new OtelSpanAdapter(inner);
+    const err = new Error("boom");
+
+    span.recordException(err);
+
+    expect(inner.exceptions).toHaveLength(1);
+    expect(inner.exceptions[0]?.exception).toBe(err);
+  });
+
+  it("forwards recordException for string messages", () => {
+    const inner = new FakeOtelSpan();
+    const span = new OtelSpanAdapter(inner);
+
+    span.recordException("plain message");
+
+    expect(inner.exceptions[0]?.exception).toBe("plain message");
+  });
+
+  it("translates setStatus codes", () => {
+    const inner = new FakeOtelSpan();
+    const span = new OtelSpanAdapter(inner);
+
+    span.setStatus({ code: "ok" });
+    expect(inner.status.code).toBe(OtelSpanStatusCode.OK);
+
+    span.setStatus({ code: "error", message: "failed" });
+    expect(inner.status.code).toBe(OtelSpanStatusCode.ERROR);
+    expect(inner.status.message).toBe("failed");
+
+    span.setStatus({ code: "unset" });
+    expect(inner.status.code).toBe(OtelSpanStatusCode.UNSET);
+  });
+
+  it("ends the underlying span and reports isRecording=false", () => {
+    const inner = new FakeOtelSpan();
+    const span = new OtelSpanAdapter(inner);
+
+    expect(span.isRecording()).toBe(true);
+
+    span.end(999);
+
+    expect(inner.ended).toBe(true);
+    expect(inner.endTime).toBe(999);
+    expect(span.isRecording()).toBe(false);
+  });
+
+  it("end() is idempotent — second call is a no-op", () => {
+    const inner = new FakeOtelSpan();
+    const span = new OtelSpanAdapter(inner);
+
+    span.end(100);
+    inner.endTime = undefined; // overwrite to detect second call
+
+    span.end(200);
+
+    expect(inner.endTime).toBeUndefined();
+  });
+});

--- a/addons/observability/cap-observability-otel/__tests__/sdk-bootstrap.test.ts
+++ b/addons/observability/cap-observability-otel/__tests__/sdk-bootstrap.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for the OTLP signal URL resolver used by `bootstrapNodeSdk`.
+ *
+ * Mirrors the OpenTelemetry specification for endpoint resolution:
+ * per-signal env vars are verbatim, base endpoints get the signal path
+ * appended via the `URL` constructor (so we never produce double
+ * slashes or drop a path prefix configured on the base).
+ */
+
+import { describe, expect, it } from "bun:test";
+import { resolveSignalUrl } from "../src/sdk-bootstrap";
+
+describe("resolveSignalUrl", () => {
+  it("returns the per-signal env value verbatim when set (traces)", () => {
+    const url = resolveSignalUrl({
+      perSignalEnv: "https://collector.example.com/custom/trace-path",
+      base: "http://localhost:4318",
+      signalPath: "v1/traces",
+    });
+    expect(url).toBe("https://collector.example.com/custom/trace-path");
+  });
+
+  it("returns the per-signal env value verbatim when set (metrics)", () => {
+    const url = resolveSignalUrl({
+      perSignalEnv: "https://collector.example.com/custom/metric-path",
+      base: "http://localhost:4318",
+      signalPath: "v1/metrics",
+    });
+    expect(url).toBe("https://collector.example.com/custom/metric-path");
+  });
+
+  it("treats an empty per-signal env var as unset and falls back to base", () => {
+    const url = resolveSignalUrl({
+      perSignalEnv: "",
+      base: "http://localhost:4318",
+      signalPath: "v1/traces",
+    });
+    expect(url).toBe("http://localhost:4318/v1/traces");
+  });
+
+  it("appends v1/traces to the base when no per-signal env is set", () => {
+    const url = resolveSignalUrl({
+      perSignalEnv: undefined,
+      base: "http://localhost:4318",
+      signalPath: "v1/traces",
+    });
+    expect(url).toBe("http://localhost:4318/v1/traces");
+  });
+
+  it("appends v1/metrics to the base when no per-signal env is set", () => {
+    const url = resolveSignalUrl({
+      perSignalEnv: undefined,
+      base: "http://localhost:4318",
+      signalPath: "v1/metrics",
+    });
+    expect(url).toBe("http://localhost:4318/v1/metrics");
+  });
+
+  it("does not double-slash when the base already has a trailing slash", () => {
+    const url = resolveSignalUrl({
+      perSignalEnv: undefined,
+      base: "http://localhost:4318/",
+      signalPath: "v1/traces",
+    });
+    expect(url).toBe("http://localhost:4318/v1/traces");
+  });
+
+  it("preserves a path prefix on the base endpoint", () => {
+    // The OTel spec allows a base such as `https://gateway/otlp` for
+    // collectors mounted behind a reverse proxy. `new URL` only
+    // honours the prefix when the base ends in `/`, which the
+    // resolver normalises before joining.
+    const url = resolveSignalUrl({
+      perSignalEnv: undefined,
+      base: "https://gateway.example.com/otlp",
+      signalPath: "v1/traces",
+    });
+    expect(url).toBe("https://gateway.example.com/otlp/v1/traces");
+  });
+
+  it("preserves a path prefix on the base endpoint (trailing slash)", () => {
+    const url = resolveSignalUrl({
+      perSignalEnv: undefined,
+      base: "https://gateway.example.com/otlp/",
+      signalPath: "v1/metrics",
+    });
+    expect(url).toBe("https://gateway.example.com/otlp/v1/metrics");
+  });
+
+  it("returns undefined when neither per-signal env nor base is set", () => {
+    const url = resolveSignalUrl({
+      perSignalEnv: undefined,
+      base: undefined,
+      signalPath: "v1/traces",
+    });
+    expect(url).toBeUndefined();
+  });
+
+  it("treats an empty base as unset and returns undefined", () => {
+    const url = resolveSignalUrl({
+      perSignalEnv: undefined,
+      base: "",
+      signalPath: "v1/traces",
+    });
+    expect(url).toBeUndefined();
+  });
+});

--- a/addons/observability/cap-observability-otel/package.json
+++ b/addons/observability/cap-observability-otel/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@linchkit/cap-observability-otel",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "files": [
+    "src/",
+    "package.json",
+    "README.md"
+  ],
+  "exports": {
+    ".": "./src/index.ts",
+    "./capability": "./src/capability.ts",
+    "./adapter": "./src/create-otel-adapter.ts",
+    "./bootstrap": "./src/sdk-bootstrap.ts"
+  },
+  "scripts": {
+    "test": "bun test"
+  },
+  "peerDependencies": {
+    "@linchkit/core": "^0.2.0",
+    "@opentelemetry/api": "^1.9.0"
+  },
+  "dependencies": {
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.218.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
+    "@opentelemetry/resources": "^2.7.0",
+    "@opentelemetry/sdk-metrics": "^2.7.0",
+    "@opentelemetry/sdk-node": "^0.218.0",
+    "@opentelemetry/semantic-conventions": "^1.41.0"
+  },
+  "devDependencies": {
+    "@linchkit/core": "workspace:*",
+    "@opentelemetry/api": "^1.9.0",
+    "typescript": "^6.0.2"
+  },
+  "linchkit": {
+    "minCoreVersion": "^0.1.0",
+    "type": "standard",
+    "category": "system"
+  }
+}

--- a/addons/observability/cap-observability-otel/package.json
+++ b/addons/observability/cap-observability-otel/package.json
@@ -37,7 +37,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "minCoreVersion": "^0.1.0",
+    "minCoreVersion": "^0.2.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/observability/cap-observability-otel/src/capability.ts
+++ b/addons/observability/cap-observability-otel/src/capability.ts
@@ -1,0 +1,42 @@
+/**
+ * cap-observability-otel capability descriptor.
+ *
+ * Phase 1 ships the adapter + bootstrap helpers only; the capability
+ * descriptor itself is a shape-only registration so the host can list
+ * it alongside other capabilities. Registration does NOT auto-start
+ * the OTel SDK or auto-swap the observability bundle — both are
+ * runtime + network side-effects that callers must opt in to
+ * explicitly.
+ *
+ * Opt-in path:
+ * ```ts
+ * import { setObservability } from "@linchkit/core/server";
+ * import {
+ *   bootstrapNodeSdk,
+ *   createOtelAdapter,
+ * } from "@linchkit/cap-observability-otel";
+ *
+ * const sdk = bootstrapNodeSdk({ serviceName: "linchkit-server" });
+ * sdk.start();
+ * setObservability(createOtelAdapter({ serviceName: "linchkit-server" }));
+ * ```
+ */
+
+import { defineCapability } from "@linchkit/core";
+
+export const capObservabilityOtel = defineCapability({
+  name: "cap-observability-otel",
+  label: "OpenTelemetry Observability",
+  description:
+    "OpenTelemetry adapter for the LinchKit observability seam. " +
+    "Provides createOtelAdapter() + bootstrapNodeSdk() helpers; the " +
+    "host opts in by calling setObservability(createOtelAdapter(...)) " +
+    "after bootstrapping the NodeSDK.",
+  type: "standard",
+  category: "system",
+  version: "0.1.0",
+  group: "observability",
+  // Explicit opt-in only — OTel has runtime + network cost so the host
+  // must call setObservability(...) themselves.
+  autoInstall: false,
+});

--- a/addons/observability/cap-observability-otel/src/create-otel-adapter.ts
+++ b/addons/observability/cap-observability-otel/src/create-otel-adapter.ts
@@ -1,0 +1,113 @@
+/**
+ * Factory that produces an `Observability` bundle backed by the
+ * OpenTelemetry SDK.
+ *
+ * Usage (manual bootstrap path):
+ * ```ts
+ * import { setObservability } from "@linchkit/core/server";
+ * import {
+ *   bootstrapNodeSdk,
+ *   createOtelAdapter,
+ * } from "@linchkit/cap-observability-otel";
+ *
+ * // Construct + start the NodeSDK BEFORE creating the adapter so
+ * // `trace.getTracer(...)` and `metrics.getMeter(...)` resolve to the
+ * // real providers (not the no-op stubs).
+ * const sdk = bootstrapNodeSdk({ serviceName: "my-service" });
+ * sdk.start();
+ *
+ * setObservability(createOtelAdapter({ serviceName: "my-service" }));
+ * ```
+ *
+ * The adapter only depends on `@opentelemetry/api` at runtime, which
+ * uses a global provider registry. That means the adapter does NOT
+ * start the SDK on its own — surprise auto-start is bad. Callers opt in
+ * via `bootstrapNodeSdk()` (or any other provider registration of
+ * their choice).
+ *
+ * Dependency-injection slots (`tracerProvider` / `meterProvider`) let
+ * tests pass a fake OTel `Tracer` / `Meter` without touching the global
+ * registry — see `__tests__/create-otel-adapter.test.ts`.
+ */
+
+import type { Observability } from "@linchkit/core/server";
+import {
+  type Meter as OtelMeter,
+  type Tracer as OtelTracer,
+  metrics as otelMetrics,
+  trace as otelTrace,
+} from "@opentelemetry/api";
+import { OtelMeterAdapter } from "./otel-meter-adapter";
+import { OtelTracerAdapter } from "./otel-tracer-adapter";
+
+// ── Options ──────────────────────────────────────────────
+
+/**
+ * Resolver returning an OTel `Tracer`. The default resolver calls
+ * `trace.getTracer(name, version)` from `@opentelemetry/api`. Tests
+ * override this slot to inject a fake.
+ */
+export type OtelTracerProvider = (name: string, version?: string) => OtelTracer;
+
+/**
+ * Resolver returning an OTel `Meter`. The default resolver calls
+ * `metrics.getMeter(name, version)` from `@opentelemetry/api`.
+ */
+export type OtelMeterProvider = (name: string, version?: string) => OtelMeter;
+
+/** Options accepted by `createOtelAdapter`. */
+export interface CreateOtelAdapterOptions {
+  /**
+   * Logical name passed to `trace.getTracer(...)` /
+   * `metrics.getMeter(...)`. Convention: use the service name (matches
+   * the `service.name` resource attribute set in `bootstrapNodeSdk`).
+   *
+   * @default "linchkit"
+   */
+  serviceName?: string;
+  /**
+   * Optional version string forwarded to `trace.getTracer(name,
+   * version)` / `metrics.getMeter(name, version)`. Useful for routing
+   * sampling rules per service version.
+   */
+  serviceVersion?: string;
+  /**
+   * Override the tracer resolver. Defaults to
+   * `(name, version) => trace.getTracer(name, version)`. Pass a fake
+   * here in tests.
+   */
+  tracerProvider?: OtelTracerProvider;
+  /**
+   * Override the meter resolver. Defaults to
+   * `(name, version) => metrics.getMeter(name, version)`. Pass a fake
+   * here in tests.
+   */
+  meterProvider?: OtelMeterProvider;
+}
+
+// ── Factory ──────────────────────────────────────────────
+
+const DEFAULT_SERVICE_NAME = "linchkit";
+
+/**
+ * Build an `Observability` bundle whose `tracer` + `meter` delegate to
+ * the OTel SDK currently registered via `@opentelemetry/api`'s global
+ * providers (or via the `tracerProvider` / `meterProvider` overrides).
+ *
+ * Returns a frozen object so call sites can stash the bundle without
+ * worrying about mutation.
+ */
+export function createOtelAdapter(options: CreateOtelAdapterOptions = {}): Observability {
+  const name = options.serviceName ?? DEFAULT_SERVICE_NAME;
+  const version = options.serviceVersion;
+
+  const tracerResolver: OtelTracerProvider =
+    options.tracerProvider ?? ((n, v) => otelTrace.getTracer(n, v));
+  const meterResolver: OtelMeterProvider =
+    options.meterProvider ?? ((n, v) => otelMetrics.getMeter(n, v));
+
+  const tracer = new OtelTracerAdapter(tracerResolver(name, version));
+  const meter = new OtelMeterAdapter(meterResolver(name, version));
+
+  return Object.freeze({ tracer, meter });
+}

--- a/addons/observability/cap-observability-otel/src/index.ts
+++ b/addons/observability/cap-observability-otel/src/index.ts
@@ -1,0 +1,33 @@
+/**
+ * @linchkit/cap-observability-otel — public API
+ *
+ * Adapter that wires LinchKit's observability seam
+ * (`packages/core/src/observability/*`) to the OpenTelemetry SDK.
+ *
+ * Two entry points:
+ * 1. `createOtelAdapter()` — returns an `Observability` bundle to pass
+ *    to `setObservability(...)`.
+ * 2. `bootstrapNodeSdk()` — constructs a `NodeSDK` with OTLP/HTTP
+ *    trace + metric exporters; caller owns `.start()` and
+ *    `.shutdown()`.
+ *
+ * Spec 28 M3 / issue #130.
+ */
+
+export { capObservabilityOtel } from "./capability";
+export {
+  type CreateOtelAdapterOptions,
+  createOtelAdapter,
+  type OtelMeterProvider,
+  type OtelTracerProvider,
+} from "./create-otel-adapter";
+export {
+  OtelCounterAdapter,
+  OtelHistogramAdapter,
+  OtelMeterAdapter,
+} from "./otel-meter-adapter";
+export { OtelSpanAdapter, OtelTracerAdapter } from "./otel-tracer-adapter";
+export {
+  type BootstrapNodeSdkOptions,
+  bootstrapNodeSdk,
+} from "./sdk-bootstrap";

--- a/addons/observability/cap-observability-otel/src/otel-meter-adapter.ts
+++ b/addons/observability/cap-observability-otel/src/otel-meter-adapter.ts
@@ -1,0 +1,86 @@
+/**
+ * OpenTelemetry Meter adapter.
+ *
+ * Wraps `@opentelemetry/api`'s `Meter` so it satisfies LinchKit core's
+ * `Meter` / `Counter` / `Histogram` interface from
+ * `packages/core/src/observability/meter.ts`.
+ *
+ * Mapping:
+ * - `Counter.add(value, attributes)` → OTel `Counter.add(value, attrs)`.
+ * - `Histogram.record(value, attributes)` → OTel
+ *   `Histogram.record(value, attrs)`.
+ * - `InstrumentOptions.description` / `unit` are forwarded verbatim;
+ *   OTel uses the same field names.
+ *
+ * No buffering or batching is added here — the OTel SDK's
+ * `PeriodicExportingMetricReader` (configured by `sdk-bootstrap.ts`)
+ * handles export cadence.
+ */
+
+import type {
+  Counter,
+  Histogram,
+  InstrumentOptions,
+  Meter,
+  MetricAttributes,
+} from "@linchkit/core/server";
+import type {
+  Attributes as OtelAttributes,
+  Counter as OtelCounter,
+  Histogram as OtelHistogram,
+  Meter as OtelMeter,
+} from "@opentelemetry/api";
+
+// ── Counter wrapper ──────────────────────────────────────
+
+/** Wraps an OTel `Counter` to satisfy LinchKit's `Counter` interface. */
+export class OtelCounterAdapter implements Counter {
+  constructor(private readonly inner: OtelCounter) {}
+
+  add(value: number, attributes?: MetricAttributes): void {
+    this.inner.add(value, attributes as OtelAttributes | undefined);
+  }
+}
+
+// ── Histogram wrapper ────────────────────────────────────
+
+/** Wraps an OTel `Histogram` to satisfy LinchKit's `Histogram` interface. */
+export class OtelHistogramAdapter implements Histogram {
+  constructor(private readonly inner: OtelHistogram) {}
+
+  record(value: number, attributes?: MetricAttributes): void {
+    this.inner.record(value, attributes as OtelAttributes | undefined);
+  }
+}
+
+// ── Meter wrapper ────────────────────────────────────────
+
+/**
+ * Wraps an OTel `Meter` to satisfy LinchKit's `Meter` interface.
+ *
+ * The wrapped instruments are NOT cached — OTel's own meter
+ * implementation deduplicates by name internally, so re-creating an
+ * instrument with the same name is cheap and returns the same
+ * underlying instrument.
+ */
+export class OtelMeterAdapter implements Meter {
+  constructor(private readonly inner: OtelMeter) {}
+
+  createCounter(name: string, options?: InstrumentOptions): Counter {
+    return new OtelCounterAdapter(
+      this.inner.createCounter(name, {
+        description: options?.description,
+        unit: options?.unit,
+      }),
+    );
+  }
+
+  createHistogram(name: string, options?: InstrumentOptions): Histogram {
+    return new OtelHistogramAdapter(
+      this.inner.createHistogram(name, {
+        description: options?.description,
+        unit: options?.unit,
+      }),
+    );
+  }
+}

--- a/addons/observability/cap-observability-otel/src/otel-tracer-adapter.ts
+++ b/addons/observability/cap-observability-otel/src/otel-tracer-adapter.ts
@@ -116,8 +116,12 @@ export class OtelSpanAdapter implements Span {
   }
 
   isRecording(): boolean {
-    // Core's contract: returns true until end() has been called.
-    return !this.ended;
+    // After end() we always report false; before that, defer to the inner
+    // OTel span. A wrapped NonRecordingSpan (sampler dropped it, no SDK
+    // installed, etc.) already returns false — preserving that signal lets
+    // callers skip expensive attribute computation on dropped spans.
+    if (this.ended) return false;
+    return this.inner.isRecording();
   }
 }
 

--- a/addons/observability/cap-observability-otel/src/otel-tracer-adapter.ts
+++ b/addons/observability/cap-observability-otel/src/otel-tracer-adapter.ts
@@ -1,0 +1,143 @@
+/**
+ * OpenTelemetry Tracer adapter.
+ *
+ * Wraps `@opentelemetry/api`'s `Tracer` / `Span` so it satisfies LinchKit
+ * core's `Tracer` / `Span` interface from
+ * `packages/core/src/observability/tracer.ts`. Call sites in core (and
+ * other capabilities) talk to the LinchKit interface and stay decoupled
+ * from the OTel SDK.
+ *
+ * Field-mapping notes:
+ * - `SpanKind` is a string union in core, an enum in OTel. We translate
+ *   on the way in (`mapSpanKind`).
+ * - `SpanStatusCode` is `"unset" | "ok" | "error"` in core; OTel's
+ *   `SpanStatusCode` is an enum with the same three semantics
+ *   (`UNSET = 0`, `OK = 1`, `ERROR = 2`).
+ * - `recordException` accepts `Error | string` in core. OTel accepts the
+ *   same plus an `Exception` shape; we forward the value as-is so the
+ *   underlying SDK can normalize.
+ * - `startTime` in core is "epoch milliseconds"; OTel accepts the same
+ *   numeric form on `startSpan`.
+ *
+ * Phase 1 intentionally does NOT propagate OTel `Context` — call sites
+ * use the returned `Span` handle directly with `try { ... } finally
+ * { span.end() }`, matching the seam contract in the core comments.
+ */
+
+import type {
+  Span,
+  SpanAttributes,
+  SpanAttributeValue,
+  SpanKind,
+  SpanStatus,
+  StartSpanOptions,
+  Tracer,
+} from "@linchkit/core/server";
+import {
+  type Attributes as OtelAttributes,
+  type AttributeValue as OtelAttributeValue,
+  type Span as OtelSpan,
+  SpanKind as OtelSpanKind,
+  SpanStatusCode as OtelSpanStatusCode,
+  type Tracer as OtelTracer,
+} from "@opentelemetry/api";
+
+// ── Span kind translation ────────────────────────────────
+
+const SPAN_KIND_MAP: Readonly<Record<SpanKind, OtelSpanKind>> = Object.freeze({
+  internal: OtelSpanKind.INTERNAL,
+  server: OtelSpanKind.SERVER,
+  client: OtelSpanKind.CLIENT,
+  producer: OtelSpanKind.PRODUCER,
+  consumer: OtelSpanKind.CONSUMER,
+});
+
+function mapSpanKind(kind: SpanKind | undefined): OtelSpanKind {
+  return kind ? SPAN_KIND_MAP[kind] : OtelSpanKind.INTERNAL;
+}
+
+// ── Status code translation ──────────────────────────────
+
+function mapStatusCode(code: SpanStatus["code"]): OtelSpanStatusCode {
+  switch (code) {
+    case "ok":
+      return OtelSpanStatusCode.OK;
+    case "error":
+      return OtelSpanStatusCode.ERROR;
+    default:
+      return OtelSpanStatusCode.UNSET;
+  }
+}
+
+// ── Span wrapper ─────────────────────────────────────────
+
+/**
+ * Wraps an OTel `Span` so it satisfies LinchKit's `Span` interface.
+ * Tracks an `ended` flag locally so `isRecording()` matches the noop
+ * implementation's semantics — once `end()` has been called, the span
+ * is no longer recording from the caller's perspective.
+ */
+export class OtelSpanAdapter implements Span {
+  private ended = false;
+
+  constructor(private readonly inner: OtelSpan) {}
+
+  setAttribute(key: string, value: SpanAttributeValue): this {
+    // OTel's setAttribute accepts the same union (string / number /
+    // boolean / homogeneous array) so forwarding is safe.
+    this.inner.setAttribute(key, value as OtelAttributeValue);
+    return this;
+  }
+
+  setAttributes(attrs: SpanAttributes): this {
+    this.inner.setAttributes(attrs as OtelAttributes);
+    return this;
+  }
+
+  recordException(error: Error | string): this {
+    this.inner.recordException(error);
+    return this;
+  }
+
+  setStatus(status: SpanStatus): this {
+    this.inner.setStatus({
+      code: mapStatusCode(status.code),
+      message: status.message,
+    });
+    return this;
+  }
+
+  end(endTime?: number): void {
+    if (this.ended) {
+      return;
+    }
+    this.ended = true;
+    this.inner.end(endTime);
+  }
+
+  isRecording(): boolean {
+    // Core's contract: returns true until end() has been called.
+    return !this.ended;
+  }
+}
+
+// ── Tracer wrapper ───────────────────────────────────────
+
+/**
+ * Wraps an OTel `Tracer` so it satisfies LinchKit's `Tracer` interface.
+ * `tracerName` / `tracerVersion` are forwarded to
+ * `trace.getTracer(name, version)` by the caller when the adapter is
+ * constructed.
+ */
+export class OtelTracerAdapter implements Tracer {
+  constructor(private readonly inner: OtelTracer) {}
+
+  startSpan(name: string, options?: StartSpanOptions): Span {
+    const otelSpan = this.inner.startSpan(name, {
+      kind: mapSpanKind(options?.kind),
+      attributes: options?.attributes as OtelAttributes | undefined,
+      startTime: options?.startTime,
+    });
+    return new OtelSpanAdapter(otelSpan);
+  }
+}

--- a/addons/observability/cap-observability-otel/src/sdk-bootstrap.ts
+++ b/addons/observability/cap-observability-otel/src/sdk-bootstrap.ts
@@ -1,0 +1,147 @@
+/**
+ * NodeSDK bootstrap helper.
+ *
+ * Lives in its own module so the OTel adapter factory
+ * (`create-otel-adapter.ts`) can be imported in environments that don't
+ * have `@opentelemetry/sdk-node` available (e.g. browser bundles that
+ * still want the seam types). Callers explicitly opt in by importing
+ * this module.
+ *
+ * Usage:
+ * ```ts
+ * import { bootstrapNodeSdk } from "@linchkit/cap-observability-otel/bootstrap";
+ *
+ * const sdk = bootstrapNodeSdk({
+ *   serviceName: "linchkit-server",
+ *   serviceVersion: "0.2.0",
+ *   // endpoint resolves from OTEL_EXPORTER_OTLP_ENDPOINT if omitted
+ * });
+ * sdk.start();
+ *
+ * // Graceful shutdown
+ * process.on("SIGTERM", async () => { await sdk.shutdown(); });
+ * ```
+ *
+ * No auto-start. Surprise startup means a service silently opens a
+ * network connection to whatever `OTEL_EXPORTER_OTLP_ENDPOINT` points
+ * at — bad default. The caller's `sdk.start()` is the single explicit
+ * opt-in.
+ */
+
+import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from "@opentelemetry/semantic-conventions";
+
+// ── Options ──────────────────────────────────────────────
+
+/** Options accepted by `bootstrapNodeSdk`. */
+export interface BootstrapNodeSdkOptions {
+  /**
+   * Service name. Sets the `service.name` resource attribute and is
+   * surfaced in every exported span / metric. Should match the value
+   * passed to `createOtelAdapter({ serviceName })`.
+   *
+   * @default "linchkit"
+   */
+  serviceName?: string;
+  /**
+   * Optional service version. Sets the `service.version` resource
+   * attribute.
+   */
+  serviceVersion?: string;
+  /**
+   * Base OTLP/HTTP endpoint (e.g. `http://localhost:4318`). The
+   * trace exporter posts to `${endpoint}/v1/traces`, the metric
+   * exporter to `${endpoint}/v1/metrics` — the OTel SDK appends those
+   * paths automatically when only the base is provided via env.
+   *
+   * Falls back to the `OTEL_EXPORTER_OTLP_ENDPOINT` env var; if that
+   * is also unset the exporters default to `http://localhost:4318`.
+   */
+  endpoint?: string;
+  /**
+   * Optional headers attached to every OTLP/HTTP request (e.g.
+   * `{ "authorization": "Bearer ..." }`). Forwarded to both the trace
+   * and metric exporters.
+   */
+  headers?: Record<string, string>;
+  /**
+   * Metric export interval in milliseconds. Defaults to OTel SDK
+   * default (60_000ms / 60s).
+   */
+  metricExportIntervalMs?: number;
+  /**
+   * Disable the metric reader entirely. Useful when only tracing is
+   * desired or when metrics are exported via a different reader.
+   *
+   * @default false
+   */
+  disableMetrics?: boolean;
+  /**
+   * Disable the trace exporter entirely. Useful when only metrics are
+   * desired.
+   *
+   * @default false
+   */
+  disableTraces?: boolean;
+}
+
+// ── Bootstrap ────────────────────────────────────────────
+
+const DEFAULT_SERVICE_NAME = "linchkit";
+
+/**
+ * Build a `NodeSDK` configured with the OTLP/HTTP trace + metric
+ * exporters and a `service.name` resource. Caller must invoke
+ * `.start()` to register the providers globally.
+ *
+ * Returns the constructed `NodeSDK` so the caller owns its lifecycle —
+ * including graceful shutdown via `await sdk.shutdown()`.
+ */
+export function bootstrapNodeSdk(options: BootstrapNodeSdkOptions = {}): NodeSDK {
+  const serviceName = options.serviceName ?? DEFAULT_SERVICE_NAME;
+  const endpoint = options.endpoint ?? process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+  const headers = options.headers;
+
+  const resource = resourceFromAttributes({
+    [ATTR_SERVICE_NAME]: serviceName,
+    ...(options.serviceVersion ? { [ATTR_SERVICE_VERSION]: options.serviceVersion } : {}),
+  });
+
+  // OTLP exporters resolve their endpoint from `url` if provided; when
+  // `url` is undefined they fall back to env vars themselves, so it is
+  // safe to pass `undefined` here.
+  const traceExporter = options.disableTraces
+    ? undefined
+    : new OTLPTraceExporter({
+        url: endpoint ? `${trimSlash(endpoint)}/v1/traces` : undefined,
+        headers,
+      });
+
+  const metricReader = options.disableMetrics
+    ? undefined
+    : new PeriodicExportingMetricReader({
+        exporter: new OTLPMetricExporter({
+          url: endpoint ? `${trimSlash(endpoint)}/v1/metrics` : undefined,
+          headers,
+        }),
+        ...(options.metricExportIntervalMs !== undefined
+          ? { exportIntervalMillis: options.metricExportIntervalMs }
+          : {}),
+      });
+
+  return new NodeSDK({
+    resource,
+    ...(traceExporter ? { traceExporter } : {}),
+    ...(metricReader ? { metricReader } : {}),
+  });
+}
+
+// ── Helpers ──────────────────────────────────────────────
+
+function trimSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}

--- a/addons/observability/cap-observability-otel/src/sdk-bootstrap.ts
+++ b/addons/observability/cap-observability-otel/src/sdk-bootstrap.ts
@@ -18,8 +18,13 @@
  * });
  * sdk.start();
  *
- * // Graceful shutdown
- * process.on("SIGTERM", async () => { await sdk.shutdown(); });
+ * // Graceful shutdown — handle both SIGTERM and SIGINT.
+ * for (const signal of ["SIGTERM", "SIGINT"] as const) {
+ *   process.on(signal, async () => {
+ *     await sdk.shutdown();
+ *     process.exit(0);
+ *   });
+ * }
  * ```
  *
  * No auto-start. Surprise startup means a service silently opens a
@@ -55,11 +60,17 @@ export interface BootstrapNodeSdkOptions {
   /**
    * Base OTLP/HTTP endpoint (e.g. `http://localhost:4318`). The
    * trace exporter posts to `${endpoint}/v1/traces`, the metric
-   * exporter to `${endpoint}/v1/metrics` — the OTel SDK appends those
-   * paths automatically when only the base is provided via env.
+   * exporter to `${endpoint}/v1/metrics`.
    *
-   * Falls back to the `OTEL_EXPORTER_OTLP_ENDPOINT` env var; if that
-   * is also unset the exporters default to `http://localhost:4318`.
+   * Resolution follows the OpenTelemetry specification:
+   * 1. Per-signal env var (`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` /
+   *    `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`) is used as-is — no path
+   *    suffix is appended.
+   * 2. Otherwise this `endpoint` option (or the base env var
+   *    `OTEL_EXPORTER_OTLP_ENDPOINT`) is treated as the base and the
+   *    signal-specific path (`v1/traces` / `v1/metrics`) is appended.
+   * 3. If nothing is set the exporters default to
+   *    `http://localhost:4318`.
    */
   endpoint?: string;
   /**
@@ -103,7 +114,7 @@ const DEFAULT_SERVICE_NAME = "linchkit";
  */
 export function bootstrapNodeSdk(options: BootstrapNodeSdkOptions = {}): NodeSDK {
   const serviceName = options.serviceName ?? DEFAULT_SERVICE_NAME;
-  const endpoint = options.endpoint ?? process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+  const baseEndpoint = options.endpoint ?? process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
   const headers = options.headers;
 
   const resource = resourceFromAttributes({
@@ -111,22 +122,34 @@ export function bootstrapNodeSdk(options: BootstrapNodeSdkOptions = {}): NodeSDK
     ...(options.serviceVersion ? { [ATTR_SERVICE_VERSION]: options.serviceVersion } : {}),
   });
 
-  // OTLP exporters resolve their endpoint from `url` if provided; when
-  // `url` is undefined they fall back to env vars themselves, so it is
-  // safe to pass `undefined` here.
+  // Per the OTel spec, per-signal env vars are used verbatim and base
+  // endpoints have the signal path appended. When neither is set we
+  // pass `undefined` so the exporter falls back to its built-in default
+  // (`http://localhost:4318/v1/<signal>`).
+  const traceUrl = resolveSignalUrl({
+    perSignalEnv: process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
+    base: baseEndpoint,
+    signalPath: "v1/traces",
+  });
+  const metricUrl = resolveSignalUrl({
+    perSignalEnv: process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
+    base: baseEndpoint,
+    signalPath: "v1/metrics",
+  });
+
   const traceExporter = options.disableTraces
     ? undefined
     : new OTLPTraceExporter({
-        url: endpoint ? `${trimSlash(endpoint)}/v1/traces` : undefined,
-        headers,
+        ...(traceUrl !== undefined ? { url: traceUrl } : {}),
+        ...(headers !== undefined ? { headers } : {}),
       });
 
   const metricReader = options.disableMetrics
     ? undefined
     : new PeriodicExportingMetricReader({
         exporter: new OTLPMetricExporter({
-          url: endpoint ? `${trimSlash(endpoint)}/v1/metrics` : undefined,
-          headers,
+          ...(metricUrl !== undefined ? { url: metricUrl } : {}),
+          ...(headers !== undefined ? { headers } : {}),
         }),
         ...(options.metricExportIntervalMs !== undefined
           ? { exportIntervalMillis: options.metricExportIntervalMs }
@@ -142,6 +165,33 @@ export function bootstrapNodeSdk(options: BootstrapNodeSdkOptions = {}): NodeSDK
 
 // ── Helpers ──────────────────────────────────────────────
 
-function trimSlash(value: string): string {
-  return value.endsWith("/") ? value.slice(0, -1) : value;
+/**
+ * Resolve the final exporter URL for a single OTLP signal.
+ *
+ * - If the per-signal env var is set, return it verbatim (OTel spec
+ *   says signal-specific endpoints are NOT modified).
+ * - Else if a base endpoint is provided, join it with the signal path
+ *   using `URL` so we never produce double slashes or drop a configured
+ *   path prefix.
+ * - Else return `undefined` so the exporter falls back to its built-in
+ *   default.
+ *
+ * Exported for testability.
+ */
+export function resolveSignalUrl(args: {
+  perSignalEnv: string | undefined;
+  base: string | undefined;
+  signalPath: string;
+}): string | undefined {
+  const { perSignalEnv, base, signalPath } = args;
+  if (perSignalEnv !== undefined && perSignalEnv !== "") {
+    return perSignalEnv;
+  }
+  if (base === undefined || base === "") {
+    return undefined;
+  }
+  // `URL` only honours a relative path correctly when the base ends in
+  // "/" — otherwise the last path segment is replaced. Normalise once.
+  const normalised = base.endsWith("/") ? base : `${base}/`;
+  return new URL(signalPath, normalised).toString();
 }

--- a/addons/observability/cap-observability-otel/tsconfig.json
+++ b/addons/observability/cap-observability-otel/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun-types"]
+  },
+  "include": ["src", "__tests__"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -303,6 +303,27 @@
         "@linchkit/core": "^0.2.0",
       },
     },
+    "addons/observability/cap-observability-otel": {
+      "name": "@linchkit/cap-observability-otel",
+      "version": "0.1.0",
+      "dependencies": {
+        "@opentelemetry/exporter-metrics-otlp-http": "^0.218.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
+        "@opentelemetry/resources": "^2.7.0",
+        "@opentelemetry/sdk-metrics": "^2.7.0",
+        "@opentelemetry/sdk-node": "^0.218.0",
+        "@opentelemetry/semantic-conventions": "^1.41.0",
+      },
+      "devDependencies": {
+        "@linchkit/core": "workspace:*",
+        "@opentelemetry/api": "^1.9.0",
+        "typescript": "^6.0.2",
+      },
+      "peerDependencies": {
+        "@linchkit/core": "^0.2.0",
+        "@opentelemetry/api": "^1.9.0",
+      },
+    },
     "addons/permission/cap-permission": {
       "name": "@linchkit/cap-permission",
       "version": "1.0.0",
@@ -341,6 +362,7 @@
         "@linchkit/core": "^0.2.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-i18next": ">=14.0.0",
       },
     },
     "packages/cli": {
@@ -644,6 +666,10 @@
 
     "@graphql-yoga/typed-event-target": ["@graphql-yoga/typed-event-target@3.0.2", "https://registry.npmmirror.com/@graphql-yoga/typed-event-target/-/typed-event-target-3.0.2.tgz", { "dependencies": { "@repeaterjs/repeater": "^3.0.4", "tslib": "^2.8.1" } }, "sha512-ZpJxMqB+Qfe3rp6uszCQoag4nSw42icURnBRfFYSOmTgEeOe4rD0vYlbA8spvCu2TlCesNTlEN9BLWtQqLxabA=="],
 
+    "@grpc/grpc-js": ["@grpc/grpc-js@1.14.3", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA=="],
+
+    "@grpc/proto-loader": ["@grpc/proto-loader@0.8.1", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.5", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg=="],
+
     "@hono/node-server": ["@hono/node-server@1.19.11", "https://registry.npmmirror.com/@hono/node-server/-/node-server-1.19.11.tgz", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
 
     "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
@@ -671,6 +697,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "https://registry.npmmirror.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "https://registry.npmmirror.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
 
     "@linchkit/cap-adapter-mcp": ["@linchkit/cap-adapter-mcp@workspace:addons/adapter-mcp/cap-adapter-mcp"],
 
@@ -701,6 +729,8 @@
     "@linchkit/cap-migration": ["@linchkit/cap-migration@workspace:addons/migration/cap-migration"],
 
     "@linchkit/cap-notification": ["@linchkit/cap-notification@workspace:addons/notification/cap-notification"],
+
+    "@linchkit/cap-observability-otel": ["@linchkit/cap-observability-otel@workspace:addons/observability/cap-observability-otel"],
 
     "@linchkit/cap-permission": ["@linchkit/cap-permission@workspace:addons/permission/cap-permission"],
 
@@ -752,9 +782,85 @@
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.218.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw=="],
+
+    "@opentelemetry/configuration": ["@opentelemetry/configuration@0.218.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "yaml": "^2.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" } }, "sha512-W8wIz7H2R1pufR5jfjb3gU2XkMpm2x/7b1RJcsuzvd70Il/rWWE+g5/Od7hQKrxRTSrTrOWlru101PWXz5I1EQ=="],
+
+    "@opentelemetry/context-async-hooks": ["@opentelemetry/context-async-hooks@2.7.1", "", { "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/exporter-logs-otlp-grpc": ["@opentelemetry/exporter-logs-otlp-grpc@0.218.0", "", { "dependencies": { "@grpc/grpc-js": "^1.14.3", "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.218.0", "@opentelemetry/otlp-grpc-exporter-base": "0.218.0", "@opentelemetry/otlp-transformer": "0.218.0", "@opentelemetry/sdk-logs": "0.218.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-hoxrNH1l/Xy6F9WTJ5IK+6j1r9nQFlPOmrnTlhYHTySdunfXLmUCPv3bQtKYntxag9h3wLYBZQ2HI6FOx+BT2g=="],
+
+    "@opentelemetry/exporter-logs-otlp-http": ["@opentelemetry/exporter-logs-otlp-http@0.218.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.218.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.218.0", "@opentelemetry/otlp-transformer": "0.218.0", "@opentelemetry/sdk-logs": "0.218.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Qx+4rpVHzgg89dawcWRHyt+XRXeLnhFz/qBtvggmjkcgPUdr+NAB0/u/eIPA8yAeJV0J80Vz43JZCh/XFvZFGw=="],
+
+    "@opentelemetry/exporter-logs-otlp-proto": ["@opentelemetry/exporter-logs-otlp-proto@0.218.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.218.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.218.0", "@opentelemetry/otlp-transformer": "0.218.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-logs": "0.218.0", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-1/noQNsp9gXD75HPzgjBrcF1+XTtry7pFAUfxVEJgg7mPv2AawKQuYkhMmJ8qjxz4Ubc3Y8bwvfxevXsKTq4cg=="],
+
+    "@opentelemetry/exporter-metrics-otlp-grpc": ["@opentelemetry/exporter-metrics-otlp-grpc@0.218.0", "", { "dependencies": { "@grpc/grpc-js": "^1.14.3", "@opentelemetry/core": "2.7.1", "@opentelemetry/exporter-metrics-otlp-http": "0.218.0", "@opentelemetry/otlp-exporter-base": "0.218.0", "@opentelemetry/otlp-grpc-exporter-base": "0.218.0", "@opentelemetry/otlp-transformer": "0.218.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-metrics": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-YapQ9vNMX0NSZF6LK5pWAFfjpJleV2O9uYWfYGeb/5F1Kb9rPGK8tZDMJFa/sOksgdFuflDvYuA0B4qjDB4fjQ=="],
+
+    "@opentelemetry/exporter-metrics-otlp-http": ["@opentelemetry/exporter-metrics-otlp-http@0.218.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.218.0", "@opentelemetry/otlp-transformer": "0.218.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-metrics": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-bV7d2OuMpZu2+gAaxUAhzfZ0h3WVZk8ETQUEE3DNSntbTaMpuITjtm8I0rNyHFdm7Ax57K6ty7SgFXlBmOLIvQ=="],
+
+    "@opentelemetry/exporter-metrics-otlp-proto": ["@opentelemetry/exporter-metrics-otlp-proto@0.218.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/exporter-metrics-otlp-http": "0.218.0", "@opentelemetry/otlp-exporter-base": "0.218.0", "@opentelemetry/otlp-transformer": "0.218.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-metrics": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-ubLddKjWULhla9YZRCj/rTBeppjJYE4e9w0icx5mTu3eFhWjQzbV75NYjXuIlEG+NJsBl6d+sTFw5Qu+oej4oQ=="],
+
+    "@opentelemetry/exporter-prometheus": ["@opentelemetry/exporter-prometheus@0.218.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-metrics": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-RT5oEyu1kddZJ1vt7/BUo5wV+P7hpNAESsR3dUd3+8deHuX7gWNoCOZn+SfDT+hJHlIJ5h/AxiCLXIrutswDJg=="],
+
+    "@opentelemetry/exporter-trace-otlp-grpc": ["@opentelemetry/exporter-trace-otlp-grpc@0.218.0", "", { "dependencies": { "@grpc/grpc-js": "^1.14.3", "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.218.0", "@opentelemetry/otlp-grpc-exporter-base": "0.218.0", "@opentelemetry/otlp-transformer": "0.218.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-3fXxVQEj9TNAFaCi79JeFKfeLd0sDtInaR3gaZDVlzNSPHtz8PZuCV34JKWjD4XXzT20IdMe8IpX6mRVNDA4Tw=="],
+
+    "@opentelemetry/exporter-trace-otlp-http": ["@opentelemetry/exporter-trace-otlp-http@0.218.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.218.0", "@opentelemetry/otlp-transformer": "0.218.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-8dqezsmPhtKitIK/eTipZhYl9EX2/gNQ5zUMhaz3uxEURwfkNf8IPvo6yNfrzbxdtpAOybS/+h7wmIWYqFSpiw=="],
+
+    "@opentelemetry/exporter-trace-otlp-proto": ["@opentelemetry/exporter-trace-otlp-proto@0.218.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.218.0", "@opentelemetry/otlp-transformer": "0.218.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-r1Msf8SNLRmwh9J6XQ5uh82D7CdDWMNHnPB7LAVHjzut0TkSeKc5KcIvr4SvHvfk/xwN5gxC+VLKQ1k0o8PSPw=="],
+
+    "@opentelemetry/exporter-zipkin": ["@opentelemetry/exporter-zipkin@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0" } }, "sha512-mfsD9bKAxcKrh5+y08TPodvClBO0CznBE3p79YAGnO81WI4LrdsGA65T53e4iTSbCalW4WaUpkbeJcbpyIUHfg=="],
+
+    "@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.218.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.218.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-mIZil8Es+sYDK5m+DQiwAwF57F14TF2YlEqvIjZ/RQWcxDBwRGsKfdK2Tv65OU9meQKCMzSIFS9mxAcnAb6Bkg=="],
+
+    "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.218.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-transformer": "0.218.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA=="],
+
+    "@opentelemetry/otlp-grpc-exporter-base": ["@opentelemetry/otlp-grpc-exporter-base@0.218.0", "", { "dependencies": { "@grpc/grpc-js": "^1.14.3", "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.218.0", "@opentelemetry/otlp-transformer": "0.218.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-H/lCGJ536N98VpYJOaWTQOkv4Dx6TnmStK6Rqfu1W7KkFbPAx04hjdYEMZF/YbnHzPUSIK4kM6OE2GKGBTpV9A=="],
+
+    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.218.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.218.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-logs": "0.218.0", "@opentelemetry/sdk-metrics": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ=="],
+
+    "@opentelemetry/propagator-b3": ["@opentelemetry/propagator-b3@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-RJid6E2CKyeGfKBzXKF21ejabGMHypFkPAh3qZ+NvI+SGjuIye79t3PmiqcDgtRzdKH6ynXzbfslQ8DfpRUg2A=="],
+
+    "@opentelemetry/propagator-jaeger": ["@opentelemetry/propagator-jaeger@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-KMjVBHzP4N60bOzxja76M1F1hZZ43lGPga5ix+mkv9+kk1nx9SbkxSvJsMbuVUxdPQmsPTqGShmhN8ulrMOg6Q=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ=="],
+
+    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.218.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.218.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag=="],
+
+    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ=="],
+
+    "@opentelemetry/sdk-node": ["@opentelemetry/sdk-node@0.218.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.218.0", "@opentelemetry/configuration": "0.218.0", "@opentelemetry/context-async-hooks": "2.7.1", "@opentelemetry/core": "2.7.1", "@opentelemetry/exporter-logs-otlp-grpc": "0.218.0", "@opentelemetry/exporter-logs-otlp-http": "0.218.0", "@opentelemetry/exporter-logs-otlp-proto": "0.218.0", "@opentelemetry/exporter-metrics-otlp-grpc": "0.218.0", "@opentelemetry/exporter-metrics-otlp-http": "0.218.0", "@opentelemetry/exporter-metrics-otlp-proto": "0.218.0", "@opentelemetry/exporter-prometheus": "0.218.0", "@opentelemetry/exporter-trace-otlp-grpc": "0.218.0", "@opentelemetry/exporter-trace-otlp-http": "0.218.0", "@opentelemetry/exporter-trace-otlp-proto": "0.218.0", "@opentelemetry/exporter-zipkin": "2.7.1", "@opentelemetry/instrumentation": "0.218.0", "@opentelemetry/otlp-exporter-base": "0.218.0", "@opentelemetry/propagator-b3": "2.7.1", "@opentelemetry/propagator-jaeger": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-logs": "0.218.0", "@opentelemetry/sdk-metrics": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1", "@opentelemetry/sdk-trace-node": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-tPMjHrLV5gsfNdYqoRHjeGbCAZBXXD9c1Qo/2ut7VwnUABDNh76xNxrT0SEhkIIJuCN45bbN1vZnYL1gY0IkOg=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw=="],
+
+    "@opentelemetry/sdk-trace-node": ["@opentelemetry/sdk-trace-node@2.7.1", "", { "dependencies": { "@opentelemetry/context-async-hooks": "2.7.1", "@opentelemetry/core": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
+
     "@oxc-project/types": ["@oxc-project/types@0.120.0", "https://registry.npmmirror.com/@oxc-project/types/-/types-0.120.0.tgz", {}, "sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg=="],
 
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1", "@protobufjs/inquire": "^1.1.0" } }, "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.1", "", {}, "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "https://registry.npmmirror.com/@radix-ui/number/-/number-1.1.1.tgz", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
@@ -1212,6 +1318,8 @@
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
+    "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
+
     "agent-base": ["agent-base@7.1.4", "https://registry.npmmirror.com/agent-base/-/agent-base-7.1.4.tgz", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "ai": ["ai@6.0.134", "", { "dependencies": { "@ai-sdk/gateway": "3.0.77", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-YalNEaavld/kE444gOcsMKXdVVRGEe0SK77fAFcWYcqLg+a7xKnEet8bdfrEAJTfnMjj01rhgrIL10903w1a5Q=="],
@@ -1291,6 +1399,8 @@
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "citty": ["citty@0.2.1", "https://registry.npmmirror.com/citty/-/citty-0.2.1.tgz", {}, "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg=="],
+
+    "cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
 
     "class-variance-authority": ["class-variance-authority@0.7.1", "https://registry.npmmirror.com/class-variance-authority/-/class-variance-authority-0.7.1.tgz", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
@@ -1652,6 +1762,8 @@
 
     "import-fresh": ["import-fresh@3.3.1", "https://registry.npmmirror.com/import-fresh/-/import-fresh-3.3.1.tgz", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
+    "import-in-the-middle": ["import-in-the-middle@3.0.1", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA=="],
+
     "inherits": ["inherits@2.0.4", "https://registry.npmmirror.com/inherits/-/inherits-2.0.4.tgz", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
@@ -1778,9 +1890,13 @@
 
     "lodash-es": ["lodash-es@4.17.23", "", {}, "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="],
 
+    "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
+
     "lodash.startcase": ["lodash.startcase@4.4.0", "", {}, "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="],
 
     "log-symbols": ["log-symbols@6.0.0", "https://registry.npmmirror.com/log-symbols/-/log-symbols-6.0.0.tgz", { "dependencies": { "chalk": "^5.3.0", "is-unicode-supported": "^1.3.0" } }, "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw=="],
+
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
@@ -1827,6 +1943,8 @@
     "minimist": ["minimist@1.2.8", "https://registry.npmmirror.com/minimist/-/minimist-1.2.8.tgz", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "mlly": ["mlly@1.8.2", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA=="],
+
+    "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
 
     "mongodb": ["mongodb@7.1.0", "", { "dependencies": { "@mongodb-js/saslprep": "^1.3.0", "bson": "^7.1.1", "mongodb-connection-string-url": "^7.0.0" }, "peerDependencies": { "@aws-sdk/credential-providers": "^3.806.0", "@mongodb-js/zstd": "^7.0.0", "gcp-metadata": "^7.0.1", "kerberos": "^7.0.0", "mongodb-client-encryption": ">=7.0.0 <7.1.0", "snappy": "^7.3.2", "socks": "^2.8.6" }, "optionalPeers": ["@aws-sdk/credential-providers", "@mongodb-js/zstd", "gcp-metadata", "kerberos", "mongodb-client-encryption", "snappy", "socks"] }, "sha512-kMfnKunbolQYwCIyrkxNJFB4Ypy91pYqua5NargS/f8ODNSJxT03ZU3n1JqL4mCzbSih8tvmMEMLpKTT7x5gCg=="],
 
@@ -2000,6 +2118,8 @@
 
     "prosemirror-view": ["prosemirror-view@1.41.7", "", { "dependencies": { "prosemirror-model": "^1.20.0", "prosemirror-state": "^1.0.0", "prosemirror-transform": "^1.1.0" } }, "sha512-jUwKNCEIGiqdvhlS91/2QAg21e4dfU5bH2iwmSDQeosXJgKF7smG0YSplOWK0cjSNgIqXe7VXqo7EIfUFJdt3w=="],
 
+    "protobufjs": ["protobufjs@7.5.8", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.1", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA=="],
+
     "proxy-addr": ["proxy-addr@2.0.7", "https://registry.npmmirror.com/proxy-addr/-/proxy-addr-2.0.7.tgz", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
@@ -2063,6 +2183,8 @@
     "require-directory": ["require-directory@2.1.1", "https://registry.npmmirror.com/require-directory/-/require-directory-2.1.1.tgz", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "require-from-string": ["require-from-string@2.0.2", "https://registry.npmmirror.com/require-from-string/-/require-from-string-2.0.2.tgz", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
 
     "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
@@ -2317,6 +2439,8 @@
     "y18n": ["y18n@5.0.8", "https://registry.npmmirror.com/y18n/-/y18n-5.0.8.tgz", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
     "yallist": ["yallist@3.1.1", "https://registry.npmmirror.com/yallist/-/yallist-3.1.1.tgz", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "yargs": ["yargs@17.7.2", "https://registry.npmmirror.com/yargs/-/yargs-17.7.2.tgz", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 


### PR DESCRIPTION
## Summary
Spec 28 M3+ Phase 1. New addon `@linchkit/cap-observability-otel` wires the existing `packages/core/src/observability/` seam (Tracer + Meter interfaces) to OpenTelemetry SDK.

## Design
- **Adapter** (`./adapter`) — `createOtelAdapter(opts)` returns a frozen `Observability` bundle whose tracer/meter delegate to OTel. DI slots (`tracerProvider`/`meterProvider`) sidestep `mock.module` cross-test leaks and keep tests isolated.
- **Bootstrap** (`./bootstrap`) — `bootstrapNodeSdk(opts)` builds `NodeSDK` with OTLP/HTTP trace + metric exporters. Honours `OTEL_EXPORTER_OTLP_ENDPOINT`; supports `disableTraces` / `disableMetrics` toggles; **does not auto-start** (users opt in).
- **Capability** — `autoInstall: false` (OTel has runtime + network cost).
- **Idempotent `end()`** — extra safety beyond OTel's contract.

Split exports (`./adapter` vs `./bootstrap`) so environments without `sdk-node` (e.g., browser/edge) can import the lighter adapter.

## OTel package versions (verified via context7)
- `@opentelemetry/api ^1.9.0` (peer)
- `@opentelemetry/sdk-node ^0.218.0`
- `@opentelemetry/exporter-trace-otlp-http ^0.218.0`
- `@opentelemetry/exporter-metrics-otlp-http ^0.218.0`
- `@opentelemetry/sdk-metrics ^2.7.0`
- `@opentelemetry/resources ^2.7.0` (post-2.x `resourceFromAttributes` API)
- `@opentelemetry/semantic-conventions ^1.41.0`

## Out of scope (Phase 2+)
- Context propagation across async boundaries
- Auto-instrumentations (HTTP, Drizzle, etc.)
- Logs exporter

## Verification
- `bun run check` — clean (1151 files)
- `bun run typecheck` — clean
- `bun test` — 5178 pass / 3 skip / 0 fail (325 files)
- 22 tests / 49 assertions for this addon

## Test plan
- [x] Span lifecycle (start, attributes, status ok/error, recordException, end)
- [x] `end()` idempotent under double-call
- [x] Counter `add`/Histogram `record` forward to OTel meter
- [x] `createOtelAdapter` returns frozen bundle satisfying `Observability`
- [x] `bootstrapNodeSdk` honours endpoint env + disable toggles

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenTelemetry observability integration: tracer and meter adapters, plus a frozen adapter factory
  * Node.js SDK bootstrap helper to configure OTLP endpoints, headers, and enable/disable traces or metrics

* **Documentation**
  * Comprehensive README with usage examples, env var guidance, and Phase 1 feature notes

* **Tests**
  * Expanded test coverage for tracer, span, meter, counter, histogram, adapter factory, and endpoint resolution

* **Chores**
  * Package exports and TypeScript configuration added for the new package

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laofahai/linchkit/pull/329?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->