### PR TITLE
feat(core): proposal migration pipeline (closes #114)

### DIFF
--- a/packages/core/__tests__/proposal-migration-detector.test.ts
+++ b/packages/core/__tests__/proposal-migration-detector.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "bun:test";
+import {
+  buildMigrationSnapshot,
+  detectMigrationChanges,
+  isTypeWidening,
+} from "../src/migration/proposal-migration-detector";
+import type { EntitySnapshot } from "../src/migration/proposal-migration-types";
+
+// ── Fixtures ──────────────────────────────────────────────────
+
+function purchaseRequest(): EntitySnapshot {
+  return {
+    name: "purchase_request",
+    fields: {
+      id: { type: "string", required: true },
+      amount: { type: "number" },
+      note: { type: "string" },
+    },
+  };
+}
+
+function supplier(): EntitySnapshot {
+  return {
+    name: "supplier",
+    fields: {
+      id: { type: "string", required: true },
+      name: { type: "string", required: true },
+    },
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe("detectMigrationChanges", () => {
+  it("emits no changes for identical snapshots", () => {
+    const before = buildMigrationSnapshot([purchaseRequest()]);
+    const after = buildMigrationSnapshot([purchaseRequest()]);
+    expect(detectMigrationChanges({ before, after })).toEqual([]);
+  });
+
+  it("detects an added optional column as add_column", () => {
+    const before = buildMigrationSnapshot([purchaseRequest()]);
+    const afterEntity = purchaseRequest();
+    afterEntity.fields.priority = { type: "string" };
+    const after = buildMigrationSnapshot([afterEntity]);
+    const changes = detectMigrationChanges({ before, after });
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toMatchObject({
+      kind: "add_column",
+      entity: "purchase_request",
+      field: "priority",
+    });
+  });
+
+  it("detects a dropped column as drop_column with previousDefinition captured", () => {
+    const before = buildMigrationSnapshot([purchaseRequest()]);
+    const afterEntity = purchaseRequest();
+    delete afterEntity.fields.note;
+    const after = buildMigrationSnapshot([afterEntity]);
+    const changes = detectMigrationChanges({ before, after });
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toMatchObject({
+      kind: "drop_column",
+      entity: "purchase_request",
+      field: "note",
+      previousDefinition: { type: "string" },
+    });
+  });
+
+  it("detects an altered column type", () => {
+    const beforeEntity = purchaseRequest();
+    const afterEntity = purchaseRequest();
+    afterEntity.fields.note = { type: "text" };
+    const before = buildMigrationSnapshot([beforeEntity]);
+    const after = buildMigrationSnapshot([afterEntity]);
+    const changes = detectMigrationChanges({ before, after });
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toMatchObject({
+      kind: "alter_column_type",
+      entity: "purchase_request",
+      field: "note",
+      fromType: "string",
+      toType: "text",
+    });
+  });
+
+  it("emits create_table for a brand-new entity", () => {
+    const before = buildMigrationSnapshot([purchaseRequest()]);
+    const after = buildMigrationSnapshot([purchaseRequest(), supplier()]);
+    const changes = detectMigrationChanges({ before, after });
+    expect(changes).toHaveLength(1);
+    expect(changes[0]?.kind).toBe("create_table");
+  });
+
+  it("emits drop_table for a removed entity", () => {
+    const before = buildMigrationSnapshot([purchaseRequest(), supplier()]);
+    const after = buildMigrationSnapshot([purchaseRequest()]);
+    const changes = detectMigrationChanges({ before, after });
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toMatchObject({ kind: "drop_table", entity: "supplier" });
+  });
+
+  it("recognises a rename when the rename map is provided", () => {
+    const beforeEntity = purchaseRequest();
+    const afterEntity = purchaseRequest();
+    delete afterEntity.fields.note;
+    afterEntity.fields.remarks = { type: "string" };
+    const changes = detectMigrationChanges({
+      before: buildMigrationSnapshot([beforeEntity]),
+      after: buildMigrationSnapshot([afterEntity]),
+      renames: { purchase_request: { note: "remarks" } },
+    });
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toMatchObject({
+      kind: "rename_column",
+      entity: "purchase_request",
+      fromField: "note",
+      toField: "remarks",
+    });
+  });
+
+  it("falls back to drop+add when no rename map is given", () => {
+    const beforeEntity = purchaseRequest();
+    const afterEntity = purchaseRequest();
+    delete afterEntity.fields.note;
+    afterEntity.fields.remarks = { type: "string" };
+    const changes = detectMigrationChanges({
+      before: buildMigrationSnapshot([beforeEntity]),
+      after: buildMigrationSnapshot([afterEntity]),
+    });
+    const kinds = changes.map((c) => c.kind).sort();
+    expect(kinds).toEqual(["add_column", "drop_column"]);
+  });
+
+  it("detects FK additions and drops", () => {
+    const beforeEntity: EntitySnapshot = {
+      ...purchaseRequest(),
+      fields: { ...purchaseRequest().fields, supplier_id: { type: "string" } },
+    };
+    const afterEntity: EntitySnapshot = {
+      ...beforeEntity,
+      foreignKeys: [{ field: "supplier_id", toEntity: "supplier" }],
+    };
+    const before = buildMigrationSnapshot([beforeEntity, supplier()]);
+    const after = buildMigrationSnapshot([afterEntity, supplier()]);
+    const changes = detectMigrationChanges({ before, after });
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toMatchObject({
+      kind: "add_foreign_key",
+      entity: "purchase_request",
+    });
+
+    // And the inverse direction:
+    const reverse = detectMigrationChanges({ before: after, after: before });
+    expect(reverse).toHaveLength(1);
+    expect(reverse[0]?.kind).toBe("drop_foreign_key");
+  });
+
+  it("isTypeWidening returns true for known widening pairs only", () => {
+    expect(isTypeWidening("string", "text")).toBe(true);
+    expect(isTypeWidening("date", "datetime")).toBe(true);
+    expect(isTypeWidening("number", "number")).toBe(true);
+    expect(isTypeWidening("text", "string")).toBe(false);
+    expect(isTypeWidening("string", "number")).toBe(false);
+  });
+});

--- a/packages/core/__tests__/proposal-migration-planner.test.ts
+++ b/packages/core/__tests__/proposal-migration-planner.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "bun:test";
+import { planMigration } from "../src/migration/proposal-migration-planner";
+import type { MigrationChange } from "../src/migration/proposal-migration-types";
+
+describe("planMigration", () => {
+  it("classifies an optional add_column as safe", () => {
+    const plan = planMigration([
+      {
+        kind: "add_column",
+        entity: "order",
+        field: "priority",
+        definition: { type: "string" },
+      },
+    ]);
+    expect(plan.classification).toBe("safe");
+    expect(plan.forward).toHaveLength(1);
+    expect(plan.forward[0]?.name).toBe("expand");
+    expect(plan.forward[0]?.statements[0]).toBe(
+      'ALTER TABLE "order" ADD COLUMN "priority" varchar(255) NULL;',
+    );
+    expect(plan.rollback).toEqual(['ALTER TABLE "order" DROP COLUMN "priority";']);
+  });
+
+  it("classifies a required add_column without default as expand", () => {
+    const plan = planMigration([
+      {
+        kind: "add_column",
+        entity: "order",
+        field: "supplier_id",
+        definition: { type: "string", required: true },
+      },
+    ]);
+    expect(plan.classification).toBe("expand");
+    expect(plan.forward[0]?.statements[0]).toContain("NOT NULL");
+  });
+
+  it("classifies drop_column as contract and routes to contract phase", () => {
+    const change: MigrationChange = {
+      kind: "drop_column",
+      entity: "order",
+      field: "legacy_notes",
+      previousDefinition: { type: "string" },
+    };
+    const plan = planMigration([change]);
+    expect(plan.classification).toBe("contract");
+    expect(plan.forward[0]?.name).toBe("contract");
+    expect(plan.forward[0]?.statements[0]).toBe('ALTER TABLE "order" DROP COLUMN "legacy_notes";');
+    // Rollback recreates the column from the previousDefinition
+    expect(plan.rollback[0]).toBe(
+      'ALTER TABLE "order" ADD COLUMN "legacy_notes" varchar(255) NULL;',
+    );
+  });
+
+  it("classifies a widening alter_column_type as safe", () => {
+    const plan = planMigration([
+      {
+        kind: "alter_column_type",
+        entity: "order",
+        field: "note",
+        fromType: "string",
+        toType: "text",
+      },
+    ]);
+    expect(plan.classification).toBe("safe");
+    expect(plan.forward[0]?.name).toBe("migrate");
+  });
+
+  it("classifies a narrowing alter_column_type as breaking", () => {
+    const plan = planMigration([
+      {
+        kind: "alter_column_type",
+        entity: "order",
+        field: "note",
+        fromType: "text",
+        toType: "string",
+      },
+    ]);
+    expect(plan.classification).toBe("breaking");
+  });
+
+  it("routes add_foreign_key to expand phase with REFERENCES clause", () => {
+    const plan = planMigration([
+      {
+        kind: "add_foreign_key",
+        entity: "order_line",
+        foreignKey: { field: "order_id", toEntity: "order" },
+      },
+    ]);
+    expect(plan.classification).toBe("expand");
+    expect(plan.forward[0]?.name).toBe("expand");
+    expect(plan.forward[0]?.statements[0]).toBe(
+      'ALTER TABLE "order_line" ADD CONSTRAINT "fk_order_line_order_id" ' +
+        'FOREIGN KEY ("order_id") REFERENCES "order"("id");',
+    );
+    // Rollback drops the constraint
+    expect(plan.rollback[0]).toBe(
+      'ALTER TABLE "order_line" DROP CONSTRAINT "fk_order_line_order_id";',
+    );
+  });
+
+  it("emits a CREATE TABLE statement for create_table changes", () => {
+    const plan = planMigration([
+      {
+        kind: "create_table",
+        entity: "audit_log",
+        definition: {
+          name: "audit_log",
+          fields: {
+            id: { type: "string", required: true },
+            message: { type: "text" },
+          },
+        },
+      },
+    ]);
+    expect(plan.classification).toBe("safe");
+    expect(plan.forward[0]?.statements[0]).toContain('CREATE TABLE "audit_log"');
+    expect(plan.forward[0]?.statements[0]).toContain('"id" varchar(255) NOT NULL');
+    expect(plan.forward[0]?.statements[0]).toContain('"message" text NULL');
+  });
+
+  it("produces a rename plan with reversible rollback", () => {
+    const plan = planMigration([
+      {
+        kind: "rename_column",
+        entity: "order",
+        fromField: "supplier",
+        toField: "vendor",
+        definition: { type: "string" },
+      },
+    ]);
+    expect(plan.classification).toBe("expand");
+    expect(plan.forward[0]?.name).toBe("migrate");
+    expect(plan.forward[0]?.statements[0]).toBe(
+      'ALTER TABLE "order" RENAME COLUMN "supplier" TO "vendor";',
+    );
+    expect(plan.rollback[0]).toBe('ALTER TABLE "order" RENAME COLUMN "vendor" TO "supplier";');
+  });
+
+  it("rolls up the worst classification across multiple changes", () => {
+    const plan = planMigration([
+      {
+        kind: "add_column",
+        entity: "order",
+        field: "priority",
+        definition: { type: "string" },
+      },
+      {
+        kind: "drop_column",
+        entity: "order",
+        field: "legacy_notes",
+        previousDefinition: { type: "string" },
+      },
+    ]);
+    expect(plan.classification).toBe("contract");
+    expect(plan.forward.map((p) => p.name)).toEqual(["expand", "contract"]);
+  });
+
+  it("rejects unsafe SQL identifiers", () => {
+    expect(() =>
+      planMigration([
+        {
+          kind: "add_column",
+          entity: 'order"; DROP TABLE users;--',
+          field: "priority",
+          definition: { type: "string" },
+        },
+      ]),
+    ).toThrow(/Unsafe SQL identifier/);
+  });
+
+  it("returns an empty plan for an empty change list", () => {
+    const plan = planMigration([]);
+    expect(plan.classification).toBe("safe");
+    expect(plan.forward).toEqual([]);
+    expect(plan.rollback).toEqual([]);
+    expect(plan.summary).toContain("No schema changes");
+  });
+});

--- a/packages/core/__tests__/proposal-migration-planner.test.ts
+++ b/packages/core/__tests__/proposal-migration-planner.test.ts
@@ -175,4 +175,205 @@ describe("planMigration", () => {
     expect(plan.rollback).toEqual([]);
     expect(plan.summary).toContain("No schema changes");
   });
+
+  // ── DEFAULT rendering (Gemini review #1) ───────────────────
+
+  it("renders a string DEFAULT and escapes embedded single quotes", () => {
+    const plan = planMigration([
+      {
+        kind: "add_column",
+        entity: "order",
+        field: "status",
+        definition: { type: "string", default: "o'reilly" },
+      },
+    ]);
+    expect(plan.forward[0]?.statements[0]).toBe(
+      "ALTER TABLE \"order\" ADD COLUMN \"status\" varchar(255) DEFAULT 'o''reilly' NULL;",
+    );
+  });
+
+  it("renders numeric and boolean DEFAULTs without quoting", () => {
+    const plan = planMigration([
+      {
+        kind: "add_column",
+        entity: "order",
+        field: "qty",
+        definition: { type: "number", default: 0 },
+      },
+      {
+        kind: "add_column",
+        entity: "order",
+        field: "active",
+        definition: { type: "boolean", default: true, required: true },
+      },
+    ]);
+    expect(plan.forward[0]?.statements[0]).toBe(
+      'ALTER TABLE "order" ADD COLUMN "qty" double precision DEFAULT 0 NULL;',
+    );
+    expect(plan.forward[0]?.statements[1]).toBe(
+      'ALTER TABLE "order" ADD COLUMN "active" boolean DEFAULT true NOT NULL;',
+    );
+  });
+
+  it("renders a JSON DEFAULT as a quoted JSON literal", () => {
+    const plan = planMigration([
+      {
+        kind: "add_column",
+        entity: "order",
+        field: "tags",
+        definition: { type: "json", default: { audit: true } },
+      },
+    ]);
+    expect(plan.forward[0]?.statements[0]).toBe(
+      'ALTER TABLE "order" ADD COLUMN "tags" jsonb DEFAULT \'{"audit":true}\' NULL;',
+    );
+  });
+
+  // ── UNIQUE constraint (Gemini review #1) ───────────────────
+
+  it("renders a UNIQUE constraint when the field is marked unique", () => {
+    const plan = planMigration([
+      {
+        kind: "add_column",
+        entity: "user",
+        field: "email",
+        definition: { type: "string", required: true, unique: true },
+      },
+    ]);
+    expect(plan.forward[0]?.statements[0]).toBe(
+      'ALTER TABLE "user" ADD COLUMN "email" varchar(255) NOT NULL UNIQUE;',
+    );
+  });
+
+  // ── PRIMARY KEY on id (Gemini review #2) ───────────────────
+
+  it("marks the id column as PRIMARY KEY in CREATE TABLE", () => {
+    const plan = planMigration([
+      {
+        kind: "create_table",
+        entity: "audit_log",
+        definition: {
+          name: "audit_log",
+          fields: {
+            id: { type: "string", required: true },
+            message: { type: "text" },
+          },
+        },
+      },
+    ]);
+    expect(plan.forward[0]?.statements[0]).toContain('"id" varchar(255) NOT NULL PRIMARY KEY');
+    // Non-id columns should NOT get PRIMARY KEY appended.
+    expect(plan.forward[0]?.statements[0]).toContain('"message" text NULL');
+    expect(plan.forward[0]?.statements[0]).not.toContain('"message" text NULL PRIMARY KEY');
+  });
+
+  it("throws when a create_table change has no persistable columns", () => {
+    expect(() =>
+      planMigration([
+        {
+          kind: "create_table",
+          entity: "empty_table",
+          definition: {
+            name: "empty_table",
+            fields: {},
+          },
+        },
+      ]),
+    ).toThrow(/Cannot create table empty_table with no columns/);
+  });
+
+  it("throws when all columns are filtered out as computed", () => {
+    expect(() =>
+      planMigration([
+        {
+          kind: "create_table",
+          entity: "all_computed",
+          definition: {
+            name: "all_computed",
+            fields: {
+              total: { type: "computed" },
+            },
+          },
+        },
+      ]),
+    ).toThrow(/Cannot create table all_computed with no columns/);
+  });
+
+  // ── Contract-phase ordering (Gemini review #3) ─────────────
+
+  it("emits drop_foreign_key before drop_column and drop_table in the contract phase", () => {
+    const plan = planMigration([
+      // Detector emits drops in order: drop_table, drop_column, drop_foreign_key
+      // The planner must reorder them so FK drops come first, then column drops,
+      // then table drops — PostgreSQL otherwise rejects DROP TABLE / COLUMN
+      // when a constraint still references it.
+      {
+        kind: "drop_table",
+        entity: "supplier",
+        previousDefinition: {
+          name: "supplier",
+          fields: { id: { type: "string", required: true } },
+        },
+      },
+      {
+        kind: "drop_column",
+        entity: "order",
+        field: "legacy_notes",
+        previousDefinition: { type: "string" },
+      },
+      {
+        kind: "drop_foreign_key",
+        entity: "order",
+        foreignKey: { field: "supplier_id", toEntity: "supplier" },
+      },
+    ]);
+    const contractPhase = plan.forward.find((p) => p.name === "contract");
+    expect(contractPhase).toBeDefined();
+    expect(contractPhase?.statements).toEqual([
+      'ALTER TABLE "order" DROP CONSTRAINT "fk_order_supplier_id";',
+      'ALTER TABLE "order" DROP COLUMN "legacy_notes";',
+      'DROP TABLE "supplier";',
+    ]);
+    // The plan's recorded `changes` array preserves the original input order
+    // — only the SQL emission within the contract phase is reordered.
+    expect(plan.changes.map((c) => c.kind)).toEqual([
+      "drop_table",
+      "drop_column",
+      "drop_foreign_key",
+    ]);
+  });
+
+  it("preserves non-contract order while reordering only the contract block", () => {
+    const plan = planMigration([
+      {
+        kind: "drop_table",
+        entity: "supplier",
+        previousDefinition: {
+          name: "supplier",
+          fields: { id: { type: "string", required: true } },
+        },
+      },
+      {
+        kind: "add_column",
+        entity: "order",
+        field: "priority",
+        definition: { type: "string" },
+      },
+      {
+        kind: "drop_foreign_key",
+        entity: "order",
+        foreignKey: { field: "supplier_id", toEntity: "supplier" },
+      },
+    ]);
+    // expand phase keeps the lone add_column; contract phase reorders FK → table.
+    const expandPhase = plan.forward.find((p) => p.name === "expand");
+    const contractPhase = plan.forward.find((p) => p.name === "contract");
+    expect(expandPhase?.statements).toEqual([
+      'ALTER TABLE "order" ADD COLUMN "priority" varchar(255) NULL;',
+    ]);
+    expect(contractPhase?.statements).toEqual([
+      'ALTER TABLE "order" DROP CONSTRAINT "fk_order_supplier_id";',
+      'DROP TABLE "supplier";',
+    ]);
+  });
 });

--- a/packages/core/__tests__/proposal-migration-validator.test.ts
+++ b/packages/core/__tests__/proposal-migration-validator.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "bun:test";
+import { planMigration } from "../src/migration/proposal-migration-planner";
+import { validateMigrationPlan } from "../src/migration/proposal-migration-validator";
+
+describe("validateMigrationPlan", () => {
+  it("returns valid + reversible for a pure additive plan", () => {
+    const plan = planMigration([
+      {
+        kind: "add_column",
+        entity: "order",
+        field: "priority",
+        definition: { type: "string" },
+      },
+    ]);
+    const result = validateMigrationPlan(plan);
+    expect(result.valid).toBe(true);
+    expect(result.destructive).toBe(false);
+    expect(result.reversibility).toBe("reversible");
+    expect(result.dataLossSimulationRequired).toBe(false);
+    expect(result.issues).toEqual([]);
+  });
+
+  it("flags drop_column as a destructive error and marks irreversible", () => {
+    const plan = planMigration([
+      {
+        kind: "drop_column",
+        entity: "order",
+        field: "legacy_notes",
+        previousDefinition: { type: "string" },
+      },
+    ]);
+    const result = validateMigrationPlan(plan);
+    expect(result.valid).toBe(false);
+    expect(result.destructive).toBe(true);
+    expect(result.reversibility).toBe("irreversible");
+    expect(result.dataLossSimulationRequired).toBe(true);
+    expect(result.issues.some((i) => i.rule === "destructive_drop_column")).toBe(true);
+    expect(result.issues[0]?.reversibility).toBe("irreversible");
+  });
+
+  it("flags a lossy alter as breaking + irreversible", () => {
+    const plan = planMigration([
+      {
+        kind: "alter_column_type",
+        entity: "order",
+        field: "note",
+        fromType: "text",
+        toType: "string",
+      },
+    ]);
+    const result = validateMigrationPlan(plan);
+    expect(result.valid).toBe(false);
+    expect(result.reversibility).toBe("irreversible");
+    expect(result.issues.some((i) => i.rule === "lossy_type_change")).toBe(true);
+  });
+
+  it("treats widening alter as safe (no errors, reversible)", () => {
+    const plan = planMigration([
+      {
+        kind: "alter_column_type",
+        entity: "order",
+        field: "note",
+        fromType: "string",
+        toType: "text",
+      },
+    ]);
+    const result = validateMigrationPlan(plan);
+    expect(result.valid).toBe(true);
+    expect(result.reversibility).toBe("reversible");
+    expect(result.issues).toEqual([]);
+  });
+
+  it("warns on add_required_column_without_default but stays valid", () => {
+    const plan = planMigration([
+      {
+        kind: "add_column",
+        entity: "order",
+        field: "supplier_id",
+        definition: { type: "string", required: true },
+      },
+    ]);
+    const result = validateMigrationPlan(plan);
+    expect(result.valid).toBe(true);
+    expect(result.reversibility).toBe("partial");
+    expect(result.issues.some((i) => i.rule === "add_required_column_without_default")).toBe(true);
+  });
+
+  it("flags drop_foreign_key as a destructive warning (no error)", () => {
+    const plan = planMigration([
+      {
+        kind: "drop_foreign_key",
+        entity: "order_line",
+        foreignKey: { field: "order_id", toEntity: "order" },
+      },
+    ]);
+    const result = validateMigrationPlan(plan);
+    // No errors — just a warning + destructive flag for integrity loss
+    expect(result.valid).toBe(true);
+    expect(result.destructive).toBe(true);
+    expect(result.dataLossSimulationRequired).toBe(true);
+    expect(result.issues.some((i) => i.rule === "drop_foreign_key_relaxes_integrity")).toBe(true);
+  });
+
+  it("rename emits an info issue, plan stays valid + reversible", () => {
+    const plan = planMigration([
+      {
+        kind: "rename_column",
+        entity: "order",
+        fromField: "supplier",
+        toField: "vendor",
+        definition: { type: "string" },
+      },
+    ]);
+    const result = validateMigrationPlan(plan);
+    expect(result.valid).toBe(true);
+    expect(result.reversibility).toBe("reversible");
+    expect(result.issues.some((i) => i.rule === "rename_requires_dual_read")).toBe(true);
+  });
+
+  it("aggregates worst reversibility across mixed changes", () => {
+    const plan = planMigration([
+      {
+        kind: "add_column",
+        entity: "order",
+        field: "priority",
+        definition: { type: "string" },
+      },
+      {
+        kind: "drop_column",
+        entity: "order",
+        field: "legacy_notes",
+        previousDefinition: { type: "string" },
+      },
+    ]);
+    const result = validateMigrationPlan(plan);
+    expect(result.reversibility).toBe("irreversible");
+    expect(result.destructive).toBe(true);
+  });
+});

--- a/packages/core/src/migration/index.ts
+++ b/packages/core/src/migration/index.ts
@@ -1,0 +1,37 @@
+/**
+ * Migration pipeline barrel.
+ *
+ * Re-exports the Proposal Migration types, detector, planner, and validator
+ * defined in Spec 62. Pure, runtime-agnostic — no Drizzle or live DB calls.
+ */
+
+export {
+  buildMigrationSnapshot,
+  type DetectMigrationChangesOptions,
+  detectMigrationChanges,
+  isTypeWidening,
+} from "./proposal-migration-detector";
+export { planMigration } from "./proposal-migration-planner";
+export type {
+  AddColumnChange,
+  AddForeignKeyChange,
+  AlterColumnTypeChange,
+  CreateTableChange,
+  DropColumnChange,
+  DropForeignKeyChange,
+  DropTableChange,
+  EntitySnapshot,
+  MigrationChange,
+  MigrationClassification,
+  MigrationForeignKey,
+  MigrationIssueSeverity,
+  MigrationPhase,
+  MigrationPlan,
+  MigrationSnapshot,
+  MigrationValidationIssue,
+  MigrationValidationResult,
+  RenameColumnChange,
+  ReversibilityTag,
+} from "./proposal-migration-types";
+
+export { validateMigrationPlan } from "./proposal-migration-validator";

--- a/packages/core/src/migration/proposal-migration-detector.ts
+++ b/packages/core/src/migration/proposal-migration-detector.ts
@@ -1,0 +1,257 @@
+/**
+ * Proposal Migration Detector (Spec 62 §3)
+ *
+ * Diffs two entity snapshots (`before` / `after`) and emits a list of
+ * structured {@link MigrationChange} items. Pure and runtime-agnostic — no
+ * Drizzle, no live DB, no Proposal Engine coupling.
+ *
+ * Rename detection is opt-in: callers pass an optional `renames` map because
+ * snapshots alone cannot distinguish "drop X + add Y" from "rename X to Y".
+ * The Proposal payload is expected to declare renames explicitly.
+ */
+import type { FieldDefinition } from "../types/entity";
+import type {
+  EntitySnapshot,
+  MigrationChange,
+  MigrationForeignKey,
+  MigrationSnapshot,
+} from "./proposal-migration-types";
+
+/** Options accepted by {@link detectMigrationChanges}. */
+export interface DetectMigrationChangesOptions {
+  before: MigrationSnapshot;
+  after: MigrationSnapshot;
+  /**
+   * Explicit per-entity rename map. Keys are entity names; values are
+   * `{ from → to }` mappings indicating which `before` field maps to which
+   * `after` field. Without this, a diff that removes X and adds Y is treated
+   * as a drop+add pair.
+   */
+  renames?: Record<string, Record<string, string>>;
+}
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function fkKey(fk: MigrationForeignKey): string {
+  return fk.name ?? `${fk.field}__${fk.toEntity}__${fk.toField ?? "id"}`;
+}
+
+function indexForeignKeys(entity: EntitySnapshot): Map<string, MigrationForeignKey> {
+  const map = new Map<string, MigrationForeignKey>();
+  for (const fk of entity.foreignKeys ?? []) {
+    map.set(fkKey(fk), fk);
+  }
+  return map;
+}
+
+// ── Detection ────────────────────────────────────────────────
+
+/**
+ * Compute the list of migration changes required to evolve `before` into
+ * `after`. Order is stable and deterministic:
+ *
+ *  1. Table-level changes (create / drop)
+ *  2. Column-level renames (per entity)
+ *  3. Column-level drops
+ *  4. Column-level adds
+ *  5. Column type alters
+ *  6. FK drops then adds
+ *
+ * This ordering matches the expand → migrate → contract execution model and
+ * keeps the planner simple.
+ */
+export function detectMigrationChanges(options: DetectMigrationChangesOptions): MigrationChange[] {
+  const { before, after, renames = {} } = options;
+  const changes: MigrationChange[] = [];
+
+  const beforeNames = new Set(Object.keys(before.entities));
+  const afterNames = new Set(Object.keys(after.entities));
+
+  // 1a. Table creates
+  for (const name of afterNames) {
+    if (!beforeNames.has(name)) {
+      const def = after.entities[name];
+      if (!def) continue;
+      changes.push({ kind: "create_table", entity: name, definition: def });
+    }
+  }
+
+  // 1b. Table drops
+  for (const name of beforeNames) {
+    if (!afterNames.has(name)) {
+      const def = before.entities[name];
+      if (!def) continue;
+      changes.push({ kind: "drop_table", entity: name, previousDefinition: def });
+    }
+  }
+
+  // 2-5. Column-level diff for entities present in both snapshots
+  for (const name of afterNames) {
+    if (!beforeNames.has(name)) continue;
+    const beforeEntity = before.entities[name];
+    const afterEntity = after.entities[name];
+    if (!beforeEntity || !afterEntity) continue;
+
+    const entityRenames = renames[name] ?? {};
+    diffEntityColumns({
+      entity: name,
+      before: beforeEntity,
+      after: afterEntity,
+      renames: entityRenames,
+      sink: changes,
+    });
+    diffEntityForeignKeys({
+      entity: name,
+      before: beforeEntity,
+      after: afterEntity,
+      sink: changes,
+    });
+  }
+
+  return changes;
+}
+
+interface DiffColumnsOptions {
+  entity: string;
+  before: EntitySnapshot;
+  after: EntitySnapshot;
+  renames: Record<string, string>;
+  sink: MigrationChange[];
+}
+
+function diffEntityColumns(options: DiffColumnsOptions): void {
+  const { entity, before, after, renames, sink } = options;
+
+  const renamedFrom = new Set(Object.keys(renames));
+  const renamedTo = new Set(Object.values(renames));
+
+  // Emit renames first so subsequent diffs treat them as already handled
+  for (const [from, to] of Object.entries(renames)) {
+    const def = before.fields[from] ?? after.fields[to];
+    if (!def) continue;
+    sink.push({
+      kind: "rename_column",
+      entity,
+      fromField: from,
+      toField: to,
+      definition: def,
+    });
+  }
+
+  // Drops: in before but not in after, and not part of a rename
+  for (const [field, prev] of Object.entries(before.fields)) {
+    if (renamedFrom.has(field)) continue;
+    if (after.fields[field]) continue;
+    sink.push({
+      kind: "drop_column",
+      entity,
+      field,
+      previousDefinition: prev,
+    });
+  }
+
+  // Adds: in after but not in before, and not the target of a rename
+  for (const [field, def] of Object.entries(after.fields)) {
+    if (renamedTo.has(field)) continue;
+    if (before.fields[field]) continue;
+    sink.push({
+      kind: "add_column",
+      entity,
+      field,
+      definition: def,
+    });
+  }
+
+  // Type alters: present in both, but `type` differs. Renames are checked
+  // separately via the post-rename type because the column name has changed.
+  for (const [field, prev] of Object.entries(before.fields)) {
+    if (renamedFrom.has(field)) continue;
+    const next = after.fields[field];
+    if (!next) continue;
+    if (prev.type !== next.type) {
+      sink.push({
+        kind: "alter_column_type",
+        entity,
+        field,
+        fromType: prev.type,
+        toType: next.type,
+      });
+    }
+  }
+
+  // Renamed columns may also change type; emit an alter on the new name.
+  for (const [from, to] of Object.entries(renames)) {
+    const prev = before.fields[from];
+    const next = after.fields[to];
+    if (!prev || !next) continue;
+    if (prev.type !== next.type) {
+      sink.push({
+        kind: "alter_column_type",
+        entity,
+        field: to,
+        fromType: prev.type,
+        toType: next.type,
+      });
+    }
+  }
+}
+
+interface DiffForeignKeysOptions {
+  entity: string;
+  before: EntitySnapshot;
+  after: EntitySnapshot;
+  sink: MigrationChange[];
+}
+
+function diffEntityForeignKeys(options: DiffForeignKeysOptions): void {
+  const { entity, before, after, sink } = options;
+  const beforeFks = indexForeignKeys(before);
+  const afterFks = indexForeignKeys(after);
+
+  // Drops first
+  for (const [key, fk] of beforeFks.entries()) {
+    if (!afterFks.has(key)) {
+      sink.push({ kind: "drop_foreign_key", entity, foreignKey: fk });
+    }
+  }
+  // Then adds
+  for (const [key, fk] of afterFks.entries()) {
+    if (!beforeFks.has(key)) {
+      sink.push({ kind: "add_foreign_key", entity, foreignKey: fk });
+    }
+  }
+}
+
+// ── Convenience builders ─────────────────────────────────────
+
+/**
+ * Build a snapshot from a flat array of entity snapshots. Convenience helper
+ * for callers that already work with arrays of {@link EntitySnapshot}.
+ */
+export function buildMigrationSnapshot(entities: EntitySnapshot[]): MigrationSnapshot {
+  const map: Record<string, EntitySnapshot> = {};
+  for (const e of entities) {
+    map[e.name] = e;
+  }
+  return { entities: map };
+}
+
+/**
+ * Lightweight check used by the planner / validator: does the type change
+ * widen the column (lossless) or narrow it (lossy)?
+ *
+ * Rules mirror Spec 09 §4.5 widening matrix:
+ *  - string  → text:    widen
+ *  - date    → datetime: widen
+ *  - same → same:        identity (widen)
+ *  - everything else:    narrow / incompatible
+ */
+export function isTypeWidening(
+  fromType: FieldDefinition["type"],
+  toType: FieldDefinition["type"],
+): boolean {
+  if (fromType === toType) return true;
+  if (fromType === "string" && toType === "text") return true;
+  if (fromType === "date" && toType === "datetime") return true;
+  return false;
+}

--- a/packages/core/src/migration/proposal-migration-planner.ts
+++ b/packages/core/src/migration/proposal-migration-planner.ts
@@ -1,0 +1,355 @@
+/**
+ * Proposal Migration Planner (Spec 62 §4 + §6)
+ *
+ * Given a list of detected {@link MigrationChange}s, produce an
+ * expand → migrate → contract plan with per-phase SQL strings plus a
+ * rollback script. Pure string generation — no Drizzle runtime.
+ *
+ * SQL emitted here targets PostgreSQL syntax (the project's primary backend).
+ * Identifiers are quoted with double quotes and validated against a strict
+ * allow-list to defend against injection, since callers may forward Proposal
+ * payloads sourced from AI suggestions.
+ */
+import type { FieldDefinition } from "../types/entity";
+import { isTypeWidening } from "./proposal-migration-detector";
+import type {
+  AddColumnChange,
+  AddForeignKeyChange,
+  AlterColumnTypeChange,
+  CreateTableChange,
+  DropColumnChange,
+  DropForeignKeyChange,
+  DropTableChange,
+  EntitySnapshot,
+  MigrationChange,
+  MigrationClassification,
+  MigrationForeignKey,
+  MigrationPhase,
+  MigrationPlan,
+  RenameColumnChange,
+} from "./proposal-migration-types";
+
+// ── Identifier safety ────────────────────────────────────────
+
+/**
+ * Allow only conservative SQL identifiers: letters, digits, underscores, and
+ * a leading non-digit. Anything else throws — Proposals must use entity /
+ * field names that already pass the LinchKit naming rules.
+ */
+const SAFE_IDENT = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function quoteIdent(name: string): string {
+  if (!SAFE_IDENT.test(name)) {
+    throw new Error(`Unsafe SQL identifier: ${name}`);
+  }
+  return `"${name}"`;
+}
+
+// ── Type mapping ─────────────────────────────────────────────
+
+/**
+ * Map a LinchKit field type to its SQL column type. Mirrors the conventions
+ * used by `generateDrizzleSchemaFile()` so future integration is seamless.
+ */
+function sqlTypeFor(type: FieldDefinition["type"]): string {
+  switch (type) {
+    case "string":
+      return "varchar(255)";
+    case "text":
+      return "text";
+    case "number":
+      return "double precision";
+    case "boolean":
+      return "boolean";
+    case "date":
+      return "date";
+    case "datetime":
+      return "timestamp with time zone";
+    case "enum":
+      // Enums are stored as text; the enum constraint lives at the
+      // application layer (Zod) per current LinchKit conventions.
+      return "text";
+    case "json":
+      return "jsonb";
+    case "state":
+      return "text";
+    case "computed":
+      // Computed fields are not persisted; planner should never see one.
+      throw new Error("Computed fields are not persisted and cannot be migrated");
+  }
+}
+
+function columnDdlFragment(field: string, def: FieldDefinition): string {
+  const sqlType = sqlTypeFor(def.type);
+  const nullability = def.required ? "NOT NULL" : "NULL";
+  return `${quoteIdent(field)} ${sqlType} ${nullability}`;
+}
+
+// ── Classification ───────────────────────────────────────────
+
+const SEVERITY_ORDER: Record<MigrationClassification, number> = {
+  safe: 0,
+  expand: 1,
+  contract: 2,
+  breaking: 3,
+};
+
+function classifyChange(change: MigrationChange): MigrationClassification {
+  switch (change.kind) {
+    case "add_column":
+      return change.definition.required && change.definition.default === undefined
+        ? "expand"
+        : "safe";
+    case "create_table":
+      return "safe";
+    case "add_foreign_key":
+      return "expand";
+    case "drop_column":
+      return "contract";
+    case "drop_foreign_key":
+      return "contract";
+    case "drop_table":
+      return "contract";
+    case "rename_column":
+      return "expand";
+    case "alter_column_type":
+      return isTypeWidening(change.fromType, change.toType) ? "safe" : "breaking";
+  }
+}
+
+function rollupClassification(changes: MigrationChange[]): MigrationClassification {
+  let worst: MigrationClassification = "safe";
+  for (const change of changes) {
+    const c = classifyChange(change);
+    if (SEVERITY_ORDER[c] > SEVERITY_ORDER[worst]) {
+      worst = c;
+    }
+  }
+  return worst;
+}
+
+// ── Per-change SQL generation ────────────────────────────────
+
+function sqlForCreateTable(change: CreateTableChange): string[] {
+  const { entity, definition } = change;
+  const columns = Object.entries(definition.fields)
+    .filter(([, def]) => def.type !== "computed")
+    .map(([name, def]) => `  ${columnDdlFragment(name, def)}`);
+  const stmts: string[] = [`CREATE TABLE ${quoteIdent(entity)} (\n${columns.join(",\n")}\n);`];
+  for (const fk of definition.foreignKeys ?? []) {
+    stmts.push(addForeignKeySql(entity, fk));
+  }
+  return stmts;
+}
+
+function sqlForDropTable(change: DropTableChange): string {
+  return `DROP TABLE ${quoteIdent(change.entity)};`;
+}
+
+function sqlForAddColumn(change: AddColumnChange): string {
+  const fragment = columnDdlFragment(change.field, change.definition);
+  return `ALTER TABLE ${quoteIdent(change.entity)} ADD COLUMN ${fragment};`;
+}
+
+function sqlForDropColumn(change: DropColumnChange): string {
+  return `ALTER TABLE ${quoteIdent(change.entity)} DROP COLUMN ${quoteIdent(change.field)};`;
+}
+
+function sqlForAlterColumnType(change: AlterColumnTypeChange): string {
+  const sqlType = sqlTypeFor(change.toType);
+  return (
+    `ALTER TABLE ${quoteIdent(change.entity)} ` +
+    `ALTER COLUMN ${quoteIdent(change.field)} TYPE ${sqlType};`
+  );
+}
+
+function sqlForRenameColumn(change: RenameColumnChange): string {
+  return (
+    `ALTER TABLE ${quoteIdent(change.entity)} ` +
+    `RENAME COLUMN ${quoteIdent(change.fromField)} TO ${quoteIdent(change.toField)};`
+  );
+}
+
+function addForeignKeySql(entity: string, fk: MigrationForeignKey): string {
+  const constraintName = fk.name ?? `fk_${entity}_${fk.field}`;
+  const toField = fk.toField ?? "id";
+  return (
+    `ALTER TABLE ${quoteIdent(entity)} ` +
+    `ADD CONSTRAINT ${quoteIdent(constraintName)} ` +
+    `FOREIGN KEY (${quoteIdent(fk.field)}) ` +
+    `REFERENCES ${quoteIdent(fk.toEntity)}(${quoteIdent(toField)});`
+  );
+}
+
+function sqlForAddForeignKey(change: AddForeignKeyChange): string {
+  return addForeignKeySql(change.entity, change.foreignKey);
+}
+
+function sqlForDropForeignKey(change: DropForeignKeyChange): string {
+  const fk = change.foreignKey;
+  const constraintName = fk.name ?? `fk_${change.entity}_${fk.field}`;
+  return (
+    `ALTER TABLE ${quoteIdent(change.entity)} ` + `DROP CONSTRAINT ${quoteIdent(constraintName)};`
+  );
+}
+
+// ── Rollback SQL generation ──────────────────────────────────
+
+function rollbackForChange(change: MigrationChange): string[] {
+  switch (change.kind) {
+    case "add_column":
+      return [`ALTER TABLE ${quoteIdent(change.entity)} DROP COLUMN ${quoteIdent(change.field)};`];
+    case "drop_column": {
+      const fragment = columnDdlFragment(change.field, change.previousDefinition);
+      return [`ALTER TABLE ${quoteIdent(change.entity)} ADD COLUMN ${fragment};`];
+    }
+    case "alter_column_type": {
+      // Only meaningful if the original change was a widening; for narrowing
+      // the reverse would also be lossy, but we still emit the SQL so an
+      // operator can run it if they accept the risk.
+      const sqlType = sqlTypeFor(change.fromType);
+      return [
+        `ALTER TABLE ${quoteIdent(change.entity)} ` +
+          `ALTER COLUMN ${quoteIdent(change.field)} TYPE ${sqlType};`,
+      ];
+    }
+    case "add_foreign_key":
+      return [
+        sqlForDropForeignKey({
+          kind: "drop_foreign_key",
+          entity: change.entity,
+          foreignKey: change.foreignKey,
+        }),
+      ];
+    case "drop_foreign_key":
+      return [
+        sqlForAddForeignKey({
+          kind: "add_foreign_key",
+          entity: change.entity,
+          foreignKey: change.foreignKey,
+        }),
+      ];
+    case "rename_column":
+      return [
+        `ALTER TABLE ${quoteIdent(change.entity)} ` +
+          `RENAME COLUMN ${quoteIdent(change.toField)} TO ${quoteIdent(change.fromField)};`,
+      ];
+    case "create_table":
+      return [`DROP TABLE ${quoteIdent(change.entity)};`];
+    case "drop_table":
+      return sqlForCreateTable({
+        kind: "create_table",
+        entity: change.entity,
+        definition: change.previousDefinition as EntitySnapshot,
+      });
+  }
+}
+
+// ── Phase assignment ─────────────────────────────────────────
+
+interface PhaseBuckets {
+  expand: string[];
+  migrate: string[];
+  contract: string[];
+}
+
+function assignToPhases(change: MigrationChange, buckets: PhaseBuckets): void {
+  switch (change.kind) {
+    case "create_table":
+      for (const stmt of sqlForCreateTable(change)) {
+        buckets.expand.push(stmt);
+      }
+      break;
+    case "add_column":
+      buckets.expand.push(sqlForAddColumn(change));
+      break;
+    case "add_foreign_key":
+      // FKs are added in the contract phase after backfill, but planning
+      // for AI Proposals only happens once — keep it in expand for the
+      // baseline plan unless a backfill is needed. A future iteration may
+      // split this further when Proposal includes backfill data.
+      buckets.expand.push(sqlForAddForeignKey(change));
+      break;
+    case "rename_column":
+      // Rename is treated as a migrate-phase action: the column must exist
+      // before old code stops reading the old name. In a true blue/green
+      // deploy the rename would split into add-new + dual-write; here we
+      // emit the rename in `migrate` to signal that timing matters.
+      buckets.migrate.push(sqlForRenameColumn(change));
+      break;
+    case "alter_column_type":
+      buckets.migrate.push(sqlForAlterColumnType(change));
+      break;
+    case "drop_column":
+      buckets.contract.push(sqlForDropColumn(change));
+      break;
+    case "drop_foreign_key":
+      buckets.contract.push(sqlForDropForeignKey(change));
+      break;
+    case "drop_table":
+      buckets.contract.push(sqlForDropTable(change));
+      break;
+  }
+}
+
+// ── Summary ──────────────────────────────────────────────────
+
+function summarise(changes: MigrationChange[], classification: MigrationClassification): string {
+  if (changes.length === 0) {
+    return "No schema changes detected.";
+  }
+  const counts = new Map<MigrationChange["kind"], number>();
+  for (const change of changes) {
+    counts.set(change.kind, (counts.get(change.kind) ?? 0) + 1);
+  }
+  const parts: string[] = [];
+  for (const [kind, count] of counts.entries()) {
+    parts.push(`${count} × ${kind}`);
+  }
+  return `[${classification}] ${parts.join(", ")}`;
+}
+
+// ── Public API ───────────────────────────────────────────────
+
+/**
+ * Build a phased migration plan from a list of changes. The returned plan
+ * is deterministic: phases preserve insertion order, rollback is the reverse
+ * order of the forward steps, and the classification is the worst-case
+ * across all changes.
+ */
+export function planMigration(changes: MigrationChange[]): MigrationPlan {
+  const buckets: PhaseBuckets = { expand: [], migrate: [], contract: [] };
+  for (const change of changes) {
+    assignToPhases(change, buckets);
+  }
+
+  const phases: MigrationPhase[] = [];
+  if (buckets.expand.length > 0) {
+    phases.push({ name: "expand", statements: buckets.expand });
+  }
+  if (buckets.migrate.length > 0) {
+    phases.push({ name: "migrate", statements: buckets.migrate });
+  }
+  if (buckets.contract.length > 0) {
+    phases.push({ name: "contract", statements: buckets.contract });
+  }
+
+  // Rollback walks the changes in reverse so dependent ops unwind safely.
+  const rollback: string[] = [];
+  for (let i = changes.length - 1; i >= 0; i--) {
+    const change = changes[i];
+    if (!change) continue;
+    for (const stmt of rollbackForChange(change)) {
+      rollback.push(stmt);
+    }
+  }
+
+  const classification = rollupClassification(changes);
+  return {
+    changes,
+    classification,
+    forward: phases,
+    rollback,
+    summary: summarise(changes, classification),
+  };
+}

--- a/packages/core/src/migration/proposal-migration-planner.ts
+++ b/packages/core/src/migration/proposal-migration-planner.ts
@@ -79,10 +79,42 @@ function sqlTypeFor(type: FieldDefinition["type"]): string {
   }
 }
 
+/**
+ * Render a SQL literal for a column DEFAULT clause. Strings are single-quoted
+ * with embedded quotes escaped (SQL standard `''`). Numbers and booleans are
+ * coerced via `String(...)`. Objects (including arrays) are serialised to JSON
+ * and treated as string literals so jsonb / text columns get a usable default.
+ *
+ * Note: this is intentionally limited to the literal forms a Proposal payload
+ * is expected to produce. Function-call defaults (e.g. `now()`) are not
+ * supported here — they belong to a future iteration.
+ */
+function renderDefaultLiteral(value: unknown): string {
+  if (value === null) {
+    return "NULL";
+  }
+  if (typeof value === "string") {
+    return `'${value.replace(/'/g, "''")}'`;
+  }
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+  // Objects / arrays — serialise as a JSON string literal.
+  const serialised = JSON.stringify(value);
+  return `'${serialised.replace(/'/g, "''")}'`;
+}
+
 function columnDdlFragment(field: string, def: FieldDefinition): string {
   const sqlType = sqlTypeFor(def.type);
-  const nullability = def.required ? "NOT NULL" : "NULL";
-  return `${quoteIdent(field)} ${sqlType} ${nullability}`;
+  let fragment = `${quoteIdent(field)} ${sqlType}`;
+  if (def.default !== undefined) {
+    fragment += ` DEFAULT ${renderDefaultLiteral(def.default)}`;
+  }
+  fragment += def.required ? " NOT NULL" : " NULL";
+  if (def.unique) {
+    fragment += " UNIQUE";
+  }
+  return fragment;
 }
 
 // ── Classification ───────────────────────────────────────────
@@ -132,9 +164,22 @@ function rollupClassification(changes: MigrationChange[]): MigrationClassificati
 
 function sqlForCreateTable(change: CreateTableChange): string[] {
   const { entity, definition } = change;
-  const columns = Object.entries(definition.fields)
-    .filter(([, def]) => def.type !== "computed")
-    .map(([name, def]) => `  ${columnDdlFragment(name, def)}`);
+  const persistable = Object.entries(definition.fields).filter(
+    ([, def]) => def.type !== "computed",
+  );
+  if (persistable.length === 0) {
+    throw new Error(`Cannot create table ${entity} with no columns`);
+  }
+  const columns = persistable.map(([name, def]) => {
+    let fragment = columnDdlFragment(name, def);
+    // The `id` field is always the table's primary key — Spec 62 mandates
+    // every persisted entity expose an `id`. Append the constraint inline
+    // so CREATE TABLE renders a single canonical PRIMARY KEY clause.
+    if (name === "id") {
+      fragment += " PRIMARY KEY";
+    }
+    return `  ${fragment}`;
+  });
   const stmts: string[] = [`CREATE TABLE ${quoteIdent(entity)} (\n${columns.join(",\n")}\n);`];
   for (const fk of definition.foreignKeys ?? []) {
     stmts.push(addForeignKeySql(entity, fk));
@@ -253,6 +298,50 @@ interface PhaseBuckets {
   contract: string[];
 }
 
+/**
+ * Within the `contract` phase, PostgreSQL requires that referential constraints
+ * (foreign keys) be dropped before the columns or tables they reference —
+ * otherwise `DROP TABLE` / `DROP COLUMN` fails with a "depends on" error.
+ *
+ * `contract`-phase ordering (smaller value = earlier):
+ *  1. drop_foreign_key — break references first
+ *  2. drop_column      — then narrow columns
+ *  3. drop_table       — finally remove tables
+ *
+ * Non-contract changes (`expand` / `migrate`) keep their original
+ * detection order, which already matches schema-evolution best practice.
+ */
+const CONTRACT_PRIORITY: Partial<Record<MigrationChange["kind"], number>> = {
+  drop_foreign_key: 0,
+  drop_column: 1,
+  drop_table: 2,
+};
+
+function orderChangesForContractPhase(changes: MigrationChange[]): MigrationChange[] {
+  // Stable sort: contract-eligible changes keep their relative order within
+  // each priority bucket, and non-contract changes stay in their original
+  // positions relative to one another. A stable sort handles this when the
+  // comparator returns 0 for equal keys (Array.prototype.sort is stable in
+  // modern JS engines and Bun).
+  return [...changes]
+    .map((change, index) => ({ change, index }))
+    .sort((a, b) => {
+      const aPriority = CONTRACT_PRIORITY[a.change.kind];
+      const bPriority = CONTRACT_PRIORITY[b.change.kind];
+      // Both non-contract: preserve original order
+      if (aPriority === undefined && bPriority === undefined) {
+        return a.index - b.index;
+      }
+      // Non-contract before contract — leaves contract block at the end
+      // grouped by priority (FK drops → column drops → table drops).
+      if (aPriority === undefined) return -1;
+      if (bPriority === undefined) return 1;
+      if (aPriority !== bPriority) return aPriority - bPriority;
+      return a.index - b.index;
+    })
+    .map(({ change }) => change);
+}
+
 function assignToPhases(change: MigrationChange, buckets: PhaseBuckets): void {
   switch (change.kind) {
     case "create_table":
@@ -319,7 +408,11 @@ function summarise(changes: MigrationChange[], classification: MigrationClassifi
  */
 export function planMigration(changes: MigrationChange[]): MigrationPlan {
   const buckets: PhaseBuckets = { expand: [], migrate: [], contract: [] };
-  for (const change of changes) {
+  // Reorder for forward SQL emission only — `changes` and `rollback` keep
+  // their original ordering. Sorting here ensures the contract phase emits
+  // FK drops before column / table drops, which PostgreSQL requires.
+  const orderedForForward = orderChangesForContractPhase(changes);
+  for (const change of orderedForForward) {
     assignToPhases(change, buckets);
   }
 

--- a/packages/core/src/migration/proposal-migration-types.ts
+++ b/packages/core/src/migration/proposal-migration-types.ts
@@ -1,0 +1,197 @@
+/**
+ * Proposal Migration — shared types (Spec 62)
+ *
+ * Pure type-only module used by the detector, planner, and validator.
+ * Runtime-agnostic: no Drizzle runtime or live DB dependency. The pipeline
+ * operates on entity definition snapshots and emits plain SQL strings.
+ *
+ * The vocabulary intentionally narrows the broader change set in Spec 62 §3
+ * to the column-level and table-level DDL operations a Proposal can produce.
+ * Index / data-transform changes belong to a future iteration (Spec 62 §9
+ * Phase 3) and are not modelled here.
+ */
+import type { FieldDefinition } from "../types/entity";
+
+// ── Entity snapshots ──────────────────────────────────────────
+
+/**
+ * Lightweight foreign-key descriptor used in entity snapshots.
+ * Decoupled from the OntologyRegistry so callers can build snapshots from
+ * plain JSON (e.g. a Proposal payload) without pulling in runtime state.
+ */
+export interface MigrationForeignKey {
+  /** Column on the owning entity that holds the reference */
+  field: string;
+  /** Target entity name */
+  toEntity: string;
+  /** Target field on the referenced entity (defaults to "id" if omitted) */
+  toField?: string;
+  /** Stable identifier for the constraint; derived from field if omitted */
+  name?: string;
+}
+
+/**
+ * Snapshot of a single entity used by the detector. Includes only what the
+ * migration pipeline needs — name, fields, and FK relationships. Other
+ * EntityDefinition metadata (UI, semantics, exposure) is irrelevant for DDL.
+ */
+export interface EntitySnapshot {
+  name: string;
+  fields: Record<string, FieldDefinition>;
+  foreignKeys?: MigrationForeignKey[];
+}
+
+/**
+ * A snapshot of multiple entities, keyed by name. Used as the `before`/`after`
+ * inputs to {@link detectMigrationChanges}.
+ */
+export interface MigrationSnapshot {
+  entities: Record<string, EntitySnapshot>;
+}
+
+// ── Change kinds ──────────────────────────────────────────────
+
+/** Discriminated union of all migration change kinds supported by the pipeline. */
+export type MigrationChange =
+  | AddColumnChange
+  | DropColumnChange
+  | AlterColumnTypeChange
+  | AddForeignKeyChange
+  | DropForeignKeyChange
+  | RenameColumnChange
+  | CreateTableChange
+  | DropTableChange;
+
+export interface AddColumnChange {
+  kind: "add_column";
+  entity: string;
+  field: string;
+  definition: FieldDefinition;
+}
+
+export interface DropColumnChange {
+  kind: "drop_column";
+  entity: string;
+  field: string;
+  /** The dropped field's prior definition, captured for rollback */
+  previousDefinition: FieldDefinition;
+}
+
+export interface AlterColumnTypeChange {
+  kind: "alter_column_type";
+  entity: string;
+  field: string;
+  fromType: FieldDefinition["type"];
+  toType: FieldDefinition["type"];
+}
+
+export interface AddForeignKeyChange {
+  kind: "add_foreign_key";
+  entity: string;
+  foreignKey: MigrationForeignKey;
+}
+
+export interface DropForeignKeyChange {
+  kind: "drop_foreign_key";
+  entity: string;
+  foreignKey: MigrationForeignKey;
+}
+
+export interface RenameColumnChange {
+  kind: "rename_column";
+  entity: string;
+  fromField: string;
+  toField: string;
+  /** Field definition (used to preserve type on rollback) */
+  definition: FieldDefinition;
+}
+
+export interface CreateTableChange {
+  kind: "create_table";
+  entity: string;
+  definition: EntitySnapshot;
+}
+
+export interface DropTableChange {
+  kind: "drop_table";
+  entity: string;
+  /** Previous definition captured so rollback can rebuild the table */
+  previousDefinition: EntitySnapshot;
+}
+
+// ── Classification ────────────────────────────────────────────
+
+/**
+ * Migration plan classification, ordered from least to most disruptive:
+ *
+ * - `safe`: purely additive, no locks, fully reversible (e.g. add nullable column)
+ * - `expand`: additive but introduces structures the old code ignores; reversible
+ *   (e.g. add FK constraint, add new table)
+ * - `contract`: removes structures the new code no longer reads; data loss possible
+ *   but contained (e.g. drop column, drop FK)
+ * - `breaking`: irreversible or risks data loss (e.g. lossy type narrowing)
+ */
+export type MigrationClassification = "safe" | "expand" | "contract" | "breaking";
+
+// ── SQL phases ────────────────────────────────────────────────
+
+/**
+ * A single named SQL phase. Matches the expand → migrate → contract pattern
+ * from Spec 62 §6 but is generic enough to cover single-phase plans too.
+ */
+export interface MigrationPhase {
+  name: "expand" | "migrate" | "contract";
+  statements: string[];
+}
+
+// ── Migration plan ────────────────────────────────────────────
+
+/**
+ * The full plan: forward steps, rollback steps, and a classification.
+ * Forward statements are split into phases; rollback is a flat list since
+ * rollback always runs as a single contract phase from the operator's POV.
+ */
+export interface MigrationPlan {
+  /** All changes the plan covers (in original detection order) */
+  changes: MigrationChange[];
+  /** Overall classification — the most disruptive change wins */
+  classification: MigrationClassification;
+  /** Forward steps, broken into expand / migrate / contract phases */
+  forward: MigrationPhase[];
+  /** Reverse-order rollback statements (best-effort for destructive changes) */
+  rollback: string[];
+  /** Human-readable summary of the plan */
+  summary: string;
+}
+
+// ── Validation ────────────────────────────────────────────────
+
+/** Severity of a validation issue, mirroring Spec 09's compatibility result. */
+export type MigrationIssueSeverity = "error" | "warning" | "info";
+
+/** Whether a change is reversible at the SQL level. */
+export type ReversibilityTag = "reversible" | "partial" | "irreversible";
+
+export interface MigrationValidationIssue {
+  rule: string;
+  severity: MigrationIssueSeverity;
+  change: MigrationChange;
+  reason: string;
+  reversibility: ReversibilityTag;
+}
+
+export interface MigrationValidationResult {
+  /** True when there are no `error`-severity issues */
+  valid: boolean;
+  /** Whether any change in the plan is destructive */
+  destructive: boolean;
+  /** Worst-case reversibility across all changes */
+  reversibility: ReversibilityTag;
+  /**
+   * Placeholder for the dry-run data-loss simulation described in Spec 62 §5.3.
+   * The runtime-agnostic validator cannot query a live DB, so this stays a
+   * flag indicating whether a simulation _should_ run before approval.
+   */
+  dataLossSimulationRequired: boolean;
+  issues: MigrationValidationIssue[];
+}

--- a/packages/core/src/migration/proposal-migration-validator.ts
+++ b/packages/core/src/migration/proposal-migration-validator.ts
@@ -1,0 +1,209 @@
+/**
+ * Proposal Migration Validator (Spec 62 §5)
+ *
+ * Inspects a {@link MigrationPlan} and surfaces safety issues before the plan
+ * reaches a human approver. Pure, runtime-agnostic:
+ *
+ *  - Destructive operations are flagged (DROP, lossy ALTER, drop FK)
+ *  - Each change is tagged with a reversibility verdict
+ *  - `dataLossSimulationRequired` is a boolean placeholder for the dry-run
+ *    described in Spec 62 §5.3 — the runtime-agnostic validator cannot run a
+ *    real query, but it signals when one is needed.
+ *
+ * The validator never throws. All findings are returned in a
+ * {@link MigrationValidationResult}.
+ */
+import { isTypeWidening } from "./proposal-migration-detector";
+import type {
+  MigrationChange,
+  MigrationIssueSeverity,
+  MigrationPlan,
+  MigrationValidationIssue,
+  MigrationValidationResult,
+  ReversibilityTag,
+} from "./proposal-migration-types";
+
+// ── Reversibility ────────────────────────────────────────────
+
+const REVERSIBILITY_ORDER: Record<ReversibilityTag, number> = {
+  reversible: 0,
+  partial: 1,
+  irreversible: 2,
+};
+
+function reversibilityOf(change: MigrationChange): ReversibilityTag {
+  switch (change.kind) {
+    case "create_table":
+      return "reversible";
+    case "drop_table":
+      // Schema can be recreated, but stored rows are gone forever.
+      return "irreversible";
+    case "add_column":
+      // Adding an optional column is fully reversible; adding a required one
+      // with a backfilled value loses the backfilled data on rollback.
+      return change.definition.required && change.definition.default === undefined
+        ? "partial"
+        : "reversible";
+    case "drop_column":
+      return "irreversible";
+    case "alter_column_type":
+      return isTypeWidening(change.fromType, change.toType) ? "reversible" : "irreversible";
+    case "rename_column":
+      return "reversible";
+    case "add_foreign_key":
+    case "drop_foreign_key":
+      return "reversible";
+  }
+}
+
+function worstReversibility(changes: MigrationChange[]): ReversibilityTag {
+  let worst: ReversibilityTag = "reversible";
+  for (const change of changes) {
+    const tag = reversibilityOf(change);
+    if (REVERSIBILITY_ORDER[tag] > REVERSIBILITY_ORDER[worst]) {
+      worst = tag;
+    }
+  }
+  return worst;
+}
+
+// ── Destructiveness ──────────────────────────────────────────
+
+function isDestructive(change: MigrationChange): boolean {
+  switch (change.kind) {
+    case "drop_column":
+    case "drop_table":
+      return true;
+    case "alter_column_type":
+      return !isTypeWidening(change.fromType, change.toType);
+    case "drop_foreign_key":
+      // FK drop does not delete data, but downgrades referential integrity —
+      // treat as destructive so the validator surfaces a warning.
+      return true;
+    case "create_table":
+    case "add_column":
+    case "add_foreign_key":
+    case "rename_column":
+      return false;
+  }
+}
+
+// ── Per-change rules ─────────────────────────────────────────
+
+interface IssueDraft {
+  rule: string;
+  severity: MigrationIssueSeverity;
+  reason: string;
+}
+
+function rulesForChange(change: MigrationChange): IssueDraft[] {
+  const drafts: IssueDraft[] = [];
+
+  switch (change.kind) {
+    case "drop_column":
+      drafts.push({
+        rule: "destructive_drop_column",
+        severity: "error",
+        reason:
+          `Dropping column "${change.entity}.${change.field}" is destructive — ` +
+          `existing data will be lost`,
+      });
+      break;
+    case "drop_table":
+      drafts.push({
+        rule: "destructive_drop_table",
+        severity: "error",
+        reason: `Dropping table "${change.entity}" is destructive — all rows will be lost`,
+      });
+      break;
+    case "alter_column_type":
+      if (!isTypeWidening(change.fromType, change.toType)) {
+        drafts.push({
+          rule: "lossy_type_change",
+          severity: "error",
+          reason:
+            `Changing "${change.entity}.${change.field}" from "${change.fromType}" ` +
+            `to "${change.toType}" is lossy and irreversible`,
+        });
+      }
+      break;
+    case "add_column":
+      if (change.definition.required && change.definition.default === undefined) {
+        drafts.push({
+          rule: "add_required_column_without_default",
+          severity: "warning",
+          reason:
+            `Adding required column "${change.entity}.${change.field}" without a default ` +
+            `requires a backfill before NOT NULL can be enforced`,
+        });
+      }
+      break;
+    case "drop_foreign_key":
+      drafts.push({
+        rule: "drop_foreign_key_relaxes_integrity",
+        severity: "warning",
+        reason:
+          `Dropping foreign key on "${change.entity}.${change.foreignKey.field}" ` +
+          `removes referential integrity enforcement`,
+      });
+      break;
+    case "rename_column":
+      drafts.push({
+        rule: "rename_requires_dual_read",
+        severity: "info",
+        reason:
+          `Renaming "${change.entity}.${change.fromField}" → "${change.toField}" — ` +
+          `old code must dual-read during the migrate phase`,
+      });
+      break;
+    case "add_foreign_key":
+    case "create_table":
+      // No safety concerns for purely additive structures.
+      break;
+  }
+
+  return drafts;
+}
+
+// ── Public API ───────────────────────────────────────────────
+
+/**
+ * Validate a migration plan. Returns a structured result — never throws.
+ *
+ * `valid` is true only when no `error` issues are present. `destructive` and
+ * `reversibility` summarise the worst-case across the plan so callers can
+ * gate auto-execution on these fields without inspecting every issue.
+ */
+export function validateMigrationPlan(plan: MigrationPlan): MigrationValidationResult {
+  const issues: MigrationValidationIssue[] = [];
+  let destructive = false;
+
+  for (const change of plan.changes) {
+    const reversibility = reversibilityOf(change);
+    if (isDestructive(change)) {
+      destructive = true;
+    }
+    for (const draft of rulesForChange(change)) {
+      issues.push({
+        rule: draft.rule,
+        severity: draft.severity,
+        change,
+        reason: draft.reason,
+        reversibility,
+      });
+    }
+  }
+
+  const valid = !issues.some((issue) => issue.severity === "error");
+
+  return {
+    valid,
+    destructive,
+    reversibility: worstReversibility(plan.changes),
+    // Spec 62 §5.3: dry-run data-loss simulation should run whenever the
+    // plan touches existing data — i.e. anything destructive or any lossy
+    // narrowing alter. Pure validator only flags the need, not the result.
+    dataLossSimulationRequired: destructive,
+    issues,
+  };
+}


### PR DESCRIPTION
## Summary
- AI proposal-driven schema migration pipeline (Spec 62)
- Pure, runtime-agnostic: detector → planner → validator
- 4 modules + 1 barrel + 29 tests (detector 10, planner 11, validator 8)

## Details
- **Detector** (`proposal-migration-detector.ts`): diffs entity snapshots; handles create/drop table, add/drop/alter/rename column, add/drop FK; rename detection opt-in via `renames` map
- **Planner** (`proposal-migration-planner.ts`): emits expand → migrate → contract phased SQL plus rollback; pure Postgres string generation; rejects unsafe identifiers
- **Validator** (`proposal-migration-validator.ts`): flags destructive ops, tags reversibility (reversible / partial / irreversible), sets `dataLossSimulationRequired`
- **Types** (`proposal-migration-types.ts`): discriminated union of `MigrationChange`, `MigrationPlan` (phases + classification), `MigrationValidationResult`

## Scope deferred (future iterations)
- `add_index` / `drop_index` / `data_transform` change kinds (Spec 62 §3 — out of this slice)
- FK placement in contract phase (currently in expand; needs Proposal-supplied backfill payload)
- Live `dataLossSimulationRequired` execution (requires DB connection — pure validator only flags)

## Test plan
- [x] `bun run check` — clean
- [x] `bun run typecheck` — clean
- [x] `bun test` — 5623 pass / 0 fail

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)