### PR TITLE
feat(adapter-ui): tenant self-service UI (closes #133)

### DIFF
--- a/addons/adapter-ui/cap-adapter-ui/__tests__/tenant-helpers.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/tenant-helpers.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "bun:test";
+import {
+  formatBytes,
+  formatUsageRatio,
+  INVITABLE_ROLES,
+  isInvitableRole,
+  isValidEmail,
+  isValidHexColor,
+} from "../src/tenant/tenant-helpers";
+
+describe("isValidEmail", () => {
+  it("accepts a well-formed address", () => {
+    expect(isValidEmail("user@example.com")).toBe(true);
+  });
+
+  it("trims surrounding whitespace before validating", () => {
+    expect(isValidEmail("  user@example.com  ")).toBe(true);
+  });
+
+  it("rejects missing @, missing TLD, or empty input", () => {
+    expect(isValidEmail("not-an-email")).toBe(false);
+    expect(isValidEmail("user@nodomain")).toBe(false);
+    expect(isValidEmail("")).toBe(false);
+  });
+});
+
+describe("isValidHexColor", () => {
+  it("accepts 6-digit hex with leading #", () => {
+    expect(isValidHexColor("#2563eb")).toBe(true);
+  });
+
+  it("accepts 3-digit shorthand", () => {
+    expect(isValidHexColor("#abc")).toBe(true);
+  });
+
+  it("rejects values missing the leading # or with bad characters", () => {
+    expect(isValidHexColor("2563eb")).toBe(false);
+    expect(isValidHexColor("#zzzzzz")).toBe(false);
+    expect(isValidHexColor("#12")).toBe(false);
+  });
+});
+
+describe("formatBytes", () => {
+  it("returns 0 B for zero or negative input", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(-42)).toBe("0 B");
+  });
+
+  it("formats bytes using binary units", () => {
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(2048)).toBe("2.0 KB");
+    expect(formatBytes(1024 ** 2)).toBe("1.0 MB");
+    expect(formatBytes(1024 ** 3)).toBe("1.0 GB");
+  });
+
+  it("handles non-finite numbers gracefully", () => {
+    expect(formatBytes(Number.NaN)).toBe("0 B");
+    expect(formatBytes(Number.POSITIVE_INFINITY)).toBe("0 B");
+  });
+});
+
+describe("formatUsageRatio", () => {
+  it("returns a clamped percentage with a single decimal", () => {
+    expect(formatUsageRatio(50, 100)).toBe("50.0%");
+    expect(formatUsageRatio(33, 100)).toBe("33.0%");
+  });
+
+  it("clamps to 100% when used exceeds limit", () => {
+    expect(formatUsageRatio(250, 100)).toBe("100.0%");
+  });
+
+  it("returns 0% when limit is non-positive or inputs are invalid", () => {
+    expect(formatUsageRatio(10, 0)).toBe("0%");
+    expect(formatUsageRatio(10, -5)).toBe("0%");
+    expect(formatUsageRatio(Number.NaN, 100)).toBe("0%");
+  });
+});
+
+describe("isInvitableRole", () => {
+  it("returns true for admin / member / viewer", () => {
+    expect(isInvitableRole("admin")).toBe(true);
+    expect(isInvitableRole("member")).toBe(true);
+    expect(isInvitableRole("viewer")).toBe(true);
+  });
+
+  it("returns false for owner (cannot be assigned via invite)", () => {
+    expect(isInvitableRole("owner")).toBe(false);
+  });
+
+  it("returns false for unknown role strings", () => {
+    expect(isInvitableRole("superuser")).toBe(false);
+    expect(isInvitableRole("")).toBe(false);
+  });
+});
+
+describe("INVITABLE_ROLES", () => {
+  it("exposes the curated invite-time role list without owner", () => {
+    expect([...INVITABLE_ROLES]).toEqual(["admin", "member", "viewer"]);
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/src/index.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/index.ts
@@ -57,3 +57,6 @@ export { AdminLayout } from "./pages/admin-layout";
 export { EntityFormPage } from "./pages/entity-form";
 export { EntityListPage } from "./pages/entity-list";
 export { WorkspacePage } from "./pages/workspace";
+
+// Tenant self-service surface (Spec 30 M2+, issue #133)
+export * from "./tenant";

--- a/addons/adapter-ui/cap-adapter-ui/src/tenant/index.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/tenant/index.ts
@@ -1,0 +1,37 @@
+/**
+ * Tenant self-service surface — public exports.
+ *
+ * Re-exports all components, types, helpers, and the hook so consumers
+ * can import everything from `@linchkit/cap-adapter-ui/tenant` (or via
+ * the package root once added to `src/index.ts`).
+ */
+
+export type { TenantBrandingFormProps } from "./tenant-branding-form";
+export { TenantBrandingForm } from "./tenant-branding-form";
+export type { TenantConfigEditorProps } from "./tenant-config-editor";
+export { TenantConfigEditor } from "./tenant-config-editor";
+export {
+  formatBytes,
+  formatUsageRatio,
+  INVITABLE_ROLES,
+  isInvitableRole,
+  isValidEmail,
+  isValidHexColor,
+} from "./tenant-helpers";
+export type { TenantMembersTableProps } from "./tenant-members-table";
+export { TenantMembersTable } from "./tenant-members-table";
+export type {
+  InviteMemberInput,
+  TenantBranding,
+  TenantConfig,
+  TenantInvitationStatus,
+  TenantMember,
+  TenantMemberRole,
+  TenantSelfServiceSnapshot,
+  TenantUsageStats,
+} from "./tenant-self-service-types";
+export { TenantSettingsPage } from "./tenant-settings-page";
+export type { TenantUsageDashboardProps } from "./tenant-usage-dashboard";
+export { TenantUsageDashboard } from "./tenant-usage-dashboard";
+export type { UseTenantSelfServiceResult } from "./use-tenant-self-service";
+export { useTenantSelfService } from "./use-tenant-self-service";

--- a/addons/adapter-ui/cap-adapter-ui/src/tenant/tenant-branding-form.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/tenant/tenant-branding-form.tsx
@@ -1,0 +1,139 @@
+/**
+ * TenantBrandingForm — edit the tenant's app name, logo URL and primary colour.
+ *
+ * Controlled form: parent owns the initial value via `value` and is notified
+ * when the user clicks Save. Local state holds the in-progress edits so
+ * the user can revert without disturbing the persisted snapshot.
+ */
+
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+} from "@linchkit/ui-kit/components";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { isValidHexColor } from "./tenant-helpers";
+import type { TenantBranding } from "./tenant-self-service-types";
+
+export interface TenantBrandingFormProps {
+  value: TenantBranding;
+  onSave: (next: TenantBranding) => Promise<void> | void;
+  disabled?: boolean;
+}
+
+export function TenantBrandingForm({ value, onSave, disabled }: TenantBrandingFormProps) {
+  const { t } = useTranslation();
+  const [draft, setDraft] = useState<TenantBranding>(value);
+  const [saving, setSaving] = useState(false);
+
+  // Sync local draft when parent loads fresh data.
+  useEffect(() => {
+    setDraft(value);
+  }, [value]);
+
+  const colorValid = isValidHexColor(draft.primaryColor);
+  const dirty =
+    draft.appName !== value.appName ||
+    draft.logoUrl !== value.logoUrl ||
+    draft.primaryColor !== value.primaryColor;
+  const canSave = !disabled && !saving && dirty && draft.appName.trim().length > 0 && colorValid;
+
+  const handleSave = async () => {
+    if (!canSave) return;
+    setSaving(true);
+    try {
+      await onSave({ ...draft, appName: draft.appName.trim(), logoUrl: draft.logoUrl.trim() });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("tenant.branding.title", "Branding")}</CardTitle>
+        <CardDescription>
+          {t("tenant.branding.description", "Customise how this tenant appears to its members.")}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="tenant-app-name">{t("tenant.branding.appName", "App name")}</Label>
+          <Input
+            id="tenant-app-name"
+            value={draft.appName}
+            disabled={disabled}
+            onChange={(e) => setDraft((d) => ({ ...d, appName: e.target.value }))}
+            placeholder={t("tenant.branding.appNamePlaceholder", "e.g. Acme Workspace")}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="tenant-logo-url">{t("tenant.branding.logoUrl", "Logo URL")}</Label>
+          <Input
+            id="tenant-logo-url"
+            value={draft.logoUrl}
+            disabled={disabled}
+            onChange={(e) => setDraft((d) => ({ ...d, logoUrl: e.target.value }))}
+            placeholder="https://cdn.example.com/logo.svg"
+          />
+          {draft.logoUrl && (
+            <div className="mt-2 flex items-center gap-3 rounded-md border p-3">
+              <img
+                src={draft.logoUrl}
+                alt={t("tenant.branding.logoPreviewAlt", "Logo preview")}
+                className="h-10 w-10 rounded object-contain"
+                onError={(e) => {
+                  (e.currentTarget as HTMLImageElement).style.visibility = "hidden";
+                }}
+              />
+              <span className="text-xs text-muted-foreground">
+                {t("tenant.branding.logoPreview", "Logo preview")}
+              </span>
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="tenant-primary-color">
+            {t("tenant.branding.primaryColor", "Primary color")}
+          </Label>
+          <div className="flex items-center gap-3">
+            <Input
+              id="tenant-primary-color"
+              value={draft.primaryColor}
+              disabled={disabled}
+              onChange={(e) => setDraft((d) => ({ ...d, primaryColor: e.target.value }))}
+              placeholder="#2563eb"
+              className="font-mono"
+            />
+            <span
+              aria-hidden="true"
+              className="h-9 w-9 shrink-0 rounded-md border"
+              style={{ backgroundColor: colorValid ? draft.primaryColor : "transparent" }}
+            />
+          </div>
+          {!colorValid && draft.primaryColor.length > 0 && (
+            <p className="text-xs text-destructive">
+              {t("tenant.branding.invalidColor", "Enter a valid hex color, e.g. #2563eb.")}
+            </p>
+          )}
+        </div>
+
+        <div className="flex justify-end pt-2">
+          <Button onClick={handleSave} disabled={!canSave}>
+            {saving
+              ? t("tenant.branding.saving", "Saving...")
+              : t("tenant.branding.save", "Save branding")}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/tenant/tenant-config-editor.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/tenant/tenant-config-editor.tsx
@@ -1,0 +1,282 @@
+/**
+ * TenantConfigEditor — edit tenant default locale plus a KV map of feature flags.
+ *
+ * Values support boolean / string / number. Booleans render as a Switch,
+ * numbers as a numeric Input, anything else as a text Input. Users can
+ * also remove keys or add new ones at the bottom.
+ */
+
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Switch,
+} from "@linchkit/ui-kit/components";
+import { Trash2Icon } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { TenantConfig } from "./tenant-self-service-types";
+
+export interface TenantConfigEditorProps {
+  value: TenantConfig;
+  /** BCP-47 tags the tenant can choose from. */
+  availableLocales?: readonly string[];
+  onSave: (next: TenantConfig) => Promise<void> | void;
+  disabled?: boolean;
+}
+
+const DEFAULT_LOCALES = ["en", "zh-CN", "ja", "de", "fr"] as const;
+
+type FeatureKind = "boolean" | "number" | "string";
+
+interface DraftRow {
+  key: string;
+  kind: FeatureKind;
+  value: boolean | number | string;
+}
+
+function inferKind(value: unknown): FeatureKind {
+  if (typeof value === "boolean") return "boolean";
+  if (typeof value === "number") return "number";
+  return "string";
+}
+
+function toRows(features: TenantConfig["features"]): DraftRow[] {
+  return Object.entries(features).map(([key, value]) => ({
+    key,
+    kind: inferKind(value),
+    value: value as boolean | number | string,
+  }));
+}
+
+function fromRows(rows: DraftRow[]): TenantConfig["features"] {
+  const out: TenantConfig["features"] = {};
+  for (const row of rows) {
+    const cleanKey = row.key.trim();
+    if (!cleanKey) continue;
+    out[cleanKey] = row.value;
+  }
+  return out;
+}
+
+export function TenantConfigEditor({
+  value,
+  availableLocales,
+  onSave,
+  disabled,
+}: TenantConfigEditorProps) {
+  const { t } = useTranslation();
+  const locales = availableLocales ?? DEFAULT_LOCALES;
+  const [locale, setLocale] = useState(value.defaultLocale);
+  const [rows, setRows] = useState<DraftRow[]>(() => toRows(value.features));
+  const [saving, setSaving] = useState(false);
+
+  // Re-sync when parent supplies a fresh snapshot.
+  useEffect(() => {
+    setLocale(value.defaultLocale);
+    setRows(toRows(value.features));
+  }, [value]);
+
+  const dirty = useMemo(() => {
+    if (locale !== value.defaultLocale) return true;
+    const nextFeatures = fromRows(rows);
+    const nextKeys = Object.keys(nextFeatures).sort();
+    const prevKeys = Object.keys(value.features).sort();
+    if (nextKeys.length !== prevKeys.length) return true;
+    if (nextKeys.some((k, i) => k !== prevKeys[i])) return true;
+    return nextKeys.some((k) => nextFeatures[k] !== value.features[k]);
+  }, [locale, rows, value]);
+
+  const hasEmptyKey = rows.some((r) => !r.key.trim());
+  const hasDuplicateKey = useMemo(() => {
+    const seen = new Set<string>();
+    for (const r of rows) {
+      const k = r.key.trim();
+      if (!k) continue;
+      if (seen.has(k)) return true;
+      seen.add(k);
+    }
+    return false;
+  }, [rows]);
+
+  const canSave = !disabled && !saving && dirty && !hasEmptyKey && !hasDuplicateKey;
+
+  const handleSave = async () => {
+    if (!canSave) return;
+    setSaving(true);
+    try {
+      await onSave({ defaultLocale: locale, features: fromRows(rows) });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const updateRow = (index: number, patch: Partial<DraftRow>) => {
+    setRows((rs) => rs.map((r, i) => (i === index ? { ...r, ...patch } : r)));
+  };
+
+  const changeKind = (index: number, kind: FeatureKind) => {
+    setRows((rs) =>
+      rs.map((r, i) => {
+        if (i !== index) return r;
+        let nextValue: DraftRow["value"];
+        if (kind === "boolean") nextValue = Boolean(r.value);
+        else if (kind === "number") nextValue = Number(r.value) || 0;
+        else nextValue = String(r.value);
+        return { ...r, kind, value: nextValue };
+      }),
+    );
+  };
+
+  const removeRow = (index: number) => {
+    setRows((rs) => rs.filter((_, i) => i !== index));
+  };
+
+  const addRow = () => {
+    setRows((rs) => [...rs, { key: "", kind: "boolean", value: false }]);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("tenant.config.title", "Configuration")}</CardTitle>
+        <CardDescription>
+          {t(
+            "tenant.config.description",
+            "Tune tenant-level feature toggles and the default locale used when a user has not chosen their own.",
+          )}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="space-y-2">
+          <Label htmlFor="tenant-default-locale">
+            {t("tenant.config.defaultLocale", "Default locale")}
+          </Label>
+          <Select value={locale} onValueChange={setLocale} disabled={disabled}>
+            <SelectTrigger id="tenant-default-locale" className="w-60">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {locales.map((loc) => (
+                <SelectItem key={loc} value={loc}>
+                  {loc}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <Label>{t("tenant.config.features", "Feature toggles")}</Label>
+            <Button variant="outline" size="sm" onClick={addRow} disabled={disabled}>
+              {t("tenant.config.addFeature", "Add feature")}
+            </Button>
+          </div>
+
+          {rows.length === 0 && (
+            <p className="text-sm text-muted-foreground">
+              {t("tenant.config.empty", "No feature toggles defined yet.")}
+            </p>
+          )}
+
+          <div className="space-y-2">
+            {rows.map((row, index) => (
+              <div
+                // biome-ignore lint/suspicious/noArrayIndexKey: row identity is positional during editing
+                key={index}
+                className="grid grid-cols-[1fr_140px_1fr_auto] items-center gap-2 rounded-md border p-2"
+              >
+                <Input
+                  value={row.key}
+                  placeholder={t("tenant.config.keyPlaceholder", "feature_key")}
+                  onChange={(e) => updateRow(index, { key: e.target.value })}
+                  disabled={disabled}
+                  className="font-mono text-sm"
+                />
+                <Select
+                  value={row.kind}
+                  onValueChange={(v) => changeKind(index, v as FeatureKind)}
+                  disabled={disabled}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="boolean">boolean</SelectItem>
+                    <SelectItem value="number">number</SelectItem>
+                    <SelectItem value="string">string</SelectItem>
+                  </SelectContent>
+                </Select>
+
+                {row.kind === "boolean" && (
+                  <div className="flex items-center">
+                    <Switch
+                      checked={Boolean(row.value)}
+                      onCheckedChange={(v) => updateRow(index, { value: Boolean(v) })}
+                      disabled={disabled}
+                    />
+                  </div>
+                )}
+                {row.kind === "number" && (
+                  <Input
+                    type="number"
+                    value={String(row.value)}
+                    onChange={(e) => updateRow(index, { value: Number(e.target.value) })}
+                    disabled={disabled}
+                  />
+                )}
+                {row.kind === "string" && (
+                  <Input
+                    value={String(row.value)}
+                    onChange={(e) => updateRow(index, { value: e.target.value })}
+                    disabled={disabled}
+                  />
+                )}
+
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => removeRow(index)}
+                  disabled={disabled}
+                  aria-label={t("tenant.config.removeFeature", "Remove feature")}
+                >
+                  <Trash2Icon className="h-4 w-4" />
+                </Button>
+              </div>
+            ))}
+          </div>
+
+          {hasDuplicateKey && (
+            <p className="text-xs text-destructive">
+              {t("tenant.config.duplicateKey", "Feature keys must be unique.")}
+            </p>
+          )}
+          {hasEmptyKey && (
+            <p className="text-xs text-destructive">
+              {t("tenant.config.emptyKey", "Feature keys cannot be empty.")}
+            </p>
+          )}
+        </div>
+
+        <div className="flex justify-end">
+          <Button onClick={handleSave} disabled={!canSave}>
+            {saving
+              ? t("tenant.config.saving", "Saving...")
+              : t("tenant.config.save", "Save configuration")}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/tenant/tenant-helpers.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/tenant/tenant-helpers.ts
@@ -1,0 +1,54 @@
+/**
+ * Pure helpers for the tenant self-service surface.
+ *
+ * Kept dependency-free so they are easy to unit test and reuse.
+ */
+
+import type { TenantMemberRole } from "./tenant-self-service-types";
+
+/** Basic RFC-5322-ish email shape check. Strict enough for UI gating. */
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/** Returns true when the input looks like a syntactically valid email. */
+export function isValidEmail(value: string): boolean {
+  return EMAIL_RE.test(value.trim());
+}
+
+/** Hex colour validation. Accepts 3 or 6 hex digits with leading `#`. */
+const HEX_COLOR_RE = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
+export function isValidHexColor(value: string): boolean {
+  return HEX_COLOR_RE.test(value.trim());
+}
+
+/**
+ * Format a byte count as a human-readable string (KB / MB / GB / TB).
+ *
+ * Uses binary units (1024). Returns `"0 B"` for zero / negatives.
+ */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB", "PB"];
+  const exp = Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(1024)));
+  const value = bytes / 1024 ** exp;
+  // Show 1 decimal once we leave bytes; integers feel cleaner for the smallest unit.
+  return `${exp === 0 ? value : value.toFixed(1)} ${units[exp]}`;
+}
+
+/**
+ * Format a usage ratio (used / limit) as a clamped percentage string with
+ * a single decimal. Returns `"0%"` when the limit is non-positive.
+ */
+export function formatUsageRatio(used: number, limit: number): string {
+  if (!Number.isFinite(used) || !Number.isFinite(limit) || limit <= 0) return "0%";
+  const pct = Math.max(0, Math.min(used / limit, 1)) * 100;
+  return `${pct.toFixed(1)}%`;
+}
+
+/** Roles the UI offers when inviting a member. `owner` is intentionally excluded. */
+export const INVITABLE_ROLES: readonly TenantMemberRole[] = ["admin", "member", "viewer"] as const;
+
+/** True if a role is one the UI lets the current admin assign via invite. */
+export function isInvitableRole(role: string): role is TenantMemberRole {
+  return (INVITABLE_ROLES as readonly string[]).includes(role);
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/tenant/tenant-members-table.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/tenant/tenant-members-table.tsx
@@ -1,0 +1,287 @@
+/**
+ * TenantMembersTable — list members of the current tenant with role
+ * management, removal, and an "Invite member" Dialog.
+ *
+ * Mirrors the controlled-form pattern used by the branding/config tabs:
+ * data + mutations are sourced from `useTenantSelfService()` and passed
+ * in via props so the table itself stays mock/transport agnostic.
+ */
+
+import {
+  Avatar,
+  AvatarFallback,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@linchkit/ui-kit/components";
+import { Trash2Icon, UserPlusIcon } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { INVITABLE_ROLES, isValidEmail } from "./tenant-helpers";
+import type {
+  InviteMemberInput,
+  TenantMember,
+  TenantMemberRole,
+} from "./tenant-self-service-types";
+
+export interface TenantMembersTableProps {
+  members: readonly TenantMember[];
+  onInvite: (input: InviteMemberInput) => Promise<void> | void;
+  onRemove: (memberId: string) => Promise<void> | void;
+  onChangeRole?: (memberId: string, role: TenantMemberRole) => Promise<void> | void;
+  disabled?: boolean;
+}
+
+const ALL_ROLES: readonly TenantMemberRole[] = ["owner", "admin", "member", "viewer"] as const;
+
+/** Build a 1-2 char initial from a display name or email. */
+function getInitials(member: TenantMember): string {
+  const source = member.displayName?.trim() || member.email;
+  const parts = source.split(/\s+/).filter(Boolean);
+  const first = parts[0];
+  const second = parts[1];
+  if (first && second) {
+    return (first.charAt(0) + second.charAt(0)).toUpperCase();
+  }
+  return source.slice(0, 2).toUpperCase();
+}
+
+/** Format an ISO timestamp as the user's locale date; falls back to "—". */
+function formatLastActive(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleDateString();
+}
+
+export function TenantMembersTable({
+  members,
+  onInvite,
+  onRemove,
+  onChangeRole,
+  disabled,
+}: TenantMembersTableProps) {
+  const { t } = useTranslation();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteRole, setInviteRole] = useState<TenantMemberRole>("member");
+  const [submitting, setSubmitting] = useState(false);
+  const [removingId, setRemovingId] = useState<string | null>(null);
+
+  const emailValid = isValidEmail(inviteEmail);
+  const canInvite = !disabled && !submitting && emailValid;
+
+  const resetInviteForm = () => {
+    setInviteEmail("");
+    setInviteRole("member");
+  };
+
+  const handleInvite = async () => {
+    if (!canInvite) return;
+    setSubmitting(true);
+    try {
+      await onInvite({ email: inviteEmail.trim(), role: inviteRole });
+      resetInviteForm();
+      setDialogOpen(false);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleRemove = async (memberId: string) => {
+    if (disabled) return;
+    setRemovingId(memberId);
+    try {
+      await onRemove(memberId);
+    } finally {
+      setRemovingId(null);
+    }
+  };
+
+  const handleRoleChange = async (memberId: string, role: TenantMemberRole) => {
+    if (!onChangeRole || disabled) return;
+    await onChangeRole(memberId, role);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">{t("tenant.members.title", "Members")}</h2>
+          <p className="text-sm text-muted-foreground">
+            {t(
+              "tenant.members.description",
+              "Manage who has access to this tenant and what they can do.",
+            )}
+          </p>
+        </div>
+        <Dialog
+          open={dialogOpen}
+          onOpenChange={(next) => {
+            setDialogOpen(next);
+            if (!next) resetInviteForm();
+          }}
+        >
+          <Button type="button" onClick={() => setDialogOpen(true)} disabled={disabled}>
+            <UserPlusIcon className="mr-2 h-4 w-4" />
+            {t("tenant.members.invite", "Invite member")}
+          </Button>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>{t("tenant.members.inviteTitle", "Invite a new member")}</DialogTitle>
+              <DialogDescription>
+                {t(
+                  "tenant.members.inviteDescription",
+                  "Send an invitation by email. The invitee will receive a link to join this tenant.",
+                )}
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-4 py-2">
+              <div className="space-y-2">
+                <Label htmlFor="tenant-invite-email">{t("tenant.members.email", "Email")}</Label>
+                <Input
+                  id="tenant-invite-email"
+                  type="email"
+                  value={inviteEmail}
+                  onChange={(e) => setInviteEmail(e.target.value)}
+                  placeholder="name@example.com"
+                  autoComplete="off"
+                />
+                {inviteEmail.length > 0 && !emailValid && (
+                  <p className="text-xs text-destructive">
+                    {t("tenant.members.invalidEmail", "Enter a valid email address.")}
+                  </p>
+                )}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="tenant-invite-role">{t("tenant.members.role", "Role")}</Label>
+                <Select
+                  value={inviteRole}
+                  onValueChange={(v) => setInviteRole(v as TenantMemberRole)}
+                >
+                  <SelectTrigger id="tenant-invite-role">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {INVITABLE_ROLES.map((role) => (
+                      <SelectItem key={role} value={role}>
+                        {role}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setDialogOpen(false)}
+                disabled={submitting}
+              >
+                {t("tenant.members.cancel", "Cancel")}
+              </Button>
+              <Button type="button" onClick={handleInvite} disabled={!canInvite}>
+                {submitting
+                  ? t("tenant.members.sending", "Sending...")
+                  : t("tenant.members.send", "Send invite")}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-12" />
+              <TableHead>{t("tenant.members.name", "Name")}</TableHead>
+              <TableHead>{t("tenant.members.email", "Email")}</TableHead>
+              <TableHead className="w-44">{t("tenant.members.role", "Role")}</TableHead>
+              <TableHead>{t("tenant.members.lastActive", "Last active")}</TableHead>
+              <TableHead className="w-16 text-right">
+                {t("tenant.members.actions", "Actions")}
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {members.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={6} className="py-8 text-center text-sm text-muted-foreground">
+                  {t("tenant.members.empty", "No members yet. Invite someone to get started.")}
+                </TableCell>
+              </TableRow>
+            )}
+            {members.map((member) => {
+              const isOwner = member.role === "owner";
+              const removing = removingId === member.id;
+              return (
+                <TableRow key={member.id}>
+                  <TableCell>
+                    <Avatar className="h-8 w-8">
+                      <AvatarFallback>{getInitials(member)}</AvatarFallback>
+                    </Avatar>
+                  </TableCell>
+                  <TableCell className="font-medium">
+                    {member.displayName || member.email.split("@")[0]}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">{member.email}</TableCell>
+                  <TableCell>
+                    <Select
+                      value={member.role}
+                      onValueChange={(v) => handleRoleChange(member.id, v as TenantMemberRole)}
+                      disabled={disabled || !onChangeRole || isOwner}
+                    >
+                      <SelectTrigger className="h-8 w-36">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {ALL_ROLES.map((role) => (
+                          <SelectItem key={role} value={role}>
+                            {role}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </TableCell>
+                  <TableCell className="text-sm text-muted-foreground">
+                    {formatLastActive(member.joinedAt)}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => handleRemove(member.id)}
+                      disabled={disabled || removing || isOwner}
+                      aria-label={t("tenant.members.remove", "Remove member")}
+                    >
+                      <Trash2Icon className="h-4 w-4" />
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/tenant/tenant-self-service-types.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/tenant/tenant-self-service-types.ts
@@ -1,0 +1,70 @@
+/**
+ * Tenant self-service domain types.
+ *
+ * Shared between page, sub-components, and the (mock) hook.
+ * Real types should later be derived from the GraphQL schema or
+ * `defineEntity('tenant')` so they stay in sync with the backend.
+ */
+
+/** Roles a tenant member can be assigned. Keep in sync with cap-permission. */
+export type TenantMemberRole = "owner" | "admin" | "member" | "viewer";
+
+/** Status of an invitation lifecycle. */
+export type TenantInvitationStatus = "pending" | "accepted" | "expired" | "revoked";
+
+/**
+ * Visual identity for a tenant.
+ *
+ * `primaryColor` is a CSS color string (hex preferred). `logoUrl`
+ * may be empty while the tenant has no logo configured.
+ */
+export interface TenantBranding {
+  appName: string;
+  logoUrl: string;
+  primaryColor: string;
+}
+
+/**
+ * Tenant-level configuration knobs.
+ *
+ * `features` is a free-form KV map of feature toggles
+ * (boolean / string / number). `defaultLocale` is the BCP-47 tag
+ * used as fallback when a user has not picked their own locale.
+ */
+export interface TenantConfig {
+  defaultLocale: string;
+  features: Record<string, boolean | string | number>;
+}
+
+/** A single member of the current tenant. */
+export interface TenantMember {
+  id: string;
+  email: string;
+  displayName: string;
+  role: TenantMemberRole;
+  joinedAt: string;
+  status: "active" | "invited" | "suspended";
+}
+
+/** Read-only usage metrics shown in the dashboard tab. */
+export interface TenantUsageStats {
+  periodStart: string;
+  periodEnd: string;
+  requests: { used: number; limit: number };
+  storageBytes: { used: number; limit: number };
+  aiTokens: { used: number; limit: number };
+}
+
+/** Aggregate snapshot returned by the self-service hook. */
+export interface TenantSelfServiceSnapshot {
+  branding: TenantBranding;
+  config: TenantConfig;
+  members: TenantMember[];
+  usage: TenantUsageStats;
+}
+
+/** Payload for inviting a new member. */
+export interface InviteMemberInput {
+  email: string;
+  role: TenantMemberRole;
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/tenant/tenant-settings-page.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/tenant/tenant-settings-page.tsx
@@ -1,0 +1,83 @@
+/**
+ * TenantSettingsPage — top-level page that mounts the four self-service
+ * tabs (Branding | Config | Members | Usage) and wires them to the
+ * shared `useTenantSelfService()` hook.
+ *
+ * Status: PREVIEW — the underlying hook is mock-backed. See
+ * `use-tenant-self-service.ts` for the wiring TODO.
+ */
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@linchkit/ui-kit/components";
+import { useTranslation } from "react-i18next";
+import { TenantBrandingForm } from "./tenant-branding-form";
+import { TenantConfigEditor } from "./tenant-config-editor";
+import { TenantMembersTable } from "./tenant-members-table";
+import { TenantUsageDashboard } from "./tenant-usage-dashboard";
+import { useTenantSelfService } from "./use-tenant-self-service";
+
+export function TenantSettingsPage() {
+  const { t } = useTranslation();
+  const { loading, error, snapshot, saveBranding, saveConfig, inviteMember, removeMember } =
+    useTenantSelfService();
+
+  if (error) {
+    return (
+      <div className="p-6">
+        <p className="text-sm text-destructive">{error}</p>
+      </div>
+    );
+  }
+
+  if (loading || !snapshot) {
+    return (
+      <div className="p-6">
+        <p className="text-sm text-muted-foreground">
+          {t("tenant.loading", "Loading tenant settings...")}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 p-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold">{snapshot.branding.appName}</h1>
+        <p className="text-sm text-muted-foreground">
+          {t(
+            "tenant.page.subtitle",
+            "Manage your tenant's branding, configuration, members, and usage.",
+          )}
+        </p>
+      </header>
+
+      <Tabs defaultValue="branding" className="w-full">
+        <TabsList>
+          <TabsTrigger value="branding">{t("tenant.tabs.branding", "Branding")}</TabsTrigger>
+          <TabsTrigger value="config">{t("tenant.tabs.config", "Configuration")}</TabsTrigger>
+          <TabsTrigger value="members">{t("tenant.tabs.members", "Members")}</TabsTrigger>
+          <TabsTrigger value="usage">{t("tenant.tabs.usage", "Usage")}</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="branding" className="mt-4">
+          <TenantBrandingForm value={snapshot.branding} onSave={saveBranding} />
+        </TabsContent>
+
+        <TabsContent value="config" className="mt-4">
+          <TenantConfigEditor value={snapshot.config} onSave={saveConfig} />
+        </TabsContent>
+
+        <TabsContent value="members" className="mt-4">
+          <TenantMembersTable
+            members={snapshot.members}
+            onInvite={inviteMember}
+            onRemove={removeMember}
+          />
+        </TabsContent>
+
+        <TabsContent value="usage" className="mt-4">
+          <TenantUsageDashboard usage={snapshot.usage} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/tenant/tenant-usage-dashboard.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/tenant/tenant-usage-dashboard.tsx
@@ -1,0 +1,108 @@
+/**
+ * TenantUsageDashboard — read-only KPI cards summarising tenant usage
+ * for the current billing period.
+ *
+ * Three Cards (requests, storage, AI tokens) plus a placeholder line
+ * for a future detailed chart. Values come from the
+ * `useTenantSelfService()` snapshot, formatted via tenant-helpers.
+ */
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@linchkit/ui-kit/components";
+import { useTranslation } from "react-i18next";
+import { formatBytes, formatUsageRatio } from "./tenant-helpers";
+import type { TenantUsageStats } from "./tenant-self-service-types";
+
+export interface TenantUsageDashboardProps {
+  usage: TenantUsageStats;
+}
+
+interface KpiCardProps {
+  title: string;
+  primary: string;
+  secondary: string;
+  ratio: string;
+}
+
+function KpiCard({ title, primary, secondary, ratio }: KpiCardProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardDescription>{title}</CardDescription>
+        <CardTitle className="text-2xl tabular-nums">{primary}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-baseline justify-between text-xs text-muted-foreground">
+          <span>{secondary}</span>
+          <span className="font-medium">{ratio}</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+/** Format an ISO range like `"May 1 – May 31, 2026"`. Falls back gracefully. */
+function formatPeriod(startIso: string, endIso: string): string {
+  const start = new Date(startIso);
+  const end = new Date(endIso);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+    return `${startIso} – ${endIso}`;
+  }
+  return `${start.toLocaleDateString()} – ${end.toLocaleDateString()}`;
+}
+
+export function TenantUsageDashboard({ usage }: TenantUsageDashboardProps) {
+  const { t } = useTranslation();
+
+  const requestsRatio = formatUsageRatio(usage.requests.used, usage.requests.limit);
+  const storageRatio = formatUsageRatio(usage.storageBytes.used, usage.storageBytes.limit);
+  const tokensRatio = formatUsageRatio(usage.aiTokens.used, usage.aiTokens.limit);
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold">{t("tenant.usage.title", "Usage")}</h2>
+        <p className="text-sm text-muted-foreground">
+          {t("tenant.usage.period", "Billing period")}:{" "}
+          {formatPeriod(usage.periodStart, usage.periodEnd)}
+        </p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        <KpiCard
+          title={t("tenant.usage.requests", "API requests")}
+          primary={usage.requests.used.toLocaleString()}
+          secondary={t("tenant.usage.outOf", "of {{limit}}", {
+            limit: usage.requests.limit.toLocaleString(),
+          })}
+          ratio={requestsRatio}
+        />
+        <KpiCard
+          title={t("tenant.usage.storage", "Storage")}
+          primary={formatBytes(usage.storageBytes.used)}
+          secondary={t("tenant.usage.outOf", "of {{limit}}", {
+            limit: formatBytes(usage.storageBytes.limit),
+          })}
+          ratio={storageRatio}
+        />
+        <KpiCard
+          title={t("tenant.usage.aiTokens", "AI tokens")}
+          primary={usage.aiTokens.used.toLocaleString()}
+          secondary={t("tenant.usage.outOf", "of {{limit}}", {
+            limit: usage.aiTokens.limit.toLocaleString(),
+          })}
+          ratio={tokensRatio}
+        />
+      </div>
+
+      <p className="text-sm text-muted-foreground italic">
+        {t("tenant.usage.placeholder", "Detailed usage coming soon.")}
+      </p>
+    </div>
+  );
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/tenant/use-tenant-self-service.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/tenant/use-tenant-self-service.ts
@@ -1,0 +1,182 @@
+/**
+ * useTenantSelfService — central hook for the tenant settings page.
+ *
+ * Returns a snapshot of branding / config / members / usage plus mutation
+ * helpers (saveBranding, saveConfig, inviteMember, removeMember).
+ *
+ * Status: PREVIEW. Data is mocked locally so the UI renders without a
+ * live backend. Mutations only update local state.
+ *
+ * TODO: wire to GraphQL (read) + Actions (write) — track in issue #133
+ *       follow-up. Expected wiring:
+ *         - reads → `query tenant { branding, config, members, usage }`
+ *         - writes → executeAction('update_tenant_branding'),
+ *                    executeAction('update_tenant_config'),
+ *                    executeAction('invite_tenant_member'),
+ *                    executeAction('remove_tenant_member')
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import type {
+  InviteMemberInput,
+  TenantBranding,
+  TenantConfig,
+  TenantMember,
+  TenantSelfServiceSnapshot,
+  TenantUsageStats,
+} from "./tenant-self-service-types";
+
+// ── Mock snapshot ────────────────────────────────────────
+
+const MOCK_BRANDING: TenantBranding = {
+  appName: "Acme Workspace",
+  logoUrl: "",
+  primaryColor: "#2563eb",
+};
+
+const MOCK_CONFIG: TenantConfig = {
+  defaultLocale: "en",
+  features: {
+    enableAiAssistant: true,
+    enableAdvancedReports: false,
+    aiTokenBudget: 1_000_000,
+  },
+};
+
+const MOCK_MEMBERS: TenantMember[] = [
+  {
+    id: "u_owner",
+    email: "owner@example.com",
+    displayName: "Tenant Owner",
+    role: "owner",
+    joinedAt: "2026-01-01T00:00:00.000Z",
+    status: "active",
+  },
+  {
+    id: "u_admin",
+    email: "admin@example.com",
+    displayName: "Admin User",
+    role: "admin",
+    joinedAt: "2026-02-12T00:00:00.000Z",
+    status: "active",
+  },
+  {
+    id: "u_member",
+    email: "alex@example.com",
+    displayName: "Alex Member",
+    role: "member",
+    joinedAt: "2026-03-04T00:00:00.000Z",
+    status: "active",
+  },
+];
+
+const MOCK_USAGE: TenantUsageStats = {
+  periodStart: "2026-05-01T00:00:00.000Z",
+  periodEnd: "2026-05-31T23:59:59.000Z",
+  requests: { used: 42_318, limit: 100_000 },
+  storageBytes: { used: 7.4 * 1024 ** 3, limit: 25 * 1024 ** 3 },
+  aiTokens: { used: 312_450, limit: MOCK_CONFIG.features.aiTokenBudget as number },
+};
+
+const MOCK_SNAPSHOT: TenantSelfServiceSnapshot = {
+  branding: MOCK_BRANDING,
+  config: MOCK_CONFIG,
+  members: MOCK_MEMBERS,
+  usage: MOCK_USAGE,
+};
+
+// ── Hook surface ─────────────────────────────────────────
+
+export interface UseTenantSelfServiceResult {
+  loading: boolean;
+  error: string | null;
+  snapshot: TenantSelfServiceSnapshot | null;
+  refresh: () => Promise<void>;
+  saveBranding: (next: TenantBranding) => Promise<void>;
+  saveConfig: (next: TenantConfig) => Promise<void>;
+  inviteMember: (input: InviteMemberInput) => Promise<void>;
+  removeMember: (memberId: string) => Promise<void>;
+}
+
+/**
+ * Centralised access to the tenant self-service state. Today returns
+ * mock data; see file-level TODO for the planned GraphQL/Action wiring.
+ */
+export function useTenantSelfService(): UseTenantSelfServiceResult {
+  const [snapshot, setSnapshot] = useState<TenantSelfServiceSnapshot | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    // TODO: wire to GraphQL — for now resolve synchronously with the mock.
+    await Promise.resolve();
+    // Deep-ish clone so callers can mutate without poisoning the constant.
+    setSnapshot({
+      branding: { ...MOCK_SNAPSHOT.branding },
+      config: { ...MOCK_SNAPSHOT.config, features: { ...MOCK_SNAPSHOT.config.features } },
+      members: MOCK_SNAPSHOT.members.map((m) => ({ ...m })),
+      usage: {
+        ...MOCK_SNAPSHOT.usage,
+        requests: { ...MOCK_SNAPSHOT.usage.requests },
+        storageBytes: { ...MOCK_SNAPSHOT.usage.storageBytes },
+        aiTokens: { ...MOCK_SNAPSHOT.usage.aiTokens },
+      },
+    });
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const saveBranding = useCallback(async (next: TenantBranding) => {
+    // TODO: wire to Action `update_tenant_branding`.
+    await Promise.resolve();
+    setSnapshot((prev) => (prev ? { ...prev, branding: { ...next } } : prev));
+  }, []);
+
+  const saveConfig = useCallback(async (next: TenantConfig) => {
+    // TODO: wire to Action `update_tenant_config`.
+    await Promise.resolve();
+    setSnapshot((prev) =>
+      prev ? { ...prev, config: { ...next, features: { ...next.features } } } : prev,
+    );
+  }, []);
+
+  const inviteMember = useCallback(async ({ email, role }: InviteMemberInput) => {
+    // TODO: wire to Action `invite_tenant_member`.
+    await Promise.resolve();
+    setSnapshot((prev) => {
+      if (!prev) return prev;
+      const newMember: TenantMember = {
+        id: `invite_${Date.now()}`,
+        email,
+        displayName: email.split("@")[0] ?? email,
+        role,
+        joinedAt: new Date().toISOString(),
+        status: "invited",
+      };
+      return { ...prev, members: [...prev.members, newMember] };
+    });
+  }, []);
+
+  const removeMember = useCallback(async (memberId: string) => {
+    // TODO: wire to Action `remove_tenant_member`.
+    await Promise.resolve();
+    setSnapshot((prev) =>
+      prev ? { ...prev, members: prev.members.filter((m) => m.id !== memberId) } : prev,
+    );
+  }, []);
+
+  return {
+    loading,
+    error,
+    snapshot,
+    refresh,
+    saveBranding,
+    saveConfig,
+    inviteMember,
+    removeMember,
+  };
+}


### PR DESCRIPTION
## Summary
- Spec 30 M2+: tenant self-service UI capability under `cap-adapter-ui/src/tenant/`
- 4 tabs (Branding / Config / Members / Usage) driven by a single hook
- Mock data layer — wiring to real GraphQL + Actions is a follow-up
- 16 tests on pure helpers

## Components
- **TenantSettingsPage** — parent page with Shadcn `Tabs`, loading + error states
- **TenantBrandingForm** — logo URL, primary color, app name (with hex validation)
- **TenantConfigEditor** — feature toggles KV editor + tenant-level i18n default
- **TenantMembersTable** — list members with role Select; "Invite member" Dialog
- **TenantUsageDashboard** — 3 KPI Cards (requests, storage, AI tokens) + placeholder

## Hook
- **`use-tenant-self-service.ts`** — centralized fetch + mutations (`inviteMember`, `removeMember`, etc.). Mock backing; TODO comments mark wiring points.

## Test plan
- [x] `bun run check` — clean
- [x] `bun run typecheck` — clean (no tenant-file errors)
- [x] `bun test` — 5610 pass / 0 fail

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)