### PR TITLE
fix(core): DeployBuilder aborts subprocesses on timeout (closes #361)

### DIFF
--- a/.changeset/deploy-builder-abort-signal.md
+++ b/.changeset/deploy-builder-abort-signal.md
@@ -1,0 +1,11 @@
+---
+"@linchkit/core": minor
+---
+
+feat(deployment): DeployBuilder now aborts subprocesses on timeout via AbortSignal.
+
+`ProcessExecutor` signature gained an optional fourth parameter `options?: { signal?: AbortSignal }`. Custom executors implementing this type should forward the signal to their spawn mechanism (e.g., `child_process.spawn`'s `signal` option or `Bun.spawn`'s `signal` option) so timed-out processes get SIGTERM'd instead of leaking as orphans. Existing executors that ignore the new parameter remain functionally compatible but will continue to leak subprocesses on timeout.
+
+The internal `withTimeout` helper now accepts a `(signal) => Promise<T>` callback rather than a bare `Promise<T>`. The default `Bun.spawn`-backed executor forwards the signal and translates an aborted run into a clear `Subprocess aborted` error instead of the previous opaque `exit 143: <empty>`.
+
+Fixes #361.

--- a/packages/core/__tests__/deployment.test.ts
+++ b/packages/core/__tests__/deployment.test.ts
@@ -638,4 +638,29 @@ describe("DeployBuilder", () => {
     expect(result.phase).toBe("failed");
     expect(result.error).toContain("git pull error");
   });
+
+  it("treats timeoutMs=Infinity as 'no timeout' — does not abort a slow build", async () => {
+    // Bun/Node setTimeout coerces non-finite delays to 1ms; without a guard,
+    // Infinity would behave as "abort immediately" instead of "wait forever".
+    const executor: ProcessExecutor = async (_cmd, _args, _cwd, options) => {
+      // Sleep long enough that a 1ms-coerced timer would have aborted us.
+      await new Promise<void>((resolve) => setTimeout(resolve, 100));
+      if (options?.signal?.aborted) {
+        throw new Error("unexpected abort");
+      }
+      return { stdout: "Already up to date.\n", stderr: "", exitCode: 0 };
+    };
+
+    const builder = new DeployBuilder({
+      repoDir: "/tmp/fake-repo",
+      timeoutMs: Number.POSITIVE_INFINITY,
+      logger: silentLogger,
+      executor,
+    });
+
+    const result = await builder.build();
+
+    expect(result.success).toBe(true);
+    expect(result.upToDate).toBe(true);
+  });
 });

--- a/packages/core/__tests__/deployment.test.ts
+++ b/packages/core/__tests__/deployment.test.ts
@@ -4,10 +4,13 @@ import {
   createDatabaseCheck,
   createEntityCheck,
   createEventBusCheck,
+  DeployBuilder,
   detectEnvironment,
+  type ExecResult,
   GracefulShutdownManager,
   HealthCheckRegistry,
   livenessCheck,
+  type ProcessExecutor,
   validateRequiredEnvVars,
 } from "../src/deployment";
 
@@ -471,5 +474,168 @@ describe("validateRequiredEnvVars", () => {
   it("returns valid for empty required list", () => {
     const result = validateRequiredEnvVars([]);
     expect(result.valid).toBe(true);
+  });
+});
+
+// ── DeployBuilder ───────────────────────────────────────────
+
+describe("DeployBuilder", () => {
+  /** Build a stubbed executor that records every call. */
+  function makeRecordingExecutor(
+    handler: (
+      cmd: string,
+      args: string[],
+      cwd: string,
+      signal: AbortSignal | undefined,
+    ) => Promise<ExecResult>,
+  ): {
+    executor: ProcessExecutor;
+    calls: Array<{
+      cmd: string;
+      args: string[];
+      cwd: string;
+      signal: AbortSignal | undefined;
+    }>;
+  } {
+    const calls: Array<{
+      cmd: string;
+      args: string[];
+      cwd: string;
+      signal: AbortSignal | undefined;
+    }> = [];
+    const executor: ProcessExecutor = async (cmd, args, cwd, options) => {
+      calls.push({ cmd, args, cwd, signal: options?.signal });
+      return handler(cmd, args, cwd, options?.signal);
+    };
+    return { executor, calls };
+  }
+
+  it("forwards an AbortSignal to the executor on every step", async () => {
+    const { executor, calls } = makeRecordingExecutor(async (cmd, _args) => {
+      if (cmd === "git" && _args[0] === "diff") {
+        // Pretend package.json changed so the install step is reachable.
+        return { stdout: "package.json\n", stderr: "", exitCode: 0 };
+      }
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+
+    const builder = new DeployBuilder({
+      repoDir: "/tmp/fake-repo",
+      timeoutMs: 5_000,
+      logger: silentLogger,
+      executor,
+    });
+
+    const result = await builder.build();
+
+    expect(result.success).toBe(true);
+    expect(result.phase).toBe("done");
+    // Each step (pull, diff, install, build) should have received a signal.
+    expect(calls.length).toBeGreaterThanOrEqual(4);
+    for (const call of calls) {
+      expect(call.signal).toBeInstanceOf(AbortSignal);
+      // Signal must NOT be aborted after a successful, in-time call.
+      expect(call.signal?.aborted).toBe(false);
+    }
+  });
+
+  it("aborts the in-flight subprocess signal when the timeout elapses", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    const executor: ProcessExecutor = async (_cmd, _args, _cwd, options) => {
+      capturedSignal = options?.signal;
+      // Simulate a slow subprocess that does NOT cooperate with the signal —
+      // we want to assert the signal is aborted regardless of the executor's
+      // own behavior. The withTimeout wrapper rejects independently.
+      await new Promise<void>((resolve) => setTimeout(resolve, 500));
+      return { stdout: "", stderr: "", exitCode: 0 };
+    };
+
+    const builder = new DeployBuilder({
+      repoDir: "/tmp/fake-repo",
+      timeoutMs: 50,
+      logger: silentLogger,
+      executor,
+    });
+
+    const result = await builder.build();
+
+    expect(result.success).toBe(false);
+    expect(result.phase).toBe("failed");
+    expect(result.error).toContain("git pull error");
+    // The key assertion for issue #361: the signal handed to the executor
+    // must be in `aborted=true` state after the deadline fires, so that
+    // cooperative executors can SIGTERM their subprocess instead of leaking it.
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal?.aborted).toBe(true);
+  });
+
+  it("reports successful build with up-to-date repo", async () => {
+    const { executor } = makeRecordingExecutor(async (cmd, args) => {
+      if (cmd === "git" && args[0] === "pull") {
+        return { stdout: "Already up to date.\n", stderr: "", exitCode: 0 };
+      }
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+
+    const builder = new DeployBuilder({
+      repoDir: "/tmp/fake-repo",
+      timeoutMs: 5_000,
+      logger: silentLogger,
+      executor,
+    });
+
+    const result = await builder.build();
+
+    expect(result.success).toBe(true);
+    expect(result.upToDate).toBe(true);
+    // Up-to-date short-circuits the diff/install steps.
+    expect(result.depsChanged).toBe(false);
+    expect(result.installOutput).toBeUndefined();
+  });
+
+  it("surfaces non-zero git pull exit codes as a failed BuildResult", async () => {
+    const { executor } = makeRecordingExecutor(async (cmd) => {
+      if (cmd === "git") {
+        return { stdout: "", stderr: "fatal: not a git repository", exitCode: 128 };
+      }
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+
+    const builder = new DeployBuilder({
+      repoDir: "/tmp/not-a-repo",
+      timeoutMs: 5_000,
+      logger: silentLogger,
+      executor,
+    });
+
+    const result = await builder.build();
+
+    expect(result.success).toBe(false);
+    expect(result.phase).toBe("failed");
+    expect(result.error).toContain("git pull failed (exit 128)");
+  });
+
+  it("translates executor abort errors into a failed BuildResult", async () => {
+    // Mimic the defaultExecutor behavior of throwing when signal.aborted is true.
+    const executor: ProcessExecutor = async (_cmd, _args, _cwd, options) => {
+      await new Promise<void>((resolve) => setTimeout(resolve, 200));
+      if (options?.signal?.aborted) {
+        throw new Error("Subprocess aborted: git pull (sent SIGTERM)");
+      }
+      return { stdout: "", stderr: "", exitCode: 0 };
+    };
+
+    const builder = new DeployBuilder({
+      repoDir: "/tmp/fake-repo",
+      timeoutMs: 50,
+      logger: silentLogger,
+      executor,
+    });
+
+    const result = await builder.build();
+
+    expect(result.success).toBe(false);
+    expect(result.phase).toBe("failed");
+    expect(result.error).toContain("git pull error");
   });
 });

--- a/packages/core/src/deployment/builder.ts
+++ b/packages/core/src/deployment/builder.ts
@@ -23,8 +23,21 @@ export interface ExecResult {
   exitCode: number;
 }
 
-/** Inject a custom executor in tests to avoid real subprocesses. */
-export type ProcessExecutor = (cmd: string, args: string[], cwd: string) => Promise<ExecResult>;
+/**
+ * Inject a custom executor in tests to avoid real subprocesses.
+ *
+ * The optional `options.signal` is provided by {@link withTimeout} so executors
+ * can forward it to their spawn mechanism (e.g. `Bun.spawn`'s `signal` option
+ * or `child_process.spawn`'s `signal` option). When aborted, the underlying
+ * process is sent SIGTERM. Executors that ignore the signal remain functional
+ * but will leak orphan subprocesses on timeout.
+ */
+export type ProcessExecutor = (
+  cmd: string,
+  args: string[],
+  cwd: string,
+  options?: { signal?: AbortSignal },
+) => Promise<ExecResult>;
 
 export type BuildPhase = "idle" | "pulling" | "installing" | "building" | "done" | "failed";
 
@@ -110,7 +123,8 @@ export class DeployBuilder {
     let pullResult: ExecResult;
     try {
       pullResult = await withTimeout(
-        this.executor("git", ["pull", this.remote, this.branch], this.repoDir),
+        (signal) =>
+          this.executor("git", ["pull", this.remote, this.branch], this.repoDir, { signal }),
         remaining(),
       );
     } catch (err) {
@@ -151,7 +165,10 @@ export class DeployBuilder {
     if (!upToDate) {
       try {
         const diffResult = await withTimeout(
-          this.executor("git", ["diff", "--name-only", "ORIG_HEAD", "HEAD"], this.repoDir),
+          (signal) =>
+            this.executor("git", ["diff", "--name-only", "ORIG_HEAD", "HEAD"], this.repoDir, {
+              signal,
+            }),
           remaining(),
         );
         const changedFiles = diffResult.stdout.split("\n").filter(Boolean);
@@ -187,7 +204,7 @@ export class DeployBuilder {
       let installResult: ExecResult;
       try {
         installResult = await withTimeout(
-          this.executor("bun", ["install"], this.repoDir),
+          (signal) => this.executor("bun", ["install"], this.repoDir, { signal }),
           remaining(),
         );
       } catch (err) {
@@ -239,7 +256,7 @@ export class DeployBuilder {
     let buildExecResult: ExecResult;
     try {
       buildExecResult = await withTimeout(
-        this.executor("bun", ["run", this.buildScript], this.repoDir),
+        (signal) => this.executor("bun", ["run", this.buildScript], this.repoDir, { signal }),
         remaining(),
       );
     } catch (err) {
@@ -311,11 +328,16 @@ export class DeployBuilder {
 
 // ── Default executor using Bun.spawn ─────────────────────────────────────
 
-const defaultExecutor: ProcessExecutor = async (cmd, args, cwd) => {
+const defaultExecutor: ProcessExecutor = async (cmd, args, cwd, options) => {
+  const signal = options?.signal;
   const proc = Bun.spawn([cmd, ...args], {
     cwd,
     stdout: "pipe",
     stderr: "pipe",
+    // Forwarding the AbortSignal lets Bun SIGTERM the child when the caller
+    // aborts (e.g. on timeout). Without this the subprocess keeps running as
+    // an orphan after withTimeout rejects.
+    signal,
   });
   // Drain stdout and stderr concurrently to prevent deadlock when either
   // pipe's buffer fills while the other is being read sequentially.
@@ -324,18 +346,43 @@ const defaultExecutor: ProcessExecutor = async (cmd, args, cwd) => {
     new Response(proc.stderr).text(),
   ]);
   const exitCode = await proc.exited;
+  // Bun.spawn does NOT reject on abort — it SIGTERMs the child and resolves
+  // `exited` with a non-zero code (typically 143 = 128 + SIGTERM). Translate
+  // this back into a clear timeout error so call sites get a useful message
+  // instead of "exit 143: <empty output>".
+  if (signal?.aborted) {
+    throw new Error(`Subprocess aborted: ${cmd} ${args.join(" ")} (sent SIGTERM)`);
+  }
   return { stdout, stderr, exitCode };
 };
 
 // ── Helpers ───────────────────────────────────────────────────────────────
 
-function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+/**
+ * Run `task` with a hard deadline of `ms` milliseconds.
+ *
+ * The task receives an {@link AbortSignal} that fires when the deadline
+ * elapses. Cooperative tasks (e.g. `Bun.spawn` with `signal` forwarded) can
+ * terminate their underlying work — preventing orphan subprocesses that the
+ * previous Promise.race-only implementation would have leaked.
+ *
+ * Either the task's own rejection (e.g. an executor surfacing an abort as a
+ * thrown error) or the synthetic timeout rejection (when the task is unable
+ * to observe the signal in time) propagates to the caller.
+ */
+function withTimeout<T>(task: (signal: AbortSignal) => Promise<T>, ms: number): Promise<T> {
+  const controller = new AbortController();
+  const deadlineMs = Math.max(ms, 0);
   let timerId: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<never>((_, reject) => {
-    timerId = setTimeout(
-      () => reject(new Error(`Operation timed out after ${ms}ms`)),
-      Math.max(ms, 0),
-    );
+    timerId = setTimeout(() => {
+      controller.abort();
+      reject(new Error(`Operation timed out after ${deadlineMs}ms`));
+    }, deadlineMs);
   });
-  return Promise.race([promise, timeoutPromise]).finally(() => clearTimeout(timerId));
+  // Race the cooperative task against the deadline. Whoever settles first
+  // wins; the `finally` clears the timer so test runtimes don't keep alive.
+  return Promise.race([task(controller.signal), timeoutPromise]).finally(() => {
+    clearTimeout(timerId);
+  });
 }

--- a/packages/core/src/deployment/builder.ts
+++ b/packages/core/src/deployment/builder.ts
@@ -371,6 +371,12 @@ const defaultExecutor: ProcessExecutor = async (cmd, args, cwd, options) => {
  * to observe the signal in time) propagates to the caller.
  */
 function withTimeout<T>(task: (signal: AbortSignal) => Promise<T>, ms: number): Promise<T> {
+  // Infinity short-circuit — Bun/Node's setTimeout coerces non-finite or
+  // out-of-range delays to 1ms, which would abort almost immediately if a
+  // caller passed Infinity to mean "disable the timeout".
+  if (!Number.isFinite(ms)) {
+    return task(new AbortController().signal);
+  }
   const controller = new AbortController();
   const deadlineMs = Math.max(ms, 0);
   let timerId: ReturnType<typeof setTimeout> | undefined;


### PR DESCRIPTION
## Summary

Closes #361. Replaces the leaky `withTimeout` wrapper with `AbortController`-based cancellation so timed-out git/bun subprocesses get SIGTERM'd via `Bun.spawn`'s native `signal` option instead of being left as orphaned processes that hold file-system locks.

## Changes

- **`packages/core/src/deployment/builder.ts`**
  - `ProcessExecutor` signature gains an optional 4th param: `options?: { signal?: AbortSignal }`. Semver minor bump in the changeset.
  - `defaultExecutor` forwards `signal` to `Bun.spawn` and translates an aborted run into `Subprocess aborted: <cmd> (sent SIGTERM)` instead of the opaque `exit 143: <empty>`.
  - `withTimeout` refactored from `(promise, ms)` to `((signal) => promise, ms)`. All four call sites (`git pull`, `git diff`, `bun install`, `bun run <buildScript>`) thread the signal through.
- **`packages/core/__tests__/deployment.test.ts`** — 5 new tests covering happy-path signal propagation, `signal.aborted` after timeout, up-to-date short-circuit, non-zero exit codes, and abort-error → `BuildResult` translation.
- **`.changeset/deploy-builder-abort-signal.md`** — minor bump for `@linchkit/core` with migration note for custom `ProcessExecutor` implementors.

## Implementation notes

- **`Bun.spawn` abort behavior** (verified empirically): does NOT reject `proc.exited` or the stream `Response().text()` promises when aborted — it SIGTERMs the child and resolves `exited` to `143`. So `defaultExecutor` explicitly checks `signal.aborted` after drain and throws a clear error; otherwise abort would silently become exit 143 with no output.
- **No race between abort and pipe-drain**: `Promise.all([stdout, stderr])` runs concurrently; the abort just terminates the child early so both pipes close. `proc.exited` then resolves to 143.

## Cross-model review

Attempted both Codex (rate-limited — usage cap hit at 09:33) and Gemini (auto-mode harness denied piping diff to external CLI). Proceeding because:
- Implementation directly matches CodeRabbit's confirmed Bun.spawn signal pattern documented in the issue body
- Only 3 files / ~250 LOC, all bounded to deployment/builder.ts
- 5 new tests assert the cancellation contract; full bun test packages/core/ (3519 tests) passes

## Test plan

- [x] bun run check - clean
- [x] bun run typecheck - clean
- [x] bun test packages/core/__tests__/deployment.test.ts - 41/41 pass
- [x] bun test packages/core/ - 3519/3519 pass

Generated with Claude Code