### PR TITLE
feat(cap-vector-pgvector): pgvector vector store + RAG helpers (closes #165)

### DIFF
--- a/addons/vector/cap-vector-pgvector/README.md
+++ b/addons/vector/cap-vector-pgvector/README.md
@@ -1,0 +1,76 @@
+# @linchkit/cap-vector-pgvector
+
+PostgreSQL `pgvector` implementation of LinchKit's `VectorStore` contract — see
+[Spec 68 — Vector Store & RAG](../../../docs/specs/68_vector_store.md).
+
+The capability provides:
+
+- `VectorStore` contract (in `./src/types.ts` for now — promoted to core once
+  a second implementation lands; see file header for the rationale).
+- `PgVectorStore` — Drizzle-backed implementation using the `vector(N)`
+  column type, `<=>` cosine distance operator, and HNSW index.
+- `InMemoryVectorStore` — brute-force KNN for tests / dev environments and a
+  zero-config stand-in for the spec's `cap-vector-memory`.
+- Embedding pipeline (`embedAndUpsertDocuments`) that accepts any
+  `EmbeddingProvider`. A `createFunctionEmbeddingProvider()` helper wraps
+  arbitrary embed functions (e.g. Vercel AI SDK).
+- RAG helpers (`searchSimilar`, `retrieveContext`) — the P0 single-strategy
+  retrieval slice. Multi-strategy fusion (Spec 68 §3.2) is deferred.
+
+## Database setup
+
+Two SQL steps run alongside drizzle-kit's generated `CREATE TABLE`:
+
+```sql
+-- 1. Enable the extension (run once per database)
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- 2. Create the HNSW + cosine_ops index (drizzle-kit cannot express
+--    the operator class, so the capability ships this SQL by hand)
+CREATE INDEX IF NOT EXISTS idx_vectors_embedding_hnsw
+  ON _linchkit.vectors
+  USING hnsw (embedding vector_cosine_ops)
+  WITH (m = 16, ef_construction = 200);
+```
+
+Steps to wire the table itself into a host application:
+
+1. Add `cap-vector-pgvector` to `linchkit.config.ts`.
+2. Run `bun run db:generate` — this regenerates the Drizzle schema barrel
+   and invokes drizzle-kit to emit the `CREATE TABLE _linchkit.vectors`
+   migration.
+3. Apply the migration plus the two SQL statements above.
+
+## Usage
+
+```ts
+import { createCapVectorPgvector, createFunctionEmbeddingProvider, retrieveContext }
+  from "@linchkit/cap-vector-pgvector";
+
+const capVector = createCapVectorPgvector({ db });
+
+const embedder = createFunctionEmbeddingProvider({
+  dimension: 1536,
+  embed: async (text) => /* call OpenAI / Anthropic / local model */,
+});
+
+const { prompt, hits } = await retrieveContext({
+  store: capVector.vectorStore,
+  embedder,
+  query: "approval rules for capital expenditure",
+  topK: 5,
+  namespace: "meta_model",
+});
+```
+
+## Deferred (out of scope for this PR)
+
+- Multi-strategy retrieval orchestration (vector + structural + keyword) —
+  Spec 68 §3.1, lands once cap-search hooks are wired.
+- Auto-vectorization of Meta-Model definitions and business data — Spec 68
+  §4, lands as a follow-up event-handler in the same package.
+- RAG quality metrics (context_recall, faithfulness …) — Spec 68 §6.
+- Reranking and reciprocal rank fusion — Spec 68 §3 M6+ column.
+- Dedicated `cap-vector-memory` / `cap-vector-qdrant` packages — Spec 68
+  §2.2 future row. `InMemoryVectorStore` already covers the M5
+  test-only need.

--- a/addons/vector/cap-vector-pgvector/__tests__/embed.test.ts
+++ b/addons/vector/cap-vector-pgvector/__tests__/embed.test.ts
@@ -53,6 +53,42 @@ describe("createFunctionEmbeddingProvider", () => {
       /positive integer/,
     );
   });
+
+  it("rejects non-positive embedManyConcurrency", () => {
+    expect(() =>
+      createFunctionEmbeddingProvider({
+        dimension: D,
+        embed: async () => [0, 0, 0],
+        embedManyConcurrency: 0,
+      }),
+    ).toThrow(/embedManyConcurrency/);
+  });
+
+  it("bounds parallel embed() invocations in the fallback path", async () => {
+    let inFlight = 0;
+    let peakInFlight = 0;
+    const provider = createFunctionEmbeddingProvider({
+      dimension: D,
+      embedManyConcurrency: 2,
+      embed: async (text) => {
+        inFlight++;
+        peakInFlight = Math.max(peakInFlight, inFlight);
+        // Yield once so multiple inputs can pile up if concurrency is unbounded.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        inFlight--;
+        return stubEmbed(text);
+      },
+    });
+
+    const inputs = ["a", "b", "c", "d", "e", "f"];
+    const vectors = (await provider.embedMany?.(inputs)) ?? [];
+    expect(vectors).toHaveLength(inputs.length);
+    // Result order is preserved.
+    expect(vectors[0]).toEqual(stubEmbed("a"));
+    expect(vectors[5]).toEqual(stubEmbed("f"));
+    // Concurrency must never exceed the configured cap.
+    expect(peakInFlight).toBeLessThanOrEqual(2);
+  });
 });
 
 describe("embedAndUpsertDocuments", () => {

--- a/addons/vector/cap-vector-pgvector/__tests__/embed.test.ts
+++ b/addons/vector/cap-vector-pgvector/__tests__/embed.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Embedding pipeline tests — covers the function-adapter wrapper and the
+ * batch `embedAndUpsertDocuments` pipeline. A deterministic stub embedder
+ * keeps the assertions math-free.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { createFunctionEmbeddingProvider, embedAndUpsertDocuments } from "../src/embed";
+import { InMemoryVectorStore } from "../src/in-memory-store";
+
+const D = 3;
+
+/**
+ * Hash a text into a deterministic 3-d vector for testing.
+ * Positional buckets so different texts produce non-parallel vectors
+ * (cosine similarity can actually differentiate them).
+ */
+function stubEmbed(text: string): number[] {
+  const buckets = [0, 0, 0];
+  for (let i = 0; i < text.length; i++) {
+    buckets[i % 3] += text.charCodeAt(i);
+  }
+  return buckets;
+}
+
+describe("createFunctionEmbeddingProvider", () => {
+  it("synthesises embedMany when only embed is supplied", async () => {
+    const provider = createFunctionEmbeddingProvider({
+      dimension: D,
+      embed: async (text) => stubEmbed(text),
+    });
+    const [u, v] = (await provider.embedMany?.(["hi", "ho"])) ?? [];
+    expect(u).toEqual(stubEmbed("hi"));
+    expect(v).toEqual(stubEmbed("ho"));
+  });
+
+  it("uses the caller-supplied embedMany when provided", async () => {
+    let batchCalls = 0;
+    const provider = createFunctionEmbeddingProvider({
+      dimension: D,
+      embed: async (text) => stubEmbed(text),
+      embedMany: async (texts) => {
+        batchCalls++;
+        return texts.map((t) => stubEmbed(t));
+      },
+    });
+    await provider.embedMany?.(["a", "b", "c"]);
+    expect(batchCalls).toBe(1);
+  });
+
+  it("rejects non-positive dimension", () => {
+    expect(() => createFunctionEmbeddingProvider({ dimension: 0, embed: async () => [] })).toThrow(
+      /positive integer/,
+    );
+  });
+});
+
+describe("embedAndUpsertDocuments", () => {
+  it("embeds every document and persists them under the supplied namespace", async () => {
+    const store = new InMemoryVectorStore({ dimension: D });
+    const embedder = createFunctionEmbeddingProvider({
+      dimension: D,
+      embed: async (text) => stubEmbed(text),
+    });
+
+    const count = await embedAndUpsertDocuments({
+      store,
+      embedder,
+      namespace: "meta_model",
+      documents: [
+        { id: "entity:order", content: "order entity description" },
+        { id: "entity:vendor", content: "vendor entity description", metadata: { kind: "ref" } },
+      ],
+    });
+
+    expect(count).toBe(2);
+    expect(store.size()).toBe(2);
+
+    // The vendor row carried metadata through to the store.
+    const hits = await store.search(stubEmbed("vendor entity description"), {
+      namespace: "meta_model",
+    });
+    expect(hits[0]?.id).toBe("entity:vendor");
+    expect(hits[0]?.metadata.kind).toBe("ref");
+    expect(hits[0]?.content).toBe("vendor entity description");
+  });
+
+  it("returns 0 on an empty document list and does not call the embedder", async () => {
+    const store = new InMemoryVectorStore({ dimension: D });
+    let calls = 0;
+    const embedder = createFunctionEmbeddingProvider({
+      dimension: D,
+      embed: async (text) => {
+        calls++;
+        return stubEmbed(text);
+      },
+    });
+
+    const count = await embedAndUpsertDocuments({ store, embedder, documents: [] });
+    expect(count).toBe(0);
+    expect(calls).toBe(0);
+  });
+
+  it("rejects dimension mismatches between embedder and store", async () => {
+    const store = new InMemoryVectorStore({ dimension: D });
+    const embedder = createFunctionEmbeddingProvider({
+      dimension: D + 1,
+      embed: async () => [0, 0, 0, 0],
+    });
+
+    await expect(
+      embedAndUpsertDocuments({
+        store,
+        embedder,
+        documents: [{ id: "x", content: "test" }],
+      }),
+    ).rejects.toThrow(/dimension/);
+  });
+
+  it("rejects when the embedder returns the wrong number of vectors", async () => {
+    const store = new InMemoryVectorStore({ dimension: D });
+    const embedder = createFunctionEmbeddingProvider({
+      dimension: D,
+      embed: async (text) => stubEmbed(text),
+      embedMany: async (texts) => texts.slice(0, -1).map((t) => stubEmbed(t)),
+    });
+    await expect(
+      embedAndUpsertDocuments({
+        store,
+        embedder,
+        documents: [
+          { id: "a", content: "one" },
+          { id: "b", content: "two" },
+        ],
+      }),
+    ).rejects.toThrow(/2 documents/);
+  });
+});

--- a/addons/vector/cap-vector-pgvector/__tests__/in-memory-store.test.ts
+++ b/addons/vector/cap-vector-pgvector/__tests__/in-memory-store.test.ts
@@ -1,0 +1,153 @@
+/**
+ * InMemoryVectorStore tests — verifies the upsert / search / delete
+ * semantics that downstream RAG helpers and the pgvector store
+ * implementation share. Pure brute-force KNN over deterministic vectors,
+ * no AI provider or PostgreSQL required.
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { InMemoryVectorStore } from "../src/in-memory-store";
+
+const D = 4;
+
+function vec(...values: number[]): number[] {
+  if (values.length !== D) {
+    throw new Error(`vec(): expected ${D} components, got ${values.length}`);
+  }
+  return values;
+}
+
+describe("InMemoryVectorStore", () => {
+  let store: InMemoryVectorStore;
+
+  beforeEach(() => {
+    store = new InMemoryVectorStore({ dimension: D });
+  });
+
+  it("rejects vectors whose length does not match the configured dimension", async () => {
+    await expect(store.upsert({ id: "x", vector: [1, 0, 0], metadata: {} })).rejects.toThrow(
+      /expected 4/,
+    );
+  });
+
+  it("returns the nearest vector first by cosine similarity", async () => {
+    await store.upsert({ id: "a", vector: vec(1, 0, 0, 0), metadata: { label: "a" } });
+    await store.upsert({ id: "b", vector: vec(0, 1, 0, 0), metadata: { label: "b" } });
+    await store.upsert({ id: "c", vector: vec(0, 0, 1, 0), metadata: { label: "c" } });
+
+    const hits = await store.search(vec(0.9, 0.1, 0, 0));
+    expect(hits.length).toBe(3);
+    expect(hits[0]?.id).toBe("a");
+    // Scores are in [0, 1] after rescaling; nearest should be ≥ runner-up.
+    expect(hits[0]?.score).toBeGreaterThan(hits[1]?.score ?? 0);
+  });
+
+  it("respects topK", async () => {
+    for (let i = 0; i < 5; i++) {
+      await store.upsert({ id: `r${i}`, vector: vec(i + 1, 0, 0, 0), metadata: {} });
+    }
+    const hits = await store.search(vec(1, 0, 0, 0), { topK: 2 });
+    expect(hits).toHaveLength(2);
+  });
+
+  it("isolates results by namespace", async () => {
+    await store.upsert({
+      id: "x",
+      vector: vec(1, 0, 0, 0),
+      metadata: { ns: "meta" },
+      namespace: "meta_model",
+    });
+    await store.upsert({
+      id: "x",
+      vector: vec(1, 0, 0, 0),
+      metadata: { ns: "data" },
+      namespace: "data:order",
+    });
+
+    const meta = await store.search(vec(1, 0, 0, 0), { namespace: "meta_model" });
+    expect(meta).toHaveLength(1);
+    expect(meta[0]?.metadata.ns).toBe("meta");
+
+    const data = await store.search(vec(1, 0, 0, 0), { namespace: "data:order" });
+    expect(data).toHaveLength(1);
+    expect(data[0]?.metadata.ns).toBe("data");
+
+    // Default namespace bucket is empty
+    const def = await store.search(vec(1, 0, 0, 0));
+    expect(def).toHaveLength(0);
+  });
+
+  it("applies JSONB-style equality filters", async () => {
+    await store.upsert({
+      id: "1",
+      vector: vec(1, 0, 0, 0),
+      metadata: { tenant_id: "t1", entity: "order" },
+    });
+    await store.upsert({
+      id: "2",
+      vector: vec(1, 0, 0, 0),
+      metadata: { tenant_id: "t2", entity: "order" },
+    });
+    await store.upsert({
+      id: "3",
+      vector: vec(1, 0, 0, 0),
+      metadata: { tenant_id: "t1", entity: "vendor" },
+    });
+
+    const tenantOnly = await store.search(vec(1, 0, 0, 0), { filter: { tenant_id: "t1" } });
+    expect(tenantOnly.map((h) => h.id).sort()).toEqual(["1", "3"]);
+
+    const both = await store.search(vec(1, 0, 0, 0), {
+      filter: { tenant_id: "t1", entity: "order" },
+    });
+    expect(both).toHaveLength(1);
+    expect(both[0]?.id).toBe("1");
+  });
+
+  it("drops results below minScore", async () => {
+    await store.upsert({ id: "near", vector: vec(1, 0, 0, 0), metadata: {} });
+    await store.upsert({ id: "far", vector: vec(-1, 0, 0, 0), metadata: {} });
+
+    const hits = await store.search(vec(1, 0, 0, 0), { minScore: 0.9 });
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.id).toBe("near");
+  });
+
+  it("batchUpsert writes every row", async () => {
+    await store.batchUpsert([
+      { id: "a", vector: vec(1, 0, 0, 0), metadata: {} },
+      { id: "b", vector: vec(0, 1, 0, 0), metadata: {} },
+      { id: "c", vector: vec(0, 0, 1, 0), metadata: {} },
+    ]);
+    expect(store.size()).toBe(3);
+  });
+
+  it("upsert replaces an existing row under the same (id, namespace)", async () => {
+    await store.upsert({ id: "x", vector: vec(1, 0, 0, 0), metadata: { v: 1 } });
+    await store.upsert({ id: "x", vector: vec(0, 1, 0, 0), metadata: { v: 2 } });
+    expect(store.size()).toBe(1);
+
+    const hits = await store.search(vec(0, 1, 0, 0));
+    expect(hits[0]?.id).toBe("x");
+    expect(hits[0]?.metadata.v).toBe(2);
+  });
+
+  it("delete removes one row and is scoped to a namespace", async () => {
+    await store.upsert({ id: "x", vector: vec(1, 0, 0, 0), metadata: {}, namespace: "a" });
+    await store.upsert({ id: "x", vector: vec(1, 0, 0, 0), metadata: {}, namespace: "b" });
+
+    expect(await store.delete("x", { namespace: "a" })).toBe(true);
+    expect(await store.delete("x", { namespace: "a" })).toBe(false);
+    expect(store.size()).toBe(1);
+  });
+
+  it("clearNamespace drops every row under the namespace and returns the count", async () => {
+    await store.upsert({ id: "x", vector: vec(1, 0, 0, 0), metadata: {}, namespace: "ns" });
+    await store.upsert({ id: "y", vector: vec(0, 1, 0, 0), metadata: {}, namespace: "ns" });
+    await store.upsert({ id: "z", vector: vec(0, 0, 1, 0), metadata: {}, namespace: "other" });
+
+    const dropped = await store.clearNamespace("ns");
+    expect(dropped).toBe(2);
+    expect(store.size()).toBe(1);
+  });
+});

--- a/addons/vector/cap-vector-pgvector/__tests__/pgvector-store.test.ts
+++ b/addons/vector/cap-vector-pgvector/__tests__/pgvector-store.test.ts
@@ -1,0 +1,276 @@
+/**
+ * PgVectorStore unit tests — use a hand-rolled fake Drizzle DB so we can
+ * exercise the SQL plumbing without standing up PostgreSQL. The fake
+ * captures every call so assertions can inspect chunking, conflict
+ * targets, dimension validation, and the score-rescaling formula.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { createPgVectorStore, PgVectorStore } from "../src/pgvector-store";
+
+interface Recorded {
+  insertCalls: Array<{ rows: unknown[]; conflict: Record<string, unknown> | undefined }>;
+  selectCalls: number;
+  deleteCalls: number;
+  lastSelectLimit: number | undefined;
+}
+
+interface FakeDb {
+  record: Recorded;
+  insert: (...args: unknown[]) => unknown;
+  select: (...args: unknown[]) => unknown;
+  delete: (...args: unknown[]) => unknown;
+}
+
+function makeFakeDb(options: {
+  rowsToReturn?: Array<{
+    id: string;
+    namespace: string;
+    metadata: Record<string, unknown> | null;
+    content: string | null;
+    score: number | string | null;
+  }>;
+  deleteReturning?: Array<{ id: string }>;
+}): FakeDb {
+  const record: Recorded = {
+    insertCalls: [],
+    selectCalls: 0,
+    deleteCalls: 0,
+    lastSelectLimit: undefined,
+  };
+
+  const insertChain = () => {
+    let capturedRows: unknown[] = [];
+    return {
+      values: (rows: unknown) => {
+        capturedRows = Array.isArray(rows) ? rows : [rows];
+        return {
+          onConflictDoUpdate: async (conflict: Record<string, unknown>) => {
+            record.insertCalls.push({ rows: capturedRows, conflict });
+          },
+        };
+      },
+    };
+  };
+
+  const selectChain = () => {
+    return {
+      from: () => ({
+        where: () => ({
+          orderBy: () => ({
+            limit: async (n: number) => {
+              record.selectCalls++;
+              record.lastSelectLimit = n;
+              return options.rowsToReturn ?? [];
+            },
+          }),
+        }),
+      }),
+    };
+  };
+
+  const deleteChain = () => {
+    return {
+      where: () => ({
+        returning: async () => {
+          record.deleteCalls++;
+          return options.deleteReturning ?? [];
+        },
+      }),
+    };
+  };
+
+  return {
+    record,
+    insert: insertChain,
+    select: selectChain,
+    delete: deleteChain,
+  };
+}
+
+const D = 4;
+
+function vec(...values: number[]): number[] {
+  if (values.length !== D) {
+    throw new Error(`vec(): expected ${D} components, got ${values.length}`);
+  }
+  return values;
+}
+
+describe("PgVectorStore — construction", () => {
+  it("rejects when db is missing", () => {
+    expect(() => new PgVectorStore({ db: undefined, dimension: D })).toThrow(/required/);
+  });
+
+  it("rejects a non-Drizzle-shaped db", () => {
+    expect(() => new PgVectorStore({ db: {}, dimension: D })).toThrow(/insert\/select\/delete/);
+  });
+
+  it("rejects a non-positive dimension", () => {
+    const db = makeFakeDb({});
+    expect(() => new PgVectorStore({ db, dimension: 0 })).toThrow(/positive integer/);
+    expect(() => new PgVectorStore({ db, dimension: 1.5 })).toThrow(/positive integer/);
+  });
+
+  it("rejects a non-positive batch chunk size", () => {
+    const db = makeFakeDb({});
+    expect(() => new PgVectorStore({ db, dimension: D, batchChunkSize: 0 })).toThrow(
+      /batchChunkSize/,
+    );
+  });
+
+  it("createPgVectorStore factory mirrors the constructor", () => {
+    const db = makeFakeDb({});
+    const store = createPgVectorStore({ db, dimension: D });
+    expect(store).toBeInstanceOf(PgVectorStore);
+    expect(store.dimension).toBe(D);
+  });
+});
+
+describe("PgVectorStore.upsert", () => {
+  it("rejects mismatched dimension", async () => {
+    const db = makeFakeDb({});
+    const store = new PgVectorStore({ db, dimension: D });
+    await expect(store.upsert({ id: "x", vector: [1, 0, 0], metadata: {} })).rejects.toThrow(
+      /expected 4/,
+    );
+  });
+
+  it("rejects non-finite vector components (NaN / Infinity)", async () => {
+    const db = makeFakeDb({});
+    const store = new PgVectorStore({ db, dimension: D });
+    await expect(
+      store.upsert({ id: "nan", vector: vec(Number.NaN, 0, 0, 0), metadata: {} }),
+    ).rejects.toThrow(/non-finite/);
+    await expect(
+      store.upsert({ id: "inf", vector: vec(Number.POSITIVE_INFINITY, 0, 0, 0), metadata: {} }),
+    ).rejects.toThrow(/non-finite/);
+  });
+
+  it("writes a single row with the supplied namespace", async () => {
+    const db = makeFakeDb({});
+    const store = new PgVectorStore({ db, dimension: D });
+    await store.upsert({
+      id: "a",
+      vector: vec(1, 0, 0, 0),
+      metadata: { tag: "demo" },
+      namespace: "meta_model",
+    });
+    expect(db.record.insertCalls).toHaveLength(1);
+    const call = db.record.insertCalls[0];
+    if (!call) throw new Error("missing insert call");
+    expect(call.rows).toHaveLength(1);
+    const row = call.rows[0] as { id: string; namespace: string };
+    expect(row.id).toBe("a");
+    expect(row.namespace).toBe("meta_model");
+  });
+});
+
+describe("PgVectorStore.batchUpsert", () => {
+  it("is a no-op when items is empty", async () => {
+    const db = makeFakeDb({});
+    const store = new PgVectorStore({ db, dimension: D });
+    await store.batchUpsert([]);
+    expect(db.record.insertCalls).toHaveLength(0);
+  });
+
+  it("chunks oversize input into multiple INSERT statements", async () => {
+    const db = makeFakeDb({});
+    const store = new PgVectorStore({ db, dimension: D, batchChunkSize: 3 });
+    const items = Array.from({ length: 7 }, (_, i) => ({
+      id: `r${i}`,
+      vector: vec(1, 0, 0, 0),
+      metadata: { i },
+    }));
+    await store.batchUpsert(items);
+    // 7 items, chunk size 3 → 3 + 3 + 1
+    expect(db.record.insertCalls).toHaveLength(3);
+    expect(db.record.insertCalls[0]?.rows).toHaveLength(3);
+    expect(db.record.insertCalls[1]?.rows).toHaveLength(3);
+    expect(db.record.insertCalls[2]?.rows).toHaveLength(1);
+  });
+
+  it("validates every item before issuing any INSERT", async () => {
+    const db = makeFakeDb({});
+    const store = new PgVectorStore({ db, dimension: D });
+    await expect(
+      store.batchUpsert([
+        { id: "ok", vector: vec(1, 0, 0, 0), metadata: {} },
+        { id: "bad", vector: [1, 0, 0], metadata: {} },
+      ]),
+    ).rejects.toThrow(/expected 4/);
+    expect(db.record.insertCalls).toHaveLength(0);
+  });
+});
+
+describe("PgVectorStore.search", () => {
+  it("rejects non-finite query components", async () => {
+    const db = makeFakeDb({});
+    const store = new PgVectorStore({ db, dimension: D });
+    await expect(store.search(vec(Number.NaN, 0, 0, 0))).rejects.toThrow(/non-finite/);
+  });
+
+  it("clamps topK to [1, 200]", async () => {
+    const db = makeFakeDb({});
+    const store = new PgVectorStore({ db, dimension: D });
+    await store.search(vec(1, 0, 0, 0), { topK: 9999 });
+    expect(db.record.lastSelectLimit).toBe(200);
+    await store.search(vec(1, 0, 0, 0), { topK: 0 });
+    expect(db.record.lastSelectLimit).toBe(10);
+  });
+
+  it("returns rows with score coerced to a finite number", async () => {
+    const db = makeFakeDb({
+      rowsToReturn: [
+        { id: "a", namespace: "default", metadata: { x: 1 }, content: "alpha", score: 0.91 },
+        { id: "b", namespace: "default", metadata: null, content: null, score: "0.42" },
+        { id: "c", namespace: "default", metadata: {}, content: null, score: null },
+      ],
+    });
+    const store = new PgVectorStore({ db, dimension: D });
+    const hits = await store.search(vec(1, 0, 0, 0));
+    expect(hits).toHaveLength(3);
+    expect(hits[0]).toEqual({
+      id: "a",
+      namespace: "default",
+      score: 0.91,
+      metadata: { x: 1 },
+      content: "alpha",
+    });
+    expect(hits[1]?.score).toBeCloseTo(0.42);
+    expect(hits[1]?.metadata).toEqual({});
+    expect(hits[2]?.score).toBe(0);
+  });
+
+  it("drops rows below minScore", async () => {
+    const db = makeFakeDb({
+      rowsToReturn: [
+        { id: "high", namespace: "default", metadata: {}, content: null, score: 0.95 },
+        { id: "low", namespace: "default", metadata: {}, content: null, score: 0.1 },
+      ],
+    });
+    const store = new PgVectorStore({ db, dimension: D });
+    const hits = await store.search(vec(1, 0, 0, 0), { minScore: 0.5 });
+    expect(hits.map((h) => h.id)).toEqual(["high"]);
+  });
+});
+
+describe("PgVectorStore.delete / clearNamespace", () => {
+  it("delete returns true when at least one row matched", async () => {
+    const db = makeFakeDb({ deleteReturning: [{ id: "x" }] });
+    const store = new PgVectorStore({ db, dimension: D });
+    expect(await store.delete("x")).toBe(true);
+  });
+
+  it("delete returns false when no row matched", async () => {
+    const db = makeFakeDb({ deleteReturning: [] });
+    const store = new PgVectorStore({ db, dimension: D });
+    expect(await store.delete("missing")).toBe(false);
+  });
+
+  it("clearNamespace returns the number of rows removed", async () => {
+    const db = makeFakeDb({ deleteReturning: [{ id: "a" }, { id: "b" }, { id: "c" }] });
+    const store = new PgVectorStore({ db, dimension: D });
+    expect(await store.clearNamespace("ns")).toBe(3);
+  });
+});

--- a/addons/vector/cap-vector-pgvector/__tests__/rag.test.ts
+++ b/addons/vector/cap-vector-pgvector/__tests__/rag.test.ts
@@ -1,0 +1,146 @@
+/**
+ * RAG helper tests — verifies the searchSimilar / retrieveContext entry
+ * points against the in-memory store, with a deterministic stub embedder.
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { createFunctionEmbeddingProvider } from "../src/embed";
+import { InMemoryVectorStore } from "../src/in-memory-store";
+import { retrieveContext, searchSimilar } from "../src/rag";
+
+const D = 3;
+
+function stubEmbed(text: string): number[] {
+  const buckets = [0, 0, 0];
+  for (let i = 0; i < text.length; i++) {
+    buckets[i % 3] += text.charCodeAt(i);
+  }
+  return buckets;
+}
+
+describe("searchSimilar", () => {
+  let store: InMemoryVectorStore;
+
+  beforeEach(async () => {
+    store = new InMemoryVectorStore({ dimension: D });
+    await store.upsert({
+      id: "doc-a",
+      vector: stubEmbed("alpha bravo charlie"),
+      metadata: {},
+      content: "alpha bravo charlie",
+    });
+    await store.upsert({
+      id: "doc-b",
+      vector: stubEmbed("delta echo foxtrot"),
+      metadata: {},
+      content: "delta echo foxtrot",
+    });
+  });
+
+  it("embeds the query string when queryVector is omitted", async () => {
+    const embedder = createFunctionEmbeddingProvider({
+      dimension: D,
+      embed: async (text) => stubEmbed(text),
+    });
+    const hits = await searchSimilar({
+      store,
+      embedder,
+      query: "alpha bravo charlie",
+    });
+    expect(hits[0]?.id).toBe("doc-a");
+  });
+
+  it("accepts a pre-computed queryVector and skips the embedder", async () => {
+    const hits = await searchSimilar({
+      store,
+      queryVector: stubEmbed("delta echo foxtrot"),
+    });
+    expect(hits[0]?.id).toBe("doc-b");
+  });
+
+  it("throws when neither query+embedder nor queryVector is supplied", async () => {
+    await expect(searchSimilar({ store })).rejects.toThrow(/queryVector/);
+  });
+});
+
+describe("retrieveContext", () => {
+  let store: InMemoryVectorStore;
+
+  beforeEach(async () => {
+    store = new InMemoryVectorStore({ dimension: D });
+    await store.upsert({
+      id: "1",
+      vector: stubEmbed("first chunk text"),
+      metadata: {},
+      content: "first chunk text",
+    });
+    await store.upsert({
+      id: "2",
+      vector: stubEmbed("second chunk text"),
+      metadata: {},
+      content: "second chunk text",
+    });
+  });
+
+  it("formats hits into a numbered prompt block", async () => {
+    const result = await retrieveContext({
+      store,
+      queryVector: stubEmbed("first chunk text"),
+      topK: 2,
+    });
+    expect(result.hits).toHaveLength(2);
+    expect(result.prompt).toContain("[#1]");
+    expect(result.prompt).toContain("first chunk text");
+    expect(result.charCount).toBe(result.prompt.length);
+  });
+
+  it("returns a `no relevant context found` block when there are no hits", async () => {
+    const empty = new InMemoryVectorStore({ dimension: D });
+    const result = await retrieveContext({
+      store: empty,
+      queryVector: stubEmbed("anything"),
+    });
+    expect(result.hits).toHaveLength(0);
+    expect(result.prompt).toContain("no relevant context found");
+  });
+
+  it("honors maxChars by greedily dropping hits that would overflow", async () => {
+    // The prompt fits exactly the header + one block; the second block
+    // would push past maxChars and is skipped intact.
+    const result = await retrieveContext({
+      store,
+      queryVector: stubEmbed("first chunk text"),
+      topK: 2,
+      maxChars: 80,
+    });
+    expect(result.prompt.length).toBeLessThanOrEqual(80);
+    // At least one of the two hits made it into the prompt
+    expect(result.prompt).toContain("[#1]");
+  });
+
+  it("uses a custom formatHit when supplied", async () => {
+    const result = await retrieveContext({
+      store,
+      queryVector: stubEmbed("first chunk text"),
+      topK: 1,
+      formatHit: (hit, index) => `>>> ${index} :: ${hit.id} :: ${hit.score.toFixed(2)}`,
+    });
+    expect(result.prompt).toContain(">>> 1 :: ");
+  });
+
+  it("falls back to metadata.summary when content is missing", async () => {
+    const s = new InMemoryVectorStore({ dimension: D });
+    await s.upsert({
+      id: "ref",
+      vector: stubEmbed("anything"),
+      metadata: { summary: "fallback summary text" },
+    });
+
+    const result = await retrieveContext({
+      store: s,
+      queryVector: stubEmbed("anything"),
+      topK: 1,
+    });
+    expect(result.prompt).toContain("fallback summary text");
+  });
+});

--- a/addons/vector/cap-vector-pgvector/__tests__/vector-math.test.ts
+++ b/addons/vector/cap-vector-pgvector/__tests__/vector-math.test.ts
@@ -1,0 +1,94 @@
+/**
+ * vector-math tests — covers the cosine-similarity scoring contract that
+ * both the pgvector and in-memory backends honour, and the order-
+ * independent deep-equality helper that drives `matchesFilter`.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { cosineSimilarity, deepEqual, matchesFilter } from "../src/vector-math";
+
+describe("cosineSimilarity", () => {
+  it("returns 1 for identical vectors after rescale", () => {
+    // Raw cos = 1 → rescaled to (1 + 1) / 2 = 1.0
+    expect(cosineSimilarity([1, 0, 0], [1, 0, 0])).toBeCloseTo(1.0);
+  });
+
+  it("returns 0 for opposite vectors after rescale", () => {
+    // Raw cos = -1 → rescaled to 0.0
+    expect(cosineSimilarity([1, 0, 0], [-1, 0, 0])).toBeCloseTo(0.0);
+  });
+
+  it("returns 0.5 for orthogonal vectors after rescale", () => {
+    expect(cosineSimilarity([1, 0, 0], [0, 1, 0])).toBeCloseTo(0.5);
+  });
+
+  it("returns 0 when either vector is zero", () => {
+    expect(cosineSimilarity([0, 0, 0], [1, 0, 0])).toBe(0);
+  });
+
+  it("throws on length mismatch", () => {
+    expect(() => cosineSimilarity([1, 2], [1, 2, 3])).toThrow(/length mismatch/);
+  });
+});
+
+describe("deepEqual", () => {
+  it("compares primitives via Object.is", () => {
+    expect(deepEqual(1, 1)).toBe(true);
+    expect(deepEqual("a", "a")).toBe(true);
+    expect(deepEqual(Number.NaN, Number.NaN)).toBe(true);
+    expect(deepEqual(null, null)).toBe(true);
+    expect(deepEqual(undefined, undefined)).toBe(true);
+    expect(deepEqual(1, "1")).toBe(false);
+    expect(deepEqual(null, undefined)).toBe(false);
+  });
+
+  it("is order-independent for object keys (vs JSON.stringify)", () => {
+    const a = { x: 1, y: 2 };
+    const b = { y: 2, x: 1 };
+    // JSON.stringify would return distinct strings here on some engines —
+    // the helper must report equal regardless of insertion order.
+    expect(deepEqual(a, b)).toBe(true);
+  });
+
+  it("recurses into nested objects and arrays", () => {
+    const a = { nested: { arr: [1, { k: "v" }, 3] } };
+    const b = { nested: { arr: [1, { k: "v" }, 3] } };
+    expect(deepEqual(a, b)).toBe(true);
+
+    const c = { nested: { arr: [1, { k: "different" }, 3] } };
+    expect(deepEqual(a, c)).toBe(false);
+  });
+
+  it("treats arrays of different length as unequal", () => {
+    expect(deepEqual([1, 2], [1, 2, 3])).toBe(false);
+  });
+
+  it("treats arrays and objects as distinct types", () => {
+    expect(deepEqual([1, 2], { 0: 1, 1: 2, length: 2 })).toBe(false);
+  });
+
+  it("rejects when key sets differ", () => {
+    expect(deepEqual({ a: 1, b: 2 }, { a: 1 })).toBe(false);
+    expect(deepEqual({ a: 1 }, { b: 1 })).toBe(false);
+  });
+});
+
+describe("matchesFilter", () => {
+  it("passes when every filter key matches the metadata", () => {
+    expect(matchesFilter({ tenant_id: "t1", entity: "order" }, { tenant_id: "t1" })).toBe(true);
+  });
+
+  it("rejects when a required key is missing", () => {
+    expect(matchesFilter({ tenant_id: "t1" }, { entity: "order" })).toBe(false);
+  });
+
+  it("rejects when a key's value differs", () => {
+    expect(matchesFilter({ tenant_id: "t1" }, { tenant_id: "t2" })).toBe(false);
+  });
+
+  it("matches nested objects regardless of key order", () => {
+    const metadata = { ctx: { a: 1, b: 2 } };
+    const filter = { ctx: { b: 2, a: 1 } };
+    expect(matchesFilter(metadata, filter)).toBe(true);
+  });
+});

--- a/addons/vector/cap-vector-pgvector/package.json
+++ b/addons/vector/cap-vector-pgvector/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@linchkit/cap-vector-pgvector",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "files": [
+    "src/",
+    "package.json",
+    "README.md"
+  ],
+  "exports": {
+    ".": "./src/index.ts",
+    "./capability": "./src/capability.ts"
+  },
+  "scripts": {
+    "test": "bun test"
+  },
+  "peerDependencies": {
+    "@linchkit/core": "^0.2.0",
+    "drizzle-orm": "^0.45.1"
+  },
+  "devDependencies": {
+    "@linchkit/core": "workspace:*",
+    "typescript": "^6.0.2"
+  },
+  "linchkit": {
+    "minCoreVersion": "^0.2.0",
+    "type": "standard",
+    "category": "system",
+    "autoInstall": false
+  }
+}

--- a/addons/vector/cap-vector-pgvector/src/capability.ts
+++ b/addons/vector/cap-vector-pgvector/src/capability.ts
@@ -1,0 +1,95 @@
+/**
+ * cap-vector-pgvector capability definition.
+ *
+ * Wires a {@link VectorStore} implementation into the capability DI surface
+ * so downstream consumers (Spec 55 evolution, Spec 67 Meta-Model semantics,
+ * Spec 53 Chatter RAG …) can `ctx.services.get("vectorStore")` to obtain it.
+ *
+ * The host application decides whether to back the store with PostgreSQL
+ * (`PgVectorStore`) or the in-memory brute-force store
+ * (`InMemoryVectorStore`, dev/test). Either way the registered service name
+ * stays `"vectorStore"` so swapping implementations is config-only.
+ */
+
+import type { CapabilityDefinition } from "@linchkit/core";
+import { defineCapability } from "@linchkit/core";
+import { InMemoryVectorStore } from "./in-memory-store";
+import { PgVectorStore } from "./pgvector-store";
+import { DEFAULT_VECTOR_DIMENSION } from "./schema";
+import type { VectorStore } from "./types";
+
+// ── Capability options ──────────────────────────────────────
+
+export interface CapVectorPgvectorOptions {
+  /**
+   * Drizzle database instance for persistent storage. When omitted, the
+   * capability falls back to {@link InMemoryVectorStore} — only suitable
+   * for tests or dev environments without pgvector.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: Drizzle DB type varies by driver
+  db?: any;
+  /**
+   * Pre-built VectorStore instance. When provided, `db` and `dimension`
+   * are ignored. Useful for tests and for hosts that wire a custom
+   * implementation (e.g. `cap-vector-qdrant` adapter).
+   */
+  store?: VectorStore;
+  /**
+   * Vector dimension. Must match the column type emitted by the migration.
+   * Defaults to {@link DEFAULT_VECTOR_DIMENSION}.
+   */
+  dimension?: number;
+}
+
+// ── Factory ──────────────────────────────────────────────────
+
+/**
+ * Create a fully-wired cap-vector-pgvector capability.
+ *
+ * @example
+ * ```ts
+ * import { createCapVectorPgvector } from "@linchkit/cap-vector-pgvector";
+ *
+ * const capVector = createCapVectorPgvector({ db });
+ * // capVector.vectorStore is available immediately for capability setup;
+ * // downstream capabilities resolve it via services["vectorStore"].
+ * ```
+ */
+export function createCapVectorPgvector(
+  options: CapVectorPgvectorOptions = {},
+): CapabilityDefinition & { vectorStore: VectorStore } {
+  const dimension = options.dimension ?? DEFAULT_VECTOR_DIMENSION;
+  const store: VectorStore =
+    options.store ??
+    (options.db
+      ? new PgVectorStore({ db: options.db, dimension })
+      : new InMemoryVectorStore({ dimension }));
+
+  const capability = defineCapability({
+    name: "cap-vector-pgvector",
+    label: "Vector Store (pgvector)",
+    description:
+      "PostgreSQL pgvector implementation of the VectorStore contract. " +
+      "Backs Spec 55 evolution, Spec 67 Meta-Model semantics, Spec 53 Chatter RAG, " +
+      "and Spec 52 AI few-shot example retrieval. Falls back to an in-memory " +
+      "brute-force store when no Drizzle DB instance is supplied (dev / test only).",
+    type: "standard",
+    category: "system",
+    version: "0.0.1",
+    group: "vector",
+    autoInstall: false,
+    extensions: {
+      services: [
+        {
+          name: "vectorStore",
+          factory: () => store,
+        },
+      ],
+    },
+  });
+
+  return Object.assign(capability, { vectorStore: store });
+}
+
+/** Static (in-memory) capability export for shape-only consumers. */
+export const capVectorPgvector = createCapVectorPgvector;

--- a/addons/vector/cap-vector-pgvector/src/capability.ts
+++ b/addons/vector/cap-vector-pgvector/src/capability.ts
@@ -24,10 +24,12 @@ export interface CapVectorPgvectorOptions {
   /**
    * Drizzle database instance for persistent storage. When omitted, the
    * capability falls back to {@link InMemoryVectorStore} — only suitable
-   * for tests or dev environments without pgvector.
+   * for tests or dev environments without pgvector. Typed as `unknown`
+   * because the concrete driver flavour (PgDatabase, PgliteDatabase,
+   * NodePgDatabase …) varies; `PgVectorStore` validates the shape at
+   * construction time.
    */
-  // biome-ignore lint/suspicious/noExplicitAny: Drizzle DB type varies by driver
-  db?: any;
+  db?: unknown;
   /**
    * Pre-built VectorStore instance. When provided, `db` and `dimension`
    * are ignored. Useful for tests and for hosts that wire a custom

--- a/addons/vector/cap-vector-pgvector/src/embed.ts
+++ b/addons/vector/cap-vector-pgvector/src/embed.ts
@@ -21,16 +21,34 @@ import type { EmbeddingProvider, UpsertVectorInput, VectorStore } from "./types"
 
 // ── Function adapter ────────────────────────────────────────
 
+/**
+ * Default concurrency for the synthesised `embedMany` fallback.
+ *
+ * Most hosted embedding endpoints (OpenAI, Cohere, voyage) tolerate
+ * 4-8 concurrent requests before tripping the per-second token-bucket;
+ * 4 is conservative without serialising. Hosts that want different
+ * behaviour either supply a native `embedMany` or override
+ * {@link FunctionEmbeddingProviderOptions.embedManyConcurrency}.
+ */
+const DEFAULT_EMBED_MANY_CONCURRENCY = 4;
+
 export interface FunctionEmbeddingProviderOptions {
   /** Vector dimension produced by the embed function. */
   dimension: number;
   /** Single-text embedding function. */
   embed: (text: string) => Promise<number[]>;
   /**
-   * Optional batch variant. When omitted, `embedMany()` falls back to
-   * `Promise.all` over `embed()`.
+   * Optional batch variant. When omitted, `embedMany()` falls back to a
+   * concurrency-limited loop over `embed()` (see
+   * {@link embedManyConcurrency}).
    */
   embedMany?: (texts: readonly string[]) => Promise<number[][]>;
+  /**
+   * Maximum number of concurrent `embed()` calls when `embedMany` falls
+   * back. Ignored when a native `embedMany` is supplied. Must be a
+   * positive integer; defaults to {@link DEFAULT_EMBED_MANY_CONCURRENCY}.
+   */
+  embedManyConcurrency?: number;
 }
 
 /**
@@ -54,15 +72,58 @@ export function createFunctionEmbeddingProvider(
   if (!Number.isInteger(options.dimension) || options.dimension <= 0) {
     throw new Error("createFunctionEmbeddingProvider: dimension must be a positive integer");
   }
+  const concurrency = options.embedManyConcurrency ?? DEFAULT_EMBED_MANY_CONCURRENCY;
+  if (!Number.isInteger(concurrency) || concurrency <= 0) {
+    throw new Error(
+      "createFunctionEmbeddingProvider: embedManyConcurrency must be a positive integer",
+    );
+  }
+
   return {
     dimension: options.dimension,
     embed: options.embed,
     embedMany:
       options.embedMany ??
       (async (texts) => {
-        return Promise.all(texts.map((t) => options.embed(t)));
+        // Fallback path: dispatch `embed()` with a bounded concurrency
+        // pool so a large `documents` array doesn't open hundreds of
+        // simultaneous HTTP requests and trip the provider's rate limit.
+        return runWithConcurrency(texts, concurrency, options.embed);
       }),
   };
+}
+
+/**
+ * Run `task` over every input with at most `limit` in-flight promises,
+ * preserving input order in the output array.
+ *
+ * Kept inline (no extra dep) — the implementation is a simple sliding
+ * window over a worker pool.
+ */
+async function runWithConcurrency<TIn, TOut>(
+  inputs: readonly TIn[],
+  limit: number,
+  task: (input: TIn) => Promise<TOut>,
+): Promise<TOut[]> {
+  if (inputs.length === 0) return [];
+  const effectiveLimit = Math.max(1, Math.min(limit, inputs.length));
+  const results = new Array<TOut>(inputs.length);
+  let cursor = 0;
+
+  async function worker(): Promise<void> {
+    while (true) {
+      const idx = cursor++;
+      if (idx >= inputs.length) return;
+      results[idx] = await task(inputs[idx] as TIn);
+    }
+  }
+
+  const workers: Promise<void>[] = [];
+  for (let i = 0; i < effectiveLimit; i++) {
+    workers.push(worker());
+  }
+  await Promise.all(workers);
+  return results;
 }
 
 // ── Document → vector pipeline ──────────────────────────────

--- a/addons/vector/cap-vector-pgvector/src/embed.ts
+++ b/addons/vector/cap-vector-pgvector/src/embed.ts
@@ -1,0 +1,140 @@
+/**
+ * Embedding pipeline — turns records / documents into upsert payloads.
+ *
+ * Two concerns live here:
+ *
+ *  1. `createFunctionEmbeddingProvider()` — adapt an arbitrary embed
+ *     function (e.g. Vercel AI SDK's `embed()` / `embedMany()`) into the
+ *     {@link EmbeddingProvider} contract this capability consumes.
+ *
+ *  2. `embedAndUpsertDocuments()` — convenience pipeline that, given a
+ *     batch of `DocumentInput`, embeds every document via the provider
+ *     and writes the rows into a {@link VectorStore} in one round-trip.
+ *
+ * The capability deliberately does NOT bind to `@linchkit/cap-ai-provider`
+ * directly. Hosts wire the embedding source they prefer: that keeps this
+ * package importable in tests with zero AI configuration (the test fixture
+ * passes a deterministic stub provider).
+ */
+
+import type { EmbeddingProvider, UpsertVectorInput, VectorStore } from "./types";
+
+// ── Function adapter ────────────────────────────────────────
+
+export interface FunctionEmbeddingProviderOptions {
+  /** Vector dimension produced by the embed function. */
+  dimension: number;
+  /** Single-text embedding function. */
+  embed: (text: string) => Promise<number[]>;
+  /**
+   * Optional batch variant. When omitted, `embedMany()` falls back to
+   * `Promise.all` over `embed()`.
+   */
+  embedMany?: (texts: readonly string[]) => Promise<number[][]>;
+}
+
+/**
+ * Wrap a plain embed function (e.g. Vercel AI SDK) as an EmbeddingProvider.
+ *
+ * @example
+ * ```ts
+ * import { embed } from "ai";
+ * import { openai } from "@ai-sdk/openai";
+ *
+ * const model = openai.textEmbeddingModel("text-embedding-3-small");
+ * const provider = createFunctionEmbeddingProvider({
+ *   dimension: 1536,
+ *   embed: async (text) => (await embed({ model, value: text })).embedding,
+ * });
+ * ```
+ */
+export function createFunctionEmbeddingProvider(
+  options: FunctionEmbeddingProviderOptions,
+): EmbeddingProvider {
+  if (!Number.isInteger(options.dimension) || options.dimension <= 0) {
+    throw new Error("createFunctionEmbeddingProvider: dimension must be a positive integer");
+  }
+  return {
+    dimension: options.dimension,
+    embed: options.embed,
+    embedMany:
+      options.embedMany ??
+      (async (texts) => {
+        return Promise.all(texts.map((t) => options.embed(t)));
+      }),
+  };
+}
+
+// ── Document → vector pipeline ──────────────────────────────
+
+/** One source document to embed and persist. */
+export interface DocumentInput<TMeta extends Record<string, unknown> = Record<string, unknown>> {
+  /** Stable record id; reused as the upsert key. */
+  id: string;
+  /** Raw text to embed. */
+  content: string;
+  /** Metadata persisted alongside the embedding. */
+  metadata?: TMeta;
+  /** Optional namespace override (defaults to the pipeline-wide `namespace`). */
+  namespace?: string;
+}
+
+export interface EmbedAndUpsertOptions<TMeta extends Record<string, unknown>> {
+  /** Vector store to write into. */
+  store: VectorStore;
+  /** Provider used to compute embeddings. */
+  embedder: EmbeddingProvider;
+  /** Documents to embed and upsert. */
+  documents: ReadonlyArray<DocumentInput<TMeta>>;
+  /** Default namespace for documents that don't supply one. */
+  namespace?: string;
+}
+
+/**
+ * Embed every document and upsert into the vector store as a single batch.
+ * Returns the number of rows written so callers can log it.
+ */
+export async function embedAndUpsertDocuments<TMeta extends Record<string, unknown>>(
+  options: EmbedAndUpsertOptions<TMeta>,
+): Promise<number> {
+  const { store, embedder, documents, namespace } = options;
+  if (documents.length === 0) return 0;
+  if (embedder.dimension !== store.dimension) {
+    throw new Error(
+      `embedAndUpsertDocuments: embedder.dimension (${embedder.dimension}) != store.dimension (${store.dimension})`,
+    );
+  }
+
+  // Prefer the batch path so providers with bulk endpoints can amortise
+  // network latency. The function-adapter wrapper above guarantees
+  // embedMany() always exists.
+  const texts = documents.map((d) => d.content);
+  const vectors = embedder.embedMany
+    ? await embedder.embedMany(texts)
+    : await Promise.all(texts.map((t) => embedder.embed(t)));
+
+  if (vectors.length !== documents.length) {
+    throw new Error(
+      `embedAndUpsertDocuments: embedder returned ${vectors.length} vectors for ${documents.length} documents`,
+    );
+  }
+
+  const items: UpsertVectorInput<TMeta>[] = documents.map((doc, idx) => {
+    const vector = vectors[idx];
+    if (!vector || vector.length !== embedder.dimension) {
+      throw new Error(
+        `embedAndUpsertDocuments: vector ${idx} has unexpected length (got ${vector?.length ?? 0}, expected ${embedder.dimension})`,
+      );
+    }
+    return {
+      id: doc.id,
+      vector,
+      metadata: (doc.metadata ?? ({} as TMeta)) as TMeta,
+      content: doc.content,
+      namespace: doc.namespace ?? namespace,
+    };
+  });
+
+  await store.batchUpsert(items);
+  return items.length;
+}

--- a/addons/vector/cap-vector-pgvector/src/in-memory-store.ts
+++ b/addons/vector/cap-vector-pgvector/src/in-memory-store.ts
@@ -1,0 +1,142 @@
+/**
+ * InMemoryVectorStore — brute-force KNN, no database required.
+ *
+ * Used by:
+ *  - unit tests for the capability and its consumers,
+ *  - dev environments without pgvector,
+ *  - Spec 68 §2.2's `cap-vector-memory` use case (no separate package
+ *    needed yet — re-export this class from there when it ships).
+ *
+ * Brute-force cosine similarity is O(N * D) per query. That's fine for
+ * the typical test fixture (≤ 10k vectors); production deployments must
+ * use `PgVectorStore` so HNSW kicks in.
+ */
+
+import type {
+  SimilarityResult,
+  UpsertVectorInput,
+  VectorSearchOptions,
+  VectorStore,
+} from "./types";
+import { cosineSimilarity, matchesFilter } from "./vector-math";
+
+interface StoredRow {
+  id: string;
+  namespace: string;
+  vector: number[];
+  metadata: Record<string, unknown>;
+  content?: string;
+}
+
+const DEFAULT_NAMESPACE = "default";
+const DEFAULT_TOP_K = 10;
+const MAX_TOP_K = 200;
+
+export interface InMemoryVectorStoreOptions {
+  /** Vector dimension. Defaults to 1536 to match the pgvector default. */
+  dimension?: number;
+}
+
+export class InMemoryVectorStore implements VectorStore {
+  public readonly dimension: number;
+  /** Key is `${namespace}::${id}` so the same id can live in two namespaces. */
+  private readonly rows = new Map<string, StoredRow>();
+
+  constructor(options: InMemoryVectorStoreOptions = {}) {
+    this.dimension = options.dimension ?? 1536;
+    if (!Number.isInteger(this.dimension) || this.dimension <= 0) {
+      throw new Error("InMemoryVectorStore: dimension must be a positive integer");
+    }
+  }
+
+  async upsert<TMeta extends Record<string, unknown>>(
+    input: UpsertVectorInput<TMeta>,
+  ): Promise<void> {
+    this.assertDimension(input.vector, input.id);
+    const namespace = input.namespace ?? DEFAULT_NAMESPACE;
+    this.rows.set(rowKey(input.id, namespace), {
+      id: input.id,
+      namespace,
+      vector: [...input.vector],
+      metadata: { ...input.metadata },
+      content: input.content,
+    });
+  }
+
+  async batchUpsert<TMeta extends Record<string, unknown>>(
+    items: ReadonlyArray<UpsertVectorInput<TMeta>>,
+  ): Promise<void> {
+    for (const item of items) {
+      await this.upsert(item);
+    }
+  }
+
+  async search<TMeta extends Record<string, unknown> = Record<string, unknown>>(
+    queryVector: number[],
+    options: VectorSearchOptions = {},
+  ): Promise<SimilarityResult<TMeta>[]> {
+    this.assertDimension(queryVector, "<query>");
+    const namespace = options.namespace ?? DEFAULT_NAMESPACE;
+    const topK = clampTopK(options.topK);
+    const minScore = options.minScore ?? Number.NEGATIVE_INFINITY;
+    const filter = options.filter;
+
+    const candidates: SimilarityResult<TMeta>[] = [];
+    for (const row of this.rows.values()) {
+      if (row.namespace !== namespace) continue;
+      if (filter && !matchesFilter(row.metadata, filter)) continue;
+      const score = cosineSimilarity(queryVector, row.vector);
+      if (score < minScore) continue;
+      candidates.push({
+        id: row.id,
+        score,
+        metadata: row.metadata as TMeta,
+        content: row.content,
+        namespace: row.namespace,
+      });
+    }
+
+    candidates.sort((a, b) => b.score - a.score);
+    return candidates.slice(0, topK);
+  }
+
+  async delete(id: string, options: { namespace?: string } = {}): Promise<boolean> {
+    const namespace = options.namespace ?? DEFAULT_NAMESPACE;
+    return this.rows.delete(rowKey(id, namespace));
+  }
+
+  async clearNamespace(namespace: string): Promise<number> {
+    let count = 0;
+    for (const key of [...this.rows.keys()]) {
+      const row = this.rows.get(key);
+      if (row && row.namespace === namespace) {
+        this.rows.delete(key);
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /** Test helper — total stored rows across all namespaces. */
+  size(): number {
+    return this.rows.size;
+  }
+
+  private assertDimension(vector: number[], idForError: string): void {
+    if (vector.length !== this.dimension) {
+      throw new Error(
+        `InMemoryVectorStore: vector for "${idForError}" has length ${vector.length}, expected ${this.dimension}`,
+      );
+    }
+  }
+}
+
+function rowKey(id: string, namespace: string): string {
+  return `${namespace}::${id}`;
+}
+
+function clampTopK(value: number | undefined): number {
+  const v = value ?? DEFAULT_TOP_K;
+  if (!Number.isFinite(v) || v <= 0) return DEFAULT_TOP_K;
+  return Math.min(Math.floor(v), MAX_TOP_K);
+}

--- a/addons/vector/cap-vector-pgvector/src/index.ts
+++ b/addons/vector/cap-vector-pgvector/src/index.ts
@@ -1,0 +1,58 @@
+/**
+ * @linchkit/cap-vector-pgvector — public API
+ *
+ * Exports the VectorStore contract, the pgvector + in-memory
+ * implementations, the embedding pipeline, the RAG retrieval helpers,
+ * and the capability factory used by host applications.
+ *
+ * Spec 68 reference:
+ *  - §2.1 — VectorStore interface (here in `./types.ts`, see comment for
+ *    why we deferred promoting it to `@linchkit/core`).
+ *  - §2.2 — pgvector capability + HNSW index (here in `./schema.ts`).
+ *  - §2.3 — Embedding strategy (here in `./embed.ts`).
+ *  - §3   — Retrieval orchestration (P0 slice in `./rag.ts`).
+ */
+
+export type { CapVectorPgvectorOptions } from "./capability";
+export { capVectorPgvector, createCapVectorPgvector } from "./capability";
+
+// Embedding pipeline
+export type {
+  DocumentInput,
+  EmbedAndUpsertOptions,
+  FunctionEmbeddingProviderOptions,
+} from "./embed";
+export { createFunctionEmbeddingProvider, embedAndUpsertDocuments } from "./embed";
+export { InMemoryVectorStore, type InMemoryVectorStoreOptions } from "./in-memory-store";
+
+// Store implementations
+export { createPgVectorStore, PgVectorStore, type PgVectorStoreOptions } from "./pgvector-store";
+
+// RAG retrieval helpers
+export type {
+  RetrieveContextInput,
+  RetrieveContextResult,
+  SearchSimilarInput,
+} from "./rag";
+export { retrieveContext, searchSimilar } from "./rag";
+
+// Drizzle schema + constants
+export {
+  DEFAULT_NAMESPACE,
+  DEFAULT_VECTOR_DIMENSION,
+  vectorColumn,
+  vectorsTable,
+} from "./schema";
+
+// Public types
+export type {
+  EmbeddingProvider,
+  SearchSimilarOptions,
+  SimilarityResult,
+  UpsertVectorInput,
+  VectorSearchOptions,
+  VectorStore,
+} from "./types";
+
+// Math helpers (exported for consumers that want to reproduce scoring)
+export { cosineSimilarity, matchesFilter } from "./vector-math";

--- a/addons/vector/cap-vector-pgvector/src/index.ts
+++ b/addons/vector/cap-vector-pgvector/src/index.ts
@@ -55,4 +55,4 @@ export type {
 } from "./types";
 
 // Math helpers (exported for consumers that want to reproduce scoring)
-export { cosineSimilarity, matchesFilter } from "./vector-math";
+export { cosineSimilarity, deepEqual, matchesFilter } from "./vector-math";

--- a/addons/vector/cap-vector-pgvector/src/pgvector-store.ts
+++ b/addons/vector/cap-vector-pgvector/src/pgvector-store.ts
@@ -8,7 +8,8 @@
  *
  *  1. Upsert rows via `INSERT ... ON CONFLICT (id, namespace) DO UPDATE`.
  *  2. Query similarity with `ORDER BY embedding <=> $1` and convert the
- *     pgvector cosine *distance* to similarity = `1 - distance`.
+ *     pgvector cosine *distance* to a `[0, 1]` score so consumers see the
+ *     same range as `InMemoryVectorStore` — see `SCORE_RANGE` below.
  *  3. Apply optional JSONB containment filters and a minScore threshold.
  *
  * The constructor takes a pre-built Drizzle DB instance — the capability is
@@ -18,9 +19,11 @@
  * ------
  *  - All user-supplied filter values flow through Drizzle's parameter
  *    binding via the `sql` template tag → no SQL injection.
- *  - Vectors are converted to the pgvector textual form (`[1,2,3]`) once,
- *    by the `vectorColumn` customType in `./schema.ts`, so the wire format
- *    is centralized.
+ *  - The query vector is bound as a parameter (cast to `::vector` in SQL),
+ *    not concatenated, so a hostile `id` or filter cannot smuggle SQL.
+ *  - `assertDimension()` rejects vectors that contain `NaN` / `±Infinity`
+ *    before they reach the wire, so a malformed embedding cannot produce
+ *    a malformed SQL literal nor corrupt the index.
  */
 
 import { and, eq, sql } from "drizzle-orm";
@@ -34,37 +37,114 @@ import type {
 
 const DEFAULT_TOP_K = 10;
 const MAX_TOP_K = 200;
+/**
+ * Maximum number of rows per multi-row INSERT.
+ *
+ * PostgreSQL's wire protocol caps bind parameters at 65535. Each vector row
+ * binds ~6 parameters (id, namespace, embedding, metadata, content, plus
+ * `excluded.*` references in the conflict-update clause). 500 rows × ~6
+ * = ~3000 parameters leaves ample headroom while still amortising the
+ * network round-trip cost.
+ */
+const DEFAULT_BATCH_CHUNK_SIZE = 500;
+
+/**
+ * Minimal duck-typed surface this capability invokes on the Drizzle DB
+ * instance. Splitting it out keeps the `db: unknown` field type-safe at
+ * call sites without coupling the capability to any particular driver
+ * flavour (PgDatabase, PgliteDatabase, NodePgDatabase …).
+ */
+interface DrizzleDbLike {
+  insert: (...args: unknown[]) => DrizzleInsertChain;
+  select: (...args: unknown[]) => DrizzleSelectChain;
+  delete: (...args: unknown[]) => DrizzleDeleteChain;
+}
+
+interface DrizzleInsertChain {
+  values: (...args: unknown[]) => DrizzleInsertChain;
+  onConflictDoUpdate: (...args: unknown[]) => Promise<unknown>;
+}
+
+interface DrizzleSelectChain {
+  from: (...args: unknown[]) => DrizzleSelectChain;
+  where: (...args: unknown[]) => DrizzleSelectChain;
+  orderBy: (...args: unknown[]) => DrizzleSelectChain;
+  limit: (...args: unknown[]) => Promise<unknown[]>;
+}
+
+interface DrizzleDeleteChain {
+  where: (...args: unknown[]) => DrizzleDeleteChain;
+  returning: (...args: unknown[]) => Promise<unknown[]>;
+}
+
+/**
+ * Row shape returned by `search()` — fields mirror the projection in the
+ * SELECT statement below. `score` arrives as a JS number from pg but
+ * `string | number` covers drivers that surface numerics as strings.
+ */
+interface PgVectorRow {
+  id: string;
+  namespace: string;
+  metadata: Record<string, unknown> | null;
+  content: string | null;
+  score: number | string | null;
+}
+
+function asDrizzleDb(value: unknown): DrizzleDbLike {
+  if (
+    value !== null &&
+    typeof value === "object" &&
+    typeof (value as { insert?: unknown }).insert === "function" &&
+    typeof (value as { select?: unknown }).select === "function" &&
+    typeof (value as { delete?: unknown }).delete === "function"
+  ) {
+    return value as DrizzleDbLike;
+  }
+  throw new Error(
+    "PgVectorStore: `db` does not look like a Drizzle DB instance " +
+      "(missing insert/select/delete). Pass a value returned by `drizzle(client, …)`.",
+  );
+}
 
 export interface PgVectorStoreOptions {
   /**
    * Drizzle DB instance (PgDatabase | PgliteDatabase | NodePgDatabase …).
-   * The type is left as `unknown` to avoid coupling this capability to
-   * any specific driver flavour; runtime calls are duck-typed against
-   * the standard `insert / select / delete` surface.
+   * Typed as `unknown` to avoid coupling this capability to any specific
+   * driver flavour; the constructor narrows it through {@link asDrizzleDb}
+   * via a duck-typed check against the `insert / select / delete` surface.
    */
-  // biome-ignore lint/suspicious/noExplicitAny: Drizzle DB instance type varies by driver
-  db: any;
+  db: unknown;
   /**
    * Vector dimension. Must match the column type emitted by `./schema.ts`.
    * Defaults to {@link DEFAULT_VECTOR_DIMENSION}.
    */
   dimension?: number;
+  /**
+   * Override the default chunk size used by {@link PgVectorStore.batchUpsert}.
+   * Must be a positive integer; defaults to {@link DEFAULT_BATCH_CHUNK_SIZE}.
+   */
+  batchChunkSize?: number;
 }
 
 export class PgVectorStore implements VectorStore {
   public readonly dimension: number;
-  // biome-ignore lint/suspicious/noExplicitAny: Drizzle DB instance type varies by driver
-  private readonly db: any;
+  private readonly db: DrizzleDbLike;
+  private readonly batchChunkSize: number;
 
   constructor(options: PgVectorStoreOptions) {
     if (!options?.db) {
       throw new Error("PgVectorStore: `db` is required");
     }
-    this.db = options.db;
+    this.db = asDrizzleDb(options.db);
     this.dimension = options.dimension ?? DEFAULT_VECTOR_DIMENSION;
     if (!Number.isInteger(this.dimension) || this.dimension <= 0) {
       throw new Error("PgVectorStore: dimension must be a positive integer");
     }
+    const chunk = options.batchChunkSize ?? DEFAULT_BATCH_CHUNK_SIZE;
+    if (!Number.isInteger(chunk) || chunk <= 0) {
+      throw new Error("PgVectorStore: batchChunkSize must be a positive integer");
+    }
+    this.batchChunkSize = chunk;
   }
 
   async upsert<TMeta extends Record<string, unknown>>(
@@ -107,19 +187,26 @@ export class PgVectorStore implements VectorStore {
       metadata: item.metadata,
       content: item.content,
     }));
-    // Single multi-row INSERT — Drizzle accepts an array of value objects.
-    await this.db
-      .insert(vectorsTable)
-      .values(rows)
-      .onConflictDoUpdate({
-        target: [vectorsTable.id, vectorsTable.namespace],
-        set: {
-          embedding: sql`excluded.embedding`,
-          metadata: sql`excluded.metadata`,
-          content: sql`excluded.content`,
-          updatedAt: sql`now()`,
-        },
-      });
+
+    // PostgreSQL caps the bind-parameter count at 65535. Even at ~6
+    // parameters per row that's ~10k rows per statement, but providers
+    // (pglite, pg-pool) wrap that limit lower in practice. Chunking keeps
+    // a single oversize batch from blowing up.
+    for (let i = 0; i < rows.length; i += this.batchChunkSize) {
+      const chunk = rows.slice(i, i + this.batchChunkSize);
+      await this.db
+        .insert(vectorsTable)
+        .values(chunk)
+        .onConflictDoUpdate({
+          target: [vectorsTable.id, vectorsTable.namespace],
+          set: {
+            embedding: sql`excluded.embedding`,
+            metadata: sql`excluded.metadata`,
+            content: sql`excluded.content`,
+            updatedAt: sql`now()`,
+          },
+        });
+    }
   }
 
   async search<TMeta extends Record<string, unknown> = Record<string, unknown>>(
@@ -130,9 +217,10 @@ export class PgVectorStore implements VectorStore {
     const namespace = options.namespace ?? DEFAULT_NAMESPACE;
     const topK = clampTopK(options.topK);
 
-    // pgvector stores the query as a vector literal; we hand-format the
-    // textual form here because Drizzle has no first-class binding for
-    // the `vector(N)` type.
+    // pgvector accepts the textual `[x,y,z]` form as a `vector` value when
+    // the bound parameter is cast with `::vector`. We bind the literal as a
+    // standard string parameter — NEVER `sql.raw` — so a hostile component
+    // can't smuggle SQL through the query path.
     const queryLiteral = `[${queryVector.join(",")}]`;
 
     const whereParts = [eq(vectorsTable.namespace, namespace)];
@@ -144,12 +232,15 @@ export class PgVectorStore implements VectorStore {
       whereParts.push(sql`${vectorsTable.metadata} @> ${filterJson}::jsonb`);
     }
 
-    // Cosine *distance* in pgvector is `<=>`; similarity = 1 - distance.
-    // We compute the score in SQL so ORDER BY uses the index plan.
-    const scoreExpr = sql<number>`1 - (${vectorsTable.embedding} <=> ${sql.raw(`'${queryLiteral}'::vector`)})`;
+    // Cosine *distance* in pgvector is `<=>` (range [0, 2]). Cosine
+    // *similarity* = 1 - distance lives in [-1, 1]. We rescale to [0, 1]
+    // via `(x + 1) / 2`, which matches the in-memory store's
+    // `cosineSimilarity()` so `minScore` semantics line up across
+    // implementations regardless of which backend the host wires.
+    // The score is computed in SQL so ORDER BY can ride the HNSW plan.
+    const scoreExpr = sql<number>`((1 - (${vectorsTable.embedding} <=> ${queryLiteral}::vector)) + 1) / 2`;
 
-    // biome-ignore lint/suspicious/noExplicitAny: Drizzle row shape varies by driver
-    const rows: any[] = await this.db
+    const rawRows = await this.db
       .select({
         id: vectorsTable.id,
         namespace: vectorsTable.namespace,
@@ -162,10 +253,11 @@ export class PgVectorStore implements VectorStore {
       .orderBy(sql`score DESC`)
       .limit(topK);
 
+    const rows = rawRows as PgVectorRow[];
     const minScore = options.minScore;
     const hits: SimilarityResult<TMeta>[] = [];
     for (const row of rows) {
-      const score = Number(row.score) || 0;
+      const score = toFiniteNumber(row.score);
       if (minScore !== undefined && score < minScore) continue;
       hits.push({
         id: row.id,
@@ -180,8 +272,7 @@ export class PgVectorStore implements VectorStore {
 
   async delete(id: string, options: { namespace?: string } = {}): Promise<boolean> {
     const namespace = options.namespace ?? DEFAULT_NAMESPACE;
-    // biome-ignore lint/suspicious/noExplicitAny: Drizzle returning shape varies by driver
-    const result: any = await this.db
+    const result = await this.db
       .delete(vectorsTable)
       .where(and(eq(vectorsTable.id, id), eq(vectorsTable.namespace, namespace)))
       .returning({ id: vectorsTable.id });
@@ -189,19 +280,34 @@ export class PgVectorStore implements VectorStore {
   }
 
   async clearNamespace(namespace: string): Promise<number> {
-    // biome-ignore lint/suspicious/noExplicitAny: Drizzle returning shape varies by driver
-    const result: any = await this.db
+    const result = await this.db
       .delete(vectorsTable)
       .where(eq(vectorsTable.namespace, namespace))
       .returning({ id: vectorsTable.id });
     return Array.isArray(result) ? result.length : 0;
   }
 
+  /**
+   * Validate vector length AND component finiteness. Rejecting NaN /
+   * ±Infinity here prevents two failure modes downstream:
+   *   1. a malformed pgvector text literal (the wire format truncates
+   *      special floats inconsistently across drivers),
+   *   2. similarity scores becoming NaN, which would silently sort to
+   *      arbitrary positions and corrupt minScore filtering.
+   */
   private assertDimension(vector: number[], idForError: string): void {
     if (vector.length !== this.dimension) {
       throw new Error(
         `PgVectorStore: vector for "${idForError}" has length ${vector.length}, expected ${this.dimension}`,
       );
+    }
+    for (let i = 0; i < vector.length; i++) {
+      const v = vector[i];
+      if (typeof v !== "number" || !Number.isFinite(v)) {
+        throw new Error(
+          `PgVectorStore: vector for "${idForError}" has non-finite component at index ${i} (value=${String(v)})`,
+        );
+      }
     }
   }
 }
@@ -210,6 +316,15 @@ function clampTopK(value: number | undefined): number {
   const v = value ?? DEFAULT_TOP_K;
   if (!Number.isFinite(v) || v <= 0) return DEFAULT_TOP_K;
   return Math.min(Math.floor(v), MAX_TOP_K);
+}
+
+function toFiniteNumber(value: unknown): number {
+  if (typeof value === "number") return Number.isFinite(value) ? value : 0;
+  if (typeof value === "string") {
+    const n = Number.parseFloat(value);
+    return Number.isFinite(n) ? n : 0;
+  }
+  return 0;
 }
 
 /** Convenience factory mirroring the capability-level helper. */

--- a/addons/vector/cap-vector-pgvector/src/pgvector-store.ts
+++ b/addons/vector/cap-vector-pgvector/src/pgvector-store.ts
@@ -1,0 +1,218 @@
+/**
+ * PgVectorStore — Drizzle-backed implementation of VectorStore.
+ *
+ * Talks to PostgreSQL with the `vector` extension enabled. Per Spec 68 §2.2,
+ * the HNSW index over `vector_cosine_ops` is created by the capability's
+ * migration (drizzle-kit cannot emit the operator class), so all this code
+ * has to do is:
+ *
+ *  1. Upsert rows via `INSERT ... ON CONFLICT (id, namespace) DO UPDATE`.
+ *  2. Query similarity with `ORDER BY embedding <=> $1` and convert the
+ *     pgvector cosine *distance* to similarity = `1 - distance`.
+ *  3. Apply optional JSONB containment filters and a minScore threshold.
+ *
+ * The constructor takes a pre-built Drizzle DB instance — the capability is
+ * deliberately decoupled from how the host obtains its DB handle.
+ *
+ * SAFETY
+ * ------
+ *  - All user-supplied filter values flow through Drizzle's parameter
+ *    binding via the `sql` template tag → no SQL injection.
+ *  - Vectors are converted to the pgvector textual form (`[1,2,3]`) once,
+ *    by the `vectorColumn` customType in `./schema.ts`, so the wire format
+ *    is centralized.
+ */
+
+import { and, eq, sql } from "drizzle-orm";
+import { DEFAULT_NAMESPACE, DEFAULT_VECTOR_DIMENSION, vectorsTable } from "./schema";
+import type {
+  SimilarityResult,
+  UpsertVectorInput,
+  VectorSearchOptions,
+  VectorStore,
+} from "./types";
+
+const DEFAULT_TOP_K = 10;
+const MAX_TOP_K = 200;
+
+export interface PgVectorStoreOptions {
+  /**
+   * Drizzle DB instance (PgDatabase | PgliteDatabase | NodePgDatabase …).
+   * The type is left as `unknown` to avoid coupling this capability to
+   * any specific driver flavour; runtime calls are duck-typed against
+   * the standard `insert / select / delete` surface.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: Drizzle DB instance type varies by driver
+  db: any;
+  /**
+   * Vector dimension. Must match the column type emitted by `./schema.ts`.
+   * Defaults to {@link DEFAULT_VECTOR_DIMENSION}.
+   */
+  dimension?: number;
+}
+
+export class PgVectorStore implements VectorStore {
+  public readonly dimension: number;
+  // biome-ignore lint/suspicious/noExplicitAny: Drizzle DB instance type varies by driver
+  private readonly db: any;
+
+  constructor(options: PgVectorStoreOptions) {
+    if (!options?.db) {
+      throw new Error("PgVectorStore: `db` is required");
+    }
+    this.db = options.db;
+    this.dimension = options.dimension ?? DEFAULT_VECTOR_DIMENSION;
+    if (!Number.isInteger(this.dimension) || this.dimension <= 0) {
+      throw new Error("PgVectorStore: dimension must be a positive integer");
+    }
+  }
+
+  async upsert<TMeta extends Record<string, unknown>>(
+    input: UpsertVectorInput<TMeta>,
+  ): Promise<void> {
+    this.assertDimension(input.vector, input.id);
+    const namespace = input.namespace ?? DEFAULT_NAMESPACE;
+
+    await this.db
+      .insert(vectorsTable)
+      .values({
+        id: input.id,
+        namespace,
+        embedding: input.vector,
+        metadata: input.metadata,
+        content: input.content,
+      })
+      .onConflictDoUpdate({
+        target: [vectorsTable.id, vectorsTable.namespace],
+        set: {
+          embedding: input.vector,
+          metadata: input.metadata,
+          content: input.content,
+          updatedAt: sql`now()`,
+        },
+      });
+  }
+
+  async batchUpsert<TMeta extends Record<string, unknown>>(
+    items: ReadonlyArray<UpsertVectorInput<TMeta>>,
+  ): Promise<void> {
+    if (items.length === 0) return;
+    for (const item of items) {
+      this.assertDimension(item.vector, item.id);
+    }
+    const rows = items.map((item) => ({
+      id: item.id,
+      namespace: item.namespace ?? DEFAULT_NAMESPACE,
+      embedding: item.vector,
+      metadata: item.metadata,
+      content: item.content,
+    }));
+    // Single multi-row INSERT — Drizzle accepts an array of value objects.
+    await this.db
+      .insert(vectorsTable)
+      .values(rows)
+      .onConflictDoUpdate({
+        target: [vectorsTable.id, vectorsTable.namespace],
+        set: {
+          embedding: sql`excluded.embedding`,
+          metadata: sql`excluded.metadata`,
+          content: sql`excluded.content`,
+          updatedAt: sql`now()`,
+        },
+      });
+  }
+
+  async search<TMeta extends Record<string, unknown> = Record<string, unknown>>(
+    queryVector: number[],
+    options: VectorSearchOptions = {},
+  ): Promise<SimilarityResult<TMeta>[]> {
+    this.assertDimension(queryVector, "<query>");
+    const namespace = options.namespace ?? DEFAULT_NAMESPACE;
+    const topK = clampTopK(options.topK);
+
+    // pgvector stores the query as a vector literal; we hand-format the
+    // textual form here because Drizzle has no first-class binding for
+    // the `vector(N)` type.
+    const queryLiteral = `[${queryVector.join(",")}]`;
+
+    const whereParts = [eq(vectorsTable.namespace, namespace)];
+    if (options.filter && Object.keys(options.filter).length > 0) {
+      // JSONB containment — `metadata @> $filter`. The filter object is
+      // serialised once via JSON.stringify and bound as a parameter so
+      // Drizzle handles escaping.
+      const filterJson = JSON.stringify(options.filter);
+      whereParts.push(sql`${vectorsTable.metadata} @> ${filterJson}::jsonb`);
+    }
+
+    // Cosine *distance* in pgvector is `<=>`; similarity = 1 - distance.
+    // We compute the score in SQL so ORDER BY uses the index plan.
+    const scoreExpr = sql<number>`1 - (${vectorsTable.embedding} <=> ${sql.raw(`'${queryLiteral}'::vector`)})`;
+
+    // biome-ignore lint/suspicious/noExplicitAny: Drizzle row shape varies by driver
+    const rows: any[] = await this.db
+      .select({
+        id: vectorsTable.id,
+        namespace: vectorsTable.namespace,
+        metadata: vectorsTable.metadata,
+        content: vectorsTable.content,
+        score: scoreExpr.as("score"),
+      })
+      .from(vectorsTable)
+      .where(and(...whereParts))
+      .orderBy(sql`score DESC`)
+      .limit(topK);
+
+    const minScore = options.minScore;
+    const hits: SimilarityResult<TMeta>[] = [];
+    for (const row of rows) {
+      const score = Number(row.score) || 0;
+      if (minScore !== undefined && score < minScore) continue;
+      hits.push({
+        id: row.id,
+        namespace: row.namespace,
+        score,
+        metadata: (row.metadata ?? {}) as TMeta,
+        content: row.content ?? undefined,
+      });
+    }
+    return hits;
+  }
+
+  async delete(id: string, options: { namespace?: string } = {}): Promise<boolean> {
+    const namespace = options.namespace ?? DEFAULT_NAMESPACE;
+    // biome-ignore lint/suspicious/noExplicitAny: Drizzle returning shape varies by driver
+    const result: any = await this.db
+      .delete(vectorsTable)
+      .where(and(eq(vectorsTable.id, id), eq(vectorsTable.namespace, namespace)))
+      .returning({ id: vectorsTable.id });
+    return Array.isArray(result) && result.length > 0;
+  }
+
+  async clearNamespace(namespace: string): Promise<number> {
+    // biome-ignore lint/suspicious/noExplicitAny: Drizzle returning shape varies by driver
+    const result: any = await this.db
+      .delete(vectorsTable)
+      .where(eq(vectorsTable.namespace, namespace))
+      .returning({ id: vectorsTable.id });
+    return Array.isArray(result) ? result.length : 0;
+  }
+
+  private assertDimension(vector: number[], idForError: string): void {
+    if (vector.length !== this.dimension) {
+      throw new Error(
+        `PgVectorStore: vector for "${idForError}" has length ${vector.length}, expected ${this.dimension}`,
+      );
+    }
+  }
+}
+
+function clampTopK(value: number | undefined): number {
+  const v = value ?? DEFAULT_TOP_K;
+  if (!Number.isFinite(v) || v <= 0) return DEFAULT_TOP_K;
+  return Math.min(Math.floor(v), MAX_TOP_K);
+}
+
+/** Convenience factory mirroring the capability-level helper. */
+export function createPgVectorStore(options: PgVectorStoreOptions): PgVectorStore {
+  return new PgVectorStore(options);
+}

--- a/addons/vector/cap-vector-pgvector/src/rag.ts
+++ b/addons/vector/cap-vector-pgvector/src/rag.ts
@@ -1,0 +1,146 @@
+/**
+ * Retrieval orchestration helpers for RAG.
+ *
+ * Spec 68 §3 lays out a full RetrievalService that fuses vector, structural,
+ * keyword, and graphql strategies. This file ships the P0 slice — pure
+ * vector retrieval plus a prompt-context formatter — and leaves the
+ * multi-strategy fusion to a future PR that lands the cap-search /
+ * OntologyRegistry hooks (Spec 68 §3 M5-M6 column).
+ *
+ * `searchSimilar()` is the high-level entry point capability consumers use:
+ *   const ctx = await retrieveContext({ store, embedder, query: "…" });
+ *   const messages = [{ role: "system", content: ctx.prompt }, …];
+ */
+
+import type {
+  EmbeddingProvider,
+  SearchSimilarOptions,
+  SimilarityResult,
+  VectorStore,
+} from "./types";
+
+// ── searchSimilar ───────────────────────────────────────────
+
+export interface SearchSimilarInput extends SearchSimilarOptions {
+  /** Vector store to query. */
+  store: VectorStore;
+  /** Embedding provider used when `queryVector` is not pre-computed. */
+  embedder?: EmbeddingProvider;
+  /** Natural-language query. Required unless `queryVector` is supplied. */
+  query?: string;
+}
+
+/**
+ * Convenience wrapper around `VectorStore.search()` that accepts either a
+ * pre-computed embedding (`queryVector`) or a natural-language `query`
+ * which is embedded on the fly via the supplied `embedder`.
+ */
+export async function searchSimilar<
+  TMeta extends Record<string, unknown> = Record<string, unknown>,
+>(input: SearchSimilarInput): Promise<SimilarityResult<TMeta>[]> {
+  const { store, embedder, query, queryVector, ...searchOptions } = input;
+  const vector = queryVector ?? (await embedQuery(query, embedder));
+  if (!vector) {
+    throw new Error("searchSimilar: provide either `queryVector` or both `query` and `embedder`");
+  }
+  return store.search<TMeta>(vector, searchOptions);
+}
+
+async function embedQuery(
+  query: string | undefined,
+  embedder: EmbeddingProvider | undefined,
+): Promise<number[] | undefined> {
+  if (!query || !embedder) return undefined;
+  return embedder.embed(query);
+}
+
+// ── retrieveContext (RAG prompt builder) ────────────────────
+
+export interface RetrieveContextInput<TMeta extends Record<string, unknown>>
+  extends SearchSimilarInput {
+  /** Reserved for the per-hit formatter generic. */
+  _meta?: TMeta;
+  /** Maximum number of characters embedded into the final prompt block. */
+  maxChars?: number;
+  /** Header line prepended to the formatted context. */
+  header?: string;
+  /**
+   * Custom formatter for a single hit. Receives the hit and its 1-based
+   * index in the result list; should return the text for that snippet.
+   * Defaults to `"[#i] {content}"` with the metadata appended on a tail
+   * line if present.
+   */
+  formatHit?: (hit: SimilarityResult<TMeta>, index: number) => string;
+}
+
+export interface RetrieveContextResult<TMeta extends Record<string, unknown>> {
+  /** Formatted prompt block ready to splice into a system / user message. */
+  prompt: string;
+  /** Raw hits used to build the prompt (post topK / minScore filtering). */
+  hits: SimilarityResult<TMeta>[];
+  /** Total characters in the prompt (≤ `maxChars`). */
+  charCount: number;
+}
+
+const DEFAULT_HEADER = "Context retrieved from the knowledge base:";
+const DEFAULT_MAX_CHARS = 4_000;
+
+/**
+ * Fetch top-K hits and format them into a single prompt-context string.
+ *
+ * The default formatter produces one block per hit:
+ *
+ *   [#1] {content || metadata.summary}
+ *
+ * Hits are appended in score order until the cumulative character count
+ * reaches `maxChars`. The cut-off is greedy — a hit either fits whole or
+ * is skipped — so chunks stay intact and the LLM never sees a half-line.
+ */
+export async function retrieveContext<
+  TMeta extends Record<string, unknown> = Record<string, unknown>,
+>(input: RetrieveContextInput<TMeta>): Promise<RetrieveContextResult<TMeta>> {
+  const hits = await searchSimilar<TMeta>(input);
+  const header = input.header ?? DEFAULT_HEADER;
+  const maxChars = Math.max(64, input.maxChars ?? DEFAULT_MAX_CHARS);
+  const formatHit = input.formatHit ?? defaultFormatHit;
+
+  if (hits.length === 0) {
+    const empty = `${header}\n(no relevant context found)`;
+    return { prompt: empty, hits, charCount: empty.length };
+  }
+
+  const parts: string[] = [header];
+  let total = header.length;
+  for (let i = 0; i < hits.length; i++) {
+    const hit = hits[i];
+    if (!hit) continue;
+    const block = formatHit(hit, i + 1);
+    // +1 for the join "\n" separator that will sit between blocks.
+    const cost = block.length + 1;
+    if (total + cost > maxChars) break;
+    parts.push(block);
+    total += cost;
+  }
+
+  const prompt = parts.join("\n");
+  return { prompt, hits, charCount: prompt.length };
+}
+
+function defaultFormatHit<TMeta extends Record<string, unknown>>(
+  hit: SimilarityResult<TMeta>,
+  index: number,
+): string {
+  const body =
+    hit.content && hit.content.length > 0
+      ? hit.content
+      : (extractSummary(hit.metadata) ?? `(no content; id=${hit.id})`);
+  return `[#${index}] ${body}`;
+}
+
+function extractSummary(metadata: Record<string, unknown>): string | undefined {
+  for (const key of ["summary", "description", "title"]) {
+    const v = metadata[key];
+    if (typeof v === "string" && v.length > 0) return v;
+  }
+  return undefined;
+}

--- a/addons/vector/cap-vector-pgvector/src/schema.ts
+++ b/addons/vector/cap-vector-pgvector/src/schema.ts
@@ -24,7 +24,15 @@
  */
 
 import { linchkitSchema } from "@linchkit/core/server";
-import { customType, index, jsonb, text, timestamp, varchar } from "drizzle-orm/pg-core";
+import {
+  customType,
+  index,
+  jsonb,
+  text,
+  timestamp,
+  uniqueIndex,
+  varchar,
+} from "drizzle-orm/pg-core";
 
 /**
  * Default embedding dimension. Matches OpenAI `text-embedding-3-small`
@@ -60,10 +68,25 @@ export const vectorColumn = customType<{
   },
   fromDriver(value: string): number[] {
     // pgvector returns text like `[1,2,3]` — strip the brackets and parse.
+    // Use `Number.parseFloat` and reject non-finite components so a malformed
+    // driver response never silently produces a NaN-laden vector that would
+    // corrupt downstream similarity math.
     if (typeof value !== "string") return [];
     const trimmed = value.replace(/^\[|\]$/g, "").trim();
     if (trimmed.length === 0) return [];
-    return trimmed.split(",").map((s) => Number(s));
+    const parts = trimmed.split(",");
+    const out = new Array<number>(parts.length);
+    for (let i = 0; i < parts.length; i++) {
+      const raw = parts[i] ?? "";
+      const n = Number.parseFloat(raw);
+      if (!Number.isFinite(n)) {
+        throw new Error(
+          `vectorColumn.fromDriver: invalid numeric component "${raw}" at index ${i} (value="${value}")`,
+        );
+      }
+      out[i] = n;
+    }
+    return out;
   },
 });
 
@@ -88,9 +111,12 @@ export const vectorsTable = linchkitSchema.table(
     updatedAt: timestamp("updated_at", { mode: "date" }).notNull().defaultNow(),
   },
   (table) => [
-    // (id, namespace) is the upsert conflict target — kept as a plain
-    // composite index so a single id can exist in multiple namespaces.
-    index("idx_vectors_id_namespace").on(table.id, table.namespace),
+    // (id, namespace) is the upsert conflict target — it MUST be a unique
+    // index so PostgreSQL can use it as the arbiter for
+    // `INSERT ... ON CONFLICT (id, namespace) DO UPDATE`. A plain composite
+    // index would cause the upsert to fail with
+    // `no unique or exclusion constraint matching the ON CONFLICT specification`.
+    uniqueIndex("ux_vectors_id_namespace").on(table.id, table.namespace),
     index("idx_vectors_namespace").on(table.namespace),
     // HNSW operator-class index for cosine similarity is created via
     // raw SQL in the follow-up migration; drizzle-kit cannot express it.

--- a/addons/vector/cap-vector-pgvector/src/schema.ts
+++ b/addons/vector/cap-vector-pgvector/src/schema.ts
@@ -1,0 +1,98 @@
+/**
+ * cap-vector-pgvector Drizzle table definitions.
+ *
+ * A single `_linchkit.vectors` table stores every embedding (Meta-Model
+ * definitions, business-data rows, RAG chunks, …) keyed by namespace.
+ *
+ * NOTES
+ * -----
+ *  - The `embedding` column is declared via `customType` because Drizzle
+ *    does not yet ship a first-class `vector(N)` type for the pgvector
+ *    extension. The custom type emits `vector($dimension)` DDL so
+ *    drizzle-kit generate produces the right column.
+ *  - drizzle-kit cannot generate the HNSW operator-class index on its own
+ *    (it would default to btree). Spec 68 §2.2 documents that the HNSW
+ *    + cosine_ops index is created via a follow-up SQL step in the
+ *    capability's migration — same pattern as cap-search's GIN index.
+ *  - The CREATE EXTENSION statement also lives in the follow-up SQL
+ *    (Drizzle is intentionally out of the extension business).
+ *  - Schema DDL is never hand-written; once the host adds this capability
+ *    to `linchkit.config.ts` and runs `linch db generate`, drizzle-kit
+ *    emits the base CREATE TABLE. The capability ships the HNSW + pgvector
+ *    bootstrap SQL as a follow-up migration in
+ *    `addons/vector/cap-vector-pgvector/src/migrations/`.
+ */
+
+import { linchkitSchema } from "@linchkit/core/server";
+import { customType, index, jsonb, text, timestamp, varchar } from "drizzle-orm/pg-core";
+
+/**
+ * Default embedding dimension. Matches OpenAI `text-embedding-3-small`
+ * which is the most common cheap embedding model today. Hosts can stand
+ * up a second table at a different dimension if they swap providers.
+ */
+export const DEFAULT_VECTOR_DIMENSION = 1536;
+
+/** Default namespace bucket used when callers omit one. */
+export const DEFAULT_NAMESPACE = "default";
+
+/**
+ * Custom Drizzle column type wrapping pgvector's `vector(N)` type.
+ *
+ * - `data` is the in-process JS representation (number[]).
+ * - `driverData` is the wire representation accepted by pg's text
+ *   protocol (`'[1.0,2.0,3.0]'`).
+ *
+ * `toDriver` / `fromDriver` keep the conversion isolated from query
+ * sites so the rest of the code can pass plain number[] around.
+ */
+export const vectorColumn = customType<{
+  data: number[];
+  driverData: string;
+  config: { dimension: number };
+}>({
+  dataType(config) {
+    const dim = config?.dimension ?? DEFAULT_VECTOR_DIMENSION;
+    return `vector(${dim})`;
+  },
+  toDriver(value: number[]): string {
+    return `[${value.join(",")}]`;
+  },
+  fromDriver(value: string): number[] {
+    // pgvector returns text like `[1,2,3]` — strip the brackets and parse.
+    if (typeof value !== "string") return [];
+    const trimmed = value.replace(/^\[|\]$/g, "").trim();
+    if (trimmed.length === 0) return [];
+    return trimmed.split(",").map((s) => Number(s));
+  },
+});
+
+/**
+ * The single shared vectors table.
+ *
+ * The `(id, namespace)` composite key lets the same caller-supplied id
+ * appear in different namespaces without collision — e.g. an Entity
+ * named `purchase_request` can have one row in `meta_model` (the
+ * definition embedding) and one row per record in
+ * `data:purchase_request` (business data embeddings).
+ */
+export const vectorsTable = linchkitSchema.table(
+  "vectors",
+  {
+    id: varchar("id", { length: 255 }).notNull(),
+    namespace: varchar("namespace", { length: 255 }).notNull().default(DEFAULT_NAMESPACE),
+    embedding: vectorColumn("embedding", { dimension: DEFAULT_VECTOR_DIMENSION }).notNull(),
+    metadata: jsonb("metadata").notNull().default({}),
+    content: text("content"),
+    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { mode: "date" }).notNull().defaultNow(),
+  },
+  (table) => [
+    // (id, namespace) is the upsert conflict target — kept as a plain
+    // composite index so a single id can exist in multiple namespaces.
+    index("idx_vectors_id_namespace").on(table.id, table.namespace),
+    index("idx_vectors_namespace").on(table.namespace),
+    // HNSW operator-class index for cosine similarity is created via
+    // raw SQL in the follow-up migration; drizzle-kit cannot express it.
+  ],
+);

--- a/addons/vector/cap-vector-pgvector/src/types.ts
+++ b/addons/vector/cap-vector-pgvector/src/types.ts
@@ -1,0 +1,132 @@
+/**
+ * Public types for @linchkit/cap-vector-pgvector.
+ *
+ * Hosts the VectorStore contract and the embedding-provider adapter used by
+ * the pgvector implementation. The contract follows Spec 68 §2.1 closely but
+ * lives in the capability rather than `@linchkit/core` for now:
+ *
+ *  - Spec 56 (core slimming) keeps optional infrastructure out of core.
+ *  - There is only one VectorStore implementation in-tree today
+ *    (`cap-vector-pgvector`), so promoting the interface to core would
+ *    create import drag without buyers.
+ *  - When `cap-vector-memory` / `cap-vector-qdrant` land, this file moves
+ *    to `@linchkit/core/vector` and other capabilities re-export from
+ *    there. Until then the contract lives next to its only consumer.
+ */
+
+// ── Embedding adapter ───────────────────────────────────────
+
+/**
+ * Minimal embedding-provider contract that VectorStore depends on.
+ *
+ * The capability deliberately does NOT depend on `@linchkit/cap-ai-provider`
+ * directly — hosts wire whatever embedding source they prefer (OpenAI,
+ * Anthropic, local model, even a stub returning zero vectors for tests).
+ *
+ * Spec 68 §2.3: "复用 cap-ai-provider … VectorStore 的 embed() 实现委托给
+ * AI Provider." The implementation of that delegation is the host's job,
+ * not this capability's — see `createAiProviderEmbeddingProvider()` in
+ * `./embed.ts` for the canonical wiring helper.
+ */
+export interface EmbeddingProvider {
+  /** Embedding dimension produced by `embed()` (e.g. 1536 for OpenAI text-embedding-3-small). */
+  readonly dimension: number;
+  /** Compute the embedding vector for a single text. */
+  embed(text: string): Promise<number[]>;
+  /**
+   * Compute embeddings for a batch of texts. Implementations that lack a
+   * native batch API can fall back to a sequential / Promise.all loop.
+   */
+  embedMany?(texts: readonly string[]): Promise<number[][]>;
+}
+
+// ── Vector store contract ───────────────────────────────────
+
+/** A single similarity hit returned by `VectorStore.search()`. */
+export interface SimilarityResult<TMeta extends Record<string, unknown> = Record<string, unknown>> {
+  /** Caller-supplied row identifier. */
+  id: string;
+  /**
+   * Cosine similarity score in `[0, 1]`. Higher = more similar.
+   * (Postgres pgvector's `<=>` returns cosine *distance*; the store
+   * converts it to similarity = `1 - distance` before returning.)
+   */
+  score: number;
+  /** Metadata stored at `upsert()` time. */
+  metadata: TMeta;
+  /** Optional original text content, when stored. */
+  content?: string;
+  /** Namespace this row belongs to. */
+  namespace: string;
+}
+
+/** Options accepted by `VectorStore.search()`. */
+export interface VectorSearchOptions {
+  /** Maximum number of results to return (defaults to 10, hard-capped at 200). */
+  topK?: number;
+  /**
+   * Namespace scope. Defaults to `"default"`. Mirrors the spec's tenant /
+   * collection separation — `meta_model` for ontology vectors,
+   * `data:{entity_name}` for business rows, etc.
+   */
+  namespace?: string;
+  /**
+   * Metadata equality filter applied as a JSONB containment match
+   * (`metadata @> filter`). Each top-level key must equal the supplied
+   * value for the row to qualify.
+   */
+  filter?: Record<string, unknown>;
+  /** Minimum similarity score in `[0, 1]`. Results below the threshold are dropped. */
+  minScore?: number;
+}
+
+/** Options accepted by `searchSimilar()` / `retrieveContext()` orchestration helpers. */
+export interface SearchSimilarOptions extends VectorSearchOptions {
+  /** Pre-computed query embedding. When omitted, `embedder.embed(query)` is used. */
+  queryVector?: number[];
+}
+
+/** Input row for `VectorStore.upsert()` / `batchUpsert()`. */
+export interface UpsertVectorInput<
+  TMeta extends Record<string, unknown> = Record<string, unknown>,
+> {
+  /** Caller-supplied row identifier; reused as the upsert conflict target. */
+  id: string;
+  /** Embedding vector. Length must match the store's dimension. */
+  vector: number[];
+  /** Arbitrary metadata persisted alongside the vector. */
+  metadata: TMeta;
+  /** Original text content (optional but recommended for RAG). */
+  content?: string;
+  /** Namespace bucket. Defaults to `"default"`. */
+  namespace?: string;
+}
+
+/**
+ * Abstract vector-storage service used by the evolution system, Meta-Model
+ * semantic layer, AI code generation, and Chatter RAG.
+ *
+ * Implementations:
+ *  - `PgVectorStore` — PostgreSQL `vector` extension via Drizzle.
+ *  - `InMemoryVectorStore` — brute-force KNN for tests / dev. Doubles as
+ *    the Spec 68 §2.2 `cap-vector-memory` implementation.
+ */
+export interface VectorStore {
+  /** Vector dimension this store was configured for. */
+  readonly dimension: number;
+  /** Insert or update a single row. Conflict target is `(id, namespace)`. */
+  upsert<TMeta extends Record<string, unknown>>(input: UpsertVectorInput<TMeta>): Promise<void>;
+  /** Bulk variant of `upsert()` — implementations should run a single round-trip when possible. */
+  batchUpsert<TMeta extends Record<string, unknown>>(
+    items: ReadonlyArray<UpsertVectorInput<TMeta>>,
+  ): Promise<void>;
+  /** Similarity search using the supplied query vector. */
+  search<TMeta extends Record<string, unknown> = Record<string, unknown>>(
+    queryVector: number[],
+    options?: VectorSearchOptions,
+  ): Promise<SimilarityResult<TMeta>[]>;
+  /** Delete a single row by id within a namespace. Returns `true` if the row existed. */
+  delete(id: string, options?: { namespace?: string }): Promise<boolean>;
+  /** Drop every row in a namespace. Useful for tests and namespace recycling. */
+  clearNamespace(namespace: string): Promise<number>;
+}

--- a/addons/vector/cap-vector-pgvector/src/types.ts
+++ b/addons/vector/cap-vector-pgvector/src/types.ts
@@ -48,8 +48,16 @@ export interface SimilarityResult<TMeta extends Record<string, unknown> = Record
   id: string;
   /**
    * Cosine similarity score in `[0, 1]`. Higher = more similar.
-   * (Postgres pgvector's `<=>` returns cosine *distance*; the store
-   * converts it to similarity = `1 - distance` before returning.)
+   *
+   * Both backends rescale raw cosine similarity (`[-1, 1]`) into
+   * `[0, 1]` via `(sim + 1) / 2` so callers see identical ranges
+   * regardless of which `VectorStore` implementation is wired:
+   *   - `InMemoryVectorStore` applies the rescale in JS
+   *     (see `cosineSimilarity()` in `./vector-math.ts`).
+   *   - `PgVectorStore` applies the rescale in the SQL projection
+   *     (so the HNSW `ORDER BY` plan still kicks in).
+   * `minScore` filtering uses this rescaled range — `0.5` means
+   * orthogonal, `1.0` identical, `0.0` opposite.
    */
   score: number;
   /** Metadata stored at `upsert()` time. */

--- a/addons/vector/cap-vector-pgvector/src/vector-math.ts
+++ b/addons/vector/cap-vector-pgvector/src/vector-math.ts
@@ -41,8 +41,12 @@ export function cosineSimilarity(a: number[], b: number[]): number {
 /**
  * Shallow JSONB-style containment check. Each top-level key in `filter`
  * must equal the corresponding value in `metadata` for the row to pass.
- * Nested objects are compared via `JSON.stringify` — cheap, deterministic,
- * and good enough for the equality filters Spec 68 §2.1 sketches.
+ *
+ * Nested values are compared via {@link deepEqual} — a structural walk
+ * that is order-independent for object keys (so `{a:1,b:2}` equals
+ * `{b:2,a:1}`, unlike `JSON.stringify` which depends on insertion order).
+ * This mirrors PostgreSQL's `jsonb @>` operator semantics, which the
+ * pgvector backend uses on the server side.
  */
 export function matchesFilter(
   metadata: Record<string, unknown>,
@@ -50,18 +54,49 @@ export function matchesFilter(
 ): boolean {
   for (const [key, expected] of Object.entries(filter)) {
     if (!Object.hasOwn(metadata, key)) return false;
-    const actual = metadata[key];
-    if (actual === expected) continue;
-    if (
-      typeof actual === "object" &&
-      actual !== null &&
-      typeof expected === "object" &&
-      expected !== null
-    ) {
-      if (JSON.stringify(actual) !== JSON.stringify(expected)) return false;
-      continue;
+    if (!deepEqual(metadata[key], expected)) return false;
+  }
+  return true;
+}
+
+/**
+ * Order-independent structural equality for plain JSON-like values.
+ *
+ * - Primitives are compared with `Object.is` (so `NaN === NaN`).
+ * - Arrays must have matching length and element-wise equality.
+ * - Plain objects must share the same key set and each key's values must
+ *   themselves be `deepEqual`.
+ *
+ * No support for class instances, Maps, Sets, Dates, RegExps … on
+ * purpose: filter payloads come from JSON / JSONB, which only contains
+ * those JS shapes.
+ */
+export function deepEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (typeof a !== typeof b) return false;
+  if (a === null || b === null) return false;
+  if (typeof a !== "object" || typeof b !== "object") return false;
+
+  const aIsArray = Array.isArray(a);
+  const bIsArray = Array.isArray(b);
+  if (aIsArray !== bIsArray) return false;
+
+  if (aIsArray && bIsArray) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i])) return false;
     }
-    return false;
+    return true;
+  }
+
+  const aObj = a as Record<string, unknown>;
+  const bObj = b as Record<string, unknown>;
+  const aKeys = Object.keys(aObj);
+  const bKeys = Object.keys(bObj);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const key of aKeys) {
+    if (!Object.hasOwn(bObj, key)) return false;
+    if (!deepEqual(aObj[key], bObj[key])) return false;
   }
   return true;
 }

--- a/addons/vector/cap-vector-pgvector/src/vector-math.ts
+++ b/addons/vector/cap-vector-pgvector/src/vector-math.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared vector / metadata utilities.
+ *
+ * Kept separate from the store implementations so both the in-memory
+ * brute-force search and the test suite can reuse the exact same
+ * cosine-similarity definition without duplicating the math.
+ */
+
+/**
+ * Cosine similarity in `[-1, 1]` rescaled to `[0, 1]`.
+ *
+ * The pgvector store returns `1 - (a <=> b)` which is already in
+ * `[0, 1]` for non-negative inner products; the in-memory store
+ * applies the same rescale so consumers see identical ranges across
+ * implementations. The standard math says
+ *   cosine_sim = (a · b) / (||a|| * ||b||)
+ * and we rescale via `(x + 1) / 2` so a hit and a miss always live on
+ * the same axis.
+ */
+export function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length !== b.length) {
+    throw new Error(`cosineSimilarity: length mismatch (${a.length} vs ${b.length})`);
+  }
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    const av = a[i] ?? 0;
+    const bv = b[i] ?? 0;
+    dot += av * bv;
+    normA += av * av;
+    normB += bv * bv;
+  }
+  if (normA === 0 || normB === 0) return 0;
+  const raw = dot / (Math.sqrt(normA) * Math.sqrt(normB));
+  // Clamp to defeat tiny FP drift before rescaling.
+  const clamped = Math.max(-1, Math.min(1, raw));
+  return (clamped + 1) / 2;
+}
+
+/**
+ * Shallow JSONB-style containment check. Each top-level key in `filter`
+ * must equal the corresponding value in `metadata` for the row to pass.
+ * Nested objects are compared via `JSON.stringify` — cheap, deterministic,
+ * and good enough for the equality filters Spec 68 §2.1 sketches.
+ */
+export function matchesFilter(
+  metadata: Record<string, unknown>,
+  filter: Record<string, unknown>,
+): boolean {
+  for (const [key, expected] of Object.entries(filter)) {
+    if (!Object.hasOwn(metadata, key)) return false;
+    const actual = metadata[key];
+    if (actual === expected) continue;
+    if (
+      typeof actual === "object" &&
+      actual !== null &&
+      typeof expected === "object" &&
+      expected !== null
+    ) {
+      if (JSON.stringify(actual) !== JSON.stringify(expected)) return false;
+      continue;
+    }
+    return false;
+  }
+  return true;
+}

--- a/addons/vector/cap-vector-pgvector/tsconfig.json
+++ b/addons/vector/cap-vector-pgvector/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun-types"]
+  },
+  "include": ["src", "__tests__"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -391,6 +391,53 @@
         "react-i18next": ">=14.0.0",
       },
     },
+    "addons/theme/cap-theme": {
+      "name": "@linchkit/cap-theme",
+      "version": "0.1.0",
+      "dependencies": {
+        "lucide-react": "^1.7.0",
+      },
+      "devDependencies": {
+        "@linchkit/cap-adapter-ui": "workspace:*",
+        "@linchkit/core": "workspace:*",
+      },
+      "peerDependencies": {
+        "@linchkit/cap-adapter-ui": "^1.0.0",
+        "@linchkit/core": "^0.2.0",
+        "react": "^19.0.0",
+        "react-i18next": ">=14.0.0",
+      },
+    },
+    "addons/vector/cap-vector-pgvector": {
+      "name": "@linchkit/cap-vector-pgvector",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@linchkit/core": "workspace:*",
+        "typescript": "^6.0.2",
+      },
+      "peerDependencies": {
+        "@linchkit/core": "^0.2.0",
+        "drizzle-orm": "^0.45.1",
+      },
+    },
+    "addons/view-calendar/cap-view-calendar": {
+      "name": "@linchkit/cap-view-calendar",
+      "version": "0.1.0",
+      "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "date-fns": "^4.1.0",
+      },
+      "devDependencies": {
+        "@linchkit/cap-adapter-ui": "workspace:*",
+        "@linchkit/core": "workspace:*",
+        "typescript": "^6.0.2",
+      },
+      "peerDependencies": {
+        "@linchkit/cap-adapter-ui": "^1.0.0",
+        "@linchkit/core": "^0.2.0",
+        "react": "^19.0.0",
+      },
+    },
     "addons/view-kanban/cap-view-kanban": {
       "name": "@linchkit/cap-view-kanban",
       "version": "0.1.0",
@@ -790,6 +837,12 @@
     "@linchkit/cap-search": ["@linchkit/cap-search@workspace:addons/search/cap-search"],
 
     "@linchkit/cap-search-ui": ["@linchkit/cap-search-ui@workspace:addons/search/cap-search-ui"],
+
+    "@linchkit/cap-theme": ["@linchkit/cap-theme@workspace:addons/theme/cap-theme"],
+
+    "@linchkit/cap-vector-pgvector": ["@linchkit/cap-vector-pgvector@workspace:addons/vector/cap-vector-pgvector"],
+
+    "@linchkit/cap-view-calendar": ["@linchkit/cap-view-calendar@workspace:addons/view-calendar/cap-view-calendar"],
 
     "@linchkit/cap-view-kanban": ["@linchkit/cap-view-kanban@workspace:addons/view-kanban/cap-view-kanban"],
 


### PR DESCRIPTION
## Summary

Implements Spec 68 — new capability `addons/vector/cap-vector-pgvector` providing a pluggable vector store backed by PostgreSQL `pgvector`, plus an embedding pipeline and a minimal RAG orchestration helper.

## What's new

- **`VectorStore`** interface (`types.ts`) — `upsert`, `search`, `delete`, `count`; multi-namespace support; JSONB-style metadata filters.
- **`InMemoryVectorStore`** — pure-JS fallback for tests and dev environments without a Postgres backend.
- **`PgVectorStore`** — Drizzle-backed implementation. `INSERT … ON CONFLICT (id, namespace) DO UPDATE` for upsert; `ORDER BY embedding <=> $1` with cosine distance for search; metadata containment filter and `minScore` threshold supported.
- **Embedding pipeline** (`embed.ts`) — `createFunctionEmbeddingProvider({embed, embedMany?})` synthesises a batch method when only `embed` is provided. `embedAndUpsertDocuments({embedder, store, docs, namespace?})` chunks and persists.
- **RAG orchestration** (`rag.ts`) — `searchSimilar` accepts either a pre-computed `queryVector` or a NL `query` (embedded on the fly); `retrieveContext` formats top-K hits into a prompt-ready block honouring `maxChars`, custom `formatHit`, and metadata fallback.
- **OCA shell** (`capability.ts`) — `autoInstall: false` because pgvector requires the `vector` extension to be enabled on the database; consumers opt in.

## DDL

`schema.ts` declares the Drizzle table for vectors. The pgvector HNSW operator-class index (`vector_cosine_ops`) is created by the capability's migration, not by this PR — drizzle-kit cannot emit operator classes.

## Tests

25 unit tests pass against the in-memory store + RAG helpers. PgVectorStore is covered by the type contract; live pgvector integration tests will land in a follow-up that runs against the Docker compose Postgres.

Full suite: **5417 pass / 0 fail**.

## Deferred (follow-ups)

- Live pgvector integration tests (need DB harness).
- Hybrid search (vector + full-text), reranking — Spec 68 phase 2.
- A `linch vector migrate` CLI for the HNSW index DDL.

## Quality gates

- `bun run check` ✅
- `bun run typecheck` ✅
- `bun test` ✅ 5417/0

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vector storage capability with PostgreSQL pgvector and in-memory support for semantic search and similarity-based retrieval.
  * Added embedding pipeline to convert documents to vectors with configurable embedding providers.
  * Added Retrieval Augmented Generation (RAG) helpers for context retrieval and similarity search with metadata filtering.

* **Tests**
  * Added comprehensive test coverage for embedding, vector storage, and RAG functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laofahai/linchkit/pull/339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->