### PR TITLE
feat(core,adapter-server): BYOK per-tenant keys + usage metering (closes #132)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/src/routes/ai-byok.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/ai-byok.ts
@@ -1,0 +1,323 @@
+/**
+ * AI BYOK (Bring Your Own Key) + Usage REST endpoints — Spec 36 M2+.
+ *
+ * Routes (all tenant-scoped via the request actor + tenant resolver):
+ *   - POST   /api/ai/byok/keys              — register / overwrite a key
+ *   - DELETE /api/ai/byok/keys/:provider    — revoke a key
+ *   - GET    /api/ai/byok/keys              — list metadata for tenant
+ *   - GET    /api/ai/byok/usage             — aggregate usage for tenant
+ *
+ * Security:
+ *   - Tenant is resolved from the trusted request context via
+ *     `options.resolveRequestTenantId`. It is NEVER read from the body.
+ *   - Authentication is mandatory — anonymous requests are rejected
+ *     with HTTP 401. BYOK is a per-tenant write surface and dev-mode
+ *     `NO_AUTH_ACTOR` would happily expose every tenant's keys.
+ *   - The store is opaque to the caller: only `encryptedKeyRef` is
+ *     accepted on PUT. Plaintext keys never enter the request body.
+ *   - List responses redact `encryptedKeyRef` so an inadvertent log
+ *     of the response body cannot leak the KMS lookup token.
+ *
+ * Wiring:
+ *   The route reads `options.byokKeyStore` and `options.usageMeter`
+ *   (added to `ServerOptions` as optional dependencies). When either
+ *   is absent the corresponding endpoints return HTTP 503 with a
+ *   structured envelope — same posture as the other AI endpoints.
+ */
+
+import type { Elysia } from "elysia";
+import type { ServerOptions } from "../server";
+import { ANONYMOUS_ACTOR, badRequest, NO_AUTH_ACTOR, serviceUnavailable } from "./shared";
+
+// ── Input validation helpers ────────────────────────────────
+
+// Hard cap on string field lengths so a pathological payload can't
+// blow out memory or the audit log. Generous enough for any real
+// provider id / alias / KMS ref.
+const MAX_FIELD_LENGTH = 256;
+const MAX_KEY_REF_LENGTH = 1024;
+
+function isNonEmptyShortString(value: unknown, max: number): value is string {
+  return typeof value === "string" && value.length > 0 && value.length <= max;
+}
+
+interface PutKeyBody {
+  provider?: unknown;
+  keyAlias?: unknown;
+  encryptedKeyRef?: unknown;
+}
+
+interface ValidatedPutKey {
+  provider: string;
+  keyAlias: string;
+  encryptedKeyRef: string;
+}
+
+interface ValidationOk<T> {
+  ok: true;
+  value: T;
+}
+interface ValidationErr {
+  ok: false;
+  field: string;
+  message: string;
+}
+
+function validatePutKeyBody(
+  body: PutKeyBody | undefined,
+): ValidationOk<ValidatedPutKey> | ValidationErr {
+  if (!body || typeof body !== "object") {
+    return { ok: false, field: "body", message: "request body must be a JSON object" };
+  }
+  if (!isNonEmptyShortString(body.provider, MAX_FIELD_LENGTH)) {
+    return {
+      ok: false,
+      field: "provider",
+      message: `provider must be a non-empty string up to ${MAX_FIELD_LENGTH} chars`,
+    };
+  }
+  if (!isNonEmptyShortString(body.keyAlias, MAX_FIELD_LENGTH)) {
+    return {
+      ok: false,
+      field: "keyAlias",
+      message: `keyAlias must be a non-empty string up to ${MAX_FIELD_LENGTH} chars`,
+    };
+  }
+  if (!isNonEmptyShortString(body.encryptedKeyRef, MAX_KEY_REF_LENGTH)) {
+    return {
+      ok: false,
+      field: "encryptedKeyRef",
+      message: `encryptedKeyRef must be a non-empty string up to ${MAX_KEY_REF_LENGTH} chars`,
+    };
+  }
+  return {
+    ok: true,
+    value: {
+      provider: body.provider,
+      keyAlias: body.keyAlias,
+      encryptedKeyRef: body.encryptedKeyRef,
+    },
+  };
+}
+
+/** Strip the KMS reference before returning a key record to a client. */
+function redactKey(
+  record: import("@linchkit/core/ai").BYOKKeyRecord,
+): Omit<import("@linchkit/core/ai").BYOKKeyRecord, "encryptedKeyRef"> {
+  const { encryptedKeyRef: _ref, ...rest } = record;
+  return rest;
+}
+
+/**
+ * Resolve the trusted tenant for a request. Returns either the
+ * tenant id or a `Response` envelope describing the failure mode so
+ * the route handlers can early-return uniformly.
+ */
+async function resolveTenantContext(
+  request: Request,
+  options: ServerOptions,
+  set: { status?: number | string | undefined },
+): Promise<{ ok: true; tenantId: string } | { ok: false; response: unknown }> {
+  const resolveRequestActor = options.resolveRequestActor;
+  const resolveRequestTenantId = options.resolveRequestTenantId;
+
+  // BYOK is sensitive — reject dev-mode no-auth. Without a real auth
+  // resolver any caller would get the elevated NO_AUTH_ACTOR identity
+  // and be able to enumerate every tenant's keys.
+  if (!resolveRequestActor) {
+    set.status = 503;
+    return {
+      ok: false,
+      response: {
+        success: false,
+        error: {
+          code: "AUTH.REQUIRED",
+          message:
+            "BYOK endpoints require an authenticated request — configure resolveRequestActor",
+        },
+      },
+    };
+  }
+
+  const actor = (await resolveRequestActor(request)) ?? ANONYMOUS_ACTOR;
+  if (actor === ANONYMOUS_ACTOR || actor === NO_AUTH_ACTOR || actor.id === "anonymous") {
+    set.status = 401;
+    return {
+      ok: false,
+      response: {
+        success: false,
+        error: { code: "AUTH.REQUIRED", message: "Authentication required" },
+      },
+    };
+  }
+
+  const tenantId = resolveRequestTenantId
+    ? await resolveRequestTenantId(request, actor)
+    : undefined;
+  if (!tenantId) {
+    set.status = 400;
+    return {
+      ok: false,
+      response: {
+        success: false,
+        error: {
+          code: "TENANT.REQUIRED",
+          message: "BYOK endpoints require a tenant-scoped request",
+        },
+      },
+    };
+  }
+  return { ok: true, tenantId };
+}
+
+export function mountAIByokRoutes(app: Elysia, options: ServerOptions): void {
+  // ── POST /api/ai/byok/keys ────────────────────────────────
+  app.post("/api/ai/byok/keys", async ({ body, request, set }) => {
+    const store = options.byokKeyStore;
+    if (!store) {
+      return serviceUnavailable(set, "BYOK key store not configured");
+    }
+
+    const tenantCtx = await resolveTenantContext(request, options, set);
+    if (!tenantCtx.ok) return tenantCtx.response;
+
+    const validated = validatePutKeyBody(body as PutKeyBody | undefined);
+    if (!validated.ok) {
+      set.status = 400;
+      return {
+        success: false,
+        error: {
+          code: "VALIDATION.FAILED",
+          field: validated.field,
+          message: validated.message,
+        },
+      };
+    }
+
+    try {
+      await store.putKey({
+        tenantId: tenantCtx.tenantId,
+        provider: validated.value.provider,
+        keyAlias: validated.value.keyAlias,
+        encryptedKeyRef: validated.value.encryptedKeyRef,
+      });
+      return { success: true, data: { ok: true } };
+    } catch (err) {
+      set.status = 500;
+      const message =
+        process.env.NODE_ENV === "production"
+          ? "Failed to register BYOK key"
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      return { success: false, error: { code: "BYOK.PUT_FAILED", message } };
+    }
+  });
+
+  // ── DELETE /api/ai/byok/keys/:provider ────────────────────
+  app.delete("/api/ai/byok/keys/:provider", async ({ params, request, set }) => {
+    const store = options.byokKeyStore;
+    if (!store) {
+      return serviceUnavailable(set, "BYOK key store not configured");
+    }
+
+    const provider = params.provider;
+    if (!isNonEmptyShortString(provider, MAX_FIELD_LENGTH)) {
+      return badRequest(set, "provider path parameter must be a non-empty short string");
+    }
+
+    const tenantCtx = await resolveTenantContext(request, options, set);
+    if (!tenantCtx.ok) return tenantCtx.response;
+
+    try {
+      await store.revokeKey({ tenantId: tenantCtx.tenantId, provider });
+      return { success: true, data: { ok: true } };
+    } catch (err) {
+      set.status = 500;
+      const message =
+        process.env.NODE_ENV === "production"
+          ? "Failed to revoke BYOK key"
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      return { success: false, error: { code: "BYOK.REVOKE_FAILED", message } };
+    }
+  });
+
+  // ── GET /api/ai/byok/keys ─────────────────────────────────
+  app.get("/api/ai/byok/keys", async ({ request, set }) => {
+    const store = options.byokKeyStore;
+    if (!store) {
+      return serviceUnavailable(set, "BYOK key store not configured");
+    }
+
+    const tenantCtx = await resolveTenantContext(request, options, set);
+    if (!tenantCtx.ok) return tenantCtx.response;
+
+    try {
+      const records = await store.listKeys({ tenantId: tenantCtx.tenantId });
+      return { success: true, data: { keys: records.map(redactKey) } };
+    } catch (err) {
+      set.status = 500;
+      const message =
+        process.env.NODE_ENV === "production"
+          ? "Failed to list BYOK keys"
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      return { success: false, error: { code: "BYOK.LIST_FAILED", message } };
+    }
+  });
+
+  // ── GET /api/ai/byok/usage?since=ISO&until=ISO ────────────
+  app.get("/api/ai/byok/usage", async ({ request, set }) => {
+    const meter = options.usageMeter;
+    if (!meter) {
+      return serviceUnavailable(set, "Usage meter not configured");
+    }
+
+    const tenantCtx = await resolveTenantContext(request, options, set);
+    if (!tenantCtx.ok) return tenantCtx.response;
+
+    const url = new URL(request.url);
+    const since = url.searchParams.get("since");
+    const until = url.searchParams.get("until");
+    if (!since || !until) {
+      return badRequest(set, "'since' and 'until' query parameters are required (ISO-8601)");
+    }
+    const sinceMs = Date.parse(since);
+    const untilMs = Date.parse(until);
+    if (Number.isNaN(sinceMs) || Number.isNaN(untilMs)) {
+      return badRequest(set, "'since' and 'until' must be valid ISO-8601 timestamps");
+    }
+    if (untilMs < sinceMs) {
+      return badRequest(set, "'until' must be greater than or equal to 'since'");
+    }
+
+    try {
+      const aggregate = await meter.aggregate({
+        tenantId: tenantCtx.tenantId,
+        since,
+        until,
+      });
+      return {
+        success: true,
+        data: {
+          tenantId: tenantCtx.tenantId,
+          since,
+          until,
+          ...aggregate,
+        },
+      };
+    } catch (err) {
+      set.status = 500;
+      const message =
+        process.env.NODE_ENV === "production"
+          ? "Failed to aggregate usage"
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      return { success: false, error: { code: "BYOK.USAGE_FAILED", message } };
+    }
+  });
+}

--- a/addons/adapter-server/cap-adapter-server/src/routes/ai-byok.ts
+++ b/addons/adapter-server/cap-adapter-server/src/routes/ai-byok.ts
@@ -270,7 +270,7 @@ export function mountAIByokRoutes(app: Elysia, options: ServerOptions): void {
   });
 
   // ── GET /api/ai/byok/usage?since=ISO&until=ISO ────────────
-  app.get("/api/ai/byok/usage", async ({ request, set }) => {
+  app.get("/api/ai/byok/usage", async ({ query, request, set }) => {
     const meter = options.usageMeter;
     if (!meter) {
       return serviceUnavailable(set, "Usage meter not configured");
@@ -279,10 +279,12 @@ export function mountAIByokRoutes(app: Elysia, options: ServerOptions): void {
     const tenantCtx = await resolveTenantContext(request, options, set);
     if (!tenantCtx.ok) return tenantCtx.response;
 
-    const url = new URL(request.url);
-    const since = url.searchParams.get("since");
-    const until = url.searchParams.get("until");
-    if (!since || !until) {
+    // Elysia parses the query string for us — read `since` / `until`
+    // off the destructured `query` object instead of re-parsing the
+    // request URL. Values arrive as `string | undefined` (or arrays
+    // when repeated); we accept only the single-string form.
+    const { since, until } = query as { since?: unknown; until?: unknown };
+    if (typeof since !== "string" || typeof until !== "string" || !since || !until) {
       return badRequest(set, "'since' and 'until' query parameters are required (ISO-8601)");
     }
     const sinceMs = Date.parse(since);

--- a/addons/adapter-server/cap-adapter-server/src/server.ts
+++ b/addons/adapter-server/cap-adapter-server/src/server.ts
@@ -49,6 +49,7 @@ import { mountProposalAPI } from "./proposal-api";
 import { mountActionRoutes } from "./routes/action-api";
 import { mountAdminRoutes } from "./routes/admin-api";
 import { mountAIRoutes } from "./routes/ai-api";
+import { mountAIByokRoutes } from "./routes/ai-byok";
 import { mountResolveIntentRoute } from "./routes/ai-resolve-intent";
 import { mountApprovalRoutes } from "./routes/approval-api";
 import { mountConfigRoutes } from "./routes/config-api";
@@ -187,6 +188,19 @@ export interface ServerOptions {
    * Receives the current yoga instance and triggers schema replacement.
    */
   rebuildGraphQLSchema?: () => GraphQLSchema;
+  /**
+   * BYOK key store (Spec 36 M2+) — when provided, enables the
+   * `/api/ai/byok/keys` endpoints for per-tenant AI key management.
+   * The store is opaque to the server: it only persists encrypted
+   * key references (KMS lookup tokens), never plaintext keys.
+   */
+  byokKeyStore?: import("@linchkit/core/ai").BYOKKeyStore;
+  /**
+   * AI usage meter (Spec 36 M2+) — when provided, enables the
+   * `/api/ai/byok/usage` endpoint for per-tenant AI usage aggregation
+   * and acts as the recording sink for completed AI calls.
+   */
+  usageMeter?: import("@linchkit/core/ai").UsageMeter;
 }
 
 // Re-export parseAcceptLanguage for external consumers
@@ -299,6 +313,10 @@ export function createServer(
   mountConfigRoutes(app, opts);
   mountConfigStoreRoutes(app, opts);
   mountAIRoutes(app, opts);
+  // Spec 36 M2+ BYOK + usage endpoints (per-tenant key store + meter).
+  // Mounted alongside the other AI routes; no-ops when the store /
+  // meter are not configured (returns 503 with a structured envelope).
+  mountAIByokRoutes(app, opts);
   // Spec 52 §2.6 canonical intent-resolution endpoint. Mounted AFTER
   // mountAIRoutes so the canonical handler (with permission scoping +
   // audit logging) wins routing for `POST /api/ai/resolve-intent` if any

--- a/packages/core/__tests__/byok-key-store.test.ts
+++ b/packages/core/__tests__/byok-key-store.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from "bun:test";
+import { createInMemoryBYOKKeyStore } from "../src/ai/byok-key-store";
+
+describe("createInMemoryBYOKKeyStore", () => {
+  // ── CRUD basics ─────────────────────────────────────────
+
+  test("putKey registers a new key that getKey can resolve", async () => {
+    const store = createInMemoryBYOKKeyStore();
+    await store.putKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      keyAlias: "prod-anthropic",
+      encryptedKeyRef: "kms:abc",
+    });
+
+    const resolution = await store.getKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+    });
+    expect(resolution.source).toBe("tenant");
+    expect(resolution.decryptedKey).toBe("kms:abc");
+    expect(resolution.provider).toBe("anthropic");
+  });
+
+  test("getKey returns source=missing when no key exists", async () => {
+    const store = createInMemoryBYOKKeyStore();
+    const resolution = await store.getKey({
+      tenantId: "tenant-a",
+      provider: "openai",
+    });
+    expect(resolution.source).toBe("missing");
+    expect(resolution.decryptedKey).toBeNull();
+  });
+
+  test("revokeKey hides the key from getKey but listKeys still shows it", async () => {
+    const store = createInMemoryBYOKKeyStore();
+    await store.putKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      keyAlias: "prod-anthropic",
+      encryptedKeyRef: "kms:abc",
+    });
+    await store.revokeKey({ tenantId: "tenant-a", provider: "anthropic" });
+
+    const resolution = await store.getKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+    });
+    expect(resolution.source).toBe("missing");
+
+    const list = await store.listKeys({ tenantId: "tenant-a" });
+    expect(list).toHaveLength(1);
+    expect(list[0]?.status).toBe("revoked");
+  });
+
+  test("revokeKey on a missing key is a no-op", async () => {
+    const store = createInMemoryBYOKKeyStore();
+    await store.revokeKey({ tenantId: "tenant-a", provider: "anthropic" });
+    const list = await store.listKeys({ tenantId: "tenant-a" });
+    expect(list).toHaveLength(0);
+  });
+
+  test("re-putting the same provider overwrites and revives the record", async () => {
+    const store = createInMemoryBYOKKeyStore();
+    await store.putKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      keyAlias: "v1",
+      encryptedKeyRef: "kms:old",
+    });
+    await store.revokeKey({ tenantId: "tenant-a", provider: "anthropic" });
+    await store.putKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      keyAlias: "v2",
+      encryptedKeyRef: "kms:new",
+    });
+
+    const resolution = await store.getKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+    });
+    expect(resolution.source).toBe("tenant");
+    expect(resolution.decryptedKey).toBe("kms:new");
+
+    const list = await store.listKeys({ tenantId: "tenant-a" });
+    expect(list).toHaveLength(1);
+    expect(list[0]?.keyAlias).toBe("v2");
+    expect(list[0]?.status).toBe("active");
+  });
+
+  // ── Multi-tenant isolation ──────────────────────────────
+
+  test("tenants cannot see each other's keys via getKey", async () => {
+    const store = createInMemoryBYOKKeyStore();
+    await store.putKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      keyAlias: "a-key",
+      encryptedKeyRef: "kms:a",
+    });
+
+    const otherTenant = await store.getKey({
+      tenantId: "tenant-b",
+      provider: "anthropic",
+    });
+    expect(otherTenant.source).toBe("missing");
+  });
+
+  test("listKeys only returns keys for the requested tenant", async () => {
+    const store = createInMemoryBYOKKeyStore();
+    await store.putKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      keyAlias: "a-key",
+      encryptedKeyRef: "kms:a",
+    });
+    await store.putKey({
+      tenantId: "tenant-b",
+      provider: "openai",
+      keyAlias: "b-key",
+      encryptedKeyRef: "kms:b",
+    });
+
+    const listA = await store.listKeys({ tenantId: "tenant-a" });
+    expect(listA.map((k) => k.tenantId)).toEqual(["tenant-a"]);
+    const listB = await store.listKeys({ tenantId: "tenant-b" });
+    expect(listB.map((k) => k.tenantId)).toEqual(["tenant-b"]);
+  });
+
+  // ── Encrypted reference handling ────────────────────────
+
+  test("encryptedKeyRef is treated as opaque (default resolver echoes it back)", async () => {
+    const store = createInMemoryBYOKKeyStore();
+    await store.putKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      keyAlias: "alias",
+      encryptedKeyRef: "ref-token",
+    });
+    const resolved = await store.getKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+    });
+    expect(resolved.decryptedKey).toBe("ref-token");
+  });
+
+  test("custom resolveEncryptedKey hook is invoked for decryption", async () => {
+    const store = createInMemoryBYOKKeyStore({
+      resolveEncryptedKey: (ref) => `decrypted:${ref}`,
+    });
+    await store.putKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      keyAlias: "alias",
+      encryptedKeyRef: "opaque",
+    });
+    const resolved = await store.getKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+    });
+    expect(resolved.decryptedKey).toBe("decrypted:opaque");
+  });
+
+  test("getKey updates lastUsedAt on successful resolve", async () => {
+    const store = createInMemoryBYOKKeyStore();
+    await store.putKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      keyAlias: "alias",
+      encryptedKeyRef: "ref",
+    });
+    const before = await store.listKeys({ tenantId: "tenant-a" });
+    expect(before[0]?.lastUsedAt).toBeUndefined();
+    await store.getKey({ tenantId: "tenant-a", provider: "anthropic" });
+    const after = await store.listKeys({ tenantId: "tenant-a" });
+    expect(after[0]?.lastUsedAt).toBeDefined();
+  });
+
+  // ── Input validation ────────────────────────────────────
+
+  test("putKey rejects empty tenantId / provider / alias / ref", async () => {
+    const store = createInMemoryBYOKKeyStore();
+    await expect(
+      store.putKey({ tenantId: "", provider: "p", keyAlias: "a", encryptedKeyRef: "r" }),
+    ).rejects.toThrow(/tenantId/);
+    await expect(
+      store.putKey({ tenantId: "t", provider: "", keyAlias: "a", encryptedKeyRef: "r" }),
+    ).rejects.toThrow(/provider/);
+    await expect(
+      store.putKey({ tenantId: "t", provider: "p", keyAlias: "", encryptedKeyRef: "r" }),
+    ).rejects.toThrow(/keyAlias/);
+    await expect(
+      store.putKey({ tenantId: "t", provider: "p", keyAlias: "a", encryptedKeyRef: "" }),
+    ).rejects.toThrow(/encryptedKeyRef/);
+  });
+});

--- a/packages/core/__tests__/byok-key-store.test.ts
+++ b/packages/core/__tests__/byok-key-store.test.ts
@@ -194,4 +194,88 @@ describe("createInMemoryBYOKKeyStore", () => {
       store.putKey({ tenantId: "t", provider: "p", keyAlias: "a", encryptedKeyRef: "" }),
     ).rejects.toThrow(/encryptedKeyRef/);
   });
+
+  // ── Clock override determinism ──────────────────────────
+  //
+  // The `now` hook lets tests pin the wall clock so `createdAt` /
+  // `lastUsedAt` are reproducible. These tests prove the hook is
+  // honored on both code paths and that callers can advance time
+  // step-by-step to assert ordering semantics.
+
+  test("putKey uses the injected `now` for createdAt", async () => {
+    const FIXED_MS = Date.UTC(2026, 4, 18, 12, 0, 0); // 2026-05-18T12:00:00Z
+    const FIXED_ISO = new Date(FIXED_MS).toISOString();
+    const store = createInMemoryBYOKKeyStore({ now: () => FIXED_MS });
+
+    await store.putKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      keyAlias: "alias",
+      encryptedKeyRef: "ref",
+    });
+
+    const list = await store.listKeys({ tenantId: "tenant-a" });
+    expect(list).toHaveLength(1);
+    expect(list[0]?.createdAt).toBe(FIXED_ISO);
+    // lastUsedAt is only set on getKey — must remain undefined.
+    expect(list[0]?.lastUsedAt).toBeUndefined();
+  });
+
+  test("getKey uses the injected `now` for lastUsedAt and supports advancing time", async () => {
+    let currentMs = Date.UTC(2026, 4, 18, 12, 0, 0); // 2026-05-18T12:00:00Z
+    const store = createInMemoryBYOKKeyStore({ now: () => currentMs });
+
+    await store.putKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      keyAlias: "alias",
+      encryptedKeyRef: "ref",
+    });
+    const createdAtIso = new Date(currentMs).toISOString();
+
+    // Advance the clock by exactly one hour, then resolve the key.
+    currentMs += 60 * 60 * 1000;
+    const expectedUsedAtIso = new Date(currentMs).toISOString();
+    await store.getKey({ tenantId: "tenant-a", provider: "anthropic" });
+
+    const list = await store.listKeys({ tenantId: "tenant-a" });
+    expect(list[0]?.createdAt).toBe(createdAtIso);
+    expect(list[0]?.lastUsedAt).toBe(expectedUsedAtIso);
+
+    // Advance again and confirm lastUsedAt moves forward — proves the
+    // record reads `now()` on every resolve, not a captured value.
+    currentMs += 30 * 60 * 1000;
+    const secondUsedAtIso = new Date(currentMs).toISOString();
+    await store.getKey({ tenantId: "tenant-a", provider: "anthropic" });
+    const list2 = await store.listKeys({ tenantId: "tenant-a" });
+    expect(list2[0]?.lastUsedAt).toBe(secondUsedAtIso);
+  });
+
+  test("re-putting an existing key preserves the original createdAt under a frozen clock", async () => {
+    let currentMs = Date.UTC(2026, 4, 18, 9, 0, 0);
+    const store = createInMemoryBYOKKeyStore({ now: () => currentMs });
+
+    await store.putKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      keyAlias: "v1",
+      encryptedKeyRef: "kms:old",
+    });
+    const originalCreatedAt = new Date(currentMs).toISOString();
+
+    // Advance the clock and overwrite — createdAt MUST stay pinned to
+    // the original moment, not move forward with `now`.
+    currentMs += 60 * 60 * 1000;
+    await store.putKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      keyAlias: "v2",
+      encryptedKeyRef: "kms:new",
+    });
+
+    const list = await store.listKeys({ tenantId: "tenant-a" });
+    expect(list).toHaveLength(1);
+    expect(list[0]?.createdAt).toBe(originalCreatedAt);
+    expect(list[0]?.keyAlias).toBe("v2");
+  });
 });

--- a/packages/core/__tests__/byok-resolver.test.ts
+++ b/packages/core/__tests__/byok-resolver.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from "bun:test";
+import { createInMemoryBYOKKeyStore } from "../src/ai/byok-key-store";
+import { resolveAIKey } from "../src/ai/byok-resolver";
+
+describe("resolveAIKey", () => {
+  // ── Resolution order ───────────────────────────────────────
+
+  test("tenant key resolves over platform default", async () => {
+    const store = createInMemoryBYOKKeyStore();
+    await store.putKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      keyAlias: "tenant-key",
+      encryptedKeyRef: "kms:tenant",
+    });
+
+    const resolution = await resolveAIKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      byokStore: store,
+      platformDefault: "platform-key",
+    });
+
+    expect(resolution.source).toBe("tenant");
+    expect(resolution.decryptedKey).toBe("kms:tenant");
+    expect(resolution.provider).toBe("anthropic");
+  });
+
+  test("platform default used when no tenant key", async () => {
+    const store = createInMemoryBYOKKeyStore();
+
+    const resolution = await resolveAIKey({
+      tenantId: "tenant-a",
+      provider: "openai",
+      byokStore: store,
+      platformDefault: "sk-platform",
+    });
+
+    expect(resolution.source).toBe("platform");
+    expect(resolution.decryptedKey).toBe("sk-platform");
+    expect(resolution.provider).toBe("openai");
+  });
+
+  test("returns missing when neither tenant nor platform has a key", async () => {
+    const store = createInMemoryBYOKKeyStore();
+
+    const resolution = await resolveAIKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      byokStore: store,
+    });
+
+    expect(resolution.source).toBe("missing");
+    expect(resolution.decryptedKey).toBeNull();
+    expect(resolution.provider).toBe("anthropic");
+  });
+
+  test("revoked tenant key falls through to platform default", async () => {
+    const store = createInMemoryBYOKKeyStore();
+    await store.putKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      keyAlias: "tenant-key",
+      encryptedKeyRef: "kms:tenant",
+    });
+    await store.revokeKey({ tenantId: "tenant-a", provider: "anthropic" });
+
+    const resolution = await resolveAIKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      byokStore: store,
+      platformDefault: "platform-key",
+    });
+
+    expect(resolution.source).toBe("platform");
+    expect(resolution.decryptedKey).toBe("platform-key");
+  });
+
+  // ── Provider isolation ─────────────────────────────────────
+
+  test("multi-provider isolation: openai key does not satisfy anthropic lookup", async () => {
+    const store = createInMemoryBYOKKeyStore();
+    await store.putKey({
+      tenantId: "tenant-a",
+      provider: "openai",
+      keyAlias: "openai-key",
+      encryptedKeyRef: "kms:openai",
+    });
+
+    const openaiResolution = await resolveAIKey({
+      tenantId: "tenant-a",
+      provider: "openai",
+      byokStore: store,
+    });
+    expect(openaiResolution.source).toBe("tenant");
+    expect(openaiResolution.decryptedKey).toBe("kms:openai");
+
+    const anthropicResolution = await resolveAIKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      byokStore: store,
+    });
+    expect(anthropicResolution.source).toBe("missing");
+    expect(anthropicResolution.decryptedKey).toBeNull();
+  });
+
+  // ── Tenant isolation ───────────────────────────────────────
+
+  test("tenant_id isolation: tenant-A key not visible to tenant-B", async () => {
+    const store = createInMemoryBYOKKeyStore();
+    await store.putKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      keyAlias: "a-key",
+      encryptedKeyRef: "kms:a",
+    });
+
+    const resolutionA = await resolveAIKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      byokStore: store,
+    });
+    expect(resolutionA.source).toBe("tenant");
+    expect(resolutionA.decryptedKey).toBe("kms:a");
+
+    const resolutionB = await resolveAIKey({
+      tenantId: "tenant-b",
+      provider: "anthropic",
+      byokStore: store,
+    });
+    expect(resolutionB.source).toBe("missing");
+    expect(resolutionB.decryptedKey).toBeNull();
+  });
+
+  // ── Edge cases ─────────────────────────────────────────────
+
+  test("empty-string platformDefault is treated as missing (does not authenticate as platform)", async () => {
+    const store = createInMemoryBYOKKeyStore();
+
+    const resolution = await resolveAIKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      byokStore: store,
+      platformDefault: "",
+    });
+
+    expect(resolution.source).toBe("missing");
+    expect(resolution.decryptedKey).toBeNull();
+  });
+
+  test("null / undefined platformDefault behave identically", async () => {
+    const store = createInMemoryBYOKKeyStore();
+
+    const nullResolution = await resolveAIKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      byokStore: store,
+      platformDefault: null,
+    });
+    expect(nullResolution.source).toBe("missing");
+    expect(nullResolution.decryptedKey).toBeNull();
+
+    const undefinedResolution = await resolveAIKey({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      byokStore: store,
+    });
+    expect(undefinedResolution.source).toBe("missing");
+    expect(undefinedResolution.decryptedKey).toBeNull();
+  });
+
+  test("rejects empty tenantId and empty provider", async () => {
+    const store = createInMemoryBYOKKeyStore();
+
+    await expect(
+      resolveAIKey({
+        tenantId: "",
+        provider: "anthropic",
+        byokStore: store,
+      }),
+    ).rejects.toThrow(/tenantId/);
+
+    await expect(
+      resolveAIKey({
+        tenantId: "tenant-a",
+        provider: "",
+        byokStore: store,
+      }),
+    ).rejects.toThrow(/provider/);
+  });
+});

--- a/packages/core/__tests__/usage-meter.test.ts
+++ b/packages/core/__tests__/usage-meter.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, test } from "bun:test";
+import { createInMemoryUsageMeter } from "../src/ai/usage-meter";
+
+/**
+ * Anchor "now" to a stable point inside the UTC day 2026-05-18 so the
+ * quota-check window is deterministic across machines / timezones.
+ */
+const FIXED_NOW_MS = Date.UTC(2026, 4, 18, 12, 0, 0); // 2026-05-18T12:00:00Z
+const fixedNow = () => FIXED_NOW_MS;
+
+describe("createInMemoryUsageMeter", () => {
+  // ── record + aggregate ─────────────────────────────────────
+
+  test("record + aggregate sums a single UTC day correctly", async () => {
+    const meter = createInMemoryUsageMeter({ now: fixedNow });
+    await meter.record({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      model: "claude-3-opus",
+      inputTokens: 100,
+      outputTokens: 50,
+      costUsd: 0.25,
+      ts: "2026-05-18T01:00:00Z",
+    });
+    await meter.record({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      model: "claude-3-opus",
+      inputTokens: 200,
+      outputTokens: 75,
+      costUsd: 0.5,
+      ts: "2026-05-18T05:30:00Z",
+    });
+
+    const agg = await meter.aggregate({
+      tenantId: "tenant-a",
+      since: "2026-05-18T00:00:00Z",
+      until: "2026-05-19T00:00:00Z",
+    });
+
+    expect(agg.totalInputTokens).toBe(300);
+    expect(agg.totalOutputTokens).toBe(125);
+    expect(agg.totalCostUsd).toBeCloseTo(0.75, 10);
+  });
+
+  test("aggregate respects UTC day boundary (excludes prior day, includes 00:00 start)", async () => {
+    const meter = createInMemoryUsageMeter({ now: fixedNow });
+    // Just before window
+    await meter.record({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      model: "claude-3-opus",
+      inputTokens: 10,
+      outputTokens: 5,
+      costUsd: 0.01,
+      ts: "2026-05-17T23:59:59.999Z",
+    });
+    // Exactly at start of window — inclusive
+    await meter.record({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      model: "claude-3-opus",
+      inputTokens: 100,
+      outputTokens: 50,
+      costUsd: 0.1,
+      ts: "2026-05-18T00:00:00.000Z",
+    });
+    // Inside window
+    await meter.record({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      model: "claude-3-opus",
+      inputTokens: 200,
+      outputTokens: 100,
+      costUsd: 0.2,
+      ts: "2026-05-18T15:00:00.000Z",
+    });
+    // Exactly at exclusive upper bound — excluded
+    await meter.record({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      model: "claude-3-opus",
+      inputTokens: 1000,
+      outputTokens: 1000,
+      costUsd: 99,
+      ts: "2026-05-19T00:00:00.000Z",
+    });
+
+    const agg = await meter.aggregate({
+      tenantId: "tenant-a",
+      since: "2026-05-18T00:00:00.000Z",
+      until: "2026-05-19T00:00:00.000Z",
+    });
+
+    expect(agg.totalInputTokens).toBe(300);
+    expect(agg.totalOutputTokens).toBe(150);
+    expect(agg.totalCostUsd).toBeCloseTo(0.3, 10);
+  });
+
+  // ── checkQuota: allow ──────────────────────────────────────
+
+  test("checkQuota allows when projected usage stays under both hard limits", async () => {
+    const meter = createInMemoryUsageMeter({ now: fixedNow });
+    await meter.record({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      model: "claude-3-opus",
+      inputTokens: 100,
+      outputTokens: 50,
+      costUsd: 0.1,
+      ts: "2026-05-18T01:00:00Z",
+    });
+
+    const result = await meter.checkQuota({
+      tenantId: "tenant-a",
+      policy: { maxTokensPerDay: 1000, maxCostUsdPerDay: 5 },
+      additionalTokensEstimate: 100,
+      additionalCostEstimate: 0.5,
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.reason).toBe("ok");
+    expect(result.remainingTokens).toBe(850); // 1000 - (100 + 50)
+    expect(result.remainingCostUsd).toBeCloseTo(4.9, 10); // 5 - 0.1
+  });
+
+  // ── checkQuota: deny on tokens ─────────────────────────────
+
+  test("checkQuota denies when projected tokens exceed maxTokensPerDay", async () => {
+    const meter = createInMemoryUsageMeter({ now: fixedNow });
+    await meter.record({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      model: "claude-3-opus",
+      inputTokens: 500,
+      outputTokens: 400,
+      costUsd: 0.5,
+      ts: "2026-05-18T01:00:00Z",
+    });
+
+    const result = await meter.checkQuota({
+      tenantId: "tenant-a",
+      policy: { maxTokensPerDay: 1000, maxCostUsdPerDay: 100 },
+      additionalTokensEstimate: 200, // 900 + 200 = 1100 > 1000
+      additionalCostEstimate: 0.1,
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe("token_limit");
+    expect(result.remainingTokens).toBe(100); // 1000 - 900
+  });
+
+  // ── checkQuota: deny on cost ───────────────────────────────
+
+  test("checkQuota denies when projected cost exceeds maxCostUsdPerDay", async () => {
+    const meter = createInMemoryUsageMeter({ now: fixedNow });
+    await meter.record({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      model: "claude-3-opus",
+      inputTokens: 100,
+      outputTokens: 50,
+      costUsd: 4.5,
+      ts: "2026-05-18T01:00:00Z",
+    });
+
+    const result = await meter.checkQuota({
+      tenantId: "tenant-a",
+      policy: { maxTokensPerDay: 100_000, maxCostUsdPerDay: 5 },
+      additionalTokensEstimate: 100,
+      additionalCostEstimate: 1, // 4.5 + 1 = 5.5 > 5
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toBe("cost_limit");
+    expect(result.remainingCostUsd).toBeCloseTo(0.5, 10);
+  });
+
+  // ── checkQuota: soft warning ───────────────────────────────
+
+  test("checkQuota raises soft_warning when projection crosses threshold but stays under hard limit", async () => {
+    const meter = createInMemoryUsageMeter({ now: fixedNow });
+    await meter.record({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      model: "claude-3-opus",
+      inputTokens: 400,
+      outputTokens: 300,
+      costUsd: 0.1,
+      ts: "2026-05-18T01:00:00Z",
+    });
+
+    const result = await meter.checkQuota({
+      tenantId: "tenant-a",
+      policy: {
+        maxTokensPerDay: 1000,
+        maxCostUsdPerDay: 100,
+        softWarnThreshold: 0.8,
+      },
+      additionalTokensEstimate: 200, // 700 + 200 = 900 >= 80% of 1000
+      additionalCostEstimate: 0.1,
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.reason).toBe("soft_warning");
+    expect(result.remainingTokens).toBe(300); // 1000 - 700
+  });
+
+  // ── Tenant isolation ───────────────────────────────────────
+
+  test("aggregate isolates per tenant (tenant-A records do not leak into tenant-B sum)", async () => {
+    const meter = createInMemoryUsageMeter({ now: fixedNow });
+    await meter.record({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      model: "claude-3-opus",
+      inputTokens: 100,
+      outputTokens: 50,
+      costUsd: 0.25,
+      ts: "2026-05-18T01:00:00Z",
+    });
+    await meter.record({
+      tenantId: "tenant-b",
+      provider: "openai",
+      model: "gpt-4",
+      inputTokens: 999,
+      outputTokens: 999,
+      costUsd: 9.99,
+      ts: "2026-05-18T02:00:00Z",
+    });
+
+    const aggA = await meter.aggregate({
+      tenantId: "tenant-a",
+      since: "2026-05-18T00:00:00Z",
+      until: "2026-05-19T00:00:00Z",
+    });
+    expect(aggA.totalInputTokens).toBe(100);
+    expect(aggA.totalOutputTokens).toBe(50);
+    expect(aggA.totalCostUsd).toBeCloseTo(0.25, 10);
+
+    const aggB = await meter.aggregate({
+      tenantId: "tenant-b",
+      since: "2026-05-18T00:00:00Z",
+      until: "2026-05-19T00:00:00Z",
+    });
+    expect(aggB.totalInputTokens).toBe(999);
+    expect(aggB.totalOutputTokens).toBe(999);
+    expect(aggB.totalCostUsd).toBeCloseTo(9.99, 10);
+  });
+
+  // ── Empty result ───────────────────────────────────────────
+
+  test("aggregate returns zeroed totals when no records fall in the window", async () => {
+    const meter = createInMemoryUsageMeter({ now: fixedNow });
+    // Record exists, but on a different day.
+    await meter.record({
+      tenantId: "tenant-a",
+      provider: "anthropic",
+      model: "claude-3-opus",
+      inputTokens: 100,
+      outputTokens: 50,
+      costUsd: 0.5,
+      ts: "2026-05-10T01:00:00Z",
+    });
+
+    const agg = await meter.aggregate({
+      tenantId: "tenant-a",
+      since: "2026-05-18T00:00:00Z",
+      until: "2026-05-19T00:00:00Z",
+    });
+
+    expect(agg.totalInputTokens).toBe(0);
+    expect(agg.totalOutputTokens).toBe(0);
+    expect(agg.totalCostUsd).toBe(0);
+  });
+
+  // ── Empty store ────────────────────────────────────────────
+
+  test("aggregate on tenant with no recorded usage returns all zeros", async () => {
+    const meter = createInMemoryUsageMeter({ now: fixedNow });
+
+    const agg = await meter.aggregate({
+      tenantId: "tenant-empty",
+      since: "2026-05-18T00:00:00Z",
+      until: "2026-05-19T00:00:00Z",
+    });
+
+    expect(agg).toEqual({
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalCostUsd: 0,
+    });
+  });
+});

--- a/packages/core/__tests__/usage-meter.test.ts
+++ b/packages/core/__tests__/usage-meter.test.ts
@@ -291,4 +291,100 @@ describe("createInMemoryUsageMeter", () => {
       totalCostUsd: 0,
     });
   });
+
+  // ── Cached tsEpochMs correctness across day boundaries ─────
+  //
+  // Regression guard for the internal "parse `ts` once at record()
+  // and reuse" optimization. If the cached epoch ever drifted from
+  // the stored ISO string, day-boundary semantics would silently
+  // misclassify entries straddling 00:00Z. We feed equivalent
+  // timestamps written in different ISO forms (Z suffix, +00:00,
+  // fractional seconds, off-zone with explicit offset) and confirm
+  // the aggregation still bins them by the actual UTC instant.
+
+  test("cached tsEpochMs respects UTC day boundary across equivalent ISO formats", async () => {
+    const meter = createInMemoryUsageMeter({ now: fixedNow });
+
+    // All four timestamps point at the exact same UTC instant —
+    // 2026-05-18T00:00:00.000Z — expressed via different ISO forms.
+    // They MUST all land inside the [2026-05-18, 2026-05-19) window.
+    const equivalents = [
+      "2026-05-18T00:00:00Z",
+      "2026-05-18T00:00:00.000Z",
+      "2026-05-18T00:00:00.000+00:00",
+      "2026-05-18T08:00:00.000+08:00", // 00:00Z expressed as +08:00 wall time
+    ];
+    for (const ts of equivalents) {
+      await meter.record({
+        tenantId: "tenant-bounds",
+        provider: "anthropic",
+        model: "claude-3-opus",
+        inputTokens: 10,
+        outputTokens: 0,
+        costUsd: 0,
+        ts,
+      });
+    }
+
+    // One entry one ms before midnight — must be excluded.
+    await meter.record({
+      tenantId: "tenant-bounds",
+      provider: "anthropic",
+      model: "claude-3-opus",
+      inputTokens: 999,
+      outputTokens: 999,
+      costUsd: 9.99,
+      ts: "2026-05-17T23:59:59.999Z",
+    });
+    // One entry one ms past the upper bound — must be excluded.
+    await meter.record({
+      tenantId: "tenant-bounds",
+      provider: "anthropic",
+      model: "claude-3-opus",
+      inputTokens: 999,
+      outputTokens: 999,
+      costUsd: 9.99,
+      ts: "2026-05-19T00:00:00.001Z",
+    });
+
+    const agg = await meter.aggregate({
+      tenantId: "tenant-bounds",
+      since: "2026-05-18T00:00:00.000Z",
+      until: "2026-05-19T00:00:00.000Z",
+    });
+
+    // 4 in-window entries × 10 input tokens each = 40. The two
+    // out-of-window entries (10 input tokens before midnight + 10
+    // after 24h) must NOT contribute.
+    expect(agg.totalInputTokens).toBe(40);
+    expect(agg.totalOutputTokens).toBe(0);
+    expect(agg.totalCostUsd).toBeCloseTo(0, 10);
+  });
+
+  test("cached tsEpochMs survives repeated aggregations without re-parse drift", async () => {
+    const meter = createInMemoryUsageMeter({ now: fixedNow });
+    await meter.record({
+      tenantId: "tenant-c",
+      provider: "anthropic",
+      model: "claude-3-opus",
+      inputTokens: 100,
+      outputTokens: 50,
+      costUsd: 0.25,
+      ts: "2026-05-18T00:00:00.000Z",
+    });
+
+    // Same window scanned multiple times — must produce identical
+    // results. Guards against any future bug where the cached epoch
+    // gets overwritten or mutated between calls.
+    for (let i = 0; i < 3; i++) {
+      const agg = await meter.aggregate({
+        tenantId: "tenant-c",
+        since: "2026-05-18T00:00:00.000Z",
+        until: "2026-05-19T00:00:00.000Z",
+      });
+      expect(agg.totalInputTokens).toBe(100);
+      expect(agg.totalOutputTokens).toBe(50);
+      expect(agg.totalCostUsd).toBeCloseTo(0.25, 10);
+    }
+  });
 });

--- a/packages/core/src/ai/byok-key-store.ts
+++ b/packages/core/src/ai/byok-key-store.ts
@@ -105,6 +105,13 @@ export interface InMemoryBYOKKeyStoreOptions {
    * it can dispatch to a KMS without leaking secrets through logs.
    */
   resolveEncryptedKey?: (encryptedKeyRef: string) => Promise<string> | string;
+
+  /**
+   * Override the wall clock used to stamp `createdAt` / `lastUsedAt`.
+   * Useful for deterministic tests; mirrors the same hook on
+   * {@link InMemoryUsageMeterOptions}. Defaults to `() => Date.now()`.
+   */
+  now?: () => number;
 }
 
 export function createInMemoryBYOKKeyStore(options?: InMemoryBYOKKeyStoreOptions): BYOKKeyStore {
@@ -112,9 +119,14 @@ export function createInMemoryBYOKKeyStore(options?: InMemoryBYOKKeyStoreOptions
   // when tenant/provider ids contain ":" or "/" characters.
   const records: Map<string, BYOKKeyRecord> = new Map();
   const resolveEncryptedKey = options?.resolveEncryptedKey ?? ((ref: string) => ref);
+  const now = options?.now ?? (() => Date.now());
 
   function buildKey(tenantId: string, provider: string): string {
     return `${tenantId}\0${provider}`;
+  }
+
+  function nowIso(): string {
+    return new Date(now()).toISOString();
   }
 
   return {
@@ -130,7 +142,7 @@ export function createInMemoryBYOKKeyStore(options?: InMemoryBYOKKeyStoreOptions
       // Update lastUsedAt on successful resolve — this is the closest
       // moment we know the key was actually used. Mutating the record
       // is safe because the Map holds the same reference.
-      record.lastUsedAt = new Date().toISOString();
+      record.lastUsedAt = nowIso();
       return { provider, decryptedKey, source: "tenant" };
     },
 
@@ -142,7 +154,7 @@ export function createInMemoryBYOKKeyStore(options?: InMemoryBYOKKeyStoreOptions
 
       const key = buildKey(tenantId, provider);
       const existing = records.get(key);
-      const createdAt = existing?.createdAt ?? new Date().toISOString();
+      const createdAt = existing?.createdAt ?? nowIso();
       records.set(key, {
         tenantId,
         provider,

--- a/packages/core/src/ai/byok-key-store.ts
+++ b/packages/core/src/ai/byok-key-store.ts
@@ -1,0 +1,191 @@
+/**
+ * BYOK Key Store
+ *
+ * Pluggable storage interface for per-tenant AI API keys. Plaintext
+ * keys are never stored or returned — callers persist only the opaque
+ * `encryptedKeyRef` produced by their KMS / secret manager.
+ *
+ * The in-memory implementation is intended for tests and dev. Real
+ * deployments wire a Drizzle-backed implementation in the adapter
+ * layer (out of scope for this module — Spec 36 M2+).
+ */
+
+import type { BYOKKeyRecord, BYOKKeyResolution } from "./byok-types";
+
+// ── Interface ───────────────────────────────────────────────
+
+/** Parameters for {@link BYOKKeyStore.getKey}. */
+export interface GetKeyParams {
+  tenantId: string;
+  provider: string;
+}
+
+/** Parameters for {@link BYOKKeyStore.putKey}. */
+export interface PutKeyParams {
+  tenantId: string;
+  provider: string;
+  keyAlias: string;
+  encryptedKeyRef: string;
+}
+
+/** Parameters for {@link BYOKKeyStore.revokeKey}. */
+export interface RevokeKeyParams {
+  tenantId: string;
+  provider: string;
+}
+
+/** Parameters for {@link BYOKKeyStore.listKeys}. */
+export interface ListKeysParams {
+  tenantId: string;
+}
+
+/**
+ * Storage contract for per-tenant BYOK keys.
+ *
+ * Implementations are responsible for tenant isolation — callers
+ * always supply `tenantId` and the store must never leak records
+ * across tenants. The interface returns a {@link BYOKKeyResolution}
+ * rather than the raw record so the resolver layer can swap in a
+ * platform-default key when the tenant has none.
+ */
+export interface BYOKKeyStore {
+  /**
+   * Look up the active key for `(tenantId, provider)`.
+   *
+   * Returns `source: "tenant"` with a non-null `decryptedKey` when an
+   * active key exists, otherwise `source: "missing"` with a `null`
+   * key. The resolver — not the store — is responsible for falling
+   * back to a platform default; the store reports only what it owns.
+   */
+  getKey(params: GetKeyParams): Promise<BYOKKeyResolution>;
+
+  /**
+   * Register or overwrite a key for `(tenantId, provider)`. Re-using
+   * the same provider replaces the prior record (and revives a
+   * previously revoked entry). `encryptedKeyRef` is opaque to the
+   * store — the KMS / secret manager owns the plaintext mapping.
+   */
+  putKey(params: PutKeyParams): Promise<void>;
+
+  /**
+   * Mark the active key for `(tenantId, provider)` as revoked.
+   * Idempotent: revoking a missing or already-revoked key is a no-op.
+   * Revoked records are retained so the listing surface (and audit)
+   * can show their history.
+   */
+  revokeKey(params: RevokeKeyParams): Promise<void>;
+
+  /**
+   * Enumerate all keys (active and revoked) for one tenant.
+   * Plaintext keys are NEVER returned — only metadata records.
+   */
+  listKeys(params: ListKeysParams): Promise<BYOKKeyRecord[]>;
+}
+
+// ── In-Memory Implementation ────────────────────────────────
+
+/**
+ * In-memory implementation of {@link BYOKKeyStore}.
+ *
+ * Backed by a Map keyed by `tenantId\0provider` so tenants share no
+ * state. Suitable for tests, demos, and dev runs — production code
+ * should plug in a persistent store via the same interface.
+ *
+ * The "decryption" here is a placeholder: it simply echoes the
+ * `encryptedKeyRef` back as the decrypted value. Real implementations
+ * must replace this with a KMS dereference. The factory accepts an
+ * optional `resolveEncryptedKey` callback so deployments can inject
+ * the real decryption pathway without rewriting the store.
+ */
+export interface InMemoryBYOKKeyStoreOptions {
+  /**
+   * Hook that turns an opaque `encryptedKeyRef` into the plaintext
+   * key the AI provider expects. Defaults to identity for tests.
+   * The hook receives only the reference — never the plaintext — so
+   * it can dispatch to a KMS without leaking secrets through logs.
+   */
+  resolveEncryptedKey?: (encryptedKeyRef: string) => Promise<string> | string;
+}
+
+export function createInMemoryBYOKKeyStore(options?: InMemoryBYOKKeyStoreOptions): BYOKKeyStore {
+  // Key shape: `${tenantId}\0${provider}`. Using NUL avoids ambiguity
+  // when tenant/provider ids contain ":" or "/" characters.
+  const records: Map<string, BYOKKeyRecord> = new Map();
+  const resolveEncryptedKey = options?.resolveEncryptedKey ?? ((ref: string) => ref);
+
+  function buildKey(tenantId: string, provider: string): string {
+    return `${tenantId}\0${provider}`;
+  }
+
+  return {
+    async getKey({ tenantId, provider }) {
+      assertNonEmpty(tenantId, "tenantId");
+      assertNonEmpty(provider, "provider");
+
+      const record = records.get(buildKey(tenantId, provider));
+      if (!record || record.status !== "active") {
+        return { provider, decryptedKey: null, source: "missing" };
+      }
+      const decryptedKey = await resolveEncryptedKey(record.encryptedKeyRef);
+      // Update lastUsedAt on successful resolve — this is the closest
+      // moment we know the key was actually used. Mutating the record
+      // is safe because the Map holds the same reference.
+      record.lastUsedAt = new Date().toISOString();
+      return { provider, decryptedKey, source: "tenant" };
+    },
+
+    async putKey({ tenantId, provider, keyAlias, encryptedKeyRef }) {
+      assertNonEmpty(tenantId, "tenantId");
+      assertNonEmpty(provider, "provider");
+      assertNonEmpty(keyAlias, "keyAlias");
+      assertNonEmpty(encryptedKeyRef, "encryptedKeyRef");
+
+      const key = buildKey(tenantId, provider);
+      const existing = records.get(key);
+      const createdAt = existing?.createdAt ?? new Date().toISOString();
+      records.set(key, {
+        tenantId,
+        provider,
+        keyAlias,
+        encryptedKeyRef,
+        status: "active",
+        createdAt,
+      });
+    },
+
+    async revokeKey({ tenantId, provider }) {
+      assertNonEmpty(tenantId, "tenantId");
+      assertNonEmpty(provider, "provider");
+
+      const key = buildKey(tenantId, provider);
+      const existing = records.get(key);
+      if (!existing) return;
+      records.set(key, { ...existing, status: "revoked" });
+    },
+
+    async listKeys({ tenantId }) {
+      assertNonEmpty(tenantId, "tenantId");
+      const out: BYOKKeyRecord[] = [];
+      for (const record of records.values()) {
+        if (record.tenantId === tenantId) out.push({ ...record });
+      }
+      // Stable order: newest first by createdAt. Falls back to alias
+      // on tie so the listing is deterministic in tests.
+      out.sort((a, b) => {
+        if (a.createdAt !== b.createdAt) {
+          return a.createdAt < b.createdAt ? 1 : -1;
+        }
+        return a.keyAlias.localeCompare(b.keyAlias);
+      });
+      return out;
+    },
+  };
+}
+
+// ── Internal helpers ────────────────────────────────────────
+
+function assertNonEmpty(value: string, name: string): void {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`BYOKKeyStore: ${name} must be a non-empty string`);
+  }
+}

--- a/packages/core/src/ai/byok-resolver.ts
+++ b/packages/core/src/ai/byok-resolver.ts
@@ -1,0 +1,73 @@
+/**
+ * BYOK Key Resolver
+ *
+ * Pure function that determines which AI API key to use for a given
+ * `(tenantId, provider)` request. Resolution order:
+ *
+ *   1. Tenant override — `byokStore.getKey()` returns an active key
+ *   2. Platform default — caller-supplied fallback for the provider
+ *   3. Missing — no key available; caller must fail closed
+ *
+ * Kept separate from {@link BYOKKeyStore} so the store stays a
+ * single-tenant lookup and the resolver owns the cross-layer policy.
+ */
+
+import type { BYOKKeyStore } from "./byok-key-store";
+import type { BYOKKeyResolution } from "./byok-types";
+
+/** Parameters for {@link resolveAIKey}. */
+export interface ResolveAIKeyParams {
+  /** Owning tenant. Required — there is no anonymous BYOK lookup. */
+  tenantId: string;
+
+  /** AI provider id (e.g. "anthropic"). */
+  provider: string;
+
+  /** Store to consult for tenant-level overrides. */
+  byokStore: BYOKKeyStore;
+
+  /**
+   * Platform-provided fallback key for this provider. Pass the
+   * decrypted plaintext (or KMS-dereferenced value) — the resolver
+   * does NOT decrypt it. Omit / pass `null` if the platform has no
+   * default for this provider.
+   */
+  platformDefault?: string | null;
+}
+
+/**
+ * Resolve an AI key. Returns a {@link BYOKKeyResolution} whose
+ * `source` field indicates which layer satisfied the lookup. When
+ * neither tenant nor platform has a key, returns `source: "missing"`
+ * with `decryptedKey === null`.
+ */
+export async function resolveAIKey(params: ResolveAIKeyParams): Promise<BYOKKeyResolution> {
+  const { tenantId, provider, byokStore, platformDefault } = params;
+
+  if (typeof tenantId !== "string" || tenantId.length === 0) {
+    throw new Error("resolveAIKey: tenantId must be a non-empty string");
+  }
+  if (typeof provider !== "string" || provider.length === 0) {
+    throw new Error("resolveAIKey: provider must be a non-empty string");
+  }
+
+  // 1. Tenant override — store reports "tenant" or "missing".
+  const tenantResolution = await byokStore.getKey({ tenantId, provider });
+  if (tenantResolution.source === "tenant" && tenantResolution.decryptedKey) {
+    return tenantResolution;
+  }
+
+  // 2. Platform default. Treat empty string the same as null so a
+  //    misconfigured env var doesn't silently authenticate as the
+  //    platform identity with no credential.
+  if (platformDefault && platformDefault.length > 0) {
+    return {
+      provider,
+      decryptedKey: platformDefault,
+      source: "platform",
+    };
+  }
+
+  // 3. Missing — explicit signal so the caller fails closed.
+  return { provider, decryptedKey: null, source: "missing" };
+}

--- a/packages/core/src/ai/byok-types.ts
+++ b/packages/core/src/ai/byok-types.ts
@@ -1,0 +1,152 @@
+/**
+ * BYOK (Bring Your Own Key) and AI Usage Control — Types
+ *
+ * Pure, runtime-agnostic types for per-tenant AI key management and
+ * usage metering (Spec 36 M2+). Plaintext keys are NEVER stored in
+ * memory or on disk — callers store an opaque `encryptedKeyRef` that
+ * points at a KMS-managed secret.
+ *
+ * Field naming follows the existing TypeScript convention in this
+ * package (camelCase). The underlying persisted entity (when promoted
+ * to a Drizzle table) is expected to use snake_case columns
+ * (`tenant_id`, `key_alias`, etc.) — those mappings live in the
+ * adapter, not here.
+ */
+
+/**
+ * A single BYOK key descriptor for one (tenant, provider) pair.
+ *
+ * Only `encryptedKeyRef` is persisted — the plaintext key never lives
+ * in this object. `lastUsedAt` is optional so freshly-issued keys can
+ * be represented before they're exercised.
+ */
+export interface BYOKKeyRecord {
+  /** Owning tenant. Required: BYOK is per-tenant by definition. */
+  tenantId: string;
+
+  /** AI provider id (e.g. "anthropic", "openai", "google"). */
+  provider: string;
+
+  /** Human-readable alias used in UI / audit (e.g. "prod-anthropic"). */
+  keyAlias: string;
+
+  /**
+   * Opaque reference to the encrypted key in a KMS / secret manager.
+   * Treat as a string identifier — this module never dereferences it.
+   */
+  encryptedKeyRef: string;
+
+  /** Lifecycle status. Revoked keys are kept for audit, not used. */
+  status: "active" | "revoked";
+
+  /** ISO-8601 timestamp when this key was registered. */
+  createdAt: string;
+
+  /** ISO-8601 timestamp of the most recent successful use, if any. */
+  lastUsedAt?: string;
+}
+
+/**
+ * Outcome of resolving an AI key for one (tenant, provider) request.
+ *
+ * `source` records the resolution path so callers can attribute cost
+ * and surface it in audit logs:
+ *   - `tenant`   — tenant has registered a BYOK key (overrides platform)
+ *   - `platform` — fell back to the platform-provided default key
+ *   - `missing`  — no key found at any layer; caller must fail closed
+ *
+ * `decryptedKey` is `null` whenever `source === "missing"`. When set,
+ * the string is the plaintext key (or KMS-decrypted payload) the
+ * caller should pass to the AI provider SDK. Callers MUST NOT log it.
+ */
+export interface BYOKKeyResolution {
+  /** AI provider id that was resolved. */
+  provider: string;
+
+  /** Plaintext (or freshly decrypted) key — `null` when missing. */
+  decryptedKey: string | null;
+
+  /** Which layer satisfied the lookup. */
+  source: "tenant" | "platform" | "missing";
+}
+
+/**
+ * Per-tenant quota policy enforced by {@link UsageMeter.checkQuota}.
+ *
+ * All limits are per UTC calendar day. `softWarnThreshold` is a
+ * fraction in (0, 1) at which a caller should surface a warning
+ * before the hard limit is reached — quotas are still allowed past
+ * the soft threshold.
+ */
+export interface UsageQuotaPolicy {
+  /** Maximum total tokens (input + output) per UTC day. */
+  maxTokensPerDay: number;
+
+  /** Maximum estimated cost (USD) per UTC day. */
+  maxCostUsdPerDay: number;
+
+  /**
+   * Soft warning threshold expressed as a fraction of the daily limit
+   * (e.g. `0.8` warns at 80% consumption). Optional; when omitted no
+   * warning state is computed.
+   */
+  softWarnThreshold?: number;
+}
+
+/**
+ * A single metered usage record. One entry per completed AI call.
+ *
+ * `ts` is the wall-clock timestamp of the call as an ISO-8601 string.
+ * The meter buckets by UTC calendar day (00:00:00Z → 23:59:59.999Z).
+ */
+export interface UsageMeterEntry {
+  /** Tenant that made the call. */
+  tenantId: string;
+
+  /** AI provider id (e.g. "anthropic"). */
+  provider: string;
+
+  /** Concrete model identifier returned by the provider. */
+  model: string;
+
+  /** Tokens consumed by the prompt. */
+  inputTokens: number;
+
+  /** Tokens emitted by the response. */
+  outputTokens: number;
+
+  /** Estimated cost of the call in USD. */
+  costUsd: number;
+
+  /** Wall-clock timestamp of the call (ISO-8601). */
+  ts: string;
+}
+
+/**
+ * Result of a pre-call quota check. `allowed` is the only mandatory
+ * field downstream code needs; the rest are for UX / observability.
+ *
+ * `remainingTokens` and `remainingCostUsd` can be negative when the
+ * projected total already exceeds the policy — callers should treat
+ * negative values as zero for display purposes but trust `allowed`
+ * for enforcement.
+ */
+export interface QuotaCheckResult {
+  /** True when the projected call fits inside the policy. */
+  allowed: boolean;
+
+  /**
+   * Machine-readable reason when blocked or warned. One of:
+   *   - "ok"            — within all limits
+   *   - "soft_warning"  — past `softWarnThreshold`, still allowed
+   *   - "token_limit"   — would exceed `maxTokensPerDay`
+   *   - "cost_limit"    — would exceed `maxCostUsdPerDay`
+   */
+  reason: "ok" | "soft_warning" | "token_limit" | "cost_limit";
+
+  /** Tokens left in today's budget BEFORE this call. */
+  remainingTokens: number;
+
+  /** USD left in today's budget BEFORE this call. */
+  remainingCostUsd: number;
+}

--- a/packages/core/src/ai/index.ts
+++ b/packages/core/src/ai/index.ts
@@ -33,6 +33,27 @@ export type {
 } from "./ai-rate-limiter";
 export { AIRateLimiter } from "./ai-rate-limiter";
 export { createNoopAIService } from "./ai-service";
+// BYOK Key Store (Spec 36 M2+)
+export type {
+  BYOKKeyStore,
+  GetKeyParams,
+  InMemoryBYOKKeyStoreOptions,
+  ListKeysParams,
+  PutKeyParams,
+  RevokeKeyParams,
+} from "./byok-key-store";
+export { createInMemoryBYOKKeyStore } from "./byok-key-store";
+// BYOK Resolver (Spec 36 M2+)
+export type { ResolveAIKeyParams } from "./byok-resolver";
+export { resolveAIKey } from "./byok-resolver";
+// BYOK / Usage Control Types (Spec 36 M2+)
+export type {
+  BYOKKeyRecord,
+  BYOKKeyResolution,
+  QuotaCheckResult,
+  UsageMeterEntry,
+  UsageQuotaPolicy,
+} from "./byok-types";
 // Anomaly Detector — moved to @linchkit/cap-ai-provider (Spec 56 Phase 2 Step 2c).
 // Context Masker
 export type {
@@ -196,3 +217,12 @@ export type {
   RecordInsight,
 } from "./record-analyzer";
 export { analyzeRecord, buildAnalysisPrompt, parseAnalysisResponse } from "./record-analyzer";
+// Usage Meter (Spec 36 M2+)
+export type {
+  AggregateUsageParams,
+  CheckQuotaParams,
+  InMemoryUsageMeterOptions,
+  UsageAggregate,
+  UsageMeter,
+} from "./usage-meter";
+export { createInMemoryUsageMeter } from "./usage-meter";

--- a/packages/core/src/ai/usage-meter.ts
+++ b/packages/core/src/ai/usage-meter.ts
@@ -77,14 +77,27 @@ export interface InMemoryUsageMeterOptions {
   now?: () => number;
 }
 
+/**
+ * Internal storage shape — augments {@link UsageMeterEntry} with the
+ * pre-parsed epoch milliseconds for `ts`. Caching the parse at `record()`
+ * time turns `aggregate()` / `checkQuota()` into a single numeric compare
+ * per entry instead of an O(n) string-parse cost on every window scan.
+ *
+ * Not exported: the public surface (`UsageMeterEntry`) intentionally
+ * stays string-only so callers don't have to keep two clocks in sync.
+ */
+interface StoredUsageMeterEntry extends UsageMeterEntry {
+  tsEpochMs: number;
+}
+
 export function createInMemoryUsageMeter(options?: InMemoryUsageMeterOptions): UsageMeter {
   // Per-tenant chronological log. We keep the full history (callers
   // can prune via a wrapper if needed) so aggregation over arbitrary
   // windows stays exact.
-  const entriesByTenant: Map<string, UsageMeterEntry[]> = new Map();
+  const entriesByTenant: Map<string, StoredUsageMeterEntry[]> = new Map();
   const now = options?.now ?? (() => Date.now());
 
-  function getEntries(tenantId: string): UsageMeterEntry[] {
+  function getEntries(tenantId: string): StoredUsageMeterEntry[] {
     let list = entriesByTenant.get(tenantId);
     if (!list) {
       list = [];
@@ -96,8 +109,12 @@ export function createInMemoryUsageMeter(options?: InMemoryUsageMeterOptions): U
   return {
     async record(entry) {
       validateEntry(entry);
+      // Parse `ts` exactly once — store the epoch alongside the entry
+      // so aggregation never re-parses. `validateEntry` already proved
+      // the timestamp is valid; this call cannot throw.
+      const tsEpochMs = parseIso(entry.ts, "entry.ts");
       const list = getEntries(entry.tenantId);
-      list.push({ ...entry });
+      list.push({ ...entry, tsEpochMs });
     },
 
     async aggregate({ tenantId, since, until }) {
@@ -112,7 +129,9 @@ export function createInMemoryUsageMeter(options?: InMemoryUsageMeterOptions): U
       let totalOutputTokens = 0;
       let totalCostUsd = 0;
       for (const entry of list) {
-        const ts = parseIso(entry.ts, "entry.ts");
+        // Use the cached epoch — populated once in `record()` — to skip
+        // a per-entry Date.parse on every aggregation pass.
+        const ts = entry.tsEpochMs;
         if (ts >= sinceMs && ts < untilMs) {
           totalInputTokens += entry.inputTokens;
           totalOutputTokens += entry.outputTokens;

--- a/packages/core/src/ai/usage-meter.ts
+++ b/packages/core/src/ai/usage-meter.ts
@@ -1,0 +1,258 @@
+/**
+ * AI Usage Meter
+ *
+ * Pluggable storage for per-call AI usage records, plus a quota
+ * checker that aggregates today's consumption against a
+ * {@link UsageQuotaPolicy}.
+ *
+ * Calendar-day windows are computed in UTC so quotas reset
+ * deterministically regardless of caller timezone — the same call at
+ * 23:59:59Z and 00:00:00Z lands in different buckets.
+ */
+
+import type { QuotaCheckResult, UsageMeterEntry, UsageQuotaPolicy } from "./byok-types";
+
+// ── Interface ───────────────────────────────────────────────
+
+/** Parameters for {@link UsageMeter.aggregate}. */
+export interface AggregateUsageParams {
+  tenantId: string;
+  /** Inclusive lower bound (ISO-8601). */
+  since: string;
+  /** Exclusive upper bound (ISO-8601). */
+  until: string;
+}
+
+/** Aggregate of usage records over a time window. */
+export interface UsageAggregate {
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCostUsd: number;
+}
+
+/** Parameters for {@link UsageMeter.checkQuota}. */
+export interface CheckQuotaParams {
+  tenantId: string;
+  policy: UsageQuotaPolicy;
+  /** Projected tokens for the next call (input + output estimate). */
+  additionalTokensEstimate: number;
+  /** Projected cost (USD) for the next call. */
+  additionalCostEstimate: number;
+}
+
+/**
+ * Pluggable metering store. Implementations must isolate by tenant
+ * and persist `UsageMeterEntry` records durably enough to back the
+ * quota check window (1 UTC day, minimum).
+ */
+export interface UsageMeter {
+  /** Append a usage record. Storage is append-only by contract. */
+  record(entry: UsageMeterEntry): Promise<void>;
+
+  /**
+   * Sum tokens and cost for one tenant in `[since, until)`. Both
+   * bounds are ISO-8601 strings; `since` is inclusive, `until` is
+   * exclusive so adjacent windows can be stitched without overlap.
+   */
+  aggregate(params: AggregateUsageParams): Promise<UsageAggregate>;
+
+  /**
+   * Decide whether a projected call fits inside today's quota. The
+   * check aggregates the current UTC day, adds the projected
+   * `additionalTokensEstimate` / `additionalCostEstimate`, and
+   * compares against `policy`. Soft-warning state is reported when
+   * the projection crosses `softWarnThreshold` without breaching the
+   * hard limit.
+   */
+  checkQuota(params: CheckQuotaParams): Promise<QuotaCheckResult>;
+}
+
+// ── In-Memory Implementation ────────────────────────────────
+
+export interface InMemoryUsageMeterOptions {
+  /**
+   * Override the wall clock — useful for deterministic tests of
+   * day-boundary behavior. Defaults to `() => Date.now()`.
+   */
+  now?: () => number;
+}
+
+export function createInMemoryUsageMeter(options?: InMemoryUsageMeterOptions): UsageMeter {
+  // Per-tenant chronological log. We keep the full history (callers
+  // can prune via a wrapper if needed) so aggregation over arbitrary
+  // windows stays exact.
+  const entriesByTenant: Map<string, UsageMeterEntry[]> = new Map();
+  const now = options?.now ?? (() => Date.now());
+
+  function getEntries(tenantId: string): UsageMeterEntry[] {
+    let list = entriesByTenant.get(tenantId);
+    if (!list) {
+      list = [];
+      entriesByTenant.set(tenantId, list);
+    }
+    return list;
+  }
+
+  return {
+    async record(entry) {
+      validateEntry(entry);
+      const list = getEntries(entry.tenantId);
+      list.push({ ...entry });
+    },
+
+    async aggregate({ tenantId, since, until }) {
+      assertNonEmpty(tenantId, "tenantId");
+      const sinceMs = parseIso(since, "since");
+      const untilMs = parseIso(until, "until");
+      if (untilMs < sinceMs) {
+        throw new Error("UsageMeter.aggregate: 'until' must be >= 'since'");
+      }
+      const list = entriesByTenant.get(tenantId) ?? [];
+      let totalInputTokens = 0;
+      let totalOutputTokens = 0;
+      let totalCostUsd = 0;
+      for (const entry of list) {
+        const ts = parseIso(entry.ts, "entry.ts");
+        if (ts >= sinceMs && ts < untilMs) {
+          totalInputTokens += entry.inputTokens;
+          totalOutputTokens += entry.outputTokens;
+          totalCostUsd += entry.costUsd;
+        }
+      }
+      return { totalInputTokens, totalOutputTokens, totalCostUsd };
+    },
+
+    async checkQuota({ tenantId, policy, additionalTokensEstimate, additionalCostEstimate }) {
+      assertNonEmpty(tenantId, "tenantId");
+      validatePolicy(policy);
+      if (!Number.isFinite(additionalTokensEstimate) || additionalTokensEstimate < 0) {
+        throw new Error(
+          "UsageMeter.checkQuota: additionalTokensEstimate must be a non-negative finite number",
+        );
+      }
+      if (!Number.isFinite(additionalCostEstimate) || additionalCostEstimate < 0) {
+        throw new Error(
+          "UsageMeter.checkQuota: additionalCostEstimate must be a non-negative finite number",
+        );
+      }
+
+      const { startIso, endIso } = utcDayWindow(now());
+      const { totalInputTokens, totalOutputTokens, totalCostUsd } = await this.aggregate({
+        tenantId,
+        since: startIso,
+        until: endIso,
+      });
+      const usedTokens = totalInputTokens + totalOutputTokens;
+
+      const projectedTokens = usedTokens + additionalTokensEstimate;
+      const projectedCost = totalCostUsd + additionalCostEstimate;
+
+      const remainingTokens = policy.maxTokensPerDay - usedTokens;
+      const remainingCostUsd = policy.maxCostUsdPerDay - totalCostUsd;
+
+      // Hard limits first — token cap before cost cap so the reason
+      // string is stable when both would trip on the same call.
+      if (projectedTokens > policy.maxTokensPerDay) {
+        return {
+          allowed: false,
+          reason: "token_limit",
+          remainingTokens,
+          remainingCostUsd,
+        };
+      }
+      if (projectedCost > policy.maxCostUsdPerDay) {
+        return {
+          allowed: false,
+          reason: "cost_limit",
+          remainingTokens,
+          remainingCostUsd,
+        };
+      }
+
+      // Soft warning — opt-in via softWarnThreshold. The projection
+      // (not the current usage) is what trips the warning so callers
+      // get a single signal per crossing rather than oscillating.
+      if (policy.softWarnThreshold !== undefined) {
+        const threshold = policy.softWarnThreshold;
+        const tokenRatio = projectedTokens / policy.maxTokensPerDay;
+        const costRatio = projectedCost / policy.maxCostUsdPerDay;
+        if (tokenRatio >= threshold || costRatio >= threshold) {
+          return {
+            allowed: true,
+            reason: "soft_warning",
+            remainingTokens,
+            remainingCostUsd,
+          };
+        }
+      }
+
+      return {
+        allowed: true,
+        reason: "ok",
+        remainingTokens,
+        remainingCostUsd,
+      };
+    },
+  };
+}
+
+// ── Internal helpers ────────────────────────────────────────
+
+/**
+ * Compute the UTC calendar day containing `epochMs`. Returns
+ * `[startIso, endIso)` — start inclusive, end exclusive — so
+ * `aggregate()` semantics line up exactly.
+ */
+function utcDayWindow(epochMs: number): { startIso: string; endIso: string } {
+  const start = new Date(epochMs);
+  start.setUTCHours(0, 0, 0, 0);
+  const end = new Date(start.getTime());
+  end.setUTCDate(end.getUTCDate() + 1);
+  return { startIso: start.toISOString(), endIso: end.toISOString() };
+}
+
+function parseIso(value: string, name: string): number {
+  const ms = Date.parse(value);
+  if (Number.isNaN(ms)) {
+    throw new Error(`UsageMeter: ${name} is not a valid ISO-8601 timestamp`);
+  }
+  return ms;
+}
+
+function assertNonEmpty(value: string, name: string): void {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`UsageMeter: ${name} must be a non-empty string`);
+  }
+}
+
+function validateEntry(entry: UsageMeterEntry): void {
+  assertNonEmpty(entry.tenantId, "entry.tenantId");
+  assertNonEmpty(entry.provider, "entry.provider");
+  assertNonEmpty(entry.model, "entry.model");
+  assertNonEmpty(entry.ts, "entry.ts");
+  parseIso(entry.ts, "entry.ts");
+  if (!Number.isFinite(entry.inputTokens) || entry.inputTokens < 0) {
+    throw new Error("UsageMeter: entry.inputTokens must be a non-negative finite number");
+  }
+  if (!Number.isFinite(entry.outputTokens) || entry.outputTokens < 0) {
+    throw new Error("UsageMeter: entry.outputTokens must be a non-negative finite number");
+  }
+  if (!Number.isFinite(entry.costUsd) || entry.costUsd < 0) {
+    throw new Error("UsageMeter: entry.costUsd must be a non-negative finite number");
+  }
+}
+
+function validatePolicy(policy: UsageQuotaPolicy): void {
+  if (!Number.isFinite(policy.maxTokensPerDay) || policy.maxTokensPerDay < 0) {
+    throw new Error("UsageMeter: policy.maxTokensPerDay must be a non-negative finite number");
+  }
+  if (!Number.isFinite(policy.maxCostUsdPerDay) || policy.maxCostUsdPerDay < 0) {
+    throw new Error("UsageMeter: policy.maxCostUsdPerDay must be a non-negative finite number");
+  }
+  if (policy.softWarnThreshold !== undefined) {
+    const t = policy.softWarnThreshold;
+    if (!Number.isFinite(t) || t <= 0 || t >= 1) {
+      throw new Error("UsageMeter: policy.softWarnThreshold must be in (0, 1)");
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Spec 36 M2+: per-tenant AI key store + usage metering + quota enforcement
- Pure runtime-agnostic primitives in core; in-memory factories for dev/test
- REST endpoints in adapter-server (mounted alongside AI routes)
- 29 tests across 3 suites

## Modules
- **`byok-types.ts`** — discriminated types: `BYOKKeyRecord`, `BYOKKeyResolution`, `UsageQuotaPolicy`, `UsageMeterEntry`, `QuotaCheckResult`
- **`byok-key-store.ts`** — `BYOKKeyStore` interface + `createInMemoryBYOKKeyStore()`; stores opaque encrypted key references (never plaintext)
- **`usage-meter.ts`** — `UsageMeter` interface + `createInMemoryUsageMeter()`; record / aggregate (UTC day windows) / quota check with soft-warn threshold
- **`byok-resolver.ts`** — `resolveAIKey()` pure function; fallback chain: tenant key → platform default → missing

## REST endpoints
- `POST   /api/ai/byok/keys` — put key (tenant-scoped)
- `DELETE /api/ai/byok/keys/:provider` — revoke
- `GET    /api/ai/byok/keys` — list metadata only (no plaintext returned)
- `GET    /api/ai/byok/usage?since=ISO&until=ISO` — aggregate usage for tenant
- Degrades gracefully (503 with structured envelope) when store / meter are not configured.

## Test plan
- [x] `bun run check` — clean
- [x] `bun run typecheck` — clean
- [x] `bun test` — 5623 pass / 0 fail

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)