### PR TITLE
feat(deployment): DeployBuilder — git pull → bun install → bun build pipeline (Spec 12 §3)

### DIFF
--- a/packages/core/__tests__/deployment-builder.test.ts
+++ b/packages/core/__tests__/deployment-builder.test.ts
@@ -1,0 +1,352 @@
+import { describe, expect, it } from "bun:test";
+import { DeployBuilder, type ExecResult, type ProcessExecutor } from "../src/deployment/builder";
+
+const REPO_DIR = "/tmp/fake-repo";
+
+const silentLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+// ── Test helpers ─────────────────────────────────────────────────────────
+
+function ok(stdout: string, stderr = ""): ExecResult {
+  return { stdout, stderr, exitCode: 0 };
+}
+
+function fail(stderr: string, exitCode = 1, stdout = ""): ExecResult {
+  return { stdout, stderr, exitCode };
+}
+
+/**
+ * Builds an executor that maps "cmd arg1 arg2" keys to ExecResult values.
+ * Throws for any unmapped command so tests fail fast on unexpected calls.
+ */
+function makeExecutor(responses: Record<string, ExecResult>): ProcessExecutor {
+  return async (cmd, args, _cwd) => {
+    const key = [cmd, ...args].join(" ");
+    const result = responses[key];
+    if (result === undefined) throw new Error(`Unexpected exec call: "${key}"`);
+    return result;
+  };
+}
+
+/** Executor that resolves after a delay — used for timeout tests */
+function slowExecutor(delayMs: number): ProcessExecutor {
+  return async (_cmd, _args, _cwd) =>
+    new Promise((resolve) => setTimeout(() => resolve(ok("done")), delayMs));
+}
+
+// ── Successful build paths ────────────────────────────────────────────────
+
+describe("DeployBuilder — success paths", () => {
+  it("reports upToDate and skips install + build when already up to date", async () => {
+    const executor = makeExecutor({
+      "git pull origin main": ok("Already up to date.\n"),
+      "bun run build": ok("Build succeeded"),
+    });
+
+    const builder = new DeployBuilder({ repoDir: REPO_DIR, executor, logger: silentLogger });
+    const result = await builder.build();
+
+    expect(result.success).toBe(true);
+    expect(result.phase).toBe("done");
+    expect(result.upToDate).toBe(true);
+    expect(result.depsChanged).toBe(false);
+    expect(result.installOutput).toBeUndefined();
+    expect(result.buildOutput).toContain("Build succeeded");
+  });
+
+  it("runs build without install when changed files do not include lockfiles", async () => {
+    const executor = makeExecutor({
+      "git pull origin main": ok("Updating abc..def\nFast-forward\n src/foo.ts | 1 +\n"),
+      "git diff --name-only HEAD~1 HEAD": ok("src/foo.ts\nsrc/bar.ts\n"),
+      "bun run build": ok("Build complete"),
+    });
+
+    const builder = new DeployBuilder({ repoDir: REPO_DIR, executor, logger: silentLogger });
+    const result = await builder.build();
+
+    expect(result.success).toBe(true);
+    expect(result.upToDate).toBe(false);
+    expect(result.depsChanged).toBe(false);
+    expect(result.installOutput).toBeUndefined();
+    expect(result.buildOutput).toContain("Build complete");
+  });
+
+  it("runs bun install when root package.json changes", async () => {
+    const executor = makeExecutor({
+      "git pull origin main": ok("Updating abc..def\n"),
+      "git diff --name-only HEAD~1 HEAD": ok("package.json\nsrc/index.ts\n"),
+      "bun install": ok("bun install v1.0.0\n"),
+      "bun run build": ok("Build done"),
+    });
+
+    const builder = new DeployBuilder({ repoDir: REPO_DIR, executor, logger: silentLogger });
+    const result = await builder.build();
+
+    expect(result.success).toBe(true);
+    expect(result.depsChanged).toBe(true);
+    expect(result.installOutput).toContain("bun install");
+    expect(result.buildOutput).toContain("Build done");
+  });
+
+  it("runs bun install when root bun.lockb changes", async () => {
+    const executor = makeExecutor({
+      "git pull origin main": ok("Updating abc..def\n"),
+      "git diff --name-only HEAD~1 HEAD": ok("bun.lockb\n"),
+      "bun install": ok("Installed\n"),
+      "bun run build": ok("OK"),
+    });
+
+    const builder = new DeployBuilder({ repoDir: REPO_DIR, executor, logger: silentLogger });
+    const result = await builder.build();
+
+    expect(result.success).toBe(true);
+    expect(result.depsChanged).toBe(true);
+  });
+
+  it("runs bun install when nested package.json changes", async () => {
+    const executor = makeExecutor({
+      "git pull origin main": ok("Updating abc..def\n"),
+      "git diff --name-only HEAD~1 HEAD": ok("packages/core/package.json\n"),
+      "bun install": ok("Installed\n"),
+      "bun run build": ok("OK"),
+    });
+
+    const builder = new DeployBuilder({ repoDir: REPO_DIR, executor, logger: silentLogger });
+    const result = await builder.build();
+
+    expect(result.depsChanged).toBe(true);
+  });
+
+  it("runs bun install when nested bun.lockb changes", async () => {
+    const executor = makeExecutor({
+      "git pull origin main": ok("Updating abc..def\n"),
+      "git diff --name-only HEAD~1 HEAD": ok("addons/auth/bun.lockb\n"),
+      "bun install": ok("Installed\n"),
+      "bun run build": ok("OK"),
+    });
+
+    const builder = new DeployBuilder({ repoDir: REPO_DIR, executor, logger: silentLogger });
+    const result = await builder.build();
+
+    expect(result.depsChanged).toBe(true);
+  });
+
+  it("respects custom remote and branch", async () => {
+    const calls: string[] = [];
+    const executor: ProcessExecutor = async (cmd, args, _cwd) => {
+      calls.push([cmd, ...args].join(" "));
+      if (cmd === "git" && args[0] === "pull") return ok("Already up to date.\n");
+      return ok("OK");
+    };
+
+    const builder = new DeployBuilder({
+      repoDir: REPO_DIR,
+      remote: "upstream",
+      branch: "release",
+      executor,
+      logger: silentLogger,
+    });
+    await builder.build();
+
+    expect(calls[0]).toBe("git pull upstream release");
+  });
+
+  it("respects custom buildScript", async () => {
+    const calls: string[] = [];
+    const executor: ProcessExecutor = async (cmd, args, _cwd) => {
+      calls.push([cmd, ...args].join(" "));
+      if (cmd === "git" && args[0] === "pull") return ok("Already up to date.\n");
+      return ok("OK");
+    };
+
+    const builder = new DeployBuilder({
+      repoDir: REPO_DIR,
+      buildScript: "build:production",
+      executor,
+      logger: silentLogger,
+    });
+    await builder.build();
+
+    expect(calls).toContain("bun run build:production");
+  });
+
+  it("includes durationMs in successful result", async () => {
+    const executor = makeExecutor({
+      "git pull origin main": ok("Already up to date.\n"),
+      "bun run build": ok("OK"),
+    });
+
+    const builder = new DeployBuilder({ repoDir: REPO_DIR, executor, logger: silentLogger });
+    const result = await builder.build();
+
+    expect(typeof result.durationMs).toBe("number");
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ── Failure paths ─────────────────────────────────────────────────────────
+
+describe("DeployBuilder — failure paths", () => {
+  it("returns failed result when git pull exits non-zero", async () => {
+    const executor = makeExecutor({
+      "git pull origin main": fail("fatal: unable to access remote", 128),
+    });
+
+    const builder = new DeployBuilder({ repoDir: REPO_DIR, executor, logger: silentLogger });
+    const result = await builder.build();
+
+    expect(result.success).toBe(false);
+    expect(result.phase).toBe("failed");
+    expect(result.error).toContain("git pull failed");
+    expect(result.error).toContain("128");
+  });
+
+  it("returns failed result when bun install exits non-zero", async () => {
+    const executor = makeExecutor({
+      "git pull origin main": ok("Updating abc..def\n"),
+      "git diff --name-only HEAD~1 HEAD": ok("package.json\n"),
+      "bun install": fail("error: package resolution failed", 1),
+    });
+
+    const builder = new DeployBuilder({ repoDir: REPO_DIR, executor, logger: silentLogger });
+    const result = await builder.build();
+
+    expect(result.success).toBe(false);
+    expect(result.phase).toBe("failed");
+    expect(result.error).toContain("bun install failed");
+    expect(result.depsChanged).toBe(true);
+  });
+
+  it("returns failed result when build script exits non-zero", async () => {
+    const executor = makeExecutor({
+      "git pull origin main": ok("Already up to date.\n"),
+      "bun run build": fail("TypeScript error: ...", 1, ""),
+    });
+
+    const builder = new DeployBuilder({ repoDir: REPO_DIR, executor, logger: silentLogger });
+    const result = await builder.build();
+
+    expect(result.success).toBe(false);
+    expect(result.phase).toBe("failed");
+    expect(result.error).toContain("bun run build failed");
+    expect(result.buildOutput).toContain("TypeScript error");
+  });
+
+  it("returns failed result when git pull executor throws", async () => {
+    const executor: ProcessExecutor = async () => {
+      throw new Error("network unreachable");
+    };
+
+    const builder = new DeployBuilder({ repoDir: REPO_DIR, executor, logger: silentLogger });
+    const result = await builder.build();
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("network unreachable");
+  });
+
+  it("returns failed result when bun install executor throws", async () => {
+    let callCount = 0;
+    const executor: ProcessExecutor = async (cmd, args) => {
+      callCount++;
+      if (cmd === "git" && args[0] === "pull") return ok("Updating abc..def\n");
+      if (cmd === "git" && args[0] === "diff") return ok("package.json\n");
+      throw new Error("bun binary missing");
+    };
+
+    const builder = new DeployBuilder({ repoDir: REPO_DIR, executor, logger: silentLogger });
+    const result = await builder.build();
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("bun install error");
+    expect(callCount).toBeGreaterThan(0);
+  });
+
+  it("proceeds with build even when git diff fails (skips install)", async () => {
+    const executor: ProcessExecutor = async (cmd, args) => {
+      if (cmd === "git" && args[0] === "pull") return ok("Updating abc..def\n");
+      if (cmd === "git" && args[0] === "diff") throw new Error("fatal: no commits yet");
+      if (cmd === "bun" && args[0] === "run") return ok("Build OK");
+      throw new Error(`Unexpected: ${[cmd, ...args].join(" ")}`);
+    };
+
+    const builder = new DeployBuilder({ repoDir: REPO_DIR, executor, logger: silentLogger });
+    const result = await builder.build();
+
+    // Install skipped, build still ran
+    expect(result.success).toBe(true);
+    expect(result.depsChanged).toBe(false);
+    expect(result.installOutput).toBeUndefined();
+  });
+});
+
+// ── Timeout path ──────────────────────────────────────────────────────────
+
+describe("DeployBuilder — timeout", () => {
+  it("returns failed result when git pull exceeds timeoutMs", async () => {
+    const builder = new DeployBuilder({
+      repoDir: REPO_DIR,
+      timeoutMs: 50,
+      executor: slowExecutor(500),
+      logger: silentLogger,
+    });
+
+    const result = await builder.build();
+
+    expect(result.success).toBe(false);
+    expect(result.phase).toBe("failed");
+    expect(result.error).toMatch(/timed out/i);
+  });
+
+  it("returns failed when already past deadline before pulling", async () => {
+    const executor = makeExecutor({});
+    const builder = new DeployBuilder({
+      repoDir: REPO_DIR,
+      timeoutMs: 0,
+      executor,
+      logger: silentLogger,
+    });
+
+    const result = await builder.build();
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("pulling");
+  });
+});
+
+// ── gitPullOutput ─────────────────────────────────────────────────────────
+
+describe("DeployBuilder — gitPullOutput", () => {
+  it("combines stdout and stderr from git pull", async () => {
+    const executor = makeExecutor({
+      "git pull origin main": {
+        stdout: "Updating abc..def\n",
+        stderr: "warning: x\n",
+        exitCode: 0,
+      },
+      "git diff --name-only HEAD~1 HEAD": ok(""),
+      "bun run build": ok("OK"),
+    });
+
+    const builder = new DeployBuilder({ repoDir: REPO_DIR, executor, logger: silentLogger });
+    const result = await builder.build();
+
+    expect(result.gitPullOutput).toContain("Updating abc..def");
+    expect(result.gitPullOutput).toContain("warning: x");
+  });
+
+  it("includes stderr from git pull in error message on failure", async () => {
+    const executor = makeExecutor({
+      "git pull origin main": { stdout: "", stderr: "fatal: repo not found", exitCode: 128 },
+    });
+
+    const builder = new DeployBuilder({ repoDir: REPO_DIR, executor, logger: silentLogger });
+    const result = await builder.build();
+
+    expect(result.error).toContain("repo not found");
+  });
+});

--- a/packages/core/__tests__/deployment-builder.test.ts
+++ b/packages/core/__tests__/deployment-builder.test.ts
@@ -23,9 +23,16 @@ function fail(stderr: string, exitCode = 1, stdout = ""): ExecResult {
 /**
  * Builds an executor that maps "cmd arg1 arg2" keys to ExecResult values.
  * Throws for any unmapped command so tests fail fast on unexpected calls.
+ * Also asserts that every call uses the expected cwd.
  */
-function makeExecutor(responses: Record<string, ExecResult>): ProcessExecutor {
-  return async (cmd, args, _cwd) => {
+function makeExecutor(
+  responses: Record<string, ExecResult>,
+  expectedCwd = REPO_DIR,
+): ProcessExecutor {
+  return async (cmd, args, cwd) => {
+    if (cwd !== expectedCwd) {
+      throw new Error(`Unexpected cwd: "${cwd}" (expected "${expectedCwd}")`);
+    }
     const key = [cmd, ...args].join(" ");
     const result = responses[key];
     if (result === undefined) throw new Error(`Unexpected exec call: "${key}"`);
@@ -62,7 +69,7 @@ describe("DeployBuilder — success paths", () => {
   it("runs build without install when changed files do not include lockfiles", async () => {
     const executor = makeExecutor({
       "git pull origin main": ok("Updating abc..def\nFast-forward\n src/foo.ts | 1 +\n"),
-      "git diff --name-only HEAD~1 HEAD": ok("src/foo.ts\nsrc/bar.ts\n"),
+      "git diff --name-only ORIG_HEAD HEAD": ok("src/foo.ts\nsrc/bar.ts\n"),
       "bun run build": ok("Build complete"),
     });
 
@@ -79,7 +86,7 @@ describe("DeployBuilder — success paths", () => {
   it("runs bun install when root package.json changes", async () => {
     const executor = makeExecutor({
       "git pull origin main": ok("Updating abc..def\n"),
-      "git diff --name-only HEAD~1 HEAD": ok("package.json\nsrc/index.ts\n"),
+      "git diff --name-only ORIG_HEAD HEAD": ok("package.json\nsrc/index.ts\n"),
       "bun install": ok("bun install v1.0.0\n"),
       "bun run build": ok("Build done"),
     });
@@ -96,7 +103,7 @@ describe("DeployBuilder — success paths", () => {
   it("runs bun install when root bun.lockb changes", async () => {
     const executor = makeExecutor({
       "git pull origin main": ok("Updating abc..def\n"),
-      "git diff --name-only HEAD~1 HEAD": ok("bun.lockb\n"),
+      "git diff --name-only ORIG_HEAD HEAD": ok("bun.lockb\n"),
       "bun install": ok("Installed\n"),
       "bun run build": ok("OK"),
     });
@@ -111,7 +118,7 @@ describe("DeployBuilder — success paths", () => {
   it("runs bun install when nested package.json changes", async () => {
     const executor = makeExecutor({
       "git pull origin main": ok("Updating abc..def\n"),
-      "git diff --name-only HEAD~1 HEAD": ok("packages/core/package.json\n"),
+      "git diff --name-only ORIG_HEAD HEAD": ok("packages/core/package.json\n"),
       "bun install": ok("Installed\n"),
       "bun run build": ok("OK"),
     });
@@ -125,7 +132,7 @@ describe("DeployBuilder — success paths", () => {
   it("runs bun install when nested bun.lockb changes", async () => {
     const executor = makeExecutor({
       "git pull origin main": ok("Updating abc..def\n"),
-      "git diff --name-only HEAD~1 HEAD": ok("addons/auth/bun.lockb\n"),
+      "git diff --name-only ORIG_HEAD HEAD": ok("addons/auth/bun.lockb\n"),
       "bun install": ok("Installed\n"),
       "bun run build": ok("OK"),
     });
@@ -156,7 +163,7 @@ describe("DeployBuilder — success paths", () => {
     expect(calls[0]).toBe("git pull upstream release");
   });
 
-  it("respects custom buildScript", async () => {
+  it("respects custom buildScript and does not run the default script", async () => {
     const calls: string[] = [];
     const executor: ProcessExecutor = async (cmd, args, _cwd) => {
       calls.push([cmd, ...args].join(" "));
@@ -173,6 +180,7 @@ describe("DeployBuilder — success paths", () => {
     await builder.build();
 
     expect(calls).toContain("bun run build:production");
+    expect(calls).not.toContain("bun run build");
   });
 
   it("includes durationMs in successful result", async () => {
@@ -209,7 +217,7 @@ describe("DeployBuilder — failure paths", () => {
   it("returns failed result when bun install exits non-zero", async () => {
     const executor = makeExecutor({
       "git pull origin main": ok("Updating abc..def\n"),
-      "git diff --name-only HEAD~1 HEAD": ok("package.json\n"),
+      "git diff --name-only ORIG_HEAD HEAD": ok("package.json\n"),
       "bun install": fail("error: package resolution failed", 1),
     });
 
@@ -328,7 +336,7 @@ describe("DeployBuilder — gitPullOutput", () => {
         stderr: "warning: x\n",
         exitCode: 0,
       },
-      "git diff --name-only HEAD~1 HEAD": ok(""),
+      "git diff --name-only ORIG_HEAD HEAD": ok(""),
       "bun run build": ok("OK"),
     });
 

--- a/packages/core/src/deployment/builder.ts
+++ b/packages/core/src/deployment/builder.ts
@@ -1,0 +1,314 @@
+/**
+ * Deploy Builder — git pull → bun install → bun build pipeline.
+ *
+ * Implements the "Builder" component described in Spec 12 §3.
+ * Pulls the latest code, installs deps only when lockfile changes,
+ * then runs the configured build script.
+ */
+
+import type { Logger } from "../types/logger";
+
+const stdoutLogger: Logger = {
+  debug: (msg, ctx) => console.debug(`[DeployBuilder] ${msg}`, ctx ?? ""),
+  info: (msg, ctx) => console.info(`[DeployBuilder] ${msg}`, ctx ?? ""),
+  warn: (msg, ctx) => console.warn(`[DeployBuilder] ${msg}`, ctx ?? ""),
+  error: (msg, ctx) => console.error(`[DeployBuilder] ${msg}`, ctx ?? ""),
+};
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+export interface ExecResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/** Inject a custom executor in tests to avoid real subprocesses. */
+export type ProcessExecutor = (cmd: string, args: string[], cwd: string) => Promise<ExecResult>;
+
+export type BuildPhase = "idle" | "pulling" | "installing" | "building" | "done" | "failed";
+
+export interface BuildResult {
+  success: boolean;
+  /** Phase at which the build stopped */
+  phase: BuildPhase;
+  /** Raw combined output from `git pull` */
+  gitPullOutput: string;
+  /** True when git reported "Already up to date" */
+  upToDate: boolean;
+  /** True when package.json or bun.lockb changed after pull */
+  depsChanged: boolean;
+  installOutput?: string;
+  buildOutput?: string;
+  durationMs: number;
+  error?: string;
+}
+
+export interface BuildConfig {
+  /** Absolute path to the repository root */
+  repoDir: string;
+  /** Git remote name (default: "origin") */
+  remote?: string;
+  /** Git branch to pull (default: "main") */
+  branch?: string;
+  /** Package script name to execute for building (default: "build") */
+  buildScript?: string;
+  /** Total timeout for the full build pipeline in ms (default: 300000) */
+  timeoutMs?: number;
+  logger?: Logger;
+  /** Injected executor for unit tests */
+  executor?: ProcessExecutor;
+}
+
+// ── DeployBuilder ────────────────────────────────────────────────────────
+
+export class DeployBuilder {
+  private readonly repoDir: string;
+  private readonly remote: string;
+  private readonly branch: string;
+  private readonly buildScript: string;
+  private readonly timeoutMs: number;
+  private readonly logger: Logger;
+  private readonly executor: ProcessExecutor;
+
+  constructor(config: BuildConfig) {
+    this.repoDir = config.repoDir;
+    this.remote = config.remote ?? "origin";
+    this.branch = config.branch ?? "main";
+    this.buildScript = config.buildScript ?? "build";
+    this.timeoutMs = config.timeoutMs ?? 300_000;
+    this.logger = config.logger ?? stdoutLogger;
+    this.executor = config.executor ?? defaultExecutor;
+  }
+
+  async build(): Promise<BuildResult> {
+    const startMs = Date.now();
+    const deadline = startMs + this.timeoutMs;
+
+    const elapsed = () => Date.now() - startMs;
+    const remaining = () => deadline - Date.now();
+
+    this.logger.info("DeployBuilder: starting build pipeline", {
+      repoDir: this.repoDir,
+      remote: this.remote,
+      branch: this.branch,
+    });
+
+    // ── Step 1: git pull ─────────────────────────────────────────────────
+    if (remaining() <= 0) {
+      return this.makeTimeoutResult(elapsed(), "pulling", "", false, false);
+    }
+
+    this.logger.info("DeployBuilder: git pull", { remote: this.remote, branch: this.branch });
+
+    let pullResult: ExecResult;
+    try {
+      pullResult = await withTimeout(
+        this.executor("git", ["pull", this.remote, this.branch], this.repoDir),
+        remaining(),
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        success: false,
+        phase: "failed",
+        gitPullOutput: "",
+        upToDate: false,
+        depsChanged: false,
+        durationMs: elapsed(),
+        error: `git pull error: ${msg}`,
+      };
+    }
+
+    const gitPullOutput = pullResult.stdout + (pullResult.stderr ? `\n${pullResult.stderr}` : "");
+
+    if (pullResult.exitCode !== 0) {
+      this.logger.error("DeployBuilder: git pull failed", { exitCode: pullResult.exitCode });
+      return {
+        success: false,
+        phase: "failed",
+        gitPullOutput,
+        upToDate: false,
+        depsChanged: false,
+        durationMs: elapsed(),
+        error: `git pull failed (exit ${pullResult.exitCode}): ${gitPullOutput}`,
+      };
+    }
+
+    const upToDate = pullResult.stdout.includes("Already up to date");
+    this.logger.info("DeployBuilder: git pull complete", { upToDate });
+
+    // ── Step 2: detect lockfile / manifest changes ────────────────────────
+    let depsChanged = false;
+    if (!upToDate) {
+      try {
+        const diffResult = await withTimeout(
+          this.executor("git", ["diff", "--name-only", "HEAD~1", "HEAD"], this.repoDir),
+          remaining(),
+        );
+        const changedFiles = diffResult.stdout.split("\n").filter(Boolean);
+        depsChanged = changedFiles.some(
+          (f) =>
+            f === "package.json" ||
+            f === "bun.lockb" ||
+            f.endsWith("/package.json") ||
+            f.endsWith("/bun.lockb"),
+        );
+        this.logger.info("DeployBuilder: deps change detection", { depsChanged, changedFiles });
+      } catch {
+        // Non-fatal: skip install on diff failure (e.g. initial commit, shallow clone)
+        this.logger.warn("DeployBuilder: git diff failed, skipping install check");
+      }
+    }
+
+    // ── Step 3: bun install (only when deps changed) ──────────────────────
+    let installOutput: string | undefined;
+    if (depsChanged) {
+      if (remaining() <= 0) {
+        return this.makeTimeoutResult(elapsed(), "installing", gitPullOutput, upToDate, true);
+      }
+
+      this.logger.info("DeployBuilder: running bun install");
+
+      let installResult: ExecResult;
+      try {
+        installResult = await withTimeout(
+          this.executor("bun", ["install"], this.repoDir),
+          remaining(),
+        );
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return {
+          success: false,
+          phase: "failed",
+          gitPullOutput,
+          upToDate,
+          depsChanged,
+          durationMs: elapsed(),
+          error: `bun install error: ${msg}`,
+        };
+      }
+
+      installOutput =
+        installResult.stdout + (installResult.stderr ? `\n${installResult.stderr}` : "");
+
+      if (installResult.exitCode !== 0) {
+        this.logger.error("DeployBuilder: bun install failed", {
+          exitCode: installResult.exitCode,
+        });
+        return {
+          success: false,
+          phase: "failed",
+          gitPullOutput,
+          upToDate,
+          depsChanged,
+          installOutput,
+          durationMs: elapsed(),
+          error: `bun install failed (exit ${installResult.exitCode}): ${installOutput}`,
+        };
+      }
+    }
+
+    // ── Step 4: bun run build ────────────────────────────────────────────
+    if (remaining() <= 0) {
+      return this.makeTimeoutResult(elapsed(), "building", gitPullOutput, upToDate, depsChanged);
+    }
+
+    this.logger.info("DeployBuilder: running build script", { script: this.buildScript });
+
+    let buildExecResult: ExecResult;
+    try {
+      buildExecResult = await withTimeout(
+        this.executor("bun", ["run", this.buildScript], this.repoDir),
+        remaining(),
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        success: false,
+        phase: "failed",
+        gitPullOutput,
+        upToDate,
+        depsChanged,
+        installOutput,
+        durationMs: elapsed(),
+        error: `bun run ${this.buildScript} error: ${msg}`,
+      };
+    }
+
+    const buildOutput =
+      buildExecResult.stdout + (buildExecResult.stderr ? `\n${buildExecResult.stderr}` : "");
+
+    if (buildExecResult.exitCode !== 0) {
+      this.logger.error("DeployBuilder: build failed", { exitCode: buildExecResult.exitCode });
+      return {
+        success: false,
+        phase: "failed",
+        gitPullOutput,
+        upToDate,
+        depsChanged,
+        installOutput,
+        buildOutput,
+        durationMs: elapsed(),
+        error: `bun run ${this.buildScript} failed (exit ${buildExecResult.exitCode}): ${buildOutput}`,
+      };
+    }
+
+    this.logger.info("DeployBuilder: build pipeline complete", { durationMs: elapsed() });
+
+    return {
+      success: true,
+      phase: "done",
+      gitPullOutput,
+      upToDate,
+      depsChanged,
+      installOutput,
+      buildOutput,
+      durationMs: elapsed(),
+    };
+  }
+
+  private makeTimeoutResult(
+    durationMs: number,
+    phase: BuildPhase,
+    gitPullOutput: string,
+    upToDate: boolean,
+    depsChanged: boolean,
+  ): BuildResult {
+    this.logger.error("DeployBuilder: timed out", { phase, timeoutMs: this.timeoutMs });
+    return {
+      success: false,
+      phase: "failed",
+      gitPullOutput,
+      upToDate,
+      depsChanged,
+      durationMs,
+      error: `DeployBuilder timed out waiting to start "${phase}" after ${this.timeoutMs}ms`,
+    };
+  }
+}
+
+// ── Default executor using Bun.spawn ─────────────────────────────────────
+
+const defaultExecutor: ProcessExecutor = async (cmd, args, cwd) => {
+  const proc = Bun.spawn([cmd, ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  const exitCode = await proc.exited;
+  return { stdout, stderr, exitCode };
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`Operation timed out after ${ms}ms`)), Math.max(ms, 0)),
+    ),
+  ]);
+}

--- a/packages/core/src/deployment/builder.ts
+++ b/packages/core/src/deployment/builder.ts
@@ -96,7 +96,13 @@ export class DeployBuilder {
 
     // ── Step 1: git pull ─────────────────────────────────────────────────
     if (remaining() <= 0) {
-      return this.makeTimeoutResult(elapsed(), "pulling", "", false, false);
+      return this.makeTimeoutResult({
+        durationMs: elapsed(),
+        phase: "pulling",
+        gitPullOutput: "",
+        upToDate: false,
+        depsChanged: false,
+      });
     }
 
     this.logger.info("DeployBuilder: git pull", { remote: this.remote, branch: this.branch });
@@ -139,11 +145,13 @@ export class DeployBuilder {
     this.logger.info("DeployBuilder: git pull complete", { upToDate });
 
     // ── Step 2: detect lockfile / manifest changes ────────────────────────
+    // Use ORIG_HEAD (set by git after pull/merge) so multi-commit fast-forwards
+    // are fully covered — HEAD~1 would only compare the latest commit.
     let depsChanged = false;
     if (!upToDate) {
       try {
         const diffResult = await withTimeout(
-          this.executor("git", ["diff", "--name-only", "HEAD~1", "HEAD"], this.repoDir),
+          this.executor("git", ["diff", "--name-only", "ORIG_HEAD", "HEAD"], this.repoDir),
           remaining(),
         );
         const changedFiles = diffResult.stdout.split("\n").filter(Boolean);
@@ -165,7 +173,13 @@ export class DeployBuilder {
     let installOutput: string | undefined;
     if (depsChanged) {
       if (remaining() <= 0) {
-        return this.makeTimeoutResult(elapsed(), "installing", gitPullOutput, upToDate, true);
+        return this.makeTimeoutResult({
+          durationMs: elapsed(),
+          phase: "installing",
+          gitPullOutput,
+          upToDate,
+          depsChanged: true,
+        });
       }
 
       this.logger.info("DeployBuilder: running bun install");
@@ -211,7 +225,13 @@ export class DeployBuilder {
 
     // ── Step 4: bun run build ────────────────────────────────────────────
     if (remaining() <= 0) {
-      return this.makeTimeoutResult(elapsed(), "building", gitPullOutput, upToDate, depsChanged);
+      return this.makeTimeoutResult({
+        durationMs: elapsed(),
+        phase: "building",
+        gitPullOutput,
+        upToDate,
+        depsChanged,
+      });
     }
 
     this.logger.info("DeployBuilder: running build script", { script: this.buildScript });
@@ -268,13 +288,14 @@ export class DeployBuilder {
     };
   }
 
-  private makeTimeoutResult(
-    durationMs: number,
-    phase: BuildPhase,
-    gitPullOutput: string,
-    upToDate: boolean,
-    depsChanged: boolean,
-  ): BuildResult {
+  private makeTimeoutResult(options: {
+    durationMs: number;
+    phase: BuildPhase;
+    gitPullOutput: string;
+    upToDate: boolean;
+    depsChanged: boolean;
+  }): BuildResult {
+    const { durationMs, phase, gitPullOutput, upToDate, depsChanged } = options;
     this.logger.error("DeployBuilder: timed out", { phase, timeoutMs: this.timeoutMs });
     return {
       success: false,
@@ -296,8 +317,12 @@ const defaultExecutor: ProcessExecutor = async (cmd, args, cwd) => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const stdout = await new Response(proc.stdout).text();
-  const stderr = await new Response(proc.stderr).text();
+  // Drain stdout and stderr concurrently to prevent deadlock when either
+  // pipe's buffer fills while the other is being read sequentially.
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
   const exitCode = await proc.exited;
   return { stdout, stderr, exitCode };
 };
@@ -305,10 +330,12 @@ const defaultExecutor: ProcessExecutor = async (cmd, args, cwd) => {
 // ── Helpers ───────────────────────────────────────────────────────────────
 
 function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
-  return Promise.race([
-    promise,
-    new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error(`Operation timed out after ${ms}ms`)), Math.max(ms, 0)),
-    ),
-  ]);
+  let timerId: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timerId = setTimeout(
+      () => reject(new Error(`Operation timed out after ${ms}ms`)),
+      Math.max(ms, 0),
+    );
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => clearTimeout(timerId));
 }

--- a/packages/core/src/deployment/index.ts
+++ b/packages/core/src/deployment/index.ts
@@ -1,8 +1,17 @@
 /**
- * Deployment utilities — Health checks, graceful shutdown, environment detection.
+ * Deployment utilities — Health checks, graceful shutdown, environment detection, build pipeline.
  *
  * Server-only module. Used by the server adapter and CLI for production deployments.
  */
+
+export {
+  type BuildConfig,
+  type BuildPhase,
+  type BuildResult,
+  DeployBuilder,
+  type ExecResult,
+  type ProcessExecutor,
+} from "./builder";
 
 export {
   detectEnvironment,


### PR DESCRIPTION
## Summary

- Adds `DeployBuilder` class to `packages/core/src/deployment/builder.ts`
- Implements the **Builder** component from Spec 12 §3: `git pull → bun install → bun build`
- Detects lockfile / manifest changes (`package.json`, `bun.lockb` — root and nested) to skip `bun install` when deps haven't changed
- Injectable `ProcessExecutor` interface makes the class fully unit-testable without real subprocesses
- 19 unit tests covering all code paths

## Implementation notes

**`packages/core/src/deployment/builder.ts`**
- `DeployBuilder` constructor accepts `BuildConfig` with injectable `executor` (default: `Bun.spawn`)
- `build()` returns `BuildResult` discriminated by `success` + `phase` + per-step outputs
- Timeout guard via `withTimeout()` + deadline arithmetic — enforced for each subprocess call
- Deps detection: after `git pull`, runs `git diff --name-only HEAD~1 HEAD`; if `package.json` or `bun.lockb` appears (at any depth), runs `bun install`
- `git diff` failure is non-fatal (e.g. shallow clone, first commit): warns and skips install
- Default logger uses `console.*` (no pino dependency) so tests run without the pino package

**`packages/core/src/deployment/index.ts`**
- Exports `DeployBuilder`, `BuildConfig`, `BuildResult`, `BuildPhase`, `ExecResult`, `ProcessExecutor`

**`packages/core/__tests__/deployment-builder.test.ts`** — 19 tests:
- Success: up-to-date, new changes without dep change, dep change via `package.json`, dep change via `bun.lockb`, nested `package.json`, nested `bun.lockb`, custom remote/branch, custom buildScript, durationMs present
- Failure: git pull non-zero exit, bun install non-zero exit, build non-zero exit, git pull executor throws, bun install executor throws
- Non-fatal: git diff failure skips install but build still runs
- Timeout: git pull exceeds `timeoutMs`, already past deadline before pulling
- Output: gitPullOutput combines stdout+stderr, stderr included in error on failure

## Spec alignment

| Spec | Section | Covered |
|------|---------|---------|
| Spec 12 | §3 Builder component | ✅ git pull → bun install → bun build |
| Spec 12 | §4 Blue-green flow steps 1–2 | ✅ pull + dep detection + install |
| Spec 12 | §3 Configurable remote/branch | ✅ `remote` + `branch` config keys |

DB migration (step 3 in §4) is deliberately out of scope — that is `cap-migration`'s responsibility and is wired by the Deployer/orchestrator, not the Builder.

## Quality gates

| Gate | Result |
|------|--------|
| `bun run check` (Biome) | ✅ 0 errors (1 schema-version info — pre-existing) |
| `bun run typecheck` | ✅ 0 new errors (pre-existing `bun-types` TS2688 — env issue, same as main) |
| `bun test` (builder only) | ✅ 19/19 pass |
| `bun test` (full suite) | ✅ no regressions — 150 pre-existing failures unchanged |
| `linch validate` | N/A — no meta-model files changed |

## Retro

- **Why this approach:** The Builder is the most bounded, independently testable piece remaining in Spec 12 after PR #342 (webhook receiver) and PR #345 (health check / graceful shutdown / env detection). It has a clear input (repoDir + config) and output (BuildResult), making it straightforward to implement and test without standing up any server. Delivering it as a standalone module lets the Deployer (blue-green orchestrator, future PR) inject it without tight coupling.

- **Alternatives considered:**
  - *Use `consoleLogger` (pino-backed)*: Rejected — pino is not installed in the remote sandbox, causing all tests that import the module to fail. The Builder only needs basic logging; a simple `console.*` wrapper is sufficient and keeps the class dependency-free.
  - *Always run `bun install` regardless of lockfile changes*: Rejected — `bun install` on a large monorepo takes ~30s even with a warm cache; skipping it when deps haven't changed is the correct optimization per Spec 12 §4 ("bun install（如果依赖变了）").
  - *Shell-out via `execa` or similar*: Rejected — `Bun.spawn` is already available and no new dependencies are allowed.

- **Security review:** No auth/tenant/input-trust surfaces touched. The Builder takes `repoDir` and config from the server operator (not from HTTP requests or user input); it executes only `git`, `bun install`, and `bun run build` in the specified directory. No secrets, tokens, or untrusted data flow through this class. No SQL, no DDL, no API endpoints.

- **Other risks:**
  - The default 5-minute timeout may be too short for very large monorepos on slow machines; callers can override via `timeoutMs`.
  - Replay-attack / concurrent-build risk (two webhook deliveries triggering two concurrent `DeployBuilder.build()` calls) is not handled here — that is the Deployer/orchestrator's responsibility.

- **Follow-ups:**
  - Deployer component: blue-green instance management + Nginx upstream swap (Spec 12 §4 steps 4–10)
  - Rollback component: quick (Nginx switch-back) and full (`git revert`) flows (Spec 12 §6)
  - Wire `DeployBuilder` into the webhook handler (PR #342) so `onDeploy` callback triggers an actual build

## Self-review checklist

- [x] Tests added/updated and passing (19 new tests)
- [x] `bun run check` green
- [x] `bun run typecheck` green (no new errors; pre-existing `bun-types` env issue unchanged)
- [x] `bun test` green (19/19 builder tests; no regressions in full suite)
- [x] `linch validate` N/A — no meta-model files changed
- [x] Spec referenced in PR body (Spec 12 §3 + §4)
- [x] Mandatory security review walked through — no auth/tenant/input-trust surfaces touched
- [x] No new dependencies
- [x] No hardcoded secrets, no `any`, no `eval`, no `new Function`
- [x] No changes outside the issue scope
- [x] Branch name follows convention (`feat/deploy-builder-72`)
- [x] Commit message follows convention (conventional commits, English)
- [x] Every comment posted has a real timestamp (no `<UTC time>` placeholder)
- [x] All commits have author = `claude-agent[bot]` ✅

Refs #72

---
_Generated by [Claude Code](https://claude.ai/code/session_015vnMWef4fsKPSqhJRd4ErT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `DeployBuilder` for automated code deployment pipelines with git operations, dependency installation, and build execution
  * Includes timeout handling for each pipeline step and comprehensive error reporting with captured output and timing information

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laofahai/linchkit/pull/354?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->