### PR TITLE
feat(deployment): GitHub webhook receiver for push-triggered deploys (Spec 12 §3)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/src/routes/deploy-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/deploy-api.ts
@@ -1,0 +1,61 @@
+/**
+ * Deployment webhook endpoint — Spec 12 §3
+ *
+ * POST /api/deploy/webhook
+ *   Receives GitHub push events, verifies the HMAC-SHA256 signature,
+ *   and fires the deploy callback when a push to the watched branch lands.
+ *
+ * Required headers:
+ *   X-Hub-Signature-256: sha256=<hex>   — GitHub webhook signature
+ *   X-GitHub-Event: push                — event type
+ *
+ * Response codes:
+ *   200 — accepted and deploy callback invoked
+ *   400 — missing headers or invalid JSON
+ *   403 — signature verification failed
+ *   503 — no webhook handler configured
+ */
+
+import type { DeployWebhookHandler } from "@linchkit/core/server";
+import type { Elysia } from "elysia";
+
+export function mountDeployRoutes(app: Elysia, handler: DeployWebhookHandler | undefined): void {
+  if (!handler) {
+    // Route is still registered so callers get 503 instead of 404
+    app.post("/api/deploy/webhook", ({ set }) => {
+      set.status = 503;
+      return { success: false, error: "Deploy webhook handler not configured" };
+    });
+    return;
+  }
+
+  app.post("/api/deploy/webhook", async ({ request, set }) => {
+    const signature = request.headers.get("x-hub-signature-256") ?? "";
+    const eventType = request.headers.get("x-github-event") ?? "";
+
+    if (!signature) {
+      set.status = 400;
+      return { success: false, error: "Missing X-Hub-Signature-256 header" };
+    }
+    if (!eventType) {
+      set.status = 400;
+      return { success: false, error: "Missing X-GitHub-Event header" };
+    }
+
+    const rawBody = await request.text();
+
+    const result = await handler.handle(rawBody, signature, eventType);
+
+    if (!result.accepted) {
+      // Signature failure → 403; other skip reasons (wrong branch, event type) → 200
+      if (result.reason === "invalid signature") {
+        set.status = 403;
+        return { success: false, error: "Signature verification failed" };
+      }
+      // Not an error — GitHub may send many event types; we just skip non-push
+      return { success: true, accepted: false, reason: result.reason };
+    }
+
+    return { success: true, accepted: true };
+  });
+}

--- a/addons/adapter-server/cap-adapter-server/src/routes/deploy-api.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/deploy-api.ts
@@ -47,10 +47,14 @@ export function mountDeployRoutes(app: Elysia, handler: DeployWebhookHandler | u
     const result = await handler.handle(rawBody, signature, eventType);
 
     if (!result.accepted) {
-      // Signature failure → 403; other skip reasons (wrong branch, event type) → 200
+      // Signature failure → 403; malformed body → 400; other skip reasons (wrong branch, event type) → 200
       if (result.reason === "invalid signature") {
         set.status = 403;
         return { success: false, error: "Signature verification failed" };
+      }
+      if (result.reason === "invalid JSON payload") {
+        set.status = 400;
+        return { success: false, error: "Invalid JSON payload" };
       }
       // Not an error — GitHub may send many event types; we just skip non-push
       return { success: true, accepted: false, reason: result.reason };

--- a/addons/adapter-server/cap-adapter-server/src/server.ts
+++ b/addons/adapter-server/cap-adapter-server/src/server.ts
@@ -36,6 +36,7 @@ import type {
 import type {
   AIAuditLogger,
   CacheManager,
+  DeployWebhookHandler,
   HealthCheckRegistry,
   InMemoryMetricsCollector,
   OnchangeEvaluator,
@@ -54,6 +55,7 @@ import { mountResolveIntentRoute } from "./routes/ai-resolve-intent";
 import { mountApprovalRoutes } from "./routes/approval-api";
 import { mountConfigRoutes } from "./routes/config-api";
 import { mountConfigStoreRoutes } from "./routes/config-store-api";
+import { mountDeployRoutes } from "./routes/deploy-api";
 import { mountEntityRoutes } from "./routes/entity-api";
 import { mountHealthRoutes } from "./routes/health";
 import { mountImportRoutes } from "./routes/import-api";
@@ -202,6 +204,12 @@ export interface ServerOptions {
    * and acts as the recording sink for completed AI calls.
    */
   usageMeter?: import("@linchkit/core/ai").UsageMeter;
+  /**
+   * GitHub deployment webhook handler (Spec 12 §3).
+   * When provided, enables `POST /api/deploy/webhook` to receive GitHub push
+   * events and trigger the configured deployment callback.
+   */
+  deployWebhookHandler?: DeployWebhookHandler;
 }
 
 // Re-export parseAcceptLanguage for external consumers
@@ -305,7 +313,7 @@ export function createServer(
   // Ensure options is defined for route modules (they expect non-optional parameter)
   const opts = options ?? {};
 
-  // ── Mount route modules ──────────────────────────────────
+  // ── Mount route modules ────────────────────────────────────
   mountAdminRoutes(app, opts, serverStartedAt);
   // Mounted AFTER admin so the canonical, minimal `/health` (Spec 12 — liveness)
   // overrides any duplicate handler in admin-api.ts. `/ready` is exclusive to
@@ -353,10 +361,13 @@ export function createServer(
     return response;
   });
 
-  // ── Proposal / Evolution / AI Insights endpoints ──────────
+  // ── Deployment webhook endpoint (Spec 12 §3) ─────────────────
+  mountDeployRoutes(app, opts.deployWebhookHandler);
+
+  // ── Proposal / Evolution / AI Insights endpoints ──────────────
   mountProposalAPI(app, executionLogger);
 
-  // ── SSE Subscription endpoint (/api/subscribe) ────────────
+  // ── SSE Subscription endpoint (/api/subscribe) ────────────────
   mountSubscriptionRoutes(app, opts);
 
   return app;

--- a/packages/core/__tests__/deployment-webhook.test.ts
+++ b/packages/core/__tests__/deployment-webhook.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, it } from "bun:test";
+import { createHmac } from "node:crypto";
+import type { DeployEvent } from "../src/deployment";
+import { DeployWebhookHandler } from "../src/deployment";
+
+// ── Helpers ─────────────────────────────────────────────────
+
+const SECRET = "test-webhook-secret-abc";
+
+function sign(body: string, secret = SECRET): string {
+  return `sha256=${createHmac("sha256", secret).update(body, "utf8").digest("hex")}`;
+}
+
+function makePushPayload(
+  opts: {
+    branch?: string;
+    commitSha?: string;
+    login?: string;
+    repo?: string;
+    deleted?: boolean;
+  } = {},
+): string {
+  return JSON.stringify({
+    ref: `refs/heads/${opts.branch ?? "main"}`,
+    after: opts.commitSha ?? "abc123def456",
+    deleted: opts.deleted ?? false,
+    sender: { login: opts.login ?? "alice" },
+    repository: { full_name: opts.repo ?? "owner/repo" },
+    head_commit: {
+      id: opts.commitSha ?? "abc123def456",
+      timestamp: "2026-05-18T09:00:00Z",
+    },
+  });
+}
+
+// ── Constructor validation ────────────────────────────────────
+
+describe("DeployWebhookHandler constructor", () => {
+  it("throws when secret is empty", () => {
+    expect(
+      () =>
+        new DeployWebhookHandler({
+          secret: "",
+          onDeploy: async () => {},
+        }),
+    ).toThrow("secret is required");
+  });
+
+  it("throws when onDeploy is missing", () => {
+    expect(
+      () =>
+        new DeployWebhookHandler({
+          secret: SECRET,
+          // biome-ignore lint/suspicious/noExplicitAny: intentional bad input
+          onDeploy: undefined as any,
+        }),
+    ).toThrow("onDeploy callback is required");
+  });
+
+  it("uses 'main' as default branchFilter", async () => {
+    const events: DeployEvent[] = [];
+    const handler = new DeployWebhookHandler({
+      secret: SECRET,
+      onDeploy: async (e) => {
+        events.push(e);
+      },
+    });
+
+    const body = makePushPayload({ branch: "main" });
+    await handler.handle(body, sign(body), "push");
+
+    expect(events).toHaveLength(1);
+  });
+});
+
+// ── verifySignature ──────────────────────────────────────────
+
+describe("verifySignature", () => {
+  const handler = new DeployWebhookHandler({
+    secret: SECRET,
+    onDeploy: async () => {},
+  });
+
+  it("returns true for correct signature", () => {
+    const body = `{"ref":"refs/heads/main"}`;
+    expect(handler.verifySignature(body, sign(body))).toBe(true);
+  });
+
+  it("returns false for wrong secret", () => {
+    const body = `{"ref":"refs/heads/main"}`;
+    expect(handler.verifySignature(body, sign(body, "wrong-secret"))).toBe(false);
+  });
+
+  it("returns false for tampered body", () => {
+    const body = `{"ref":"refs/heads/main"}`;
+    const sig = sign(body);
+    expect(handler.verifySignature(`{"ref":"refs/heads/evil"}`, sig)).toBe(false);
+  });
+
+  it("returns false for empty signature", () => {
+    const body = `{"ref":"refs/heads/main"}`;
+    expect(handler.verifySignature(body, "")).toBe(false);
+  });
+
+  it("returns false for missing sha256= prefix (raw hex only)", () => {
+    const body = `{"ref":"refs/heads/main"}`;
+    const rawHex = createHmac("sha256", SECRET).update(body, "utf8").digest("hex");
+    expect(handler.verifySignature(body, rawHex)).toBe(false);
+  });
+});
+
+// ── handle — event type filtering ────────────────────────────
+
+describe("handle — event type filtering", () => {
+  const handler = new DeployWebhookHandler({
+    secret: SECRET,
+    onDeploy: async () => {},
+  });
+
+  it("rejects non-push events with accepted=false", async () => {
+    const body = makePushPayload();
+    const result = await handler.handle(body, sign(body), "pull_request");
+
+    expect(result.accepted).toBe(false);
+    expect(result.reason).toContain("pull_request");
+  });
+
+  it("rejects ping events", async () => {
+    const body = JSON.stringify({ zen: "Non-blocking is better than blocking." });
+    const result = await handler.handle(body, sign(body), "ping");
+
+    expect(result.accepted).toBe(false);
+  });
+});
+
+// ── handle — branch filtering ────────────────────────────────
+
+describe("handle — branch filtering", () => {
+  it("accepts push to the configured branch", async () => {
+    const fired: DeployEvent[] = [];
+    const handler = new DeployWebhookHandler({
+      secret: SECRET,
+      onDeploy: async (e) => {
+        fired.push(e);
+      },
+    });
+
+    const body = makePushPayload({ branch: "main" });
+    const result = await handler.handle(body, sign(body), "push");
+
+    expect(result.accepted).toBe(true);
+    expect(fired).toHaveLength(1);
+  });
+
+  it("ignores push to a different branch", async () => {
+    const fired: DeployEvent[] = [];
+    const handler = new DeployWebhookHandler({
+      secret: SECRET,
+      onDeploy: async (e) => {
+        fired.push(e);
+      },
+    });
+
+    const body = makePushPayload({ branch: "feature/xyz" });
+    const result = await handler.handle(body, sign(body), "push");
+
+    expect(result.accepted).toBe(false);
+    expect(result.reason).toContain("feature/xyz");
+    expect(fired).toHaveLength(0);
+  });
+
+  it("respects custom branchFilter", async () => {
+    const fired: DeployEvent[] = [];
+    const handler = new DeployWebhookHandler({
+      secret: SECRET,
+      branchFilter: "production",
+      onDeploy: async (e) => {
+        fired.push(e);
+      },
+    });
+
+    const body = makePushPayload({ branch: "production" });
+    const result = await handler.handle(body, sign(body), "push");
+
+    expect(result.accepted).toBe(true);
+    expect(fired).toHaveLength(1);
+
+    const mainBody = makePushPayload({ branch: "main" });
+    const mainResult = await handler.handle(mainBody, sign(mainBody), "push");
+    expect(mainResult.accepted).toBe(false);
+  });
+
+  it("ignores branch deletion events", async () => {
+    const fired: DeployEvent[] = [];
+    const handler = new DeployWebhookHandler({
+      secret: SECRET,
+      onDeploy: async (e) => {
+        fired.push(e);
+      },
+    });
+
+    const body = makePushPayload({ branch: "main", deleted: true });
+    const result = await handler.handle(body, sign(body), "push");
+
+    expect(result.accepted).toBe(false);
+    expect(result.reason).toContain("deletion");
+    expect(fired).toHaveLength(0);
+  });
+});
+
+// ── handle — signature failure ────────────────────────────────
+
+describe("handle — signature failure", () => {
+  const handler = new DeployWebhookHandler({
+    secret: SECRET,
+    onDeploy: async () => {
+      throw new Error("should not be called");
+    },
+  });
+
+  it("returns accepted=false and reason=invalid signature", async () => {
+    const body = makePushPayload();
+    const result = await handler.handle(body, "sha256=deadbeef", "push");
+
+    expect(result.accepted).toBe(false);
+    expect(result.reason).toBe("invalid signature");
+  });
+
+  it("does NOT fire onDeploy when signature is wrong", async () => {
+    const body = makePushPayload();
+    // No throw means onDeploy was never called
+    const result = await handler.handle(body, "sha256=bad", "push");
+    expect(result.accepted).toBe(false);
+  });
+});
+
+// ── handle — JSON parsing failure ────────────────────────────
+
+describe("handle — malformed payload", () => {
+  const handler = new DeployWebhookHandler({
+    secret: SECRET,
+    onDeploy: async () => {},
+  });
+
+  it("returns accepted=false for invalid JSON", async () => {
+    const body = "not-valid-json";
+    const result = await handler.handle(body, sign(body), "push");
+
+    expect(result.accepted).toBe(false);
+    expect(result.reason).toContain("invalid JSON");
+  });
+});
+
+// ── handle — DeployEvent shape ────────────────────────────────
+
+describe("handle — DeployEvent payload", () => {
+  it("maps push payload fields to DeployEvent correctly", async () => {
+    const captured: DeployEvent[] = [];
+    const handler = new DeployWebhookHandler({
+      secret: SECRET,
+      onDeploy: async (e) => {
+        captured.push(e);
+      },
+    });
+
+    const body = makePushPayload({
+      branch: "main",
+      commitSha: "deadbeefcafe1234",
+      login: "deployer-bot",
+      repo: "acme/my-app",
+    });
+
+    await handler.handle(body, sign(body), "push");
+
+    expect(captured).toHaveLength(1);
+    const ev = captured[0] as DeployEvent;
+    expect(ev.branch).toBe("main");
+    expect(ev.commitSha).toBe("deadbeefcafe1234");
+    expect(ev.pushedBy).toBe("deployer-bot");
+    expect(ev.repository).toBe("acme/my-app");
+    expect(ev.timestamp).toBe("2026-05-18T09:00:00Z");
+  });
+});
+
+// ── handle — callback error propagation ──────────────────────
+
+describe("handle — onDeploy error propagation", () => {
+  it("propagates errors from onDeploy to the caller", async () => {
+    const handler = new DeployWebhookHandler({
+      secret: SECRET,
+      onDeploy: async () => {
+        throw new Error("deployment failed");
+      },
+    });
+
+    const body = makePushPayload();
+    await expect(handler.handle(body, sign(body), "push")).rejects.toThrow("deployment failed");
+  });
+});

--- a/packages/core/__tests__/deployment-webhook.test.ts
+++ b/packages/core/__tests__/deployment-webhook.test.ts
@@ -282,18 +282,74 @@ describe("handle — DeployEvent payload", () => {
   });
 });
 
-// ── handle — callback error propagation ──────────────────────
+// ── handle — fire-and-forget semantics ─────────────────────────
+//
+// GitHub webhooks time out at ~10s. The handler kicks off `onDeploy` without
+// awaiting it so the HTTP response can return immediately; deployment errors
+// flow into the optional `onDeployError` sink for logging.
 
-describe("handle — onDeploy error propagation", () => {
-  it("propagates errors from onDeploy to the caller", async () => {
+describe("handle — async onDeploy semantics", () => {
+  it("returns immediately even when onDeploy is slow", async () => {
+    let deployFinished = false;
+    const handler = new DeployWebhookHandler({
+      secret: SECRET,
+      onDeploy: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        deployFinished = true;
+      },
+    });
+
+    const body = makePushPayload();
+    const start = Date.now();
+    const result = await handler.handle(body, sign(body), "push");
+    const elapsed = Date.now() - start;
+
+    expect(result.accepted).toBe(true);
+    expect(elapsed).toBeLessThan(20);
+    expect(deployFinished).toBe(false);
+
+    // Drain the in-flight deploy so the test cleans up properly.
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(deployFinished).toBe(true);
+  });
+
+  it("routes async onDeploy failures to onDeployError instead of rejecting handle()", async () => {
+    const errors: Array<{ error: unknown; event: DeployEvent }> = [];
     const handler = new DeployWebhookHandler({
       secret: SECRET,
       onDeploy: async () => {
         throw new Error("deployment failed");
       },
+      onDeployError: (error, event) => {
+        errors.push({ error, event });
+      },
+    });
+
+    const body = makePushPayload({ commitSha: "deadbeef" });
+    const result = await handler.handle(body, sign(body), "push");
+    expect(result.accepted).toBe(true);
+
+    // Allow the rejected promise to settle.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(errors).toHaveLength(1);
+    expect((errors[0]?.error as Error).message).toBe("deployment failed");
+    expect(errors[0]?.event.commitSha).toBe("deadbeef");
+  });
+
+  it("does not crash when onDeploy throws and no onDeployError is configured", async () => {
+    const handler = new DeployWebhookHandler({
+      secret: SECRET,
+      onDeploy: async () => {
+        throw new Error("silent failure");
+      },
     });
 
     const body = makePushPayload();
-    await expect(handler.handle(body, sign(body), "push")).rejects.toThrow("deployment failed");
+    const result = await handler.handle(body, sign(body), "push");
+    expect(result.accepted).toBe(true);
+
+    // Give the rejected promise a tick to settle without taking down the process.
+    await new Promise((resolve) => setTimeout(resolve, 5));
   });
 });

--- a/packages/core/src/deployment/index.ts
+++ b/packages/core/src/deployment/index.ts
@@ -41,3 +41,9 @@ export {
   type HealthStatus,
   livenessCheck,
 } from "./health-check";
+export {
+  type DeployEvent,
+  type DeployWebhookConfig,
+  DeployWebhookHandler,
+  type WebhookHandleResult,
+} from "./webhook-handler";

--- a/packages/core/src/deployment/webhook-handler.ts
+++ b/packages/core/src/deployment/webhook-handler.ts
@@ -56,7 +56,7 @@ export interface WebhookHandleResult {
   reason?: string;
 }
 
-// ── Internal helpers ─────────────────────────────────────────
+// ── Internal helpers ───────────────────────────────────────────
 
 /** Raw shape of a GitHub push event payload (only the fields we use). */
 interface GitHubPushPayload {
@@ -75,14 +75,17 @@ function computeExpectedSignature(secret: string, rawBody: string): string {
 }
 
 function safeEqual(a: string, b: string): boolean {
-  // Convert both to Buffer so timingSafeEqual can be used regardless of length
+  // Reject mismatched lengths on the string before allocating a Buffer from
+  // the untrusted input (b), preventing resource exhaustion on oversized headers.
+  if (a.length !== b.length) return false;
   const bufA = Buffer.from(a, "utf8");
   const bufB = Buffer.from(b, "utf8");
+  // Byte-level length check still required for timingSafeEqual (multi-byte UTF-8).
   if (bufA.length !== bufB.length) return false;
   return timingSafeEqual(bufA, bufB);
 }
 
-// ── DeployWebhookHandler ─────────────────────────────────────
+// ── DeployWebhookHandler ───────────────────────────────────────────
 
 export class DeployWebhookHandler {
   private readonly secret: string;

--- a/packages/core/src/deployment/webhook-handler.ts
+++ b/packages/core/src/deployment/webhook-handler.ts
@@ -1,0 +1,180 @@
+/**
+ * GitHub Deployment Webhook Handler — Spec 12 §3
+ *
+ * Receives GitHub push/PR-merge webhook events, verifies the HMAC-SHA256
+ * signature, and fires a configurable deployment callback when a push to
+ * the watched branch (default: "main") is detected.
+ *
+ * Security: timing-safe signature comparison prevents timing-oracle attacks.
+ * The handler NEVER executes shell commands itself; it delegates to the
+ * `onDeploy` callback supplied by the server-layer so the logic is testable
+ * in isolation and the actual deployment strategy can evolve independently.
+ */
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+// ── Public types ─────────────────────────────────────────────
+
+/** Summary of the inbound push event, passed to the deploy callback. */
+export interface DeployEvent {
+  /** Destination branch name (e.g. "main") */
+  branch: string;
+  /** HEAD commit SHA after the push */
+  commitSha: string;
+  /** GitHub login that triggered the push */
+  pushedBy: string;
+  /** Repository full name, e.g. "owner/repo" */
+  repository: string;
+  /** ISO-8601 timestamp from the GitHub payload */
+  timestamp: string;
+}
+
+/** Options for constructing a DeployWebhookHandler. */
+export interface DeployWebhookConfig {
+  /**
+   * GitHub webhook secret used to compute the expected HMAC-SHA256.
+   * Must match the secret configured in the GitHub repository settings.
+   */
+  secret: string;
+  /**
+   * Only fire `onDeploy` when the push targets this branch.
+   * Default: "main".
+   */
+  branchFilter?: string;
+  /**
+   * Called when a qualifying push event passes signature verification.
+   * Implement git-pull → bun-install → bun-build → blue-green-switch here.
+   */
+  onDeploy: (event: DeployEvent) => Promise<void>;
+}
+
+/** Outcome of processing a single webhook request. */
+export interface WebhookHandleResult {
+  /** true = accepted and onDeploy was invoked (or will be) */
+  accepted: boolean;
+  /** Human-readable reason when accepted is false */
+  reason?: string;
+}
+
+// ── Internal helpers ─────────────────────────────────────────
+
+/** Raw shape of a GitHub push event payload (only the fields we use). */
+interface GitHubPushPayload {
+  ref?: string;
+  after?: string;
+  sender?: { login?: string };
+  repository?: { full_name?: string };
+  head_commit?: { id?: string; timestamp?: string };
+  // null when the branch is deleted (after = "0000000000000000000000000000000000000000")
+  created?: boolean;
+  deleted?: boolean;
+}
+
+function computeExpectedSignature(secret: string, rawBody: string): string {
+  return `sha256=${createHmac("sha256", secret).update(rawBody, "utf8").digest("hex")}`;
+}
+
+function safeEqual(a: string, b: string): boolean {
+  // Convert both to Buffer so timingSafeEqual can be used regardless of length
+  const bufA = Buffer.from(a, "utf8");
+  const bufB = Buffer.from(b, "utf8");
+  if (bufA.length !== bufB.length) return false;
+  return timingSafeEqual(bufA, bufB);
+}
+
+// ── DeployWebhookHandler ─────────────────────────────────────
+
+export class DeployWebhookHandler {
+  private readonly secret: string;
+  private readonly branchFilter: string;
+  private readonly onDeploy: (event: DeployEvent) => Promise<void>;
+
+  constructor(config: DeployWebhookConfig) {
+    if (!config.secret) {
+      throw new Error("DeployWebhookHandler: secret is required");
+    }
+    if (!config.onDeploy) {
+      throw new Error("DeployWebhookHandler: onDeploy callback is required");
+    }
+    this.secret = config.secret;
+    this.branchFilter = config.branchFilter ?? "main";
+    this.onDeploy = config.onDeploy;
+  }
+
+  /**
+   * Verify the HMAC-SHA256 signature on a raw webhook body.
+   *
+   * @param rawBody - The raw (un-parsed) request body string
+   * @param signature - Value of the `X-Hub-Signature-256` header
+   */
+  verifySignature(rawBody: string, signature: string): boolean {
+    if (!signature) return false;
+    const expected = computeExpectedSignature(this.secret, rawBody);
+    return safeEqual(expected, signature);
+  }
+
+  /**
+   * Process a GitHub webhook request.
+   *
+   * @param rawBody - Raw JSON string from the request body
+   * @param signature - Value of `X-Hub-Signature-256` header
+   * @param eventType - Value of `X-GitHub-Event` header (e.g. "push")
+   * @returns Result indicating whether the deploy callback was fired
+   */
+  async handle(
+    rawBody: string,
+    signature: string,
+    eventType: string,
+  ): Promise<WebhookHandleResult> {
+    // 1. Verify signature
+    if (!this.verifySignature(rawBody, signature)) {
+      return { accepted: false, reason: "invalid signature" };
+    }
+
+    // 2. Only handle push events (PR merges arrive as push events to the target branch)
+    if (eventType !== "push") {
+      return { accepted: false, reason: `event type "${eventType}" is not handled` };
+    }
+
+    // 3. Parse payload
+    let payload: GitHubPushPayload;
+    try {
+      payload = JSON.parse(rawBody) as GitHubPushPayload;
+    } catch {
+      return { accepted: false, reason: "invalid JSON payload" };
+    }
+
+    // 4. Check branch
+    const refBranch = payload.ref?.replace("refs/heads/", "");
+    if (refBranch !== this.branchFilter) {
+      return {
+        accepted: false,
+        reason: `branch "${refBranch}" does not match filter "${this.branchFilter}"`,
+      };
+    }
+
+    // 5. Ignore branch deletions (after is all zeros)
+    if (payload.deleted) {
+      return { accepted: false, reason: "branch deletion event, skipping" };
+    }
+
+    // 6. Build deploy event
+    const commitSha = payload.after ?? payload.head_commit?.id ?? "unknown";
+    const pushedBy = payload.sender?.login ?? "unknown";
+    const repository = payload.repository?.full_name ?? "unknown";
+    const timestamp = payload.head_commit?.timestamp ?? new Date().toISOString();
+
+    const event: DeployEvent = {
+      branch: refBranch ?? this.branchFilter,
+      commitSha,
+      pushedBy,
+      repository,
+      timestamp,
+    };
+
+    // 7. Fire the deploy callback (errors propagate to caller for HTTP 500)
+    await this.onDeploy(event);
+
+    return { accepted: true };
+  }
+}

--- a/packages/core/src/deployment/webhook-handler.ts
+++ b/packages/core/src/deployment/webhook-handler.ts
@@ -44,8 +44,16 @@ export interface DeployWebhookConfig {
   /**
    * Called when a qualifying push event passes signature verification.
    * Implement git-pull → bun-install → bun-build → blue-green-switch here.
+   * Invoked asynchronously (fire-and-forget) so the HTTP response can return
+   * within GitHub's 10-second webhook timeout regardless of deploy duration.
    */
   onDeploy: (event: DeployEvent) => Promise<void>;
+  /**
+   * Optional sink for errors thrown by the async `onDeploy`. Because the
+   * deployment runs after the HTTP response is sent, callers cannot observe
+   * failures via the return value — wire this to your logger to capture them.
+   */
+  onDeployError?: (error: unknown, event: DeployEvent) => void;
 }
 
 /** Outcome of processing a single webhook request. */
@@ -91,6 +99,7 @@ export class DeployWebhookHandler {
   private readonly secret: string;
   private readonly branchFilter: string;
   private readonly onDeploy: (event: DeployEvent) => Promise<void>;
+  private readonly onDeployError?: (error: unknown, event: DeployEvent) => void;
 
   constructor(config: DeployWebhookConfig) {
     if (!config.secret) {
@@ -102,6 +111,7 @@ export class DeployWebhookHandler {
     this.secret = config.secret;
     this.branchFilter = config.branchFilter ?? "main";
     this.onDeploy = config.onDeploy;
+    this.onDeployError = config.onDeployError;
   }
 
   /**
@@ -175,8 +185,14 @@ export class DeployWebhookHandler {
       timestamp,
     };
 
-    // 7. Fire the deploy callback (errors propagate to caller for HTTP 500)
-    await this.onDeploy(event);
+    // 7. Fire the deploy callback asynchronously. GitHub webhooks time out
+    //    at ~10s; full deploys (git pull + bun install + bun build) routinely
+    //    exceed that, so awaiting here would cause delivery failures and
+    //    retries. The response returns 200 once signature + payload are valid;
+    //    errors from the actual deploy flow into `onDeployError` for logging.
+    void this.onDeploy(event).catch((error: unknown) => {
+      this.onDeployError?.(error, event);
+    });
 
     return { accepted: true };
   }

--- a/packages/core/src/server-entry.ts
+++ b/packages/core/src/server-entry.ts
@@ -493,6 +493,9 @@ export {
   createDatabaseCheck,
   createEntityCheck,
   createEventBusCheck,
+  type DeployEvent,
+  type DeployWebhookConfig,
+  DeployWebhookHandler,
   detectEnvironment,
   type EnvironmentConfig,
   type EnvironmentFeatureFlags,
@@ -509,6 +512,7 @@ export {
   type ShutdownPhase,
   type ShutdownStatus,
   validateRequiredEnvVars,
+  type WebhookHandleResult,
 } from "./deployment";
 
 // === Doctor — project health check registry + built-in checks ===


### PR DESCRIPTION
## Summary

- Implements `DeployWebhookHandler` in `@linchkit/core` — HMAC-SHA256 GitHub webhook signature verification + push-event parsing with pluggable `onDeploy` callback
- Adds `POST /api/deploy/webhook` endpoint in `cap-adapter-server` via `mountDeployRoutes`
- Wires `deployWebhookHandler?: DeployWebhookHandler` into `ServerOptions` so production apps can opt in with a single config key
- 19 unit tests covering constructor validation, signature verification (correct / wrong / tampered / empty / no-prefix), event-type filtering, branch filtering (accept / skip / custom / deletion), invalid JSON, `DeployEvent` shape mapping, and error propagation

## Implementation notes

**Core (`packages/core/src/deployment/webhook-handler.ts`)**
- `verifySignature(rawBody, signature)` uses `timingSafeEqual` from `node:crypto` to prevent timing oracle attacks; always `false` for mismatched length or missing `sha256=` prefix
- `handle(rawBody, signature, eventType)` returns a `WebhookHandleResult` discriminated by `accepted` + optional `reason`; only fires `onDeploy` after all guards pass
- Branch filter defaults to `"main"`; override via `branchFilter` config key
- Deletion events (`payload.deleted === true`) are explicitly rejected to avoid spurious deploys on branch deletion

**Adapter-server (`cap-adapter-server/src/routes/deploy-api.ts`)**
- HTTP status mapping: 403 for invalid signature, 400 for missing headers, 503 when no handler is configured, 200 for accepted or non-matching (not an error — GitHub sends many event types)
- Route is always registered (even without a handler) so callers get 503 instead of 404

**Exports**
- `DeployEvent`, `DeployWebhookConfig`, `DeployWebhookHandler`, `WebhookHandleResult` added to `packages/core/src/deployment/index.ts` and re-exported from `packages/core/src/server-entry.ts`

## Spec alignment

| Spec | Section | Covered |
|------|---------|---------|
| Spec 12 | §3 Deployment webhook receiver | ✅ HMAC-SHA256 verification, push-event parsing, pluggable callback |
| Spec 12 | §3.1 Security | ✅ Timing-safe comparison, explicit signature prefix check |
| Spec 12 | §3.2 Branch filter | ✅ Configurable `branchFilter`, defaults to `"main"` |
| Spec 12 | §3.3 Deletion guard | ✅ `deleted: true` events rejected |

## Quality gates

```
bun run check         ✅  (Biome lint + format — 0 errors after auto-sort)
bun run typecheck     ❌  (pre-existing env failure: bun-types not in worktree
                           node_modules; identical failure on main branch before
                           any changes — not introduced by this PR)
bun test              ✅  19/19 tests pass in packages/core/__tests__/
linch validate        N/A (no meta-model files changed)
```

> **Note on typecheck:** The TypeScript check failure is an environment-level issue in the CI worktree (`Cannot find type definition file for 'bun-types'`). The same error reproduces on `main` with zero changes. All new code is strictly typed; no `any`, no unsafe casts beyond one intentional test-input cast documented with a `biome-ignore` comment.

## Retro

**Why this approach**
The full Spec 12 scope (blue-green deployment orchestration) spans weeks of work. The webhook receiver is the most bounded, security-critical, independently testable piece and was the clearest unblocked task in the issue backlog. Delivering it standalone lets downstream integrations (CI scripts, staging pipelines) start consuming the endpoint immediately.

**Alternatives considered**
- *Use an off-the-shelf webhook library*: Rejected — `node:crypto` already used throughout the codebase; adding a dependency for four lines of HMAC was unnecessary.
- *Inline the handler inside `deploy-api.ts`*: Rejected — placing logic in `@linchkit/core` keeps it testable without standing up a full Elysia server and reusable outside `cap-adapter-server`.

**Security review**
- **Authentication**: Webhook uses HMAC-SHA256 (`X-Hub-Signature-256`) — industry-standard GitHub webhook authentication. `timingSafeEqual` prevents timing oracle. Constant-time comparison also enforces `sha256=` prefix.
- **Authorization**: `onDeploy` callback is caller-supplied; the handler itself performs no privileged operations.
- **Tenant isolation**: Webhook is not tenant-scoped (it is a system-level infrastructure event, not a user action).
- **Input trust boundaries**: Raw HTTP body is parsed only after signature passes; untrusted fields (`payload.sender.login`, `payload.repository.full_name`) are extracted and passed to `onDeploy` — never executed.
- **Error/log leakage**: `reason` field in `WebhookHandleResult` is returned to the HTTP caller only as a `reason` key (not surfaced in logs by default); signature values are never logged.
- **DDL/SQL**: None touched.

**Other risks**
- Replay attacks: Not mitigated in this PR (standard for webhook receivers — mitigated at infrastructure level with short delivery windows). Noted as a follow-up.

**Follow-ups**
- [ ] Replay-attack guard (timestamp + nonce cache, Spec 12 §3.4 if defined)
- [ ] Blue-green deploy orchestration (Spec 12 §§4-6)
- [ ] Integration test with live Elysia server (requires test fixtures for full adapter-server)

## Self-review checklist

- [x] No `any` type (one `as any` in test with `biome-ignore` comment for intentional bad-input test)
- [x] No hardcoded secrets
- [x] No `eval` / `new Function`
- [x] All user inputs validated before use
- [x] `timingSafeEqual` used for HMAC comparison
- [x] No new npm dependencies introduced
- [x] Exports alphabetically sorted (Biome enforced)
- [x] Tests cover golden path + every rejection branch
- [x] Module boundary respected (`core` imports only `node:crypto`, no circular deps)
- [x] `CommandLayer` not bypassed (webhook uses HMAC auth by design — no actor context needed)

Partial #72

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTJ9nzM1PvDre3drGkMvXa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub deployment webhook support enabling the server to receive and process GitHub push events
  * Integrated HMAC-SHA256 signature verification to ensure webhook authenticity and security
  * Configurable branch filtering and custom event callbacks for seamless deployment workflow integration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laofahai/linchkit/pull/342?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->