### PR TITLE
feat(core): EventBusReplayService — in-memory replay (resolves #337 additively, refs #137)

### DIFF
--- a/packages/core/__tests__/event-bus-replay-service.test.ts
+++ b/packages/core/__tests__/event-bus-replay-service.test.ts
@@ -1,0 +1,527 @@
+import { describe, expect, it } from "bun:test";
+import { createEventBus, EventBus, EventHandlerRegistry } from "../src/event/event-bus";
+import {
+  createEventBusReplayService,
+  type EventBusReplayMeta,
+} from "../src/event/event-bus-replay-service";
+import type { EventRecord } from "../src/types/event";
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeEvent(
+  type: string,
+  executionId: string,
+  overrides: Partial<EventRecord> = {},
+): EventRecord {
+  return {
+    id: crypto.randomUUID(),
+    type,
+    category: "runtime",
+    timestamp: new Date(),
+    actor: { type: "system", id: "test" },
+    executionId,
+    payload: { key: "value" },
+    ...overrides,
+  };
+}
+
+function makeSetup() {
+  const { registry, bus } = createEventBus();
+  const replay = createEventBusReplayService(bus, registry);
+  return { registry, bus, replay };
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe("createEventBusReplayService", () => {
+  it("returns a service with replayById and replayByExecution", () => {
+    const { replay } = makeSetup();
+    expect(typeof replay.replayById).toBe("function");
+    expect(typeof replay.replayByExecution).toBe("function");
+  });
+});
+
+describe("replayById — dry-run (default)", () => {
+  it("returns not_found when event ID is not in log", async () => {
+    const { replay } = makeSetup();
+    const result = await replay.replayById("nonexistent-id");
+
+    expect(result.dryRun).toBe(true);
+    expect(result.replayed).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.events[0]?.status).toBe("skipped");
+    expect(result.events[0]?.skipReason).toBe("not_found");
+    expect(result.events[0]?.originEventId).toBe("nonexistent-id");
+  });
+
+  it("finds and reports handlers without firing them", async () => {
+    const { registry, bus, replay } = makeSetup();
+    const calls: string[] = [];
+
+    registry.register({
+      name: "h1",
+      listen: "record.created",
+      handler: async () => {
+        calls.push("h1");
+      },
+    });
+    registry.register({
+      name: "h2",
+      listen: "record.created",
+      handler: async () => {
+        calls.push("h2");
+      },
+    });
+
+    const event = makeEvent("record.created", "exec-1");
+    await bus.emit(event);
+    calls.length = 0; // reset after initial emit
+
+    const result = await replay.replayById(event.id);
+
+    expect(result.dryRun).toBe(true);
+    expect(result.replayed).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(result.events[0]?.status).toBe("replayed");
+    expect(result.events[0]?.originEventId).toBe(event.id);
+    expect(result.events[0]?.eventType).toBe("record.created");
+    expect(result.events[0]?.handlers.map((h) => h.handlerName)).toEqual(["h1", "h2"]);
+    expect(result.events[0]?.replayEventId).toBeUndefined();
+
+    // Dry-run must NOT invoke handlers
+    expect(calls).toEqual([]);
+  });
+
+  it("has an empty handlers list when no handlers match the event type", async () => {
+    const { bus, replay } = makeSetup();
+    const event = makeEvent("unhandled.type", "exec-1");
+    await bus.emit(event);
+
+    const result = await replay.replayById(event.id);
+
+    expect(result.replayed).toBe(1);
+    expect(result.events[0]?.handlers).toEqual([]);
+  });
+
+  it("returns a stable replayId UUID", async () => {
+    const { bus, replay } = makeSetup();
+    const event = makeEvent("record.created", "exec-1");
+    await bus.emit(event);
+
+    const result = await replay.replayById(event.id);
+    expect(result.replayId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("excludes handlers whose filter does not match the event payload", async () => {
+    const { registry, bus, replay } = makeSetup();
+
+    registry.register({
+      name: "filtered-h",
+      listen: "record.filtered",
+      filter: { status: "active" },
+      handler: async () => {},
+    });
+    registry.register({
+      name: "unfiltered-h",
+      listen: "record.filtered",
+      handler: async () => {},
+    });
+
+    const event = makeEvent("record.filtered", "exec-filter", { payload: { status: "inactive" } });
+    await bus.emit(event);
+
+    const result = await replay.replayById(event.id);
+
+    // filtered-h must not appear because payload.status !== "active"
+    expect(result.events[0]?.handlers.map((h) => h.handlerName)).toEqual(["unfiltered-h"]);
+  });
+
+  it("reports handlers sorted by priority (lower number = higher priority)", async () => {
+    const { registry, bus, replay } = makeSetup();
+
+    registry.register({
+      name: "low-prio",
+      listen: "prio.test",
+      priority: 200,
+      handler: async () => {},
+    });
+    registry.register({
+      name: "high-prio",
+      listen: "prio.test",
+      priority: 10,
+      handler: async () => {},
+    });
+    registry.register({ name: "default-prio", listen: "prio.test", handler: async () => {} });
+
+    const event = makeEvent("prio.test", "exec-prio");
+    await bus.emit(event);
+
+    const result = await replay.replayById(event.id);
+
+    expect(result.events[0]?.handlers.map((h) => h.handlerName)).toEqual([
+      "high-prio",
+      "default-prio",
+      "low-prio",
+    ]);
+  });
+});
+
+describe("replayById — live mode", () => {
+  it("re-emits the event and calls handlers again", async () => {
+    const { registry, bus, replay } = makeSetup();
+    const calls: string[] = [];
+
+    registry.register({
+      name: "h1",
+      listen: "record.created",
+      handler: async () => {
+        calls.push("h1");
+      },
+    });
+
+    const event = makeEvent("record.created", "exec-1");
+    await bus.emit(event);
+    expect(calls).toEqual(["h1"]);
+    calls.length = 0;
+
+    const result = await replay.replayById(event.id, { dryRun: false });
+
+    expect(result.dryRun).toBe(false);
+    expect(result.replayed).toBe(1);
+    expect(result.events[0]?.replayEventId).toBeDefined();
+    expect(result.events[0]?.replayEventId).not.toBe(event.id);
+
+    // Handler was called again in live mode
+    expect(calls).toEqual(["h1"]);
+  });
+
+  it("injects EventBusReplayMeta into handler context via ExecutionMeta", async () => {
+    const { registry, bus, replay } = makeSetup();
+    let capturedReplayMeta: EventBusReplayMeta | undefined;
+
+    registry.register({
+      name: "h1",
+      listen: "record.updated",
+      handler: async (_event, ctx) => {
+        capturedReplayMeta = ctx.meta.get<EventBusReplayMeta>("replay");
+      },
+    });
+
+    const event = makeEvent("record.updated", "exec-2");
+    await bus.emit(event);
+    capturedReplayMeta = undefined; // reset
+
+    const result = await replay.replayById(event.id, { dryRun: false });
+
+    expect(capturedReplayMeta).toBeDefined();
+    expect(capturedReplayMeta?.originEventId).toBe(event.id);
+    expect(capturedReplayMeta?.replayId).toBe(result.replayId);
+    expect(capturedReplayMeta?.dryRun).toBe(false);
+  });
+
+  it("assigns a new ID to the replayed event so it is distinct in the log", async () => {
+    const { registry, bus, replay } = makeSetup();
+    let seenIds: string[] = [];
+
+    registry.register({
+      name: "id-tracker",
+      listen: "state.changed",
+      handler: async (event) => {
+        seenIds.push(event.id);
+      },
+    });
+
+    const event = makeEvent("state.changed", "exec-3");
+    await bus.emit(event);
+    seenIds = [];
+
+    await replay.replayById(event.id, { dryRun: false });
+
+    expect(seenIds).toHaveLength(1);
+    expect(seenIds[0]).not.toBe(event.id);
+  });
+
+  it("assigns a unique idempotencyKey prefixed replay: when force:true", async () => {
+    const { bus, replay } = makeSetup();
+
+    const event = makeEvent("record.force", "exec-force", { idempotencyKey: "original-key" });
+    await bus.emit(event);
+
+    const result = await replay.replayById(event.id, { dryRun: false, force: true });
+
+    const replayedId = result.events[0]?.replayEventId;
+    expect(replayedId).toBeDefined();
+
+    const replayedEvent = bus.getEmittedEvents().find((e) => e.id === replayedId);
+    expect(replayedEvent?.idempotencyKey).toMatch(/^replay:/);
+    expect(replayedEvent?.idempotencyKey).not.toBe("original-key");
+  });
+
+  it("skips events that fail to emit and captures the error in errors[]", async () => {
+    const { bus, replay } = makeSetup();
+
+    const event = makeEvent("emit.failing", "exec-err");
+    await bus.emit(event);
+
+    // biome-ignore lint/suspicious/noExplicitAny: test-only override to simulate emit failure
+    (bus as any).emit = async () => {
+      throw new Error("simulated dispatch error");
+    };
+
+    const result = await replay.replayById(event.id, { dryRun: false });
+
+    expect(result.replayed).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.events[0]?.status).toBe("skipped");
+    expect(result.events[0]?.skipReason).toBe("emit_error");
+    expect(result.events[0]?.errors).toEqual([
+      { handlerName: "<emit>", message: "simulated dispatch error" },
+    ]);
+  });
+
+  it("captures sync handler errors per-event without aborting the batch (Spec 66 §4)", async () => {
+    const { registry, bus, replay } = makeSetup();
+    const calls: string[] = [];
+
+    registry.register({
+      name: "good-handler",
+      listen: "batch.test",
+      handler: async () => {
+        calls.push("good");
+      },
+    });
+    registry.register({
+      name: "bad-handler",
+      listen: "batch.fail",
+      handler: async () => {
+        throw new Error("boom");
+      },
+    });
+
+    const ok = makeEvent("batch.test", "exec-batch-err");
+    const bad = makeEvent("batch.fail", "exec-batch-err");
+    const ok2 = makeEvent("batch.test", "exec-batch-err");
+    await bus.emit(ok);
+    // Pre-emit bad without invoking the bad handler. Use a direct push instead
+    // of emit so the failure surfaces only during replay, not during seeding.
+    // biome-ignore lint/suspicious/noExplicitAny: access internal log for seeding
+    (bus as any).eventLog.push(bad);
+    await bus.emit(ok2);
+    calls.length = 0;
+
+    const result = await replay.replayByExecution("exec-batch-err", { dryRun: false });
+
+    // Bad handler throws on its event but good events still replay.
+    expect(result.replayed).toBe(2);
+    expect(result.skipped).toBe(1);
+
+    const badResult = result.events.find((e) => e.originEventId === bad.id);
+    expect(badResult?.status).toBe("skipped");
+    expect(badResult?.skipReason).toBe("emit_error");
+    expect(badResult?.errors?.[0]?.message).toBe("boom");
+
+    // Good events have an empty errors array (always present in live mode).
+    const goodResults = result.events.filter((e) => e.status === "replayed");
+    for (const r of goodResults) {
+      expect(r.errors).toEqual([]);
+    }
+
+    // Good handlers actually ran for the two ok events.
+    expect(calls).toEqual(["good", "good"]);
+  });
+
+  it("force:true bypasses dedup even when the original event had no explicit idempotencyKey (derived key collision)", async () => {
+    // Build a bus with a dedup window long enough that the original event
+    // would suppress the replay unless force:true rewrites the key.
+    const registry = new EventHandlerRegistry();
+    const bus = new EventBus({ registry, dedupWindow: 60_000 });
+    const replay = createEventBusReplayService(bus, registry);
+
+    const calls: string[] = [];
+    registry.register({
+      name: "dedup-target",
+      listen: "derived.key.test",
+      handler: async () => {
+        calls.push("hit");
+      },
+    });
+
+    // Note: makeEvent does NOT set idempotencyKey, so EventBus derives one as
+    // `${executionId}:${type}` → "exec-derived:derived.key.test". A naive replay
+    // would hit the dedup window and be suppressed.
+    const event = makeEvent("derived.key.test", "exec-derived");
+    await bus.emit(event);
+    expect(calls).toEqual(["hit"]);
+    calls.length = 0;
+
+    // First, confirm force:false IS suppressed by the derived dedup key.
+    const noForceResult = await replay.replayById(event.id, { dryRun: false });
+    expect(noForceResult.replayed).toBe(1); // bus.emit doesn't throw on dedup, just returns
+    expect(calls).toEqual([]); // …but the handler did NOT run
+
+    // Now force:true rewrites the key so the replay actually re-dispatches.
+    const forceResult = await replay.replayById(event.id, { dryRun: false, force: true });
+    expect(forceResult.replayed).toBe(1);
+    expect(calls).toEqual(["hit"]);
+
+    const replayedId = forceResult.events[0]?.replayEventId;
+    const replayedEvent = bus.getEmittedEvents().find((e) => e.id === replayedId);
+    expect(replayedEvent?.idempotencyKey).toMatch(/^replay:/);
+  });
+});
+
+describe("replayByExecution — dry-run (default)", () => {
+  it("returns empty result when no events match the execution", async () => {
+    const { replay } = makeSetup();
+    const result = await replay.replayByExecution("nonexistent-exec");
+
+    expect(result.replayed).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(result.events).toEqual([]);
+  });
+
+  it("finds all events for an execution and reports their handlers", async () => {
+    const { registry, bus, replay } = makeSetup();
+
+    registry.register({
+      name: "created-handler",
+      listen: "record.created",
+      handler: async () => {},
+    });
+
+    const execId = "exec-batch";
+    const e1 = makeEvent("record.created", execId);
+    const e2 = makeEvent("record.updated", execId);
+    const eOther = makeEvent("record.created", "exec-other");
+
+    await bus.emit(e1);
+    await bus.emit(e2);
+    await bus.emit(eOther);
+
+    const result = await replay.replayByExecution(execId);
+
+    expect(result.dryRun).toBe(true);
+    expect(result.replayed).toBe(2);
+    expect(result.events.map((e) => e.originEventId).sort()).toEqual([e1.id, e2.id].sort());
+
+    const createdResult = result.events.find((e) => e.eventType === "record.created");
+    expect(createdResult?.handlers.map((h) => h.handlerName)).toEqual(["created-handler"]);
+
+    const updatedResult = result.events.find((e) => e.eventType === "record.updated");
+    expect(updatedResult?.handlers).toEqual([]);
+  });
+
+  it("does not set truncated flag when events are within limit", async () => {
+    const { bus, replay } = makeSetup();
+    const execId = "exec-small";
+    await bus.emit(makeEvent("record.created", execId));
+
+    const result = await replay.replayByExecution(execId);
+    expect(result.truncated).toBeUndefined();
+    expect(result.totalAvailable).toBe(1);
+  });
+
+  it("dry-run results honor handler filter and priority order (parity with EventBus dispatch)", async () => {
+    const { registry, bus, replay } = makeSetup();
+
+    registry.register({
+      name: "skip-filtered",
+      listen: "filtered.prio",
+      filter: { status: "active" },
+      priority: 5,
+      handler: async () => {},
+    });
+    registry.register({
+      name: "low",
+      listen: "filtered.prio",
+      priority: 200,
+      handler: async () => {},
+    });
+    registry.register({
+      name: "high",
+      listen: "filtered.prio",
+      priority: 10,
+      handler: async () => {},
+    });
+    registry.register({
+      name: "default",
+      listen: "filtered.prio",
+      handler: async () => {},
+    });
+
+    const event = makeEvent("filtered.prio", "exec-fp", { payload: { status: "inactive" } });
+    await bus.emit(event);
+
+    const result = await replay.replayByExecution("exec-fp");
+
+    // "skip-filtered" excluded by filter; rest sorted ascending by priority.
+    expect(result.events[0]?.handlers.map((h) => h.handlerName)).toEqual([
+      "high",
+      "default",
+      "low",
+    ]);
+    // Dry-run errors array is always present and empty.
+    expect(result.events[0]?.errors).toEqual([]);
+  });
+});
+
+describe("replayByExecution — truncation guard", () => {
+  it("sets truncated:true and totalAvailable when events exceed MAX_EVENTS_PER_REPLAY", async () => {
+    // Reach the 10k cap. We need an EventBus whose event log can hold > 10k
+    // events; the default cap is 1000, so override.
+    const registry = new EventHandlerRegistry();
+    const bus = new EventBus({ registry, maxEventLogSize: 20_000 });
+    const replay = createEventBusReplayService(bus, registry);
+
+    const execId = "exec-huge";
+    const TOTAL = 10_005;
+    for (let i = 0; i < TOTAL; i++) {
+      await bus.emit(makeEvent("bulk.event", execId));
+    }
+
+    const result = await replay.replayByExecution(execId);
+    expect(result.truncated).toBe(true);
+    expect(result.totalAvailable).toBe(TOTAL);
+    expect(result.events.length).toBe(10_000);
+  });
+});
+
+describe("replayByExecution — live mode", () => {
+  it("re-emits all execution events with replay metadata", async () => {
+    const { registry, bus, replay } = makeSetup();
+    const seenMetas: Array<EventBusReplayMeta | undefined> = [];
+
+    registry.register({
+      name: "meta-collector",
+      listen: "record.created",
+      handler: async (_event, ctx) => {
+        seenMetas.push(ctx.meta.get<EventBusReplayMeta>("replay"));
+      },
+    });
+
+    const execId = "exec-live";
+    const e1 = makeEvent("record.created", execId);
+    const e2 = makeEvent("record.created", execId);
+
+    await bus.emit(e1);
+    await bus.emit(e2);
+    seenMetas.length = 0;
+
+    const result = await replay.replayByExecution(execId, { dryRun: false });
+
+    expect(result.dryRun).toBe(false);
+    expect(result.replayed).toBe(2);
+    expect(seenMetas).toHaveLength(2);
+
+    // All events in the batch share the same replayId
+    const replayIds = seenMetas.map((m) => m?.replayId);
+    expect(replayIds[0]).toBe(result.replayId);
+    expect(replayIds[1]).toBe(result.replayId);
+
+    // Each origin ID points back to the source event
+    const originIds = seenMetas.map((m) => m?.originEventId).sort();
+    expect(originIds).toEqual([e1.id, e2.id].sort());
+  });
+});

--- a/packages/core/src/event/event-bus-replay-service.ts
+++ b/packages/core/src/event/event-bus-replay-service.ts
@@ -1,0 +1,277 @@
+/**
+ * EventBusReplayService — in-memory event replay over the EventBus log
+ * (Spec 66 §4.1–4.3).
+ *
+ * In-memory replay over the EventBus log — distinct from the DB-backed
+ * `EventReplayService` in `event-replay-service.ts`, which serves the
+ * production audit-trail replay use case (CLI, GraphQL, audit-ui).
+ *
+ * Supports replaying events from the EventBus in-memory log by ID or by
+ * execution ID. Two modes: dry-run (default) simulates dispatch and reports
+ * which handlers would fire; live re-emits events with replay metadata so
+ * handlers can detect and conditionally skip non-idempotent side effects.
+ */
+
+import type { EventRecord } from "../types/event";
+import { createExecutionMeta, extendExecutionMeta } from "../types/execution-meta";
+import { type EventBus, type EventHandlerRegistry, matchesFilter } from "./event-bus";
+
+// ── Spec 66 §4.3 hard limit per invocation ──────────────────
+
+const MAX_EVENTS_PER_REPLAY = 10_000;
+const DEFAULT_PRIORITY = 100;
+
+// ── Public types ─────────────────────────────────────────────
+
+/** Replay context injected into replayed events via ExecutionMeta (Spec 66 §4.3) */
+export interface EventBusReplayMeta {
+  originEventId: string;
+  replayId: string;
+  dryRun: boolean;
+}
+
+export interface EventBusReplayOptions {
+  /**
+   * When true (default), simulates dispatch and reports which handlers would
+   * fire without invoking them. No side effects, no database writes.
+   */
+  dryRun?: boolean;
+  /**
+   * When true, bypasses the EventBus dedup window so the event is dispatched
+   * even if its idempotency key was recently seen. Useful for bug-fix replays.
+   * Default: false.
+   */
+  force?: boolean;
+}
+
+export interface EventBusReplayedHandlerInfo {
+  handlerName: string;
+}
+
+/**
+ * Error captured during a single handler dispatch (live mode) or
+ * an emit-level failure that affected the whole event.
+ * `handlerName` is `"<emit>"` when the error came from the EventBus
+ * itself (e.g., dedup-window race, recursion guard) rather than a
+ * specific handler.
+ */
+export interface EventBusReplayedHandlerError {
+  handlerName: string;
+  message: string;
+}
+
+export interface EventBusReplayedEventResult {
+  originEventId: string;
+  /** ID of the newly emitted event. Set only in live mode. */
+  replayEventId?: string;
+  eventType: string;
+  handlers: EventBusReplayedHandlerInfo[];
+  status: "replayed" | "skipped";
+  /** Why the event was skipped */
+  skipReason?: "not_found" | "emit_error";
+  /**
+   * Errors captured during dispatch. Always present (may be empty) on live-mode
+   * results so callers don't need null checks. Dry-run results never accumulate
+   * errors because handlers are not invoked.
+   *
+   * Spec 66 §4 prohibits silently swallowing handler errors — every emit
+   * failure surfaces here so the caller can decide how to react.
+   */
+  errors?: EventBusReplayedHandlerError[];
+}
+
+export interface EventBusReplayResult {
+  /** Identifies this replay operation; matches `EventBusReplayMeta.replayId` on live events */
+  replayId: string;
+  dryRun: boolean;
+  replayed: number;
+  skipped: number;
+  events: EventBusReplayedEventResult[];
+  /** True when the execution's event count exceeded the 10k guard and results were truncated */
+  truncated?: boolean;
+  /**
+   * Total events available for this execution before truncation. Equal to
+   * `events.length` when `truncated` is false/absent; greater when truncated.
+   * Lets callers report "N of M events replayed" without re-querying the log.
+   */
+  totalAvailable?: number;
+}
+
+export interface EventBusReplayService {
+  /**
+   * Replay a single event from the in-memory log by its ID.
+   * Dry-run by default — pass `{ dryRun: false }` for live dispatch.
+   */
+  replayById(eventId: string, options?: EventBusReplayOptions): Promise<EventBusReplayResult>;
+
+  /**
+   * Replay all events belonging to an execution from the in-memory log.
+   * Capped at 10,000 events per invocation (Spec 66 §4.3 guard).
+   */
+  replayByExecution(
+    executionId: string,
+    options?: EventBusReplayOptions,
+  ): Promise<EventBusReplayResult>;
+}
+
+// ── Implementation ───────────────────────────────────────────
+
+function getMatchedHandlerInfos(
+  event: EventRecord,
+  registry: EventHandlerRegistry,
+): EventBusReplayedHandlerInfo[] {
+  return registry
+    .getByEvent(event.type)
+    .filter((h) => !h.filter || matchesFilter(event.payload as Record<string, unknown>, h.filter))
+    .sort((a, b) => (a.priority ?? DEFAULT_PRIORITY) - (b.priority ?? DEFAULT_PRIORITY))
+    .map((h) => ({ handlerName: h.name }));
+}
+
+async function dispatchReplayBatch(
+  events: EventRecord[],
+  bus: EventBus,
+  registry: EventHandlerRegistry,
+  options: EventBusReplayOptions,
+  replayId: string,
+): Promise<EventBusReplayedEventResult[]> {
+  const dryRun = options.dryRun ?? true;
+  const results: EventBusReplayedEventResult[] = [];
+
+  for (const event of events) {
+    const handlerInfos = getMatchedHandlerInfos(event, registry);
+
+    if (dryRun) {
+      results.push({
+        originEventId: event.id,
+        eventType: event.type,
+        handlers: handlerInfos,
+        status: "replayed",
+        errors: [],
+      });
+    } else {
+      const replayMeta: EventBusReplayMeta = {
+        originEventId: event.id,
+        replayId,
+        dryRun: false,
+      };
+
+      const baseMeta = event.meta ?? createExecutionMeta();
+      // systemOverrides ensures replay key is always set even if base meta has it
+      const newMeta = extendExecutionMeta(baseMeta, {}, { replay: replayMeta });
+
+      // force:true assigns a unique key so dedup never suppresses the replay.
+      // Important: EventBus derives a key from `${executionId}:${type}` when
+      // `idempotencyKey` is absent, so simply preserving the original event's
+      // missing key would still collide with the original on the dedup window.
+      // We therefore unconditionally set a unique replay-scoped key when
+      // force:true. When force:false we preserve the original key (or absence
+      // thereof) and let the dedup window decide.
+      const replayedEvent: EventRecord = {
+        ...event,
+        id: crypto.randomUUID(),
+        timestamp: new Date(),
+        idempotencyKey: options.force ? `replay:${replayId}:${event.id}` : event.idempotencyKey,
+        meta: newMeta,
+      };
+
+      // Per Spec 66 §4: handler errors must never silently bubble out of replay.
+      // Each emit is wrapped so a thrown sync handler doesn't abort the batch.
+      try {
+        await bus.emit(replayedEvent);
+        results.push({
+          originEventId: event.id,
+          replayEventId: replayedEvent.id,
+          eventType: event.type,
+          handlers: handlerInfos,
+          status: "replayed",
+          errors: [],
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        results.push({
+          originEventId: event.id,
+          eventType: event.type,
+          handlers: handlerInfos,
+          status: "skipped",
+          skipReason: "emit_error",
+          errors: [{ handlerName: "<emit>", message }],
+        });
+      }
+    }
+  }
+
+  return results;
+}
+
+export function createEventBusReplayService(
+  bus: EventBus,
+  registry: EventHandlerRegistry,
+): EventBusReplayService {
+  return {
+    async replayById(eventId, options = {}) {
+      const replayId = crypto.randomUUID();
+      const dryRun = options.dryRun ?? true;
+
+      const log = bus.getEmittedEvents();
+      const event = log.find((e) => e.id === eventId);
+
+      if (!event) {
+        return {
+          replayId,
+          dryRun,
+          replayed: 0,
+          skipped: 1,
+          events: [
+            {
+              originEventId: eventId,
+              eventType: "unknown",
+              handlers: [],
+              status: "skipped",
+              skipReason: "not_found",
+              errors: [],
+            },
+          ],
+        };
+      }
+
+      const eventResults = await dispatchReplayBatch([event], bus, registry, options, replayId);
+      return {
+        replayId,
+        dryRun,
+        replayed: eventResults.filter((e) => e.status === "replayed").length,
+        skipped: eventResults.filter((e) => e.status === "skipped").length,
+        events: eventResults,
+      };
+    },
+
+    async replayByExecution(executionId, options = {}) {
+      const replayId = crypto.randomUUID();
+      const dryRun = options.dryRun ?? true;
+
+      const log = bus.getEmittedEvents();
+      const matching = log.filter((e) => e.executionId === executionId);
+
+      if (matching.length === 0) {
+        return { replayId, dryRun, replayed: 0, skipped: 0, events: [], totalAvailable: 0 };
+      }
+
+      // Spec 66 §4.3 guard: cap at MAX_EVENTS_PER_REPLAY.
+      // When truncation kicks in, surface `truncated: true` and `totalAvailable`
+      // so callers can warn operators that the batch is incomplete.
+      const totalAvailable = matching.length;
+      const truncated = totalAvailable > MAX_EVENTS_PER_REPLAY;
+      const capped = truncated ? matching.slice(0, MAX_EVENTS_PER_REPLAY) : matching;
+
+      const eventResults = await dispatchReplayBatch(capped, bus, registry, options, replayId);
+      return {
+        replayId,
+        dryRun,
+        replayed: eventResults.filter((e) => e.status === "replayed").length,
+        skipped: eventResults.filter((e) => e.status === "skipped").length,
+        events: eventResults,
+        totalAvailable,
+        ...(truncated ? { truncated } : {}),
+      };
+    },
+  };
+}

--- a/packages/core/src/event/index.ts
+++ b/packages/core/src/event/index.ts
@@ -17,6 +17,16 @@ export {
   matchesFilter,
 } from "./event-bus";
 export {
+  createEventBusReplayService,
+  type EventBusReplayedEventResult,
+  type EventBusReplayedHandlerError,
+  type EventBusReplayedHandlerInfo,
+  type EventBusReplayMeta,
+  type EventBusReplayOptions,
+  type EventBusReplayResult,
+  type EventBusReplayService,
+} from "./event-bus-replay-service";
+export {
   type BatchReplayResult,
   createEventReplayService,
   type EventDetail,


### PR DESCRIPTION
## Summary

Resolves PR #337's architectural conflict additively (Option A from the [conflict report](https://github.com/laofahai/linchkit/pull/337#issuecomment-4486407140)). The DB-backed `EventReplayService` on main remains untouched — it continues to back the production audit-trail replay path (CLI, GraphQL events resolvers, audit-ui). This PR adds a NEW, SEPARATE in-memory replay service for short-window dev/test scenarios over the EventBus in-memory log.

Two services, one for each use case, no overlap.

## What's in the new service

- `EventBusReplayService` (interface) + `createEventBusReplayService()` (factory) in `packages/core/src/event/event-bus-replay-service.ts`
- Two scopes: `replayById(eventId)` and `replayByExecution(executionId)` (Spec 66 §4.1)
- Two modes: **dry-run** (default — reports handlers without firing) and **live** (re-emits with `EventBusReplayMeta` in ExecutionMeta) (Spec 66 §4.2)
- Safety guards: 10,000-event cap surfaced via `truncated: boolean` + `totalAvailable: number` (Spec 66 §4.3)
- Carries forward all 6 Gemini review fixes from PR #337's worktree:
  - Typed per-handler error reporting via `EventBusReplayedHandlerError` — no silent swallowing
  - `force: true` bypasses derived idempotency keys
  - Dry-run honors handler.filter and priority order, matching EventBus.dispatch semantics
  - Per-event try/catch — one failing handler doesn't kill the batch
  - matchesFilter properly imported

## Naming — EventBus prefix for coexistence

EventReplayService → EventBusReplayService, createEventReplayService → createEventBusReplayService, ReplayResult → EventBusReplayResult, etc. Verified no symbol clash in event/index.ts, core/index.ts, or 7+ downstream consumers of the existing DB-backed service.

## Cross-model review

Cross-model review unavailable this round — Codex hit usage cap and the auto-mode harness denied piping diff to Gemini CLI. Code already reviewed by Gemini on PR #337's worktree; this PR is the same logic with rename-only changes. Gemini bot will re-review on PR open.

## Test plan

- [x] bun run check — clean
- [x] bun run typecheck — clean
- [x] bun test — 5908 / 0 fail / 3 skip across 372 files
- [x] New file tests: 20 / 20 pass

## Follow-up

PR #337 will be closed in favor of this PR.

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event replay functionality with dry-run mode to preview affected handlers and live mode to re-emit events.
  * Replay events by individual ID or by execution batch.
  * Control deduplication behavior with force mode for replayed events.
  * Robust error handling captures failures per event without aborting replay batches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laofahai/linchkit/pull/365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->