### PR TITLE
feat(cap-keyboard-shortcuts): global registry + cheatsheet (refs #121)

### DIFF
--- a/addons/keyboard-shortcuts/cap-keyboard-shortcuts/README.md
+++ b/addons/keyboard-shortcuts/cap-keyboard-shortcuts/README.md
@@ -1,0 +1,71 @@
+# @linchkit/cap-keyboard-shortcuts
+
+Global keyboard shortcut registry, `useShortcut` hook, and a `Shift+?`
+cheatsheet overlay for LinchKit apps. Refs #121.
+
+## Installation
+
+```bash
+bun add @linchkit/cap-keyboard-shortcuts
+```
+
+This capability is not auto-installed — opt in by activating
+`capKeyboardShortcuts` in your host app.
+
+## Usage
+
+Mount the provider once near your React root:
+
+```tsx
+import { ShortcutCheatsheet, ShortcutProvider } from "@linchkit/cap-keyboard-shortcuts";
+
+export function App({ children }: { children: React.ReactNode }) {
+  return (
+    <ShortcutProvider>
+      {children}
+      <ShortcutCheatsheet />
+    </ShortcutProvider>
+  );
+}
+```
+
+Register a shortcut from any component:
+
+```tsx
+import { useShortcut } from "@linchkit/cap-keyboard-shortcuts";
+
+export function SaveButton({ onSave }: { onSave: () => void }) {
+  useShortcut({
+    keys: "Mod+S",
+    description: "Save the current document",
+    scope: "Editor",
+    handler: () => onSave(),
+  });
+  return <button onClick={onSave}>Save</button>;
+}
+```
+
+`Mod` resolves to `Meta` on macOS / iOS and `Ctrl` everywhere else.
+Sequences are supported via space-separated chords: `keys: "g h"` fires
+after pressing `g` then `h` within one second.
+
+## Cheatsheet binding
+
+`<ShortcutCheatsheet />` opens on `Shift+?` by default. Override or disable:
+
+```tsx
+<ShortcutCheatsheet triggerKeys="Mod+/" />
+<ShortcutCheatsheet triggerKeys={null} open={isOpen} onOpenChange={setOpen} />
+```
+
+## Editable-target bail-out
+
+Shortcuts ignore `keydown` events that originate inside `INPUT`,
+`TEXTAREA`, `SELECT`, or `contentEditable` elements — pass
+`allowInInput: true` on the registration to opt back in.
+
+## Peer dependencies
+
+- `@linchkit/core` ^0.2.0
+- `react` ^19.0.0
+- `react-i18next` ^14

--- a/addons/keyboard-shortcuts/cap-keyboard-shortcuts/__tests__/key-matcher.test.ts
+++ b/addons/keyboard-shortcuts/cap-keyboard-shortcuts/__tests__/key-matcher.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for the key-matcher parser + comparator.
+ *
+ * No DOM — we hand-craft `KeyEventLike` objects so the suite runs under
+ * bun's default test runner. Platform is always passed explicitly so the
+ * suite is deterministic regardless of where it executes.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { formatKeys, matchChord, parseChord, parseKeys } from "../src/key-matcher";
+import type { KeyEventLike } from "../src/types";
+
+function keyEvent(partial: Partial<KeyEventLike> & { key: string }): KeyEventLike {
+  return {
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    ...partial,
+  };
+}
+
+describe("parseChord", () => {
+  it("resolves Mod to Meta on mac", () => {
+    const chord = parseChord("Mod+K", "mac");
+    expect(chord).toEqual({ key: "k", meta: true, ctrl: false, alt: false, shift: false });
+  });
+
+  it("resolves Mod to Ctrl on non-mac platforms", () => {
+    const chord = parseChord("Mod+K", "other");
+    expect(chord).toEqual({ key: "k", meta: false, ctrl: true, alt: false, shift: false });
+  });
+
+  it("normalizes the Shift+/ chord", () => {
+    const chord = parseChord("Shift+/", "other");
+    expect(chord).toEqual({ key: "/", meta: false, ctrl: false, alt: false, shift: true });
+  });
+
+  it("rejects chords with no non-modifier key", () => {
+    expect(() => parseChord("Shift+Ctrl", "other")).toThrow();
+  });
+
+  it("rejects chords with multiple non-modifier keys", () => {
+    expect(() => parseChord("K+L", "other")).toThrow();
+  });
+});
+
+describe("parseKeys", () => {
+  it("parses a single-chord shortcut into one entry", () => {
+    const chords = parseKeys("Mod+K", "mac");
+    expect(chords).toHaveLength(1);
+  });
+
+  it("splits sequences on whitespace", () => {
+    const chords = parseKeys("g h", "other");
+    expect(chords).toHaveLength(2);
+    expect(chords[0]?.key).toBe("g");
+    expect(chords[1]?.key).toBe("h");
+  });
+
+  it("collapses multiple spaces between chord tokens", () => {
+    const chords = parseKeys("g   h", "other");
+    expect(chords).toHaveLength(2);
+  });
+});
+
+describe("matchChord — Mod+K", () => {
+  it("matches Meta+K on macOS", () => {
+    const chord = parseChord("Mod+K", "mac");
+    expect(matchChord(chord, keyEvent({ key: "k", metaKey: true }))).toBe(true);
+  });
+
+  it("does not match Ctrl+K on macOS (Mod resolved to Meta)", () => {
+    const chord = parseChord("Mod+K", "mac");
+    expect(matchChord(chord, keyEvent({ key: "k", ctrlKey: true }))).toBe(false);
+  });
+
+  it("matches Ctrl+K on non-mac platforms", () => {
+    const chord = parseChord("Mod+K", "other");
+    expect(matchChord(chord, keyEvent({ key: "k", ctrlKey: true }))).toBe(true);
+  });
+
+  it("does not match plain K (no modifier)", () => {
+    const chord = parseChord("Mod+K", "other");
+    expect(matchChord(chord, keyEvent({ key: "k" }))).toBe(false);
+  });
+
+  it("does not match Ctrl+Shift+K (extra modifier)", () => {
+    const chord = parseChord("Mod+K", "other");
+    expect(matchChord(chord, keyEvent({ key: "k", ctrlKey: true, shiftKey: true }))).toBe(false);
+  });
+
+  it("is case-insensitive on the event key", () => {
+    const chord = parseChord("Mod+K", "other");
+    expect(matchChord(chord, keyEvent({ key: "K", ctrlKey: true }))).toBe(true);
+  });
+});
+
+describe("matchChord — Shift+/", () => {
+  it("matches Shift+/ exactly", () => {
+    const chord = parseChord("Shift+/", "other");
+    expect(matchChord(chord, keyEvent({ key: "/", shiftKey: true }))).toBe(true);
+  });
+
+  it("does not match plain /", () => {
+    const chord = parseChord("Shift+/", "other");
+    expect(matchChord(chord, keyEvent({ key: "/" }))).toBe(false);
+  });
+
+  it("does not match unrelated keys", () => {
+    const chord = parseChord("Shift+/", "other");
+    expect(matchChord(chord, keyEvent({ key: "a", shiftKey: true }))).toBe(false);
+  });
+});
+
+describe("matchChord — modifier-only events", () => {
+  it("ignores a bare Shift keydown", () => {
+    const chord = parseChord("Shift+/", "other");
+    expect(matchChord(chord, keyEvent({ key: "Shift", shiftKey: true }))).toBe(false);
+  });
+
+  it("ignores a bare Control keydown", () => {
+    const chord = parseChord("Mod+K", "other");
+    expect(matchChord(chord, keyEvent({ key: "Control", ctrlKey: true }))).toBe(false);
+  });
+
+  it("ignores a bare Meta keydown", () => {
+    const chord = parseChord("Mod+K", "mac");
+    expect(matchChord(chord, keyEvent({ key: "Meta", metaKey: true }))).toBe(false);
+  });
+});
+
+describe("formatKeys", () => {
+  it("renders Mod+K with the platform glyph on mac", () => {
+    expect(formatKeys("Mod+K", "mac")).toBe("⌘+K");
+  });
+
+  it("renders Mod+K with Ctrl on non-mac platforms", () => {
+    expect(formatKeys("Mod+K", "other")).toBe("Ctrl+K");
+  });
+
+  it("joins sequence chords with a space", () => {
+    expect(formatKeys("g h", "other")).toBe("G H");
+  });
+});

--- a/addons/keyboard-shortcuts/cap-keyboard-shortcuts/__tests__/shortcut-registry.test.ts
+++ b/addons/keyboard-shortcuts/cap-keyboard-shortcuts/__tests__/shortcut-registry.test.ts
@@ -1,11 +1,14 @@
 /**
  * Tests for the ShortcutRegistry — registration lifecycle, conflict
  * detection, scope grouping, sequence dispatch, editable-target bail-out,
- * and `when` predicate gating.
+ * `when` predicate gating, modifier-only event filtering, and the
+ * sequence-shadowing arbitration that defers single-key shortcuts when a
+ * longer registered sequence shares the same prefix.
  */
 
 import { describe, expect, it } from "bun:test";
-import { ShortcutRegistry } from "../src/shortcut-registry";
+import { MODIFIER_KEYS } from "../src/key-matcher";
+import { type RegistryScheduler, ShortcutRegistry } from "../src/shortcut-registry";
 import type { KeyEventLike } from "../src/types";
 
 function event(partial: Partial<KeyEventLike> & { key: string }): KeyEventLike {
@@ -15,6 +18,38 @@ function event(partial: Partial<KeyEventLike> & { key: string }): KeyEventLike {
     altKey: false,
     shiftKey: false,
     ...partial,
+  };
+}
+
+/** Manual scheduler — tests advance time by invoking `flush()`. */
+function createManualScheduler() {
+  interface Pending {
+    handle: number;
+    fire: () => void;
+  }
+  const pending: Pending[] = [];
+  let nextHandle = 1;
+  const scheduler: RegistryScheduler = {
+    setTimeout(fire) {
+      const handle = nextHandle++;
+      pending.push({ handle, fire });
+      return handle;
+    },
+    clearTimeout(handle) {
+      const idx = pending.findIndex((p) => p.handle === handle);
+      if (idx >= 0) pending.splice(idx, 1);
+    },
+  };
+  return {
+    scheduler,
+    flush(): number {
+      const snapshot = pending.splice(0, pending.length);
+      for (const item of snapshot) item.fire();
+      return snapshot.length;
+    },
+    pendingCount(): number {
+      return pending.length;
+    },
   };
 }
 
@@ -250,5 +285,196 @@ describe("ShortcutRegistry.listShortcuts", () => {
     });
     const snapshots = registry.listShortcuts();
     expect(snapshots.map((s) => s.scope)).toEqual(["Search", "Editor", "Editor"]);
+  });
+});
+
+describe("MODIFIER_KEYS export", () => {
+  it("exposes a set the registry can consume to filter modifier-only events", () => {
+    expect(MODIFIER_KEYS.has("shift")).toBe(true);
+    expect(MODIFIER_KEYS.has("control")).toBe(true);
+    expect(MODIFIER_KEYS.has("meta")).toBe(true);
+    expect(MODIFIER_KEYS.has("alt")).toBe(true);
+    // Non-modifier keys should not appear.
+    expect(MODIFIER_KEYS.has("k")).toBe(false);
+    expect(MODIFIER_KEYS.has("g")).toBe(false);
+  });
+});
+
+describe("ShortcutRegistry modifier-only events", () => {
+  it("does not let a bare Control press break a sequence", () => {
+    const registry = new ShortcutRegistry({
+      platform: "other",
+      sequenceTimeoutMs: 1000,
+    });
+    let fired = 0;
+    registry.register({
+      keys: "g h",
+      description: "Go home",
+      handler: () => {
+        fired++;
+      },
+    });
+    let now = 1000;
+    expect(registry.dispatch({ event: event({ key: "g" }), now })).toBe(false);
+    // User taps Ctrl mid-sequence — must be ignored, NOT pushed to buffer.
+    now += 50;
+    const ctrlOnly = event({ key: "Control", ctrlKey: true });
+    expect(registry.dispatch({ event: ctrlOnly, now })).toBe(false);
+    now += 50;
+    expect(registry.dispatch({ event: event({ key: "h" }), now })).toBe(true);
+    expect(fired).toBe(1);
+  });
+
+  it("ignores Shift, Meta, Alt, and bare key-less events", () => {
+    const registry = new ShortcutRegistry({ platform: "other" });
+    let fired = 0;
+    registry.register({
+      keys: "Mod+K",
+      description: "Open search",
+      handler: () => {
+        fired++;
+      },
+    });
+    for (const key of ["Shift", "Meta", "Alt", "Control"]) {
+      expect(
+        registry.dispatch({
+          event: event({ key, shiftKey: key === "Shift", metaKey: key === "Meta" }),
+        }),
+      ).toBe(false);
+    }
+    expect(registry.dispatch({ event: event({ key: "" }) })).toBe(false);
+    expect(fired).toBe(0);
+  });
+});
+
+describe("ShortcutRegistry sequence-shadowing arbitration", () => {
+  it("defers single-key 'g' when a sequence 'g h' is also registered", () => {
+    const { scheduler, pendingCount } = createManualScheduler();
+    const registry = new ShortcutRegistry({
+      platform: "other",
+      sequencePrefixDelayMs: 200,
+      scheduler,
+    });
+    let singleFired = 0;
+    let sequenceFired = 0;
+    registry.register({
+      keys: "g",
+      description: "Single g",
+      handler: () => {
+        singleFired++;
+      },
+    });
+    registry.register({
+      keys: "g h",
+      description: "Go home",
+      handler: () => {
+        sequenceFired++;
+      },
+    });
+
+    // Pressing "g" must NOT immediately fire the single — it's parked.
+    let now = 1000;
+    expect(registry.dispatch({ event: event({ key: "g" }), now })).toBe(false);
+    expect(singleFired).toBe(0);
+    expect(pendingCount()).toBe(1);
+
+    // Pressing "h" within the window completes the sequence and cancels
+    // the pending single-key dispatch.
+    now += 50;
+    expect(registry.dispatch({ event: event({ key: "h" }), now })).toBe(true);
+    expect(sequenceFired).toBe(1);
+    expect(singleFired).toBe(0);
+    expect(pendingCount()).toBe(0);
+  });
+
+  it("fires single-key 'g' after the prefix-delay timeout when no follow-up arrives", () => {
+    const { scheduler, flush } = createManualScheduler();
+    const registry = new ShortcutRegistry({
+      platform: "other",
+      sequencePrefixDelayMs: 200,
+      scheduler,
+    });
+    let singleFired = 0;
+    let sequenceFired = 0;
+    registry.register({
+      keys: "g",
+      description: "Single g",
+      handler: () => {
+        singleFired++;
+      },
+    });
+    registry.register({
+      keys: "g h",
+      description: "Go home",
+      handler: () => {
+        sequenceFired++;
+      },
+    });
+
+    expect(registry.dispatch({ event: event({ key: "g" }), now: 1000 })).toBe(false);
+    expect(singleFired).toBe(0);
+
+    // Simulate the prefix-delay timer firing.
+    const fired = flush();
+    expect(fired).toBe(1);
+    expect(singleFired).toBe(1);
+    expect(sequenceFired).toBe(0);
+  });
+
+  it("fires single-key immediately when no sequence prefix matches", () => {
+    const { scheduler, pendingCount } = createManualScheduler();
+    const registry = new ShortcutRegistry({
+      platform: "other",
+      sequencePrefixDelayMs: 200,
+      scheduler,
+    });
+    let singleFired = 0;
+    // "z" is unrelated to the "g h" sequence below, so it should fire now.
+    registry.register({
+      keys: "z",
+      description: "Single z",
+      handler: () => {
+        singleFired++;
+      },
+    });
+    registry.register({
+      keys: "g h",
+      description: "Go home",
+      handler: () => {},
+    });
+
+    expect(registry.dispatch({ event: event({ key: "z" }) })).toBe(true);
+    expect(singleFired).toBe(1);
+    expect(pendingCount()).toBe(0);
+  });
+
+  it("cancels a deferred single-key dispatch if its target shortcut is unregistered", () => {
+    const { scheduler, flush, pendingCount } = createManualScheduler();
+    const registry = new ShortcutRegistry({
+      platform: "other",
+      sequencePrefixDelayMs: 200,
+      scheduler,
+    });
+    let singleFired = 0;
+    const singleId = registry.register({
+      keys: "g",
+      description: "Single g",
+      handler: () => {
+        singleFired++;
+      },
+    });
+    registry.register({
+      keys: "g h",
+      description: "Go home",
+      handler: () => {},
+    });
+
+    expect(registry.dispatch({ event: event({ key: "g" }), now: 1000 })).toBe(false);
+    expect(pendingCount()).toBe(1);
+
+    registry.unregister(singleId);
+    expect(pendingCount()).toBe(0);
+    flush();
+    expect(singleFired).toBe(0);
   });
 });

--- a/addons/keyboard-shortcuts/cap-keyboard-shortcuts/__tests__/shortcut-registry.test.ts
+++ b/addons/keyboard-shortcuts/cap-keyboard-shortcuts/__tests__/shortcut-registry.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Tests for the ShortcutRegistry — registration lifecycle, conflict
+ * detection, scope grouping, sequence dispatch, editable-target bail-out,
+ * and `when` predicate gating.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { ShortcutRegistry } from "../src/shortcut-registry";
+import type { KeyEventLike } from "../src/types";
+
+function event(partial: Partial<KeyEventLike> & { key: string }): KeyEventLike {
+  return {
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    ...partial,
+  };
+}
+
+describe("ShortcutRegistry.register / unregister", () => {
+  it("registers and lists a shortcut with its scope", () => {
+    const registry = new ShortcutRegistry({ platform: "other" });
+    registry.register({
+      keys: "Mod+K",
+      description: "Open search",
+      scope: "Search",
+      handler: () => {},
+    });
+    const snapshots = registry.listShortcuts();
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0]?.scope).toBe("Search");
+    expect(snapshots[0]?.enabled).toBe(true);
+  });
+
+  it("removes a shortcut on unregister", () => {
+    const registry = new ShortcutRegistry({ platform: "other" });
+    const id = registry.register({
+      keys: "Mod+K",
+      description: "Open search",
+      handler: () => {},
+    });
+    expect(registry.size()).toBe(1);
+    registry.unregister(id);
+    expect(registry.size()).toBe(0);
+  });
+
+  it("defaults the scope to 'global'", () => {
+    const registry = new ShortcutRegistry({ platform: "other" });
+    registry.register({ keys: "Mod+K", description: "X", handler: () => {} });
+    expect(registry.listShortcuts()[0]?.scope).toBe("global");
+  });
+});
+
+describe("ShortcutRegistry conflict detection", () => {
+  it("warns when two enabled handlers register the same keys in the same scope", () => {
+    const messages: string[] = [];
+    const registry = new ShortcutRegistry({
+      platform: "other",
+      warn: (msg) => messages.push(msg),
+    });
+    registry.register({ keys: "Mod+K", description: "A", scope: "Nav", handler: () => {} });
+    registry.register({ keys: "Mod+K", description: "B", scope: "Nav", handler: () => {} });
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain("duplicate shortcut");
+    expect(messages[0]).toContain("Nav");
+  });
+
+  it("does not warn when conflicting handlers live in different scopes", () => {
+    const messages: string[] = [];
+    const registry = new ShortcutRegistry({
+      platform: "other",
+      warn: (msg) => messages.push(msg),
+    });
+    registry.register({ keys: "Mod+K", description: "A", scope: "Nav", handler: () => {} });
+    registry.register({ keys: "Mod+K", description: "B", scope: "Edit", handler: () => {} });
+    expect(messages).toHaveLength(0);
+  });
+
+  it("treats modifier order as equivalent (Shift+Mod+K === Mod+Shift+K)", () => {
+    const messages: string[] = [];
+    const registry = new ShortcutRegistry({
+      platform: "other",
+      warn: (msg) => messages.push(msg),
+    });
+    registry.register({
+      keys: "Shift+Mod+K",
+      description: "A",
+      scope: "Nav",
+      handler: () => {},
+    });
+    registry.register({
+      keys: "Mod+Shift+K",
+      description: "B",
+      scope: "Nav",
+      handler: () => {},
+    });
+    expect(messages).toHaveLength(1);
+  });
+
+  it("ignores conflicts when the existing handler is disabled via when", () => {
+    const messages: string[] = [];
+    const registry = new ShortcutRegistry({
+      platform: "other",
+      warn: (msg) => messages.push(msg),
+    });
+    registry.register({
+      keys: "Mod+K",
+      description: "A",
+      scope: "Nav",
+      handler: () => {},
+      when: () => false,
+    });
+    registry.register({ keys: "Mod+K", description: "B", scope: "Nav", handler: () => {} });
+    expect(messages).toHaveLength(0);
+  });
+});
+
+describe("ShortcutRegistry.dispatch", () => {
+  it("invokes the matching handler and bails on editable target without allowInInput", () => {
+    const registry = new ShortcutRegistry({ platform: "other" });
+    let fired = 0;
+    registry.register({
+      keys: "Mod+K",
+      description: "Open search",
+      handler: () => {
+        fired++;
+      },
+    });
+    const handled = registry.dispatch({
+      event: event({ key: "k", ctrlKey: true }),
+      isEditableTarget: true,
+    });
+    expect(handled).toBe(false);
+    expect(fired).toBe(0);
+  });
+
+  it("fires when allowInInput is set even inside editable elements", () => {
+    const registry = new ShortcutRegistry({ platform: "other" });
+    let fired = 0;
+    registry.register({
+      keys: "Mod+K",
+      description: "Open search",
+      allowInInput: true,
+      handler: () => {
+        fired++;
+      },
+    });
+    const handled = registry.dispatch({
+      event: event({ key: "k", ctrlKey: true }),
+      isEditableTarget: true,
+    });
+    expect(handled).toBe(true);
+    expect(fired).toBe(1);
+  });
+
+  it("matches a two-step sequence within the timeout window", () => {
+    const registry = new ShortcutRegistry({
+      platform: "other",
+      sequenceTimeoutMs: 1000,
+    });
+    let fired = 0;
+    registry.register({
+      keys: "g h",
+      description: "Go home",
+      handler: () => {
+        fired++;
+      },
+    });
+    let now = 1000;
+    expect(registry.dispatch({ event: event({ key: "g" }), now })).toBe(false);
+    now += 500;
+    expect(registry.dispatch({ event: event({ key: "h" }), now })).toBe(true);
+    expect(fired).toBe(1);
+  });
+
+  it("does not match a sequence when the inter-key gap exceeds the timeout", () => {
+    const registry = new ShortcutRegistry({
+      platform: "other",
+      sequenceTimeoutMs: 500,
+    });
+    let fired = 0;
+    registry.register({
+      keys: "g h",
+      description: "Go home",
+      handler: () => {
+        fired++;
+      },
+    });
+    let now = 1000;
+    registry.dispatch({ event: event({ key: "g" }), now });
+    now += 1000; // exceeds 500ms window
+    expect(registry.dispatch({ event: event({ key: "h" }), now })).toBe(false);
+    expect(fired).toBe(0);
+  });
+
+  it("skips shortcuts whose when() predicate currently returns false", () => {
+    const registry = new ShortcutRegistry({ platform: "other" });
+    let allowed = false;
+    let fired = 0;
+    registry.register({
+      keys: "Mod+K",
+      description: "X",
+      when: () => allowed,
+      handler: () => {
+        fired++;
+      },
+    });
+    expect(registry.dispatch({ event: event({ key: "k", ctrlKey: true }) })).toBe(false);
+    allowed = true;
+    expect(registry.dispatch({ event: event({ key: "k", ctrlKey: true }) })).toBe(true);
+    expect(fired).toBe(1);
+  });
+});
+
+describe("ShortcutRegistry.listShortcuts", () => {
+  it("returns the enabled flag based on the when predicate", () => {
+    const registry = new ShortcutRegistry({ platform: "other" });
+    let allowed = false;
+    registry.register({
+      keys: "Mod+K",
+      description: "X",
+      when: () => allowed,
+      handler: () => {},
+    });
+    expect(registry.listShortcuts()[0]?.enabled).toBe(false);
+    allowed = true;
+    expect(registry.listShortcuts()[0]?.enabled).toBe(true);
+  });
+
+  it("groups multiple shortcuts by scope in insertion order", () => {
+    const registry = new ShortcutRegistry({ platform: "other" });
+    registry.register({
+      keys: "Mod+K",
+      description: "Open search",
+      scope: "Search",
+      handler: () => {},
+    });
+    registry.register({
+      keys: "Mod+S",
+      description: "Save",
+      scope: "Editor",
+      handler: () => {},
+    });
+    registry.register({
+      keys: "Mod+P",
+      description: "Print",
+      scope: "Editor",
+      handler: () => {},
+    });
+    const snapshots = registry.listShortcuts();
+    expect(snapshots.map((s) => s.scope)).toEqual(["Search", "Editor", "Editor"]);
+  });
+});

--- a/addons/keyboard-shortcuts/cap-keyboard-shortcuts/__tests__/use-shortcut.test.ts
+++ b/addons/keyboard-shortcuts/cap-keyboard-shortcuts/__tests__/use-shortcut.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for `useShortcut` — the React hook that registers / unregisters
+ * a shortcut against the surrounding registry.
+ *
+ * Bun's default test runner has no DOM. Following the same pattern as
+ * cap-search-ui/useSearchClient.test.ts, we mock React's hook surface in
+ * this file. Because `mock.module("react", ...)` leaks across files in
+ * bun's shared test process, this file is the SINGLE place in
+ * cap-keyboard-shortcuts that imports the hook — every other test stays
+ * away from React so the mock cannot pollute them.
+ *
+ * What we verify:
+ *   - calling the hook registers a shortcut on the provided registry
+ *   - the cleanup function returned from the registration effect
+ *     unregisters the shortcut (i.e. it cleans up on unmount)
+ *   - the `when` predicate is read live so the dispatcher honors the
+ *     latest predicate value, not a stale capture
+ */
+
+import { afterAll, beforeAll, describe, expect, it, mock } from "bun:test";
+
+// Capture the effects React would run so we can drive them manually.
+// Effects either return nothing (void) or a cleanup callback — we wrap
+// the cleanup branch in parens so biome's noConfusingVoidType rule stays
+// happy without losing the "no cleanup" case.
+type EffectCleanup = () => void;
+type EffectFn = () => EffectCleanup | undefined;
+const queuedEffects: EffectFn[] = [];
+const refStore: Array<{ current: unknown }> = [];
+let refCursor = 0;
+
+let registryForContext: unknown = null;
+
+beforeAll(() => {
+  mock.module("react", () => ({
+    useRef<T>(initial: T) {
+      const slot = refStore[refCursor];
+      if (slot) {
+        refCursor++;
+        return slot as { current: T };
+      }
+      const ref = { current: initial };
+      refStore.push(ref);
+      refCursor++;
+      return ref as { current: T };
+    },
+    useEffect(fn: EffectFn) {
+      queuedEffects.push(fn);
+    },
+    useContext() {
+      return registryForContext;
+    },
+    // Stub the rest so importing the hook module never throws even if
+    // future edits add more React calls.
+    useState<T>(initial: T) {
+      return [initial, () => {}] as const;
+    },
+    useMemo<T>(factory: () => T) {
+      return factory();
+    },
+    useCallback<T>(fn: T) {
+      return fn;
+    },
+    createContext() {
+      return { Provider: () => null, Consumer: () => null };
+    },
+  }));
+});
+
+afterAll(() => {
+  // Reset bookkeeping — module mocks are process-wide in bun:test.
+  queuedEffects.length = 0;
+  refStore.length = 0;
+  refCursor = 0;
+  registryForContext = null;
+});
+
+// Import AFTER the React mock is installed so the hook resolves against it.
+const { useShortcut } = await import("../src/use-shortcut");
+const { ShortcutRegistry } = await import("../src/shortcut-registry");
+
+function runQueuedEffects(): Array<() => void> {
+  const cleanups: Array<() => void> = [];
+  // Snapshot + clear so freshly-queued effects from nested hooks don't loop.
+  const pending = queuedEffects.splice(0, queuedEffects.length);
+  for (const fn of pending) {
+    const result = fn();
+    if (typeof result === "function") cleanups.push(result);
+  }
+  return cleanups;
+}
+
+function resetHookState(registry: unknown) {
+  refStore.length = 0;
+  refCursor = 0;
+  queuedEffects.length = 0;
+  registryForContext = registry;
+}
+
+describe("useShortcut", () => {
+  it("registers a shortcut on the registry while mounted", () => {
+    const registry = new ShortcutRegistry({ platform: "other" });
+    resetHookState(registry);
+
+    useShortcut({
+      keys: "Mod+K",
+      description: "Open search",
+      handler: () => {},
+    });
+
+    runQueuedEffects();
+    expect(registry.size()).toBe(1);
+  });
+
+  it("unregisters the shortcut when the cleanup function runs (unmount)", () => {
+    const registry = new ShortcutRegistry({ platform: "other" });
+    resetHookState(registry);
+
+    useShortcut({
+      keys: "Mod+S",
+      description: "Save",
+      handler: () => {},
+    });
+
+    const cleanups = runQueuedEffects();
+    expect(registry.size()).toBe(1);
+
+    for (const cleanup of cleanups) cleanup();
+    expect(registry.size()).toBe(0);
+  });
+
+  it("honors the latest when() predicate during dispatch", () => {
+    const registry = new ShortcutRegistry({ platform: "other" });
+    resetHookState(registry);
+
+    let allowed = false;
+    let fired = 0;
+    useShortcut({
+      keys: "Mod+K",
+      description: "Conditional",
+      when: () => allowed,
+      handler: () => {
+        fired++;
+      },
+    });
+
+    runQueuedEffects();
+
+    const event = {
+      key: "k",
+      ctrlKey: true,
+      metaKey: false,
+      altKey: false,
+      shiftKey: false,
+    };
+
+    expect(registry.dispatch({ event })).toBe(false);
+    expect(fired).toBe(0);
+
+    allowed = true;
+    expect(registry.dispatch({ event })).toBe(true);
+    expect(fired).toBe(1);
+  });
+});

--- a/addons/keyboard-shortcuts/cap-keyboard-shortcuts/__tests__/use-shortcut.test.ts
+++ b/addons/keyboard-shortcuts/cap-keyboard-shortcuts/__tests__/use-shortcut.test.ts
@@ -161,4 +161,31 @@ describe("useShortcut", () => {
     expect(registry.dispatch({ event })).toBe(true);
     expect(fired).toBe(1);
   });
+
+  it("no-ops when keys is null (conditional registration)", () => {
+    const registry = new ShortcutRegistry({ platform: "other" });
+    resetHookState(registry);
+
+    useShortcut({
+      keys: null,
+      description: "Disabled trigger",
+      handler: () => {},
+    });
+
+    runQueuedEffects();
+    expect(registry.size()).toBe(0);
+  });
+
+  it("no-ops when keys is undefined (conditional registration)", () => {
+    const registry = new ShortcutRegistry({ platform: "other" });
+    resetHookState(registry);
+
+    useShortcut({
+      description: "Disabled trigger",
+      handler: () => {},
+    });
+
+    runQueuedEffects();
+    expect(registry.size()).toBe(0);
+  });
 });

--- a/addons/keyboard-shortcuts/cap-keyboard-shortcuts/package.json
+++ b/addons/keyboard-shortcuts/cap-keyboard-shortcuts/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@linchkit/cap-keyboard-shortcuts",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "files": [
+    "src/",
+    "package.json",
+    "README.md"
+  ],
+  "exports": {
+    ".": "./src/index.ts",
+    "./capability": "./src/capability.ts"
+  },
+  "scripts": {
+    "test": "bun test"
+  },
+  "peerDependencies": {
+    "@linchkit/core": "^0.2.0",
+    "react": "^19.0.0",
+    "react-i18next": "^14"
+  },
+  "devDependencies": {
+    "@linchkit/core": "workspace:*"
+  },
+  "linchkit": {
+    "minCoreVersion": "^0.2.0",
+    "type": "standard",
+    "category": "system",
+    "autoInstall": false
+  }
+}

--- a/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/ShortcutCheatsheet.tsx
+++ b/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/ShortcutCheatsheet.tsx
@@ -1,0 +1,162 @@
+/**
+ * `<ShortcutCheatsheet>` — modal overlay listing every registered shortcut
+ * grouped by `scope`. Default open trigger is `Shift+?` (configurable via
+ * `triggerKeys`); the overlay closes on `Escape`. Visibility is owned
+ * locally so the component is drop-in — host apps can also pass `open` /
+ * `onOpenChange` to control it externally.
+ *
+ * Rendering stays intentionally framework-light: we use plain divs +
+ * Tailwind utility classes so cap-keyboard-shortcuts has no dependency
+ * on the ui-kit. Translations resolve through `react-i18next` against
+ * the bundles registered by the capability's `i18n` extension.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { detectPlatform, formatKeys } from "./key-matcher";
+import { useShortcutRegistry } from "./ShortcutProvider";
+import type { ShortcutSnapshot } from "./types";
+import { useShortcut } from "./use-shortcut";
+
+export interface ShortcutCheatsheetProps {
+  /**
+   * Key combination that toggles the overlay. Defaults to `"Shift+?"`.
+   * Pass `null` to disable the built-in trigger and rely on `open`.
+   */
+  triggerKeys?: string | null;
+  /** External controlled-open hook. */
+  open?: boolean;
+  /** Called whenever the overlay should open/close. */
+  onOpenChange?: (open: boolean) => void;
+}
+
+const DEFAULT_TRIGGER = "Shift+?";
+
+export function ShortcutCheatsheet(props: ShortcutCheatsheetProps) {
+  const { triggerKeys = DEFAULT_TRIGGER, open, onOpenChange } = props;
+  const { t } = useTranslation();
+  const registry = useShortcutRegistry();
+  const platform = useMemo(() => detectPlatform(), []);
+
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isControlled = open !== undefined;
+  const isOpen = isControlled ? Boolean(open) : internalOpen;
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (!isControlled) setInternalOpen(next);
+      onOpenChange?.(next);
+    },
+    [isControlled, onOpenChange],
+  );
+
+  // Built-in toggle shortcut. We register only when triggerKeys is set so
+  // hosts can opt out cleanly.
+  useShortcut({
+    keys: triggerKeys ?? "Shift+F24", // unreachable key when disabled
+    description: t("keyboardShortcuts.cheatsheet.toggleDescription", "Toggle shortcut cheatsheet"),
+    scope: t("keyboardShortcuts.cheatsheet.scope", "Help"),
+    handler: () => {
+      if (triggerKeys === null) return;
+      setOpen(!isOpen);
+    },
+  });
+
+  // Esc to close — we wire this with a plain effect rather than a
+  // shortcut so it works even when focus is in an editable element.
+  useEffect(() => {
+    if (!isOpen) return;
+    function handleKey(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setOpen(false);
+      }
+    }
+    if (typeof window === "undefined") return;
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [isOpen, setOpen]);
+
+  const snapshots = registry.listShortcuts();
+  const grouped = useMemo(() => groupByScope(snapshots), [snapshots]);
+  const scopes = Object.keys(grouped);
+
+  if (!isOpen) return null;
+
+  const title = t("keyboardShortcuts.cheatsheet.title", "Keyboard shortcuts");
+  const emptyLabel = t("keyboardShortcuts.cheatsheet.empty", "No shortcuts are registered yet.");
+  const closeLabel = t("keyboardShortcuts.cheatsheet.close", "Close");
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+    >
+      {/* Dedicated backdrop button — covers the inert area behind the
+          dialog and is keyboard-activatable so a11y lint is happy. */}
+      <button
+        type="button"
+        aria-label={closeLabel}
+        tabIndex={-1}
+        className="absolute inset-0 cursor-default bg-black/50"
+        onClick={() => setOpen(false)}
+      />
+      <div className="relative max-h-[80vh] w-full max-w-2xl overflow-y-auto rounded-lg border bg-background p-6 shadow-lg">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-semibold">{title}</h2>
+          <button
+            type="button"
+            aria-label={closeLabel}
+            className="rounded-md px-2 py-1 text-sm text-muted-foreground hover:bg-muted"
+            onClick={() => setOpen(false)}
+          >
+            ×
+          </button>
+        </div>
+        {scopes.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{emptyLabel}</p>
+        ) : (
+          <div className="space-y-6">
+            {scopes.map((scope) => {
+              const items = grouped[scope];
+              if (!items) return null;
+              return (
+                <section key={scope}>
+                  <h3 className="mb-2 text-sm font-medium uppercase tracking-wide text-muted-foreground">
+                    {scope}
+                  </h3>
+                  <ul className="space-y-1.5">
+                    {items.map((item) => (
+                      <li
+                        key={item.id}
+                        className="flex items-center justify-between gap-4 rounded-md px-2 py-1.5 text-sm hover:bg-muted"
+                      >
+                        <span className="flex-1">{item.description}</span>
+                        <kbd className="rounded border bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
+                          {formatKeys(item.keys, platform)}
+                        </kbd>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function groupByScope(snapshots: readonly ShortcutSnapshot[]): Record<string, ShortcutSnapshot[]> {
+  const grouped: Record<string, ShortcutSnapshot[]> = {};
+  for (const snapshot of snapshots) {
+    const key = snapshot.scope;
+    const bucket = grouped[key] ?? [];
+    bucket.push(snapshot);
+    grouped[key] = bucket;
+  }
+  return grouped;
+}

--- a/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/ShortcutCheatsheet.tsx
+++ b/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/ShortcutCheatsheet.tsx
@@ -50,16 +50,14 @@ export function ShortcutCheatsheet(props: ShortcutCheatsheetProps) {
     [isControlled, onOpenChange],
   );
 
-  // Built-in toggle shortcut. We register only when triggerKeys is set so
-  // hosts can opt out cleanly.
+  // Built-in toggle shortcut. `useShortcut` no-ops when `keys` is
+  // null/undefined, so the cheatsheet stays absent from its own list when
+  // the host has disabled the trigger.
   useShortcut({
-    keys: triggerKeys ?? "Shift+F24", // unreachable key when disabled
+    keys: triggerKeys,
     description: t("keyboardShortcuts.cheatsheet.toggleDescription", "Toggle shortcut cheatsheet"),
     scope: t("keyboardShortcuts.cheatsheet.scope", "Help"),
-    handler: () => {
-      if (triggerKeys === null) return;
-      setOpen(!isOpen);
-    },
+    handler: () => setOpen(!isOpen),
   });
 
   // Esc to close — we wire this with a plain effect rather than a

--- a/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/ShortcutProvider.tsx
+++ b/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/ShortcutProvider.tsx
@@ -1,0 +1,86 @@
+/**
+ * `<ShortcutProvider>` — mounts a single global `keydown` listener and
+ * exposes the per-tree {@link ShortcutRegistry} via React context so child
+ * components can register shortcuts via {@link useShortcut}.
+ *
+ * Editable-target bail-out lives here (not in the registry) because the
+ * registry is DOM-agnostic. We mirror the pattern that landed for the
+ * global search shortcut in PR #319 (`GlobalSearchInput.tsx`): when the
+ * keydown's `target` is an `INPUT`, `TEXTAREA`, `SELECT`, or a
+ * `contentEditable` element, we skip the dispatch — unless the matched
+ * shortcut opts in via `allowInInput: true`.
+ *
+ * The provider intentionally creates the registry once via `useState`'s
+ * lazy initializer so StrictMode double-renders don't churn it.
+ */
+
+import { createContext, type ReactNode, useContext, useEffect, useState } from "react";
+import { type RegistryOptions, ShortcutRegistry } from "./shortcut-registry";
+
+const ShortcutContext = createContext<ShortcutRegistry | null>(null);
+
+export interface ShortcutProviderProps {
+  children: ReactNode;
+  /** Optional registry options forwarded to the {@link ShortcutRegistry}. */
+  options?: RegistryOptions;
+  /**
+   * Element to attach the keydown listener to. Defaults to `window`.
+   * Tests inject a fake target so we don't need a real DOM.
+   */
+  target?: EventTarget;
+}
+
+export function ShortcutProvider(props: ShortcutProviderProps) {
+  const { children, options, target } = props;
+  // Lazy init so the registry survives StrictMode re-renders.
+  const [registry] = useState(() => new ShortcutRegistry(options));
+
+  useEffect(() => {
+    const listenTarget: EventTarget | undefined =
+      target ?? (typeof window === "undefined" ? undefined : window);
+    if (!listenTarget) return;
+
+    function handleKeydown(event: Event) {
+      const keyEvent = event as KeyboardEvent;
+      const editable = isEditableTarget(keyEvent);
+      const handled = registry.dispatch({ event: keyEvent, isEditableTarget: editable });
+      if (handled && typeof keyEvent.preventDefault === "function") {
+        keyEvent.preventDefault();
+      }
+    }
+
+    listenTarget.addEventListener("keydown", handleKeydown);
+    return () => {
+      listenTarget.removeEventListener("keydown", handleKeydown);
+    };
+  }, [registry, target]);
+
+  return <ShortcutContext.Provider value={registry}>{children}</ShortcutContext.Provider>;
+}
+
+/**
+ * Read the registry from context. Throws when called outside a provider —
+ * loud failure beats silent no-op when a `useShortcut` call is misplaced.
+ */
+export function useShortcutRegistry(): ShortcutRegistry {
+  const registry = useContext(ShortcutContext);
+  if (!registry) {
+    throw new Error(
+      "cap-keyboard-shortcuts: useShortcut / useShortcutRegistry called outside a <ShortcutProvider>",
+    );
+  }
+  return registry;
+}
+
+/**
+ * Decide whether a keydown event originated inside an editable element.
+ * Mirrors the heuristic used by cap-search-ui's global search input.
+ */
+function isEditableTarget(event: KeyboardEvent): boolean {
+  const target = event.target as HTMLElement | null;
+  if (!target) return false;
+  const tag = target.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+  if (target.isContentEditable) return true;
+  return false;
+}

--- a/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/capability.ts
+++ b/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/capability.ts
@@ -1,0 +1,35 @@
+/**
+ * Capability definition for cap-keyboard-shortcuts.
+ *
+ * Provides a React-side keyboard-shortcut registry plus a cheatsheet
+ * overlay. The capability itself contributes nothing to the runtime
+ * pipeline — its surface is component / hook based — but we still ship a
+ * `defineCapability` shape so it can be activated through the standard
+ * addon mechanism and so its i18n bundles register into the host's
+ * react-i18next instance automatically.
+ *
+ * Issue: #121
+ * Spec: 14 (System Capabilities)
+ */
+
+import { defineCapability } from "@linchkit/core";
+import en from "./i18n/locales/en.json";
+import zhCN from "./i18n/locales/zh-CN.json";
+
+export const capKeyboardShortcuts = defineCapability({
+  name: "cap-keyboard-shortcuts",
+  label: "Keyboard Shortcuts",
+  description:
+    "Global keyboard shortcut registry, useShortcut hook, and Shift+? cheatsheet overlay.",
+  type: "standard",
+  category: "system",
+  version: "0.1.0",
+  group: "keyboard-shortcuts",
+  autoInstall: false,
+  extensions: {
+    i18n: {
+      en,
+      "zh-CN": zhCN,
+    },
+  },
+});

--- a/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/i18n/locales/en.json
+++ b/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/i18n/locales/en.json
@@ -1,0 +1,11 @@
+{
+  "keyboardShortcuts": {
+    "cheatsheet": {
+      "title": "Keyboard shortcuts",
+      "empty": "No shortcuts are registered yet.",
+      "close": "Close",
+      "scope": "Help",
+      "toggleDescription": "Toggle shortcut cheatsheet"
+    }
+  }
+}

--- a/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/i18n/locales/zh-CN.json
+++ b/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/i18n/locales/zh-CN.json
@@ -1,0 +1,11 @@
+{
+  "keyboardShortcuts": {
+    "cheatsheet": {
+      "title": "键盘快捷键",
+      "empty": "尚未注册任何快捷键。",
+      "close": "关闭",
+      "scope": "帮助",
+      "toggleDescription": "切换快捷键速查表"
+    }
+  }
+}

--- a/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/index.ts
+++ b/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/index.ts
@@ -15,6 +15,7 @@ export { capKeyboardShortcuts } from "./capability";
 export {
   detectPlatform,
   formatKeys,
+  MODIFIER_KEYS,
   matchChord,
   parseChord,
   parseKeys,
@@ -26,14 +27,17 @@ export {
   useShortcutRegistry,
 } from "./ShortcutProvider";
 export {
+  DEFAULT_SEQUENCE_PREFIX_DELAY_MS,
   DEFAULT_SEQUENCE_TIMEOUT_MS,
   type RegistryOptions,
+  type RegistryScheduler,
   ShortcutRegistry,
 } from "./shortcut-registry";
 export type {
   KeyChord,
   KeyEventLike,
   Platform,
+  RegisterShortcutOptions,
   ShortcutHandler,
   ShortcutId,
   ShortcutOptions,

--- a/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/index.ts
+++ b/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Public surface for @linchkit/cap-keyboard-shortcuts.
+ *
+ * Host apps typically only import:
+ *   - `<ShortcutProvider>` — mount once at the app root.
+ *   - `useShortcut({ keys, handler, description })` — per-component.
+ *   - `<ShortcutCheatsheet />` — drop-in overlay bound to Shift+? by default.
+ *
+ * Lower-level building blocks (registry, parsers) are also exported so
+ * other capabilities can build on top of them without re-implementing
+ * the matcher.
+ */
+
+export { capKeyboardShortcuts } from "./capability";
+export {
+  detectPlatform,
+  formatKeys,
+  matchChord,
+  parseChord,
+  parseKeys,
+} from "./key-matcher";
+export { ShortcutCheatsheet, type ShortcutCheatsheetProps } from "./ShortcutCheatsheet";
+export {
+  ShortcutProvider,
+  type ShortcutProviderProps,
+  useShortcutRegistry,
+} from "./ShortcutProvider";
+export {
+  DEFAULT_SEQUENCE_TIMEOUT_MS,
+  type RegistryOptions,
+  ShortcutRegistry,
+} from "./shortcut-registry";
+export type {
+  KeyChord,
+  KeyEventLike,
+  Platform,
+  ShortcutHandler,
+  ShortcutId,
+  ShortcutOptions,
+  ShortcutSnapshot,
+} from "./types";
+export { useShortcut } from "./use-shortcut";

--- a/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/key-matcher.ts
+++ b/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/key-matcher.ts
@@ -1,0 +1,156 @@
+/**
+ * Key matcher — parses a `keys` string into chord(s) and tests them against
+ * `KeyboardEvent`-like objects.
+ *
+ * Platform handling: the special `Mod` modifier resolves to `Meta` on macOS
+ * and `Ctrl` everywhere else. Detection is centralized in `detectPlatform()`
+ * which inspects `navigator.platform` / `navigator.userAgent` and falls back
+ * to `"other"` in non-browser contexts (SSR, bun test runner) so behavior is
+ * deterministic. Tests inject the platform via the optional `platform`
+ * parameter to avoid relying on the host environment.
+ */
+
+import type { KeyChord, KeyEventLike, Platform } from "./types";
+
+/** Modifier-only key names that should never count as the chord's "key". */
+const MODIFIER_KEYS = new Set([
+  "shift",
+  "control",
+  "ctrl",
+  "alt",
+  "option",
+  "meta",
+  "cmd",
+  "command",
+  "mod",
+]);
+
+/**
+ * Detect whether the current runtime is macOS / iOS. The check is intentionally
+ * conservative — when there is no `navigator` (SSR, bun test, node), we return
+ * `"other"` so `Mod` resolves to `Ctrl`. Callers that need explicit control
+ * pass the `platform` argument directly.
+ */
+export function detectPlatform(): Platform {
+  if (typeof navigator === "undefined") return "other";
+  const platform = navigator.platform || "";
+  const userAgent = navigator.userAgent || "";
+  const isApple = /Mac|iPhone|iPad|iPod/.test(platform) || /Mac|iPhone|iPad|iPod/.test(userAgent);
+  return isApple ? "mac" : "other";
+}
+
+/** Normalize a single token: trim + lowercase. */
+function normalizeToken(token: string): string {
+  return token.trim().toLowerCase();
+}
+
+/**
+ * Parse one chord string (e.g. `"Mod+Shift+K"`) into a {@link KeyChord}.
+ *
+ * Throws when:
+ *   - the chord is empty or only modifiers (no non-modifier "key" component)
+ *   - more than one non-modifier key is present (e.g. `"K+L"`)
+ */
+export function parseChord(chord: string, platform: Platform = detectPlatform()): KeyChord {
+  const tokens = chord.split("+").map(normalizeToken).filter(Boolean);
+  if (tokens.length === 0) {
+    throw new Error(`cap-keyboard-shortcuts: empty chord "${chord}"`);
+  }
+
+  let meta = false;
+  let ctrl = false;
+  let alt = false;
+  let shift = false;
+  let key: string | null = null;
+
+  for (const token of tokens) {
+    if (token === "mod") {
+      if (platform === "mac") meta = true;
+      else ctrl = true;
+      continue;
+    }
+    if (token === "meta" || token === "cmd" || token === "command") {
+      meta = true;
+      continue;
+    }
+    if (token === "ctrl" || token === "control") {
+      ctrl = true;
+      continue;
+    }
+    if (token === "alt" || token === "option") {
+      alt = true;
+      continue;
+    }
+    if (token === "shift") {
+      shift = true;
+      continue;
+    }
+    if (key !== null) {
+      throw new Error(
+        `cap-keyboard-shortcuts: chord "${chord}" has multiple non-modifier keys ("${key}", "${token}")`,
+      );
+    }
+    key = token;
+  }
+
+  if (key === null) {
+    throw new Error(`cap-keyboard-shortcuts: chord "${chord}" has no non-modifier key`);
+  }
+
+  return { key, meta, ctrl, alt, shift };
+}
+
+/**
+ * Parse a full `keys` string into a list of chords. A single space separates
+ * sequence steps; chords themselves are joined by `+`. Multiple consecutive
+ * spaces collapse to one delimiter.
+ */
+export function parseKeys(keys: string, platform: Platform = detectPlatform()): KeyChord[] {
+  const parts = keys.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) {
+    throw new Error(`cap-keyboard-shortcuts: empty keys string "${keys}"`);
+  }
+  return parts.map((part) => parseChord(part, platform));
+}
+
+/**
+ * Test whether a {@link KeyEventLike} matches a parsed {@link KeyChord}.
+ *
+ * Modifier-only events (e.g. user just pressed `Shift`) never match — we
+ * require an actual non-modifier key press. The chord's modifier set must
+ * match exactly (no extra, no missing modifiers).
+ */
+export function matchChord(chord: KeyChord, event: KeyEventLike): boolean {
+  const eventKey = (event.key || "").toLowerCase();
+  if (!eventKey) return false;
+  if (MODIFIER_KEYS.has(eventKey)) return false;
+  if (eventKey !== chord.key) return false;
+
+  const meta = Boolean(event.metaKey);
+  const ctrl = Boolean(event.ctrlKey);
+  const alt = Boolean(event.altKey);
+  const shift = Boolean(event.shiftKey);
+
+  return meta === chord.meta && ctrl === chord.ctrl && alt === chord.alt && shift === chord.shift;
+}
+
+/** Human-readable serializer used by the cheatsheet ("Mod+K" → "⌘+K" / "Ctrl+K"). */
+export function formatKeys(keys: string, platform: Platform = detectPlatform()): string {
+  const chords = parseKeys(keys, platform);
+  return chords
+    .map((chord) => {
+      const parts: string[] = [];
+      if (chord.meta) parts.push(platform === "mac" ? "⌘" : "Meta");
+      if (chord.ctrl) parts.push("Ctrl");
+      if (chord.alt) parts.push(platform === "mac" ? "⌥" : "Alt");
+      if (chord.shift) parts.push(platform === "mac" ? "⇧" : "Shift");
+      parts.push(chord.key.length === 1 ? chord.key.toUpperCase() : capitalize(chord.key));
+      return parts.join("+");
+    })
+    .join(" ");
+}
+
+function capitalize(value: string): string {
+  if (value.length === 0) return value;
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}

--- a/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/key-matcher.ts
+++ b/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/key-matcher.ts
@@ -12,8 +12,14 @@
 
 import type { KeyChord, KeyEventLike, Platform } from "./types";
 
-/** Modifier-only key names that should never count as the chord's "key". */
-const MODIFIER_KEYS = new Set([
+/**
+ * Modifier-only key names that should never count as the chord's "key".
+ *
+ * Exported so the registry can filter out modifier-only `keydown` events
+ * before they pollute the sequence buffer (e.g. pressing just `Ctrl`
+ * while preparing a `Mod+K G` chord).
+ */
+export const MODIFIER_KEYS: ReadonlySet<string> = new Set([
   "shift",
   "control",
   "ctrl",

--- a/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/shortcut-registry.ts
+++ b/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/shortcut-registry.ts
@@ -1,0 +1,249 @@
+/**
+ * In-memory shortcut registry. One instance is created per
+ * `<ShortcutProvider>` and lives for the lifetime of that provider.
+ *
+ * Responsibilities:
+ *   - Track registered shortcuts (insertion-ordered for stable cheatsheet output).
+ *   - Detect conflicts: two enabled handlers registered for the same
+ *     normalized `keys` within the same `scope` emit a `console.warn`.
+ *   - Dispatch a `KeyboardEvent` to the first matching handler — honoring
+ *     the `when` predicate and the editable-target bail-out (unless
+ *     `allowInInput` is set on the shortcut).
+ *   - Maintain sequence state across keypresses (for chords like `"g h"`).
+ */
+
+import { matchChord, parseKeys } from "./key-matcher";
+import type {
+  KeyChord,
+  KeyEventLike,
+  Platform,
+  ShortcutHandler,
+  ShortcutId,
+  ShortcutOptions,
+  ShortcutSnapshot,
+} from "./types";
+
+/** Default window (ms) between sequence keypresses before the buffer resets. */
+export const DEFAULT_SEQUENCE_TIMEOUT_MS = 1000;
+
+interface RegisteredShortcut {
+  id: ShortcutId;
+  keys: string;
+  /** Normalized form used for conflict detection (lowercased, no spaces). */
+  normalizedKeys: string;
+  scope: string;
+  description: string;
+  allowInInput: boolean;
+  when?: () => boolean;
+  handler: ShortcutHandler;
+  chords: KeyChord[];
+}
+
+export interface RegistryOptions {
+  /** Inject a platform tag — defaults to runtime detection at parse time. */
+  platform?: Platform;
+  /** Override the sequence timeout window. */
+  sequenceTimeoutMs?: number;
+  /** Override the conflict-warning sink (defaults to `console.warn`). */
+  warn?: (message: string) => void;
+}
+
+let nextId = 1;
+
+/** Normalize a keys string for conflict detection: split on whitespace, lowercase, sort modifiers. */
+function normalizeKeys(keys: string): string {
+  return keys
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((chord) => {
+      const tokens = chord
+        .split("+")
+        .map((token) => token.trim().toLowerCase())
+        .filter(Boolean);
+      // Stable sort so "Shift+Mod+K" === "Mod+Shift+K".
+      tokens.sort();
+      return tokens.join("+");
+    })
+    .join(" ");
+}
+
+export class ShortcutRegistry {
+  private readonly shortcuts = new Map<ShortcutId, RegisteredShortcut>();
+  private readonly sequenceTimeoutMs: number;
+  private readonly platform: Platform | undefined;
+  private readonly warn: (message: string) => void;
+
+  /** Buffer of recently matched chords (for sequence shortcuts). */
+  private sequenceBuffer: KeyChord[] = [];
+  private lastEventAt = 0;
+
+  constructor(options: RegistryOptions = {}) {
+    this.sequenceTimeoutMs = options.sequenceTimeoutMs ?? DEFAULT_SEQUENCE_TIMEOUT_MS;
+    this.platform = options.platform;
+    this.warn = options.warn ?? ((message) => console.warn(message));
+  }
+
+  /**
+   * Register a shortcut. Returns the assigned id — pass it to
+   * `unregister()` to clean up (typically from a hook's effect cleanup).
+   */
+  register(options: ShortcutOptions): ShortcutId {
+    const chords = parseKeys(options.keys, this.platform);
+    const normalizedKeys = normalizeKeys(options.keys);
+    const scope = options.scope ?? "global";
+    const id = `shortcut-${nextId++}`;
+
+    // Conflict detection — only against currently enabled handlers in same scope.
+    const conflict = this.findConflict(normalizedKeys, scope);
+    if (conflict) {
+      this.warn(
+        `cap-keyboard-shortcuts: duplicate shortcut "${options.keys}" in scope "${scope}" — ` +
+          `existing handler will be shadowed by the new one ("${options.description}" vs "${conflict.description}").`,
+      );
+    }
+
+    this.shortcuts.set(id, {
+      id,
+      keys: options.keys,
+      normalizedKeys,
+      scope,
+      description: options.description,
+      allowInInput: options.allowInInput ?? false,
+      when: options.when,
+      handler: options.handler,
+      chords,
+    });
+    return id;
+  }
+
+  /** Remove a shortcut by id. No-op if the id is unknown. */
+  unregister(id: ShortcutId): void {
+    this.shortcuts.delete(id);
+  }
+
+  /**
+   * Read-only snapshot of all registered shortcuts. Insertion order is
+   * preserved so the cheatsheet rendering stays stable across re-renders.
+   */
+  listShortcuts(): readonly ShortcutSnapshot[] {
+    return Array.from(this.shortcuts.values()).map((shortcut) => ({
+      id: shortcut.id,
+      keys: shortcut.keys,
+      scope: shortcut.scope,
+      description: shortcut.description,
+      allowInInput: shortcut.allowInInput,
+      enabled: shortcut.when ? safePredicate(shortcut.when) : true,
+    }));
+  }
+
+  /**
+   * Dispatch a keyboard event to the first matching shortcut.
+   *
+   * `isEditableTarget` is passed in (rather than read off `event.target`)
+   * so this method stays platform-agnostic — tests don't need a DOM,
+   * and `<ShortcutProvider>` performs the actual `target` inspection.
+   *
+   * Returns `true` if a handler was invoked.
+   */
+  dispatch({
+    event,
+    isEditableTarget = false,
+    now = Date.now(),
+  }: {
+    event: KeyEventLike;
+    isEditableTarget?: boolean;
+    now?: number;
+  }): boolean {
+    // Reset sequence buffer if the inter-key gap exceeded the window.
+    if (now - this.lastEventAt > this.sequenceTimeoutMs) {
+      this.sequenceBuffer = [];
+    }
+    this.lastEventAt = now;
+
+    // We don't try to match if no chord parses out of the event.
+    const eventChord: KeyChord = {
+      key: (event.key || "").toLowerCase(),
+      meta: Boolean(event.metaKey),
+      ctrl: Boolean(event.ctrlKey),
+      alt: Boolean(event.altKey),
+      shift: Boolean(event.shiftKey),
+    };
+
+    // Push to sequence buffer (bounded to a reasonable max so misuse can't
+    // grow it unbounded — longest sensible sequence is ~5 chords).
+    this.sequenceBuffer.push(eventChord);
+    if (this.sequenceBuffer.length > 8) {
+      this.sequenceBuffer = this.sequenceBuffer.slice(-8);
+    }
+
+    for (const shortcut of this.shortcuts.values()) {
+      if (isEditableTarget && !shortcut.allowInInput) continue;
+      if (shortcut.when && !safePredicate(shortcut.when)) continue;
+      if (!this.matchesShortcut(shortcut, event)) continue;
+      // Reset buffer on a successful match so the next sequence starts fresh.
+      this.sequenceBuffer = [];
+      shortcut.handler(event);
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Test whether a shortcut matches given the latest event and the current
+   * sequence buffer. Single-chord shortcuts only inspect the head chord;
+   * sequence shortcuts match against the tail of the buffer.
+   */
+  private matchesShortcut(shortcut: RegisteredShortcut, event: KeyEventLike): boolean {
+    const chords = shortcut.chords;
+    if (chords.length === 1) {
+      const single = chords[0];
+      if (!single) return false;
+      return matchChord(single, event);
+    }
+    // Sequence — compare tail of buffer to the full chord list.
+    if (this.sequenceBuffer.length < chords.length) return false;
+    const tail = this.sequenceBuffer.slice(-chords.length);
+    for (let i = 0; i < chords.length; i++) {
+      const expected = chords[i];
+      const actual = tail[i];
+      if (!expected || !actual) return false;
+      // Compare chord descriptors directly so we don't re-parse.
+      if (
+        expected.key !== actual.key ||
+        expected.meta !== actual.meta ||
+        expected.ctrl !== actual.ctrl ||
+        expected.alt !== actual.alt ||
+        expected.shift !== actual.shift
+      ) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** Walk current registrations looking for an enabled conflict in the same scope. */
+  private findConflict(normalizedKeys: string, scope: string): RegisteredShortcut | undefined {
+    for (const shortcut of this.shortcuts.values()) {
+      if (shortcut.scope !== scope) continue;
+      if (shortcut.normalizedKeys !== normalizedKeys) continue;
+      if (shortcut.when && !safePredicate(shortcut.when)) continue;
+      return shortcut;
+    }
+    return undefined;
+  }
+
+  /** Test helper — number of currently registered shortcuts. */
+  size(): number {
+    return this.shortcuts.size;
+  }
+}
+
+/** Invoke a `when` predicate guarded against thrown errors. */
+function safePredicate(predicate: () => boolean): boolean {
+  try {
+    return Boolean(predicate());
+  } catch {
+    return false;
+  }
+}

--- a/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/shortcut-registry.ts
+++ b/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/shortcut-registry.ts
@@ -12,19 +12,27 @@
  *   - Maintain sequence state across keypresses (for chords like `"g h"`).
  */
 
-import { matchChord, parseKeys } from "./key-matcher";
+import { MODIFIER_KEYS, matchChord, parseKeys } from "./key-matcher";
 import type {
   KeyChord,
   KeyEventLike,
   Platform,
+  RegisterShortcutOptions,
   ShortcutHandler,
   ShortcutId,
-  ShortcutOptions,
   ShortcutSnapshot,
 } from "./types";
 
 /** Default window (ms) between sequence keypresses before the buffer resets. */
 export const DEFAULT_SEQUENCE_TIMEOUT_MS = 1000;
+
+/**
+ * Default delay (ms) used to arbitrate between a single-key shortcut and a
+ * longer sequence that shares the same prefix. When a registered sequence
+ * shortcut's prefix matches the current buffer we wait this long for the
+ * remaining chord(s); if none arrives the single-key shortcut fires.
+ */
+export const DEFAULT_SEQUENCE_PREFIX_DELAY_MS = 200;
 
 interface RegisteredShortcut {
   id: ShortcutId;
@@ -39,13 +47,27 @@ interface RegisteredShortcut {
   chords: KeyChord[];
 }
 
+/** Scheduler abstraction so tests can drive deferred dispatch deterministically. */
+export interface RegistryScheduler {
+  setTimeout: (handler: () => void, delayMs: number) => unknown;
+  clearTimeout: (handle: unknown) => void;
+}
+
 export interface RegistryOptions {
   /** Inject a platform tag — defaults to runtime detection at parse time. */
   platform?: Platform;
   /** Override the sequence timeout window. */
   sequenceTimeoutMs?: number;
+  /**
+   * Override the delay before a single-key shortcut fires when a longer
+   * sequence shares the same prefix. Defaults to
+   * {@link DEFAULT_SEQUENCE_PREFIX_DELAY_MS}.
+   */
+  sequencePrefixDelayMs?: number;
   /** Override the conflict-warning sink (defaults to `console.warn`). */
   warn?: (message: string) => void;
+  /** Injectable scheduler — defaults to global `setTimeout`/`clearTimeout`. */
+  scheduler?: RegistryScheduler;
 }
 
 let nextId = 1;
@@ -68,27 +90,40 @@ function normalizeKeys(keys: string): string {
     .join(" ");
 }
 
+/** Bookkeeping for a single-key dispatch deferred behind a pending sequence prefix. */
+interface PendingSingle {
+  handle: unknown;
+  shortcutId: ShortcutId;
+  fire: () => void;
+}
+
 export class ShortcutRegistry {
   private readonly shortcuts = new Map<ShortcutId, RegisteredShortcut>();
   private readonly sequenceTimeoutMs: number;
+  private readonly sequencePrefixDelayMs: number;
   private readonly platform: Platform | undefined;
   private readonly warn: (message: string) => void;
+  private readonly scheduler: RegistryScheduler;
 
   /** Buffer of recently matched chords (for sequence shortcuts). */
   private sequenceBuffer: KeyChord[] = [];
   private lastEventAt = 0;
+  /** Single-key dispatch waiting for a possible sequence to complete. */
+  private pendingSingle: PendingSingle | null = null;
 
   constructor(options: RegistryOptions = {}) {
     this.sequenceTimeoutMs = options.sequenceTimeoutMs ?? DEFAULT_SEQUENCE_TIMEOUT_MS;
+    this.sequencePrefixDelayMs = options.sequencePrefixDelayMs ?? DEFAULT_SEQUENCE_PREFIX_DELAY_MS;
     this.platform = options.platform;
     this.warn = options.warn ?? ((message) => console.warn(message));
+    this.scheduler = options.scheduler ?? defaultScheduler();
   }
 
   /**
    * Register a shortcut. Returns the assigned id — pass it to
    * `unregister()` to clean up (typically from a hook's effect cleanup).
    */
-  register(options: ShortcutOptions): ShortcutId {
+  register(options: RegisterShortcutOptions): ShortcutId {
     const chords = parseKeys(options.keys, this.platform);
     const normalizedKeys = normalizeKeys(options.keys);
     const scope = options.scope ?? "global";
@@ -120,6 +155,11 @@ export class ShortcutRegistry {
   /** Remove a shortcut by id. No-op if the id is unknown. */
   unregister(id: ShortcutId): void {
     this.shortcuts.delete(id);
+    // If we were waiting to fire this exact shortcut, cancel the timer.
+    if (this.pendingSingle && this.pendingSingle.shortcutId === id) {
+      this.scheduler.clearTimeout(this.pendingSingle.handle);
+      this.pendingSingle = null;
+    }
   }
 
   /**
@@ -144,7 +184,22 @@ export class ShortcutRegistry {
    * so this method stays platform-agnostic — tests don't need a DOM,
    * and `<ShortcutProvider>` performs the actual `target` inspection.
    *
-   * Returns `true` if a handler was invoked.
+   * Dispatch order — for each event we resolve the highest-priority
+   * outcome:
+   *   1. Modifier-only events (`Ctrl`, `Shift`, etc. with no real key)
+   *      are ignored entirely so they don't pollute the sequence buffer.
+   *   2. If the new chord completes a registered sequence, that handler
+   *      fires (any pending single-key timer is cancelled).
+   *   3. Otherwise, if a registered sequence's prefix matches the buffer
+   *      AND a single-chord shortcut also matches the head event, the
+   *      single-chord dispatch is deferred for `sequencePrefixDelayMs`
+   *      so the user gets a chance to complete the sequence.
+   *   4. Otherwise the first matching single-chord shortcut fires
+   *      immediately.
+   *
+   * Returns `true` if a handler was invoked synchronously. Deferred
+   * single-key dispatches return `false` here — they fire later via the
+   * injected scheduler.
    */
   dispatch({
     event,
@@ -161,9 +216,16 @@ export class ShortcutRegistry {
     }
     this.lastEventAt = now;
 
-    // We don't try to match if no chord parses out of the event.
+    const eventKey = (event.key || "").toLowerCase();
+    // Modifier-only keydowns (just `Ctrl`, just `Shift`, …) carry no
+    // useful chord — keep them out of the buffer so they can't break
+    // sequences like "Mod+K G".
+    if (!eventKey || MODIFIER_KEYS.has(eventKey)) {
+      return false;
+    }
+
     const eventChord: KeyChord = {
-      key: (event.key || "").toLowerCase(),
+      key: eventKey,
       meta: Boolean(event.metaKey),
       ctrl: Boolean(event.ctrlKey),
       alt: Boolean(event.altKey),
@@ -177,16 +239,125 @@ export class ShortcutRegistry {
       this.sequenceBuffer = this.sequenceBuffer.slice(-8);
     }
 
+    // 1) Look for a complete sequence match (chords.length > 1). A new
+    //    keypress can complete at most one such shortcut per iteration —
+    //    fire the first one we find (insertion order wins on ties).
+    const sequenceMatch = this.findCompletedSequence(event, isEditableTarget);
+    if (sequenceMatch) {
+      // Cancel any deferred single-key dispatch — the sequence wins.
+      this.clearPendingSingle();
+      this.sequenceBuffer = [];
+      sequenceMatch.handler(event);
+      return true;
+    }
+
+    // 2) Look for the first eligible single-chord match.
+    const singleMatch = this.findSingleMatch(event, isEditableTarget);
+    if (!singleMatch) {
+      return false;
+    }
+
+    // 3) If any pending sequence prefix matches the current buffer, defer.
+    if (this.hasPendingSequencePrefix(isEditableTarget)) {
+      this.scheduleDeferredSingle(singleMatch, event);
+      return false;
+    }
+
+    // 4) Fire the single match immediately.
+    this.clearPendingSingle();
+    this.sequenceBuffer = [];
+    singleMatch.handler(event);
+    return true;
+  }
+
+  /**
+   * Find the first registered sequence (chords.length > 1) whose chord
+   * list matches the tail of the current sequence buffer.
+   */
+  private findCompletedSequence(
+    event: KeyEventLike,
+    isEditableTarget: boolean,
+  ): RegisteredShortcut | undefined {
     for (const shortcut of this.shortcuts.values()) {
+      if (shortcut.chords.length <= 1) continue;
       if (isEditableTarget && !shortcut.allowInInput) continue;
       if (shortcut.when && !safePredicate(shortcut.when)) continue;
       if (!this.matchesShortcut(shortcut, event)) continue;
-      // Reset buffer on a successful match so the next sequence starts fresh.
-      this.sequenceBuffer = [];
-      shortcut.handler(event);
-      return true;
+      return shortcut;
+    }
+    return undefined;
+  }
+
+  /** Find the first eligible single-chord (chords.length === 1) match. */
+  private findSingleMatch(
+    event: KeyEventLike,
+    isEditableTarget: boolean,
+  ): RegisteredShortcut | undefined {
+    for (const shortcut of this.shortcuts.values()) {
+      if (shortcut.chords.length !== 1) continue;
+      if (isEditableTarget && !shortcut.allowInInput) continue;
+      if (shortcut.when && !safePredicate(shortcut.when)) continue;
+      if (!this.matchesShortcut(shortcut, event)) continue;
+      return shortcut;
+    }
+    return undefined;
+  }
+
+  /**
+   * True when at least one registered sequence shortcut has a chord prefix
+   * that matches the current buffer but is not yet complete — i.e. the
+   * user might still be in the middle of typing it.
+   */
+  private hasPendingSequencePrefix(isEditableTarget: boolean): boolean {
+    const buffer = this.sequenceBuffer;
+    if (buffer.length === 0) return false;
+    for (const shortcut of this.shortcuts.values()) {
+      const chords = shortcut.chords;
+      if (chords.length <= 1) continue;
+      // Skip ineligible sequences so we don't pointlessly defer.
+      if (isEditableTarget && !shortcut.allowInInput) continue;
+      if (shortcut.when && !safePredicate(shortcut.when)) continue;
+      if (buffer.length >= chords.length) continue;
+      let matches = true;
+      for (let i = 0; i < buffer.length; i++) {
+        const expected = chords[i];
+        const actual = buffer[i];
+        if (!expected || !actual || !chordsEqual(expected, actual)) {
+          matches = false;
+          break;
+        }
+      }
+      if (matches) return true;
     }
     return false;
+  }
+
+  /**
+   * Park a single-chord dispatch behind a short timer so the user has a
+   * chance to complete a longer sequence. A new pending dispatch replaces
+   * any earlier one — only the latest single-key candidate is at stake.
+   */
+  private scheduleDeferredSingle(shortcut: RegisteredShortcut, event: KeyEventLike): void {
+    this.clearPendingSingle();
+    const targetId = shortcut.id;
+    const fire = () => {
+      this.pendingSingle = null;
+      // The shortcut may have been unregistered or disabled while waiting.
+      const current = this.shortcuts.get(targetId);
+      if (!current) return;
+      if (current.when && !safePredicate(current.when)) return;
+      this.sequenceBuffer = [];
+      current.handler(event);
+    };
+    const handle = this.scheduler.setTimeout(fire, this.sequencePrefixDelayMs);
+    this.pendingSingle = { handle, shortcutId: targetId, fire };
+  }
+
+  /** Cancel any pending deferred single-key dispatch. */
+  private clearPendingSingle(): void {
+    if (!this.pendingSingle) return;
+    this.scheduler.clearTimeout(this.pendingSingle.handle);
+    this.pendingSingle = null;
   }
 
   /**
@@ -208,16 +379,7 @@ export class ShortcutRegistry {
       const expected = chords[i];
       const actual = tail[i];
       if (!expected || !actual) return false;
-      // Compare chord descriptors directly so we don't re-parse.
-      if (
-        expected.key !== actual.key ||
-        expected.meta !== actual.meta ||
-        expected.ctrl !== actual.ctrl ||
-        expected.alt !== actual.alt ||
-        expected.shift !== actual.shift
-      ) {
-        return false;
-      }
+      if (!chordsEqual(expected, actual)) return false;
     }
     return true;
   }
@@ -246,4 +408,24 @@ function safePredicate(predicate: () => boolean): boolean {
   } catch {
     return false;
   }
+}
+
+/** Strict-equality comparison for two parsed chords. */
+function chordsEqual(a: KeyChord, b: KeyChord): boolean {
+  return (
+    a.key === b.key &&
+    a.meta === b.meta &&
+    a.ctrl === b.ctrl &&
+    a.alt === b.alt &&
+    a.shift === b.shift
+  );
+}
+
+/** Default scheduler backed by the host's global setTimeout/clearTimeout. */
+function defaultScheduler(): RegistryScheduler {
+  return {
+    setTimeout: (handler, delayMs) =>
+      (globalThis.setTimeout as (cb: () => void, ms: number) => unknown)(handler, delayMs),
+    clearTimeout: (handle) => (globalThis.clearTimeout as (handle: unknown) => void)(handle),
+  };
 }

--- a/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/types.ts
+++ b/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/types.ts
@@ -41,13 +41,23 @@ export interface KeyEventLike {
 /** Shortcut handler signature. The originating event is passed through. */
 export type ShortcutHandler = (event: KeyEventLike) => void;
 
-/** Shortcut registration options shared by `useShortcut` and the registry. */
+/**
+ * Shortcut options accepted by `useShortcut`. `keys` is optional/nullable
+ * to support conditional registration — `useShortcut` early-returns when
+ * `keys` is falsy without ever touching the registry. Use
+ * {@link RegisterShortcutOptions} when calling the registry directly.
+ */
 export interface ShortcutOptions {
   /**
    * Key combination(s). A single chord like `"Mod+K"` or a space-separated
    * sequence of chords like `"g h"`. See module docstring for the grammar.
+   *
+   * Pass `null` or `undefined` from `useShortcut` to skip registration
+   * entirely — useful for conditional shortcuts (e.g. a cheatsheet trigger
+   * the host has opted out of) without forcing callers to invent an
+   * "unreachable" key string.
    */
-  keys: string;
+  keys?: string | null;
   /** Invoked when the shortcut matches and (`when` ? `when()` : true) holds. */
   handler: ShortcutHandler;
   /** Optional predicate — when it returns false the shortcut is skipped. */
@@ -65,6 +75,15 @@ export interface ShortcutOptions {
    * Default false — editable targets are bailed out as a UX safety net.
    */
   allowInInput?: boolean;
+}
+
+/**
+ * Strict variant consumed by `ShortcutRegistry.register`. `keys` is required
+ * here because the registry has no way to "skip" — the hook layer is the
+ * place where conditional registration is decided.
+ */
+export interface RegisterShortcutOptions extends Omit<ShortcutOptions, "keys"> {
+  keys: string;
 }
 
 /**

--- a/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/types.ts
+++ b/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/types.ts
@@ -1,0 +1,85 @@
+/**
+ * Public type surface for cap-keyboard-shortcuts.
+ *
+ * A shortcut is described by a `keys` string (e.g. `"Mod+K"`, `"Shift+/"`,
+ * `"g h"` for a sequence), an optional `when` predicate and `scope` label,
+ * plus a required `description` used by the cheatsheet UI.
+ *
+ * Keys grammar (case-insensitive token names):
+ *   - `Mod` resolves to `Meta` on macOS / iOS, `Ctrl` everywhere else.
+ *   - Recognized modifier tokens: `Mod`, `Meta`, `Cmd`, `Command`, `Ctrl`,
+ *     `Control`, `Alt`, `Option`, `Shift`.
+ *   - Non-modifier token is the "key" — typically a letter, digit, or named
+ *     key (e.g. `Escape`, `Enter`, `?`, `/`).
+ *   - Multiple chords separated by a single space form a sequence (e.g.
+ *     `"g h"` triggers after pressing `g` then `h` within `sequenceTimeoutMs`).
+ *   - A single chord may contain at most one non-modifier key.
+ */
+
+/** Shortcut identifier produced by the registry. */
+export type ShortcutId = string;
+
+/** A parsed key chord — modifiers plus a single non-modifier key. */
+export interface KeyChord {
+  /** Lowercased non-modifier key (e.g. "k", "/", "escape"). */
+  key: string;
+  meta: boolean;
+  ctrl: boolean;
+  alt: boolean;
+  shift: boolean;
+}
+
+/** Minimal subset of `KeyboardEvent` the matcher reads. */
+export interface KeyEventLike {
+  key: string;
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  altKey?: boolean;
+  shiftKey?: boolean;
+}
+
+/** Shortcut handler signature. The originating event is passed through. */
+export type ShortcutHandler = (event: KeyEventLike) => void;
+
+/** Shortcut registration options shared by `useShortcut` and the registry. */
+export interface ShortcutOptions {
+  /**
+   * Key combination(s). A single chord like `"Mod+K"` or a space-separated
+   * sequence of chords like `"g h"`. See module docstring for the grammar.
+   */
+  keys: string;
+  /** Invoked when the shortcut matches and (`when` ? `when()` : true) holds. */
+  handler: ShortcutHandler;
+  /** Optional predicate — when it returns false the shortcut is skipped. */
+  when?: () => boolean;
+  /**
+   * Optional grouping label used by the cheatsheet (e.g. "Navigation").
+   * Defaults to "global".
+   */
+  scope?: string;
+  /** Human-readable description rendered in the cheatsheet. Required. */
+  description: string;
+  /**
+   * When true, the shortcut still fires while focus is in an editable
+   * element (`INPUT` / `TEXTAREA` / `SELECT` / contentEditable).
+   * Default false — editable targets are bailed out as a UX safety net.
+   */
+  allowInInput?: boolean;
+}
+
+/**
+ * Read-only snapshot of a registered shortcut. Returned by
+ * `registry.listShortcuts()` and consumed by `<ShortcutCheatsheet>`.
+ */
+export interface ShortcutSnapshot {
+  id: ShortcutId;
+  keys: string;
+  scope: string;
+  description: string;
+  allowInInput: boolean;
+  /** True when no `when` predicate is set OR the predicate currently passes. */
+  enabled: boolean;
+}
+
+/** Platform tag used by the `Mod` modifier resolver. */
+export type Platform = "mac" | "other";

--- a/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/use-shortcut.ts
+++ b/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/use-shortcut.ts
@@ -1,0 +1,42 @@
+/**
+ * `useShortcut(...)` — register a single shortcut for the lifetime of a
+ * component. Internally calls `registry.register` on mount and
+ * `registry.unregister` on cleanup. Re-registers when the `keys`,
+ * `scope`, `description`, or `allowInInput` change so the latest config
+ * is always live; the handler / `when` predicate are read through a ref
+ * so callers don't need to memoize them.
+ */
+
+import { useEffect, useRef } from "react";
+import { useShortcutRegistry } from "./ShortcutProvider";
+import type { ShortcutOptions } from "./types";
+
+export function useShortcut(options: ShortcutOptions): void {
+  const registry = useShortcutRegistry();
+  const handlerRef = useRef(options.handler);
+  const whenRef = useRef(options.when);
+
+  // Keep the refs current without invalidating the registration effect.
+  useEffect(() => {
+    handlerRef.current = options.handler;
+    whenRef.current = options.when;
+  }, [options.handler, options.when]);
+
+  useEffect(() => {
+    const id = registry.register({
+      keys: options.keys,
+      scope: options.scope,
+      description: options.description,
+      allowInInput: options.allowInInput,
+      handler: (event) => handlerRef.current(event),
+      when: () => {
+        const predicate = whenRef.current;
+        return predicate ? Boolean(predicate()) : true;
+      },
+    });
+    return () => {
+      registry.unregister(id);
+    };
+    // Deliberately exclude handler / when — they are read through refs.
+  }, [registry, options.keys, options.scope, options.description, options.allowInInput]);
+}

--- a/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/use-shortcut.ts
+++ b/addons/keyboard-shortcuts/cap-keyboard-shortcuts/src/use-shortcut.ts
@@ -5,6 +5,12 @@
  * `scope`, `description`, or `allowInInput` change so the latest config
  * is always live; the handler / `when` predicate are read through a ref
  * so callers don't need to memoize them.
+ *
+ * Conditional registration: pass `keys: null` (or omit it / pass
+ * `undefined`) to skip registration entirely. The hook still runs all
+ * its React calls in a stable order — only the registry side-effect is
+ * gated. This lets callers like `<ShortcutCheatsheet>` accept an opt-out
+ * trigger without inventing an "unreachable" placeholder key.
  */
 
 import { useEffect, useRef } from "react";
@@ -22,9 +28,15 @@ export function useShortcut(options: ShortcutOptions): void {
     whenRef.current = options.when;
   }, [options.handler, options.when]);
 
+  // `keys` may be null/undefined to disable registration. Normalize to
+  // empty so the effect dep array stays a primitive and React doesn't
+  // see `undefined` swing back-and-forth.
+  const keys = options.keys ?? "";
+
   useEffect(() => {
+    if (!keys) return;
     const id = registry.register({
-      keys: options.keys,
+      keys,
       scope: options.scope,
       description: options.description,
       allowInInput: options.allowInInput,
@@ -38,5 +50,5 @@ export function useShortcut(options: ShortcutOptions): void {
       registry.unregister(id);
     };
     // Deliberately exclude handler / when — they are read through refs.
-  }, [registry, options.keys, options.scope, options.description, options.allowInInput]);
+  }, [registry, keys, options.scope, options.description, options.allowInInput]);
 }

--- a/addons/keyboard-shortcuts/cap-keyboard-shortcuts/tsconfig.json
+++ b/addons/keyboard-shortcuts/cap-keyboard-shortcuts/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun-types"]
+  },
+  "include": ["src", "__tests__"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -281,6 +281,18 @@
         "@linchkit/core": "^0.2.0",
       },
     },
+    "addons/keyboard-shortcuts/cap-keyboard-shortcuts": {
+      "name": "@linchkit/cap-keyboard-shortcuts",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@linchkit/core": "workspace:*",
+      },
+      "peerDependencies": {
+        "@linchkit/core": "^0.2.0",
+        "react": "^19.0.0",
+        "react-i18next": "^14",
+      },
+    },
     "addons/migration/cap-migration": {
       "name": "@linchkit/cap-migration",
       "version": "1.0.0",
@@ -341,6 +353,7 @@
         "@linchkit/core": "^0.2.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-i18next": ">=14.0.0",
       },
     },
     "packages/cli": {
@@ -693,6 +706,8 @@
     "@linchkit/cap-file-storage": ["@linchkit/cap-file-storage@workspace:addons/file-storage/cap-file-storage"],
 
     "@linchkit/cap-flow-restate": ["@linchkit/cap-flow-restate@workspace:addons/flow-restate/cap-flow-restate"],
+
+    "@linchkit/cap-keyboard-shortcuts": ["@linchkit/cap-keyboard-shortcuts@workspace:addons/keyboard-shortcuts/cap-keyboard-shortcuts"],
 
     "@linchkit/cap-life-demo": ["@linchkit/cap-life-demo@workspace:addons/demo/cap-life-demo"],
 


### PR DESCRIPTION
## Summary
New capability \`@linchkit/cap-keyboard-shortcuts\` from #121 (Spec 14) subset. Global keyboard-shortcut registry, React hook, and cheatsheet overlay.

## API
- \`<ShortcutProvider>\` — single global keydown listener
- \`useShortcut({ keys, handler, when, scope, description, allowInInput })\` — register + cleanup
- \`<ShortcutCheatsheet />\` — overlay grouped by scope (default bound to Shift+?)

## Key matching (\`src/key-matcher.ts\`)
- \`Mod\` resolves per-platform: \`Meta\` on mac, \`Ctrl\` elsewhere. \`detectPlatform()\` inspects \`navigator.platform || userAgent\` with SSR-safe \`"other"\` fallback. Tests always pass platform explicitly for deterministic CI.
- Sequence chords (e.g. \`g h\`) matched within ~1s timeout
- Modifier-only keypresses don't match
- **Bail on editable targets** (\`INPUT\` / \`TEXTAREA\` / \`SELECT\` / \`isContentEditable\`) unless \`allowInInput: true\` — same pattern as cap-search-ui's GlobalSearchInput

## Registry
- register / unregister
- Conflict warning when two enabled handlers share the same keys within a scope
- \`listShortcuts\` snapshot for cheatsheet rendering

## i18n
en + zh-CN under \`src/i18n/locales/\` via the capability's \`extensions.i18n\` slot. Components resolve translations through the host's global \`react-i18next\` so the peerDep surface stays minimal.

## Verification
- \`bun run check\` — clean (1155 files)
- \`bun run typecheck\` — clean
- \`bun test\` — 5196 pass / 3 skip / 0 fail (325 files)
- 40 scoped tests / 59 assertions across 3 files

## Test plan
- [x] Mod resolution per-platform
- [x] Shift+/ matches
- [x] modifier-only doesn't match
- [x] formatKeys joins sequence chords with a space
- [x] register/unregister + conflict warning + scope isolation
- [x] sequence dispatch with timeout
- [x] allowInInput + when gating
- [x] listShortcuts grouping
- [x] mount registration + cleanup on unmount + live \`when\` predicate

Refs #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)