### PR TITLE
feat(cap-view-calendar): month/week/day calendar view via @dnd-kit (refs #86)

### DIFF
--- a/addons/view-calendar/cap-view-calendar/README.md
+++ b/addons/view-calendar/cap-view-calendar/README.md
@@ -1,0 +1,65 @@
+# @linchkit/cap-view-calendar
+
+Calendar view capability — month / week / day grid for entities with a date field.
+
+Implements one of the advanced view types described in [Spec 54](../../docs/specs/54_advanced_ui_features.md). Tracks [issue #86](https://github.com/laofahai/linchkit/issues/86).
+
+## Install
+
+```bash
+bun add @linchkit/cap-view-calendar
+```
+
+Register it alongside `cap-adapter-ui` (the calendar is rendered inside the React UI shell):
+
+```ts
+import { capViewCalendar } from "@linchkit/cap-view-calendar";
+// pass to your capability set
+```
+
+`autoInstall: false` — opt in per project.
+
+## Usage
+
+```tsx
+import { CalendarBoard } from "@linchkit/cap-view-calendar";
+
+<CalendarBoard
+  entity="task"
+  dateField="due_date"
+  endDateField="end_date"   // optional, enables multi-day bars
+  titleField="title"
+  data={records}
+  initialMode="month"        // "month" | "week" | "day"
+  onEventClick={(record) => router.navigate(`/tasks/${record.id}`)}
+  onMoveEvent={(record, newDate) => updateDueDate(record.id, newDate)}
+/>;
+```
+
+### Props
+
+| Prop          | Type                                | Required | Notes                                                |
+| ------------- | ----------------------------------- | :------: | ---------------------------------------------------- |
+| `entity`      | `string`                            | yes      | Entity name (used for keying / labelling)            |
+| `dateField`   | `string`                            | yes      | Field holding the event start date                   |
+| `titleField`  | `string`                            | yes      | Field rendered as the chip title                     |
+| `data`        | `Record<string, unknown>[]`         | yes      | Source records                                       |
+| `endDateField`| `string`                            | no       | Enables multi-day bars                               |
+| `initialMode` | `"month" \| "week" \| "day"`        | no       | Default: `"month"`                                   |
+| `currentDate` | `Date`                              | no       | Controlled focal date                                |
+| `onDateChange`| `(date: Date) => void`              | no       | Fires when the user navigates                        |
+| `loading`     | `boolean`                           | no       | Renders the loading slot                             |
+| `error`       | `Error \| null`                     | no       | Renders the error slot                               |
+| `onEventClick`| `(record) => void`                  | no       | Fires when an event chip is clicked                  |
+| `onMoveEvent` | `(record, newDate: Date) => void`   | no       | Fires after the user drops an event on a new day     |
+
+## Architecture notes
+
+- Pure date logic lives in `use-calendar-data.ts` — fully covered by `__tests__/use-calendar-data.test.ts`.
+- Rendering is `CalendarBoard` → `CalendarGrid` → `CalendarEvent`.
+- Drag-and-drop uses `@dnd-kit/core` (matches the rest of LinchKit's interactive views).
+- Headless data layer: the component never calls GraphQL — pass `data` from the host.
+
+## License
+
+MIT, part of the LinchKit project.

--- a/addons/view-calendar/cap-view-calendar/__tests__/CalendarBoard.test.tsx
+++ b/addons/view-calendar/cap-view-calendar/__tests__/CalendarBoard.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Surface tests for CalendarBoard.
+ *
+ * Bun's default runner has no DOM, so we don't render React end-to-end
+ * (mirrors the cap-search-ui convention). Instead we verify the
+ * exported surface and prop contract holds — the wire contract that
+ * downstream consumers depend on.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+const surface = await import("../src/index");
+const { capViewCalendar } = surface;
+
+describe("cap-view-calendar capability", () => {
+  it("declares the expected metadata", () => {
+    expect(capViewCalendar.name).toBe("cap-view-calendar");
+    expect(capViewCalendar.type).toBe("standard");
+    expect(capViewCalendar.category).toBe("view");
+    expect(capViewCalendar.version).toBe("0.1.0");
+    expect(capViewCalendar.autoInstall).toBe(false);
+  });
+
+  it("depends on cap-adapter-ui", () => {
+    expect(capViewCalendar.dependencies).toEqual(["cap-adapter-ui"]);
+  });
+});
+
+describe("cap-view-calendar exports", () => {
+  it("exposes the rendering surface", () => {
+    expect(typeof surface.CalendarBoard).toBe("function");
+    expect(typeof surface.CalendarGrid).toBe("function");
+    expect(typeof surface.CalendarEvent).toBe("function");
+  });
+
+  it("exposes the pure-logic helpers", () => {
+    expect(typeof surface.parseCalendarDate).toBe("function");
+    expect(typeof surface.toDayKey).toBe("function");
+    expect(typeof surface.getCalendarRange).toBe("function");
+    expect(typeof surface.toEventChips).toBe("function");
+    expect(typeof surface.bucketChipsIntoCells).toBe("function");
+    expect(typeof surface.useCalendarData).toBe("function");
+  });
+});
+
+describe("CalendarBoard prop contract", () => {
+  it("accepts the documented prop shape without runtime errors", () => {
+    // Compile-time check via type — assigning a valid prop bag must succeed.
+    const props: import("../src/types").CalendarBoardProps = {
+      entity: "task",
+      dateField: "due_date",
+      titleField: "title",
+      data: [
+        { id: 1, due_date: "2026-05-16", title: "Review" },
+        { id: 2, due_date: "2026-05-17", end_date: "2026-05-19", title: "Workshop" },
+      ],
+      endDateField: "end_date",
+      initialMode: "month",
+      onEventClick: () => {
+        /* noop */
+      },
+      onMoveEvent: () => {
+        /* noop */
+      },
+    };
+    expect(props.entity).toBe("task");
+    expect(props.data.length).toBe(2);
+  });
+
+  it("treats all view-mode discriminants as assignable", () => {
+    const modes: import("../src/types").CalendarViewMode[] = ["month", "week", "day"];
+    expect(modes.length).toBe(3);
+  });
+});

--- a/addons/view-calendar/cap-view-calendar/__tests__/use-calendar-data.test.ts
+++ b/addons/view-calendar/cap-view-calendar/__tests__/use-calendar-data.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { describe, expect, it } from "bun:test";
+import { DAY_DROPPABLE_PREFIX, dayDroppableId, parseDayDroppableId } from "../src/droppable-ids";
 import {
   bucketChipsIntoCells,
   getCalendarRange,
@@ -19,20 +20,36 @@ describe("parseCalendarDate", () => {
     expect(parseCalendarDate("")).toBeNull();
   });
 
-  it("parses ISO strings, Date objects, and epoch ms", () => {
-    const iso = parseCalendarDate("2026-05-16");
-    expect(iso).toBeInstanceOf(Date);
-    expect(iso?.getFullYear()).toBe(2026);
+  it("parses ISO strings via parseISO", () => {
+    const dateOnly = parseCalendarDate("2026-05-16");
+    expect(dateOnly).toBeInstanceOf(Date);
+    expect(dateOnly?.getFullYear()).toBe(2026);
 
-    const native = parseCalendarDate(new Date("2026-05-16T12:00:00Z"));
-    expect(native?.getUTCDate()).toBe(16);
+    const withTime = parseCalendarDate("2026-05-16T09:30:00Z");
+    expect(withTime).toBeInstanceOf(Date);
+    expect(withTime?.getUTCHours()).toBe(9);
+  });
 
+  it("passes Date inputs through (when valid)", () => {
+    const input = new Date("2026-05-16T12:00:00Z");
+    const out = parseCalendarDate(input);
+    expect(out).toBe(input);
+    expect(out?.getUTCDate()).toBe(16);
+  });
+
+  it("returns null for an Invalid Date input", () => {
+    expect(parseCalendarDate(new Date("not-a-date"))).toBeNull();
+  });
+
+  it("parses epoch ms numbers", () => {
     const ms = parseCalendarDate(1747353600000);
     expect(ms).toBeInstanceOf(Date);
   });
 
-  it("returns null for unparseable strings", () => {
+  it("returns null for non-ISO strings (no native Date fallback)", () => {
     expect(parseCalendarDate("not-a-date")).toBeNull();
+    // Legacy human-readable form parsed by `new Date(string)` must NOT slip through.
+    expect(parseCalendarDate("May 16 2026")).toBeNull();
   });
 });
 
@@ -114,13 +131,47 @@ describe("toEventChips", () => {
     expect(chips[0]?.end.getDate()).toBe(chips[0]?.start.getDate());
   });
 
-  it("synthesises a stable id when record.id is missing", () => {
-    const chips = toEventChips({
-      records: [{ due_date: "2026-05-16", title: "Standalone" }],
-      dateField: "due_date",
-      titleField: "title",
-    });
-    expect(chips[0]?.id).toBe("chip-0");
+  it("throws when a record is missing its id field", () => {
+    expect(() =>
+      toEventChips({
+        records: [{ due_date: "2026-05-16", title: "Standalone" }],
+        dateField: "due_date",
+        titleField: "title",
+      }),
+    ).toThrow(/must have an `id` field/);
+  });
+
+  it("throws when id is null or empty", () => {
+    expect(() =>
+      toEventChips({
+        records: [{ id: null, due_date: "2026-05-16", title: "Null" }],
+        dateField: "due_date",
+        titleField: "title",
+      }),
+    ).toThrow(/must have an `id` field/);
+    expect(() =>
+      toEventChips({
+        records: [{ id: "", due_date: "2026-05-16", title: "Empty" }],
+        dateField: "due_date",
+        titleField: "title",
+      }),
+    ).toThrow(/must have an `id` field/);
+  });
+});
+
+describe("dayDroppableId", () => {
+  it("prefixes the day key with the shared constant", () => {
+    expect(dayDroppableId("2026-05-16")).toBe(`${DAY_DROPPABLE_PREFIX}2026-05-16`);
+  });
+
+  it("round-trips through parseDayDroppableId", () => {
+    const id = dayDroppableId("2026-05-16");
+    expect(parseDayDroppableId(id)).toBe("2026-05-16");
+  });
+
+  it("returns null for unrelated droppable ids", () => {
+    expect(parseDayDroppableId("chip:abc")).toBeNull();
+    expect(parseDayDroppableId("2026-05-16")).toBeNull();
   });
 });
 

--- a/addons/view-calendar/cap-view-calendar/__tests__/use-calendar-data.test.ts
+++ b/addons/view-calendar/cap-view-calendar/__tests__/use-calendar-data.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Pure-logic tests for the calendar data pipeline. No DOM is required —
+ * we exercise date bucketing, week boundaries, and multi-day spans.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  bucketChipsIntoCells,
+  getCalendarRange,
+  parseCalendarDate,
+  toDayKey,
+  toEventChips,
+} from "../src/use-calendar-data";
+
+describe("parseCalendarDate", () => {
+  it("returns null for empty input", () => {
+    expect(parseCalendarDate(null)).toBeNull();
+    expect(parseCalendarDate(undefined)).toBeNull();
+    expect(parseCalendarDate("")).toBeNull();
+  });
+
+  it("parses ISO strings, Date objects, and epoch ms", () => {
+    const iso = parseCalendarDate("2026-05-16");
+    expect(iso).toBeInstanceOf(Date);
+    expect(iso?.getFullYear()).toBe(2026);
+
+    const native = parseCalendarDate(new Date("2026-05-16T12:00:00Z"));
+    expect(native?.getUTCDate()).toBe(16);
+
+    const ms = parseCalendarDate(1747353600000);
+    expect(ms).toBeInstanceOf(Date);
+  });
+
+  it("returns null for unparseable strings", () => {
+    expect(parseCalendarDate("not-a-date")).toBeNull();
+  });
+});
+
+describe("toDayKey", () => {
+  it("formats a date as local yyyy-MM-dd without UTC drift", () => {
+    const date = new Date(2026, 4, 16); // May 16 2026 local
+    expect(toDayKey(date)).toBe("2026-05-16");
+  });
+
+  it("zero-pads single-digit month and day", () => {
+    const date = new Date(2026, 0, 7);
+    expect(toDayKey(date)).toBe("2026-01-07");
+  });
+});
+
+describe("getCalendarRange", () => {
+  const anchor = new Date(2026, 4, 16); // Saturday May 16 2026
+
+  it("expands month view to full weeks", () => {
+    const { start, end } = getCalendarRange(anchor, "month");
+    // May 2026 starts on a Friday, so week-aligned (Sunday start) ⇒ Apr 26.
+    expect(toDayKey(start)).toBe("2026-04-26");
+    // May 2026 ends on Sunday May 31; week-aligned end is Sat Jun 6.
+    expect(toDayKey(end)).toBe("2026-06-06");
+  });
+
+  it("aligns week view to Sunday→Saturday around the anchor", () => {
+    const { start, end } = getCalendarRange(anchor, "week");
+    expect(toDayKey(start)).toBe("2026-05-10");
+    expect(toDayKey(end)).toBe("2026-05-16");
+  });
+
+  it("collapses day view to the anchor date", () => {
+    const { start, end } = getCalendarRange(anchor, "day");
+    expect(toDayKey(start)).toBe(toDayKey(end));
+    expect(toDayKey(start)).toBe("2026-05-16");
+  });
+});
+
+describe("toEventChips", () => {
+  it("drops records without a parseable start date", () => {
+    const chips = toEventChips({
+      records: [{ id: 1, due_date: "2026-05-16" }, { id: 2, due_date: null }, { id: 3 }],
+      dateField: "due_date",
+      titleField: "title",
+    });
+    expect(chips.length).toBe(1);
+    expect(chips[0]?.id).toBe("1");
+  });
+
+  it("falls back to id when title is missing", () => {
+    const chips = toEventChips({
+      records: [{ id: "abc", due_date: "2026-05-16" }],
+      dateField: "due_date",
+      titleField: "title",
+    });
+    expect(chips[0]?.title).toBe("abc");
+  });
+
+  it("uses endDateField when later than start", () => {
+    const chips = toEventChips({
+      records: [{ id: 1, start: "2026-05-16", finish: "2026-05-18" }],
+      dateField: "start",
+      endDateField: "finish",
+      titleField: "title",
+    });
+    expect(chips[0]?.start.getDate()).toBe(16);
+    expect(chips[0]?.end.getDate()).toBe(18);
+  });
+
+  it("collapses end back to start when end < start", () => {
+    const chips = toEventChips({
+      records: [{ id: 1, start: "2026-05-20", finish: "2026-05-18" }],
+      dateField: "start",
+      endDateField: "finish",
+      titleField: "title",
+    });
+    // Bad end is ignored.
+    expect(chips[0]?.end.getDate()).toBe(chips[0]?.start.getDate());
+  });
+
+  it("synthesises a stable id when record.id is missing", () => {
+    const chips = toEventChips({
+      records: [{ due_date: "2026-05-16", title: "Standalone" }],
+      dateField: "due_date",
+      titleField: "title",
+    });
+    expect(chips[0]?.id).toBe("chip-0");
+  });
+});
+
+describe("bucketChipsIntoCells", () => {
+  const range = getCalendarRange(new Date(2026, 4, 16), "week");
+
+  it("places single-day events on their start day only", () => {
+    const chips = toEventChips({
+      records: [{ id: 1, due_date: "2026-05-12", title: "T" }],
+      dateField: "due_date",
+      titleField: "title",
+    });
+    const cells = bucketChipsIntoCells({ chips, range, focalMonth: new Date(2026, 4, 16) });
+    const counts = cells.map((cell) => cell.events.length);
+    expect(counts).toEqual([0, 0, 1, 0, 0, 0, 0]);
+  });
+
+  it("spans multi-day events across every overlapping cell", () => {
+    const chips = toEventChips({
+      records: [{ id: 1, start: "2026-05-11", finish: "2026-05-14", title: "Span" }],
+      dateField: "start",
+      endDateField: "finish",
+      titleField: "title",
+    });
+    const cells = bucketChipsIntoCells({ chips, range, focalMonth: new Date(2026, 4, 16) });
+    const days = cells.filter((cell) => cell.events.length > 0).map((cell) => cell.key);
+    expect(days).toEqual(["2026-05-11", "2026-05-12", "2026-05-13", "2026-05-14"]);
+  });
+
+  it("flags cells outside the focal month for month view styling", () => {
+    const monthRange = getCalendarRange(new Date(2026, 4, 16), "month");
+    const cells = bucketChipsIntoCells({
+      chips: [],
+      range: monthRange,
+      focalMonth: new Date(2026, 4, 16),
+    });
+    const firstInFocal = cells.find((cell) => cell.date.getMonth() === 4);
+    const lastBefore = cells.find((cell) => cell.date.getMonth() === 3);
+    expect(firstInFocal?.inFocalMonth).toBe(true);
+    expect(lastBefore?.inFocalMonth).toBe(false);
+  });
+
+  it("sorts overlapping events by start ascending", () => {
+    const chips = toEventChips({
+      records: [
+        { id: "later", due_date: "2026-05-12T15:00:00Z", title: "later" },
+        { id: "earlier", due_date: "2026-05-12T09:00:00Z", title: "earlier" },
+      ],
+      dateField: "due_date",
+      titleField: "title",
+    });
+    const cells = bucketChipsIntoCells({ chips, range, focalMonth: new Date(2026, 4, 16) });
+    const targetCell = cells.find((cell) => cell.events.length === 2);
+    expect(targetCell?.events.map((event) => event.id)).toEqual(["earlier", "later"]);
+  });
+});

--- a/addons/view-calendar/cap-view-calendar/package.json
+++ b/addons/view-calendar/cap-view-calendar/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@linchkit/cap-view-calendar",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "files": [
+    "src/",
+    "package.json",
+    "README.md"
+  ],
+  "exports": {
+    ".": "./src/index.ts",
+    "./capability": "./src/capability.ts"
+  },
+  "scripts": {
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "date-fns": "^4.1.0"
+  },
+  "peerDependencies": {
+    "@linchkit/core": "^0.2.0",
+    "@linchkit/cap-adapter-ui": "^1.0.0",
+    "react": "^19.0.0"
+  },
+  "devDependencies": {
+    "@linchkit/core": "workspace:*",
+    "@linchkit/cap-adapter-ui": "workspace:*",
+    "typescript": "^6.0.2"
+  },
+  "linchkit": {
+    "minCoreVersion": "^0.2.0",
+    "type": "standard",
+    "category": "view",
+    "autoInstall": false
+  }
+}

--- a/addons/view-calendar/cap-view-calendar/src/CalendarBoard.tsx
+++ b/addons/view-calendar/cap-view-calendar/src/CalendarBoard.tsx
@@ -14,6 +14,7 @@ import { DndContext, type DragEndEvent, PointerSensor, useSensor, useSensors } f
 import { addDays, addMonths, format, parse, startOfDay, subDays, subMonths } from "date-fns";
 import { useCallback, useMemo, useState } from "react";
 import { CalendarGrid } from "./CalendarGrid";
+import { parseDayDroppableId } from "./droppable-ids";
 import type { CalendarBoardProps, CalendarRecord, CalendarViewMode } from "./types";
 import { useCalendarData } from "./use-calendar-data";
 
@@ -97,9 +98,8 @@ export function CalendarBoard(props: CalendarBoardProps) {
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
       if (!onMoveEvent || !event.over) return;
-      const overId = String(event.over.id);
-      if (!overId.startsWith("day:")) return;
-      const dayKey = overId.slice("day:".length);
+      const dayKey = parseDayDroppableId(String(event.over.id));
+      if (dayKey === null) return;
       const record = chipsById.get(String(event.active.id));
       if (!record) return;
       const targetDate = parse(dayKey, "yyyy-MM-dd", new Date());

--- a/addons/view-calendar/cap-view-calendar/src/CalendarBoard.tsx
+++ b/addons/view-calendar/cap-view-calendar/src/CalendarBoard.tsx
@@ -1,0 +1,202 @@
+/**
+ * CalendarBoard — top-level view component.
+ *
+ * Renders a header (mode toggle + date navigation) and delegates the cell
+ * grid to CalendarGrid. Drag-and-drop lives at this level so the host's
+ * `onMoveEvent` callback receives the resolved target date.
+ *
+ * The component is *headless* in the sense that it carries no API
+ * dependencies — callers pass `data` directly. This keeps the capability
+ * independent of cap-adapter-ui's data fetching layer.
+ */
+
+import { DndContext, type DragEndEvent, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
+import { addDays, addMonths, format, parse, startOfDay, subDays, subMonths } from "date-fns";
+import { useCallback, useMemo, useState } from "react";
+import { CalendarGrid } from "./CalendarGrid";
+import type { CalendarBoardProps, CalendarRecord, CalendarViewMode } from "./types";
+import { useCalendarData } from "./use-calendar-data";
+
+const MODE_OPTIONS: readonly CalendarViewMode[] = ["month", "week", "day"] as const;
+
+function formatHeader(date: Date, mode: CalendarViewMode): string {
+  if (mode === "month") return format(date, "MMMM yyyy");
+  if (mode === "day") return format(date, "EEEE, MMMM d, yyyy");
+  return format(date, "'Week of' MMM d, yyyy");
+}
+
+/**
+ * Top-level calendar capability surface. See README for the prop contract.
+ */
+export function CalendarBoard(props: CalendarBoardProps) {
+  const {
+    entity,
+    dateField,
+    endDateField,
+    titleField,
+    data,
+    initialMode = "month",
+    currentDate: controlledDate,
+    onDateChange,
+    loading = false,
+    error = null,
+    onEventClick,
+    onMoveEvent,
+  } = props;
+
+  const [mode, setMode] = useState<CalendarViewMode>(initialMode);
+  const [internalDate, setInternalDate] = useState<Date>(() => startOfDay(new Date()));
+  const currentDate = controlledDate ?? internalDate;
+
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }));
+
+  const { cells } = useCalendarData({
+    records: data,
+    dateField,
+    endDateField,
+    titleField,
+    currentDate,
+    mode,
+  });
+
+  const setCurrentDate = useCallback(
+    (next: Date) => {
+      if (controlledDate === undefined) setInternalDate(next);
+      onDateChange?.(next);
+    },
+    [controlledDate, onDateChange],
+  );
+
+  const handlePrev = useCallback(() => {
+    if (mode === "month") setCurrentDate(subMonths(currentDate, 1));
+    else if (mode === "week") setCurrentDate(subDays(currentDate, 7));
+    else setCurrentDate(subDays(currentDate, 1));
+  }, [mode, currentDate, setCurrentDate]);
+
+  const handleNext = useCallback(() => {
+    if (mode === "month") setCurrentDate(addMonths(currentDate, 1));
+    else if (mode === "week") setCurrentDate(addDays(currentDate, 7));
+    else setCurrentDate(addDays(currentDate, 1));
+  }, [mode, currentDate, setCurrentDate]);
+
+  const handleToday = useCallback(() => {
+    setCurrentDate(startOfDay(new Date()));
+  }, [setCurrentDate]);
+
+  // Map drag end to the host's onMoveEvent callback.
+  const chipsById = useMemo(() => {
+    const map = new Map<string, CalendarRecord>();
+    for (const cell of cells) {
+      for (const chip of cell.events) {
+        map.set(chip.id, chip.record);
+      }
+    }
+    return map;
+  }, [cells]);
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      if (!onMoveEvent || !event.over) return;
+      const overId = String(event.over.id);
+      if (!overId.startsWith("day:")) return;
+      const dayKey = overId.slice("day:".length);
+      const record = chipsById.get(String(event.active.id));
+      if (!record) return;
+      const targetDate = parse(dayKey, "yyyy-MM-dd", new Date());
+      if (Number.isNaN(targetDate.getTime())) return;
+      onMoveEvent(record, startOfDay(targetDate));
+    },
+    [chipsById, onMoveEvent],
+  );
+
+  // ── State branches ────────────────────────────────────────
+
+  if (error) {
+    return (
+      <div
+        data-testid="calendar-error"
+        className="rounded border border-destructive bg-destructive/5 p-4 text-sm text-destructive"
+      >
+        {error.message || "Failed to load calendar"}
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div
+        data-testid="calendar-loading"
+        className="flex items-center justify-center py-16 text-sm text-muted-foreground"
+      >
+        Loading calendar…
+      </div>
+    );
+  }
+
+  const isEmpty = cells.every((cell) => cell.events.length === 0);
+
+  return (
+    <div data-testid="calendar-board" data-entity={entity} className="space-y-3">
+      <header className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-1 rounded border border-border bg-muted/30 p-0.5">
+          {MODE_OPTIONS.map((option) => (
+            <button
+              key={option}
+              type="button"
+              data-testid={`mode-${option}`}
+              onClick={() => setMode(option)}
+              className={`rounded px-2 py-1 text-xs capitalize ${
+                mode === option ? "bg-background shadow-sm" : "text-muted-foreground"
+              }`}
+            >
+              {option}
+            </button>
+          ))}
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={handleToday}
+            className="rounded border border-border px-2 py-1 text-xs hover:bg-muted/50"
+          >
+            Today
+          </button>
+          <button
+            type="button"
+            aria-label="Previous"
+            onClick={handlePrev}
+            className="rounded border border-border px-2 py-1 text-xs hover:bg-muted/50"
+          >
+            ‹
+          </button>
+          <span className="min-w-[180px] text-center text-sm font-medium">
+            {formatHeader(currentDate, mode)}
+          </span>
+          <button
+            type="button"
+            aria-label="Next"
+            onClick={handleNext}
+            className="rounded border border-border px-2 py-1 text-xs hover:bg-muted/50"
+          >
+            ›
+          </button>
+        </div>
+      </header>
+
+      <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+        <CalendarGrid
+          cells={cells}
+          mode={mode}
+          draggable={Boolean(onMoveEvent)}
+          onEventClick={(chip) => onEventClick?.(chip.record)}
+        />
+      </DndContext>
+
+      {isEmpty && (
+        <div data-testid="calendar-empty" className="text-center text-xs text-muted-foreground">
+          No events in this range.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/addons/view-calendar/cap-view-calendar/src/CalendarEvent.tsx
+++ b/addons/view-calendar/cap-view-calendar/src/CalendarEvent.tsx
@@ -1,0 +1,50 @@
+/**
+ * CalendarEvent — single draggable event chip rendered inside a day cell.
+ *
+ * Wraps @dnd-kit's useDraggable so the host's onMoveEvent receives the
+ * dropped target day. Stops click propagation so the surrounding day cell
+ * doesn't also receive a click.
+ */
+
+import { useDraggable } from "@dnd-kit/core";
+import type { CSSProperties } from "react";
+import type { CalendarEventChip } from "./types";
+
+export interface CalendarEventProps {
+  chip: CalendarEventChip;
+  /** When true, the chip is purely visual (no drag handle). */
+  draggable?: boolean;
+  /** Click handler — receives the source record. */
+  onClick?: (chip: CalendarEventChip) => void;
+}
+
+export function CalendarEvent({ chip, draggable = true, onClick }: CalendarEventProps) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: chip.id,
+    disabled: !draggable,
+  });
+
+  const style: CSSProperties = {
+    transform: transform ? `translate3d(${transform.x}px, ${transform.y}px, 0)` : undefined,
+    opacity: isDragging ? 0.5 : undefined,
+  };
+
+  return (
+    <button
+      type="button"
+      ref={setNodeRef}
+      style={style}
+      data-testid="calendar-event"
+      onClick={(event) => {
+        event.stopPropagation();
+        onClick?.(chip);
+      }}
+      className="block w-full truncate rounded bg-primary/10 px-1 py-0.5 text-left text-[10px] leading-tight text-primary hover:bg-primary/20 focus:outline-none focus:ring-1 focus:ring-ring"
+      title={chip.title}
+      {...listeners}
+      {...attributes}
+    >
+      {chip.title}
+    </button>
+  );
+}

--- a/addons/view-calendar/cap-view-calendar/src/CalendarGrid.tsx
+++ b/addons/view-calendar/cap-view-calendar/src/CalendarGrid.tsx
@@ -1,0 +1,115 @@
+/**
+ * CalendarGrid — pure presentation of the bucketed day cells.
+ *
+ * Mode controls layout:
+ * - month: 7-column grid with full week padding.
+ * - week:  7-column single-row grid.
+ * - day:   single tall column.
+ *
+ * Each day cell is a droppable target so events can be re-parented onto it
+ * via drag-and-drop. Click on empty space inside a cell is a no-op (matches
+ * Spec 54 — click handlers live on the events themselves).
+ */
+
+import { useDroppable } from "@dnd-kit/core";
+import { format, isToday } from "date-fns";
+import { CalendarEvent } from "./CalendarEvent";
+import type { CalendarDayCell, CalendarEventChip, CalendarViewMode } from "./types";
+
+const WEEKDAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+
+export interface CalendarGridProps {
+  cells: CalendarDayCell[];
+  mode: CalendarViewMode;
+  draggable: boolean;
+  onEventClick?: (chip: CalendarEventChip) => void;
+}
+
+interface DayCellProps {
+  cell: CalendarDayCell;
+  mode: CalendarViewMode;
+  draggable: boolean;
+  onEventClick?: (chip: CalendarEventChip) => void;
+}
+
+function DayCell({ cell, mode, draggable, onEventClick }: DayCellProps) {
+  const { setNodeRef, isOver } = useDroppable({ id: `day:${cell.key}` });
+  const today = isToday(cell.date);
+  const muted = mode === "month" && !cell.inFocalMonth;
+
+  const baseClass = "flex flex-col gap-1 border border-border p-1 text-left";
+  const sizeClass = mode === "day" ? "min-h-[400px]" : "min-h-[90px]";
+  const stateClass = [
+    muted ? "bg-muted/20 text-muted-foreground/60" : "",
+    isOver ? "ring-2 ring-primary/60" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div
+      ref={setNodeRef}
+      data-testid="calendar-day-cell"
+      data-day={cell.key}
+      className={`${baseClass} ${sizeClass} ${stateClass}`.trim()}
+    >
+      <div className="flex items-center justify-between text-[11px]">
+        <span
+          className={
+            today
+              ? "inline-flex h-5 w-5 items-center justify-center rounded-full bg-primary text-primary-foreground"
+              : ""
+          }
+        >
+          {format(cell.date, "d")}
+        </span>
+        {cell.events.length > 0 && (
+          <span className="text-muted-foreground">{cell.events.length}</span>
+        )}
+      </div>
+      <div className="flex flex-col gap-0.5">
+        {cell.events.map((chip) => (
+          <CalendarEvent
+            key={`${cell.key}:${chip.id}`}
+            chip={chip}
+            draggable={draggable}
+            onClick={onEventClick}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function CalendarGrid({ cells, mode, draggable, onEventClick }: CalendarGridProps) {
+  const columns = mode === "day" ? 1 : 7;
+  const showWeekdayHeader = mode !== "day";
+
+  return (
+    <div data-testid="calendar-grid" data-mode={mode}>
+      {showWeekdayHeader && (
+        <div
+          className="grid border-b border-border bg-muted/40 text-center text-[11px] font-medium text-muted-foreground"
+          style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}
+        >
+          {WEEKDAY_LABELS.map((label) => (
+            <div key={label} className="py-1">
+              {label}
+            </div>
+          ))}
+        </div>
+      )}
+      <div className="grid" style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}>
+        {cells.map((cell) => (
+          <DayCell
+            key={cell.key}
+            cell={cell}
+            mode={mode}
+            draggable={draggable}
+            onEventClick={onEventClick}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/addons/view-calendar/cap-view-calendar/src/CalendarGrid.tsx
+++ b/addons/view-calendar/cap-view-calendar/src/CalendarGrid.tsx
@@ -14,6 +14,7 @@
 import { useDroppable } from "@dnd-kit/core";
 import { format, isToday } from "date-fns";
 import { CalendarEvent } from "./CalendarEvent";
+import { dayDroppableId } from "./droppable-ids";
 import type { CalendarDayCell, CalendarEventChip, CalendarViewMode } from "./types";
 
 const WEEKDAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
@@ -33,7 +34,7 @@ interface DayCellProps {
 }
 
 function DayCell({ cell, mode, draggable, onEventClick }: DayCellProps) {
-  const { setNodeRef, isOver } = useDroppable({ id: `day:${cell.key}` });
+  const { setNodeRef, isOver } = useDroppable({ id: dayDroppableId(cell.key) });
   const today = isToday(cell.date);
   const muted = mode === "month" && !cell.inFocalMonth;
 

--- a/addons/view-calendar/cap-view-calendar/src/capability.ts
+++ b/addons/view-calendar/cap-view-calendar/src/capability.ts
@@ -1,0 +1,22 @@
+/**
+ * cap-view-calendar capability definition.
+ *
+ * Headless calendar surface for cap-adapter-ui. Logic lives in
+ * use-calendar-data; rendering ships as CalendarBoard. Auto-installation is
+ * opt-in because not every project wants a calendar view by default.
+ */
+
+import { defineCapability } from "@linchkit/core";
+
+export const capViewCalendar = defineCapability({
+  name: "cap-view-calendar",
+  label: "Calendar View",
+  description:
+    "Month / week / day calendar renderer for entities with a date field. Pairs with cap-adapter-ui.",
+  type: "standard",
+  category: "view",
+  version: "0.1.0",
+  group: "view-calendar",
+  dependencies: ["cap-adapter-ui"],
+  autoInstall: false,
+});

--- a/addons/view-calendar/cap-view-calendar/src/droppable-ids.ts
+++ b/addons/view-calendar/cap-view-calendar/src/droppable-ids.ts
@@ -1,0 +1,21 @@
+/**
+ * Droppable-id helpers — keep the magic prefix in a single place so the
+ * grid (producer) and the board (consumer) cannot drift apart.
+ */
+
+/** Prefix applied to all calendar day droppables. */
+export const DAY_DROPPABLE_PREFIX = "day:" as const;
+
+/** Build a droppable id for a given day key (yyyy-MM-dd). */
+export function dayDroppableId(dayKey: string): string {
+  return `${DAY_DROPPABLE_PREFIX}${dayKey}`;
+}
+
+/**
+ * Parse a droppable id back into its day-key payload. Returns `null` when
+ * the id was not produced by `dayDroppableId`.
+ */
+export function parseDayDroppableId(droppableId: string): string | null {
+  if (!droppableId.startsWith(DAY_DROPPABLE_PREFIX)) return null;
+  return droppableId.slice(DAY_DROPPABLE_PREFIX.length);
+}

--- a/addons/view-calendar/cap-view-calendar/src/index.ts
+++ b/addons/view-calendar/cap-view-calendar/src/index.ts
@@ -10,6 +10,11 @@ export { CalendarBoard } from "./CalendarBoard";
 export { CalendarEvent, type CalendarEventProps } from "./CalendarEvent";
 export { CalendarGrid, type CalendarGridProps } from "./CalendarGrid";
 export { capViewCalendar } from "./capability";
+export {
+  DAY_DROPPABLE_PREFIX,
+  dayDroppableId,
+  parseDayDroppableId,
+} from "./droppable-ids";
 export type {
   CalendarBoardProps,
   CalendarDayCell,

--- a/addons/view-calendar/cap-view-calendar/src/index.ts
+++ b/addons/view-calendar/cap-view-calendar/src/index.ts
@@ -1,0 +1,27 @@
+/**
+ * @linchkit/cap-view-calendar — public exports.
+ *
+ * Re-exports the capability descriptor, the React rendering surface, the
+ * pure logic hook, and types so consumers can wire calendar views without
+ * digging into the package internals.
+ */
+
+export { CalendarBoard } from "./CalendarBoard";
+export { CalendarEvent, type CalendarEventProps } from "./CalendarEvent";
+export { CalendarGrid, type CalendarGridProps } from "./CalendarGrid";
+export { capViewCalendar } from "./capability";
+export type {
+  CalendarBoardProps,
+  CalendarDayCell,
+  CalendarEventChip,
+  CalendarRecord,
+  CalendarViewMode,
+} from "./types";
+export {
+  bucketChipsIntoCells,
+  getCalendarRange,
+  parseCalendarDate,
+  toDayKey,
+  toEventChips,
+  useCalendarData,
+} from "./use-calendar-data";

--- a/addons/view-calendar/cap-view-calendar/src/types.ts
+++ b/addons/view-calendar/cap-view-calendar/src/types.ts
@@ -38,7 +38,7 @@ export interface CalendarBoardProps {
 }
 
 export interface CalendarEventChip {
-  /** Stable id used as React key + drag id. Falls back to JSON when record.id is missing. */
+  /** Stable id used as React key + drag id. Sourced directly from `record.id`. */
   id: string;
   /** Source record. */
   record: CalendarRecord;

--- a/addons/view-calendar/cap-view-calendar/src/types.ts
+++ b/addons/view-calendar/cap-view-calendar/src/types.ts
@@ -1,0 +1,63 @@
+/**
+ * Public types for cap-view-calendar.
+ *
+ * Keeps the rendering layer (CalendarBoard / CalendarGrid) decoupled from
+ * the host's entity layer — records are plain key/value bags.
+ */
+
+export type CalendarRecord = Record<string, unknown>;
+
+/** Calendar display granularity. */
+export type CalendarViewMode = "month" | "week" | "day";
+
+export interface CalendarBoardProps {
+  /** Entity name (used purely for keying / labelling — calendar logic never touches the registry). */
+  entity: string;
+  /** Field on each record holding the start date. ISO string, Date, or epoch ms. */
+  dateField: string;
+  /** Optional field holding the end date for multi-day events. */
+  endDateField?: string;
+  /** Field rendered as the visible event title. */
+  titleField: string;
+  /** Records to place on the calendar. */
+  data: CalendarRecord[];
+  /** Initial view mode (default: "month"). */
+  initialMode?: CalendarViewMode;
+  /** Controlled current date — defaults to today on first render. */
+  currentDate?: Date;
+  /** Called when the user navigates to a new reference date. */
+  onDateChange?: (date: Date) => void;
+  /** Loading flag — renders skeleton state. */
+  loading?: boolean;
+  /** Error to surface in the error slot. */
+  error?: Error | null;
+  /** Click handler — fires when the user clicks an event chip. */
+  onEventClick?: (record: CalendarRecord) => void;
+  /** Drag handler — fires after the user drops an event on a new day. */
+  onMoveEvent?: (record: CalendarRecord, newDate: Date) => void;
+}
+
+export interface CalendarEventChip {
+  /** Stable id used as React key + drag id. Falls back to JSON when record.id is missing. */
+  id: string;
+  /** Source record. */
+  record: CalendarRecord;
+  /** Resolved start date. */
+  start: Date;
+  /** Resolved end date — equals start for single-day events. */
+  end: Date;
+  /** Title text rendered on the chip. */
+  title: string;
+}
+
+/** One cell in the rendered grid — a single day with its events. */
+export interface CalendarDayCell {
+  /** Local-date string in yyyy-MM-dd, used as React key. */
+  key: string;
+  /** Midnight in local time of the represented day. */
+  date: Date;
+  /** Events overlapping this day. Ordered by start ascending. */
+  events: CalendarEventChip[];
+  /** Whether the day belongs to the focal month (only meaningful for month view). */
+  inFocalMonth: boolean;
+}

--- a/addons/view-calendar/cap-view-calendar/src/use-calendar-data.ts
+++ b/addons/view-calendar/cap-view-calendar/src/use-calendar-data.ts
@@ -10,6 +10,7 @@ import {
   endOfWeek,
   isBefore,
   isSameDay,
+  isValid,
   parseISO,
   startOfDay,
   startOfMonth,
@@ -23,24 +24,24 @@ const WEEK_STARTS_ON = 0 as const;
 
 /**
  * Parse a date-ish field. Accepts Date, ISO string, epoch ms.
- * Returns null when the value is unset or unparseable so callers can skip the record.
+ *
+ * String inputs MUST be ISO-8601 — we deliberately do not fall back to the
+ * native `new Date(string)` constructor because its non-ISO behaviour is
+ * implementation-defined and silently varies between engines.
+ *
+ * Returns `null` when the value is unset, not one of the supported shapes,
+ * or fails ISO parsing, so callers can skip the record.
  */
 export function parseCalendarDate(value: unknown): Date | null {
   if (value === null || value === undefined || value === "") return null;
-  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+  if (value instanceof Date) return isValid(value) ? value : null;
   if (typeof value === "number") {
     const fromNumber = new Date(value);
-    return Number.isNaN(fromNumber.getTime()) ? null : fromNumber;
+    return isValid(fromNumber) ? fromNumber : null;
   }
   if (typeof value === "string") {
-    try {
-      const parsed = parseISO(value);
-      if (!Number.isNaN(parsed.getTime())) return parsed;
-    } catch {
-      // fall through
-    }
-    const native = new Date(value);
-    return Number.isNaN(native.getTime()) ? null : native;
+    const parsed = parseISO(value);
+    return isValid(parsed) ? parsed : null;
   }
   return null;
 }
@@ -86,6 +87,11 @@ export function toDayKey(date: Date): string {
 /**
  * Project records into CalendarEventChips. Records without a parseable start
  * date are dropped. Multi-day events normalize end >= start.
+ *
+ * Every record MUST carry a stable `id` field — it is used as the React key
+ * and drag-and-drop identity. Index-based fallbacks would silently break
+ * across re-renders (state loss, ghost drag targets), so we fail loudly at
+ * the boundary instead.
  */
 export function toEventChips({
   records,
@@ -113,8 +119,15 @@ export function toEventChips({
       }
     }
 
+    const rawId = record.id;
+    if (rawId === undefined || rawId === null || rawId === "") {
+      throw new Error(
+        `cap-view-calendar: record at index ${i} must have an \`id\` field — calendar chips require a stable id for React keys and drag-and-drop identity.`,
+      );
+    }
+    const id = String(rawId);
+
     const titleRaw = record[titleField];
-    const id = record.id !== undefined && record.id !== null ? String(record.id) : `chip-${i}`;
     chips.push({
       id,
       record,

--- a/addons/view-calendar/cap-view-calendar/src/use-calendar-data.ts
+++ b/addons/view-calendar/cap-view-calendar/src/use-calendar-data.ts
@@ -1,0 +1,198 @@
+/**
+ * use-calendar-data — pure-logic hook (+ helpers) that buckets records into
+ * day cells based on a reference date and view mode. No React rendering
+ * dependencies so the helpers stay test-friendly under bun:test.
+ */
+
+import {
+  eachDayOfInterval,
+  endOfMonth,
+  endOfWeek,
+  isBefore,
+  isSameDay,
+  parseISO,
+  startOfDay,
+  startOfMonth,
+  startOfWeek,
+} from "date-fns";
+import { useMemo } from "react";
+import type { CalendarDayCell, CalendarEventChip, CalendarRecord, CalendarViewMode } from "./types";
+
+/** Default week start — Sunday. Kept hard-coded to match auto-calendar.tsx. */
+const WEEK_STARTS_ON = 0 as const;
+
+/**
+ * Parse a date-ish field. Accepts Date, ISO string, epoch ms.
+ * Returns null when the value is unset or unparseable so callers can skip the record.
+ */
+export function parseCalendarDate(value: unknown): Date | null {
+  if (value === null || value === undefined || value === "") return null;
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+  if (typeof value === "number") {
+    const fromNumber = new Date(value);
+    return Number.isNaN(fromNumber.getTime()) ? null : fromNumber;
+  }
+  if (typeof value === "string") {
+    try {
+      const parsed = parseISO(value);
+      if (!Number.isNaN(parsed.getTime())) return parsed;
+    } catch {
+      // fall through
+    }
+    const native = new Date(value);
+    return Number.isNaN(native.getTime()) ? null : native;
+  }
+  return null;
+}
+
+/**
+ * Return the inclusive [start, end] range of days that should be rendered
+ * for the given mode anchored on `currentDate`. Month mode pads to full weeks.
+ */
+export function getCalendarRange(
+  currentDate: Date,
+  mode: CalendarViewMode,
+): {
+  start: Date;
+  end: Date;
+} {
+  if (mode === "day") {
+    const day = startOfDay(currentDate);
+    return { start: day, end: day };
+  }
+  if (mode === "week") {
+    return {
+      start: startOfWeek(currentDate, { weekStartsOn: WEEK_STARTS_ON }),
+      end: endOfWeek(currentDate, { weekStartsOn: WEEK_STARTS_ON }),
+    };
+  }
+  // month: pad to full weeks so the grid stays rectangular.
+  const monthStart = startOfMonth(currentDate);
+  const monthEnd = endOfMonth(currentDate);
+  return {
+    start: startOfWeek(monthStart, { weekStartsOn: WEEK_STARTS_ON }),
+    end: endOfWeek(monthEnd, { weekStartsOn: WEEK_STARTS_ON }),
+  };
+}
+
+/** Format a Date as a local yyyy-MM-dd key. Avoids UTC drift around midnight. */
+export function toDayKey(date: Date): string {
+  const year = date.getFullYear().toString().padStart(4, "0");
+  const month = (date.getMonth() + 1).toString().padStart(2, "0");
+  const day = date.getDate().toString().padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Project records into CalendarEventChips. Records without a parseable start
+ * date are dropped. Multi-day events normalize end >= start.
+ */
+export function toEventChips({
+  records,
+  dateField,
+  endDateField,
+  titleField,
+}: {
+  records: CalendarRecord[];
+  dateField: string;
+  endDateField?: string;
+  titleField: string;
+}): CalendarEventChip[] {
+  const chips: CalendarEventChip[] = [];
+  for (let i = 0; i < records.length; i += 1) {
+    const record = records[i];
+    if (!record) continue;
+    const start = parseCalendarDate(record[dateField]);
+    if (!start) continue;
+
+    let end = start;
+    if (endDateField) {
+      const parsedEnd = parseCalendarDate(record[endDateField]);
+      if (parsedEnd && !isBefore(parsedEnd, start)) {
+        end = parsedEnd;
+      }
+    }
+
+    const titleRaw = record[titleField];
+    const id = record.id !== undefined && record.id !== null ? String(record.id) : `chip-${i}`;
+    chips.push({
+      id,
+      record,
+      start,
+      end,
+      title: titleRaw === undefined || titleRaw === null || titleRaw === "" ? id : String(titleRaw),
+    });
+  }
+  return chips;
+}
+
+/**
+ * Bucket chips into day cells. An event spanning multiple days appears in
+ * every cell whose date is between start and end inclusive (local time).
+ */
+export function bucketChipsIntoCells({
+  chips,
+  range,
+  focalMonth,
+}: {
+  chips: CalendarEventChip[];
+  range: { start: Date; end: Date };
+  /** Month used to flag the `inFocalMonth` cell flag. */
+  focalMonth: Date;
+}): CalendarDayCell[] {
+  const days = eachDayOfInterval({ start: range.start, end: range.end });
+  const focalMonthIndex = focalMonth.getMonth();
+  const focalYear = focalMonth.getFullYear();
+
+  return days.map((day) => {
+    const dayStart = startOfDay(day);
+    const events = chips
+      .filter((chip) => {
+        const chipStart = startOfDay(chip.start);
+        const chipEnd = startOfDay(chip.end);
+        // chipStart <= day <= chipEnd
+        const startsOnOrBefore = isSameDay(chipStart, dayStart) || isBefore(chipStart, dayStart);
+        const endsOnOrAfter = isSameDay(chipEnd, dayStart) || !isBefore(chipEnd, dayStart);
+        return startsOnOrBefore && endsOnOrAfter;
+      })
+      .sort((a, b) => a.start.getTime() - b.start.getTime());
+
+    return {
+      key: toDayKey(dayStart),
+      date: dayStart,
+      events,
+      inFocalMonth: dayStart.getMonth() === focalMonthIndex && dayStart.getFullYear() === focalYear,
+    };
+  });
+}
+
+/**
+ * React hook: memoized projection of records into calendar cells. Pure with
+ * respect to its inputs — safe to call from CalendarBoard.
+ */
+export function useCalendarData({
+  records,
+  dateField,
+  endDateField,
+  titleField,
+  currentDate,
+  mode,
+}: {
+  records: CalendarRecord[];
+  dateField: string;
+  endDateField?: string;
+  titleField: string;
+  currentDate: Date;
+  mode: CalendarViewMode;
+}): {
+  cells: CalendarDayCell[];
+  range: { start: Date; end: Date };
+  chips: CalendarEventChip[];
+} {
+  return useMemo(() => {
+    const range = getCalendarRange(currentDate, mode);
+    const chips = toEventChips({ records, dateField, endDateField, titleField });
+    const cells = bucketChipsIntoCells({ chips, range, focalMonth: currentDate });
+    return { cells, range, chips };
+  }, [records, dateField, endDateField, titleField, currentDate, mode]);
+}

--- a/addons/view-calendar/cap-view-calendar/tsconfig.json
+++ b/addons/view-calendar/cap-view-calendar/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "__tests__/**/*.ts", "__tests__/**/*.tsx"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -341,6 +341,25 @@
         "@linchkit/core": "^0.2.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-i18next": ">=14.0.0",
+      },
+    },
+    "addons/view-calendar/cap-view-calendar": {
+      "name": "@linchkit/cap-view-calendar",
+      "version": "0.1.0",
+      "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "date-fns": "^4.1.0",
+      },
+      "devDependencies": {
+        "@linchkit/cap-adapter-ui": "workspace:*",
+        "@linchkit/core": "workspace:*",
+        "typescript": "^6.0.2",
+      },
+      "peerDependencies": {
+        "@linchkit/cap-adapter-ui": "^1.0.0",
+        "@linchkit/core": "^0.2.0",
+        "react": "^19.0.0",
       },
     },
     "packages/cli": {
@@ -709,6 +728,8 @@
     "@linchkit/cap-search": ["@linchkit/cap-search@workspace:addons/search/cap-search"],
 
     "@linchkit/cap-search-ui": ["@linchkit/cap-search-ui@workspace:addons/search/cap-search-ui"],
+
+    "@linchkit/cap-view-calendar": ["@linchkit/cap-view-calendar@workspace:addons/view-calendar/cap-view-calendar"],
 
     "@linchkit/cli": ["@linchkit/cli@workspace:packages/cli"],
 


### PR DESCRIPTION
## Summary
Second Spec 54 advanced view from #86 (kanban landed in #330). Sibling capability mirroring \`cap-view-kanban\`'s package layout, capability descriptor, and test convention.

## Modes
- **month** (default) — 6×7 grid
- **week** — single-row 7-col
- **day** — single-col

Toggle in header alongside prev / next / today controls.

## Records
- Placed by \`dateField\`
- Multi-day events render via optional \`endDateField\` spanning every overlapping cell
- Drag a chip → \`onMoveEvent(record, newDate)\` callback (host invokes a transition Action — capability never mutates date directly)

## Layout
- \`CalendarBoard.tsx\` — DndContext + header + slot orchestration
- \`CalendarGrid.tsx\` — month/week 7-col + day 1-col droppable cells
- \`CalendarEvent.tsx\` — \`useDraggable\` chip
- \`use-calendar-data.ts\` — pure helpers (\`parseCalendarDate\`, \`toDayKey\`, \`getCalendarRange\`, \`toEventChips\`, \`bucketChipsIntoCells\`, \`useCalendarData\`)
- \`types.ts\` — \`CalendarBoardProps\`, \`CalendarEventChip\`, \`CalendarDayCell\`, \`CalendarViewMode\`

## Dependencies
- **date-fns ^4.1.0** — already a \`cap-adapter-ui\` dep (auto-calendar uses it)
- **@dnd-kit/core ^6.3.1** — root dep, same as \`cap-view-kanban\`

## Verification
- \`bun run check\` — clean (1151 files)
- \`bun run typecheck\` — clean
- \`bun test\` — 5179 pass / 3 skip / 0 fail (324 files)
- 23 scoped tests / 46 assertions

## Test plan
- [x] \`parseCalendarDate\` accepts ISO strings + Date objects + rejects garbage
- [x] \`getCalendarRange\` honours week-start convention for each view mode
- [x] \`bucketChipsIntoCells\` spans multi-day events across every overlapping cell
- [x] Flags out-of-month cells for month-view styling
- [x] Sorts overlapping events by start ascending

Refs #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)