### PR TITLE
feat(core): ProposalGitCommitter — graduate approved Proposals to GitHub PRs (Spec 55 §7.7)

### DIFF
--- a/.changeset/proposal-git-committer.md
+++ b/.changeset/proposal-git-committer.md
@@ -1,0 +1,7 @@
+---
+"@linchkit/core": minor
+---
+
+feat(spec-55): ProposalGitCommitter — graduate approved Proposals to a GitHub PR
+
+Adds ProposalGitCommitter capability — graduates approved Proposals from on-disk files (via ProposalFileWriter) to a GitHub PR. The committer is a thin orchestrator: it derives a branch name from the proposal, creates the branch off the configured base, stages exactly the files written by ProposalFileWriter, commits with a structured message carrying `Proposal-ID` / `Source-Insights` trailers, pushes to the remote, and opens a PR via `gh`. Composes with `ProposalEngine.onApproved` hook — wiring is left to the caller so projects can stage or batch PRs. Subprocess runners are injectable for tests; the default implementation uses `Bun.spawn`. No breaking change.

--- a/packages/core/__tests__/proposal-git-committer.test.ts
+++ b/packages/core/__tests__/proposal-git-committer.test.ts
@@ -162,6 +162,14 @@ describe("ProposalGitCommitter.commitAndOpenPR — success path", () => {
     expect(commitMsg).toContain("feat(proposal): Auto-approve small orders");
     expect(commitMsg).toContain(`Proposal-ID: ${proposal.id}`);
     expect(commitMsg).toContain("Generated from insight #42.");
+    // Conventional Commits invariant: trailers (footer block) MUST come
+    // AFTER the body so `git interpret-trailers` and GitHub's PR parser pick
+    // them up as metadata rather than treating them as prose. (Fix for the
+    // earlier subject→trailers→body layout flagged by Gemini.)
+    const bodyIdx = commitMsg.indexOf("Generated from insight #42.");
+    const trailerIdx = commitMsg.indexOf(`Proposal-ID: ${proposal.id}`);
+    expect(bodyIdx).toBeGreaterThan(0);
+    expect(trailerIdx).toBeGreaterThan(bodyIdx);
     // --no-verify is forbidden.
     expect(calls[5].args).not.toContain("--no-verify");
 

--- a/packages/core/__tests__/proposal-git-committer.test.ts
+++ b/packages/core/__tests__/proposal-git-committer.test.ts
@@ -1,0 +1,452 @@
+/**
+ * Tests for ProposalGitCommitter (Spec 55 §7.7 graduation to PR).
+ *
+ * All subprocess interaction is mocked via injected `gitRunner` / `ghRunner`
+ * so the suite never touches real git or gh. We record every call's args and
+ * return a deterministic response per call index — this keeps the assertions
+ * obvious at the cost of some repetition.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  createProposalGitCommitter,
+  type ProposalGhRunner,
+  ProposalGitCommitter,
+  type ProposalGitCommitterRunResult,
+  type ProposalGitRunner,
+} from "../src/engine/proposal-git-committer";
+import type { ProposalChange, ProposalDefinition } from "../src/types/proposal";
+
+// ── Fixtures ────────────────────────────────────────────────
+
+const FIXED_NOW = new Date("2026-05-19T12:00:00.000Z");
+
+function makeRuleChange(name = "auto_approve_small_orders"): ProposalChange {
+  return {
+    target: "rule",
+    operation: "create",
+    name,
+    definition: { name } as never,
+  };
+}
+
+function makeApprovedProposal(overrides: Partial<ProposalDefinition> = {}): ProposalDefinition {
+  return {
+    id: "proposal_abcd1234efgh5678",
+    title: "Auto-approve small orders",
+    description: "Generated from insight #42.",
+    author: { type: "ai", id: "insight-translator", name: "Insight Translator" },
+    capability: "cap-life-demo",
+    changeType: "minor",
+    changes: [makeRuleChange()],
+    impact: {
+      schemasAffected: [],
+      actionsAffected: [],
+      rulesAffected: ["auto_approve_small_orders"],
+      dependentsAffected: [],
+      migrationRequired: false,
+    },
+    status: "approved",
+    createdAt: FIXED_NOW,
+    updatedAt: FIXED_NOW,
+    approvedAt: FIXED_NOW,
+    approvedBy: { type: "human", id: "admin-1" },
+    ...overrides,
+  };
+}
+
+const SAMPLE_FILES = ["/repo/addons/demo/cap-life-demo/src/rules/_p.rule.ts"] as const;
+
+// ── Test helpers ────────────────────────────────────────────
+
+interface RecordedCall {
+  bin: "git" | "gh";
+  args: readonly string[];
+  cwd: string;
+}
+
+function ok(stdout = "", stderr = ""): ProposalGitCommitterRunResult {
+  return { stdout, stderr, exitCode: 0 };
+}
+
+function fail(exitCode = 1, stderr = "boom", stdout = ""): ProposalGitCommitterRunResult {
+  return { stdout, stderr, exitCode };
+}
+
+/**
+ * Build a runner that returns the indexed response per call. The runner
+ * records each invocation into `calls`. If the test exhausts the queue, the
+ * runner throws so a missing stub is immediately visible.
+ */
+function makeQueueRunner(
+  bin: "git" | "gh",
+  responses: readonly ProposalGitCommitterRunResult[],
+  calls: RecordedCall[],
+): ProposalGitRunner | ProposalGhRunner {
+  let i = 0;
+  return async (args, options) => {
+    calls.push({ bin, args, cwd: options.cwd });
+    const r = responses[i];
+    i += 1;
+    if (!r) {
+      throw new Error(`No stubbed ${bin} response for call #${i} (args: ${args.join(" ")})`);
+    }
+    return r;
+  };
+}
+
+// Standard happy-path response sequence for git (9 calls — fetch through push).
+function happyGitResponses(): ProposalGitCommitterRunResult[] {
+  return [
+    ok(), // 1: fetch
+    fail(1, "fatal: needed a single revision"), // 2: rev-parse --verify branch (not exists → exit 1)
+    fail(2, "no such ref"), // 3: ls-remote (not exists)
+    ok(), // 4: checkout -b ... origin/main
+    ok(), // 5: add
+    ok(), // 6: commit
+    ok("deadbeef\n"), // 7: rev-parse HEAD
+    ok(), // 8: push
+  ];
+}
+
+function happyGhResponses(): ProposalGitCommitterRunResult[] {
+  return [ok("https://github.com/acme/repo/pull/42\n")];
+}
+
+// ── Tests ───────────────────────────────────────────────────
+
+describe("ProposalGitCommitter.commitAndOpenPR — success path", () => {
+  it("runs the full sequence and returns branch/prUrl/commitSha", async () => {
+    const calls: RecordedCall[] = [];
+    const proposal = makeApprovedProposal();
+    const files = [
+      "/repo/addons/demo/cap-life-demo/src/rules/a.rule.ts",
+      "/repo/addons/demo/cap-life-demo/src/views/b.view.ts",
+    ];
+
+    const committer = new ProposalGitCommitter({
+      rootDir: "/repo",
+      gitRunner: makeQueueRunner("git", happyGitResponses(), calls),
+      ghRunner: makeQueueRunner("gh", happyGhResponses(), calls),
+    });
+
+    const result = await committer.commitAndOpenPR(proposal, files);
+
+    // Expected branch: short-id (last 8 of id) + slug (capped at 40).
+    expect(result.branch).toBe("proposal/efgh5678-auto-approve-small-orders");
+    expect(result.prUrl).toBe("https://github.com/acme/repo/pull/42");
+    expect(result.commitSha).toBe("deadbeef");
+
+    // Verify call sequence (8 git + 1 gh = 9 calls).
+    expect(calls).toHaveLength(9);
+    expect(calls[0]).toMatchObject({ bin: "git", args: ["fetch", "origin", "main"], cwd: "/repo" });
+    expect(calls[1]).toMatchObject({
+      bin: "git",
+      args: ["rev-parse", "--verify", result.branch],
+    });
+    expect(calls[2]).toMatchObject({
+      bin: "git",
+      args: ["ls-remote", "--exit-code", "--heads", "origin", result.branch],
+    });
+    expect(calls[3]).toMatchObject({
+      bin: "git",
+      args: ["checkout", "-b", result.branch, "origin/main"],
+    });
+    // Step 5: add — files passed individually, prefixed by `--`.
+    expect(calls[4].args).toEqual(["add", "--", files[0], files[1]]);
+    // Step 6: commit — subject + body via -m.
+    expect(calls[5].bin).toBe("git");
+    expect(calls[5].args[0]).toBe("commit");
+    expect(calls[5].args[1]).toBe("-m");
+    const commitMsg = calls[5].args[2];
+    expect(commitMsg).toContain("feat(proposal): Auto-approve small orders");
+    expect(commitMsg).toContain(`Proposal-ID: ${proposal.id}`);
+    expect(commitMsg).toContain("Generated from insight #42.");
+    // --no-verify is forbidden.
+    expect(calls[5].args).not.toContain("--no-verify");
+
+    expect(calls[6]).toMatchObject({ bin: "git", args: ["rev-parse", "HEAD"] });
+    expect(calls[7]).toMatchObject({
+      bin: "git",
+      args: ["push", "-u", "origin", result.branch],
+    });
+    // gh pr create
+    expect(calls[8].bin).toBe("gh");
+    expect(calls[8].args).toContain("pr");
+    expect(calls[8].args).toContain("create");
+    expect(calls[8].args).toContain("--base");
+    expect(calls[8].args).toContain("main");
+    expect(calls[8].args).toContain("--head");
+    expect(calls[8].args).toContain(result.branch);
+  });
+
+  it("falls back to local base branch when origin/<base> checkout fails", async () => {
+    const calls: RecordedCall[] = [];
+    const gitResponses = happyGitResponses();
+    // Replace step 4 (checkout from origin/main) with a failure, then add a
+    // fallback success for checkout from local "main". Push down the rest.
+    gitResponses.splice(
+      3,
+      1,
+      fail(1, "error: pathspec 'origin/main' did not match"),
+      ok(), // fallback checkout from local "main"
+    );
+
+    const committer = new ProposalGitCommitter({
+      rootDir: "/repo",
+      gitRunner: makeQueueRunner("git", gitResponses, calls),
+      ghRunner: makeQueueRunner("gh", happyGhResponses(), calls),
+    });
+
+    const result = await committer.commitAndOpenPR(makeApprovedProposal(), [...SAMPLE_FILES]);
+    expect(result.prUrl).toBe("https://github.com/acme/repo/pull/42");
+    // Confirm fallback was used.
+    expect(calls[3].args).toEqual(["checkout", "-b", result.branch, "origin/main"]);
+    expect(calls[4].args).toEqual(["checkout", "-b", result.branch, "main"]);
+  });
+});
+
+describe("ProposalGitCommitter.commitAndOpenPR — pre-condition failures", () => {
+  it("throws when proposal is not approved and never invokes runners", async () => {
+    const calls: RecordedCall[] = [];
+    const committer = new ProposalGitCommitter({
+      rootDir: "/repo",
+      gitRunner: makeQueueRunner("git", [], calls),
+      ghRunner: makeQueueRunner("gh", [], calls),
+    });
+    const draft = makeApprovedProposal({ status: "draft" });
+
+    await expect(committer.commitAndOpenPR(draft, [...SAMPLE_FILES])).rejects.toThrow(
+      /requires status "approved"/,
+    );
+    expect(calls).toHaveLength(0);
+  });
+
+  it("throws when writtenFiles is empty and never invokes runners", async () => {
+    const calls: RecordedCall[] = [];
+    const committer = new ProposalGitCommitter({
+      rootDir: "/repo",
+      gitRunner: makeQueueRunner("git", [], calls),
+      ghRunner: makeQueueRunner("gh", [], calls),
+    });
+
+    await expect(committer.commitAndOpenPR(makeApprovedProposal(), [])).rejects.toThrow(
+      /at least one written file/,
+    );
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe("ProposalGitCommitter.commitAndOpenPR — branch collision", () => {
+  it("throws when local branch already exists and stops before remote check", async () => {
+    const calls: RecordedCall[] = [];
+    const responses: ProposalGitCommitterRunResult[] = [
+      ok(), // fetch
+      ok(), // rev-parse --verify → 0 means branch exists
+    ];
+
+    const committer = new ProposalGitCommitter({
+      rootDir: "/repo",
+      gitRunner: makeQueueRunner("git", responses, calls),
+      ghRunner: makeQueueRunner("gh", [], calls),
+    });
+
+    await expect(
+      committer.commitAndOpenPR(makeApprovedProposal(), [...SAMPLE_FILES]),
+    ).rejects.toThrow(/branch already exists locally/);
+    // Only fetch + rev-parse were called.
+    expect(calls).toHaveLength(2);
+  });
+
+  it("throws when remote branch already exists", async () => {
+    const calls: RecordedCall[] = [];
+    const responses: ProposalGitCommitterRunResult[] = [
+      ok(), // fetch
+      fail(1, "fatal: needed a single revision"), // rev-parse → branch missing locally
+      ok(), // ls-remote → 0 means branch present on remote
+    ];
+    const committer = new ProposalGitCommitter({
+      rootDir: "/repo",
+      gitRunner: makeQueueRunner("git", responses, calls),
+      ghRunner: makeQueueRunner("gh", [], calls),
+    });
+
+    await expect(
+      committer.commitAndOpenPR(makeApprovedProposal(), [...SAMPLE_FILES]),
+    ).rejects.toThrow(/branch already exists on remote/);
+    expect(calls).toHaveLength(3);
+  });
+});
+
+describe("ProposalGitCommitter.commitAndOpenPR — subprocess failures", () => {
+  it("throws and includes stderr when git push fails", async () => {
+    const calls: RecordedCall[] = [];
+    const responses = happyGitResponses();
+    responses[7] = fail(1, "remote: rejected"); // push fails
+
+    const committer = new ProposalGitCommitter({
+      rootDir: "/repo",
+      gitRunner: makeQueueRunner("git", responses, calls),
+      ghRunner: makeQueueRunner("gh", [], calls),
+    });
+
+    await expect(
+      committer.commitAndOpenPR(makeApprovedProposal(), [...SAMPLE_FILES]),
+    ).rejects.toThrow(/push.*remote: rejected/s);
+  });
+
+  it("throws and includes stderr when gh pr create fails", async () => {
+    const calls: RecordedCall[] = [];
+    const committer = new ProposalGitCommitter({
+      rootDir: "/repo",
+      gitRunner: makeQueueRunner("git", happyGitResponses(), calls),
+      ghRunner: makeQueueRunner("gh", [fail(1, "gh: no auth")], calls),
+    });
+
+    await expect(
+      committer.commitAndOpenPR(makeApprovedProposal(), [...SAMPLE_FILES]),
+    ).rejects.toThrow(/pr create.*gh: no auth/s);
+  });
+
+  it("does NOT abort when git fetch fails; warns via logger and continues", async () => {
+    const calls: RecordedCall[] = [];
+    const warnings: string[] = [];
+    const responses = happyGitResponses();
+    responses[0] = fail(1, "fatal: unable to access"); // fetch fails
+
+    const committer = new ProposalGitCommitter({
+      rootDir: "/repo",
+      logger: { warn: (m) => warnings.push(m) },
+      gitRunner: makeQueueRunner("git", responses, calls),
+      ghRunner: makeQueueRunner("gh", happyGhResponses(), calls),
+    });
+
+    const result = await committer.commitAndOpenPR(makeApprovedProposal(), [...SAMPLE_FILES]);
+    expect(result.prUrl).toBe("https://github.com/acme/repo/pull/42");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("git fetch");
+    expect(warnings[0]).toContain("fatal: unable to access");
+    // Sequence kept going: 8 git + 1 gh.
+    expect(calls).toHaveLength(9);
+  });
+});
+
+describe("ProposalGitCommitter.commitAndOpenPR — overrides", () => {
+  it("honors custom branchName, commitMessage, prTitle, prBody", async () => {
+    const calls: RecordedCall[] = [];
+    const committer = new ProposalGitCommitter({
+      rootDir: "/repo",
+      branchName: () => "custom/branch-x",
+      commitMessage: () => "custom: subject",
+      prTitle: () => "custom title",
+      prBody: () => "custom body",
+      gitRunner: makeQueueRunner("git", happyGitResponses(), calls),
+      ghRunner: makeQueueRunner("gh", happyGhResponses(), calls),
+    });
+
+    const result = await committer.commitAndOpenPR(makeApprovedProposal(), [...SAMPLE_FILES]);
+    expect(result.branch).toBe("custom/branch-x");
+    expect(calls[3].args).toEqual(["checkout", "-b", "custom/branch-x", "origin/main"]);
+    expect(calls[5].args[2]).toBe("custom: subject");
+    // PR title / body — find them positionally in the gh call.
+    const ghCall = calls[calls.length - 1];
+    expect(ghCall.args).toContain("--title");
+    expect(ghCall.args[ghCall.args.indexOf("--title") + 1]).toBe("custom title");
+    expect(ghCall.args[ghCall.args.indexOf("--body") + 1]).toBe("custom body");
+  });
+});
+
+describe("ProposalGitCommitter — slug edge cases", () => {
+  it("falls back to short-id when title produces an empty slug", async () => {
+    const calls: RecordedCall[] = [];
+    const committer = new ProposalGitCommitter({
+      rootDir: "/repo",
+      gitRunner: makeQueueRunner("git", happyGitResponses(), calls),
+      ghRunner: makeQueueRunner("gh", happyGhResponses(), calls),
+    });
+    const proposal = makeApprovedProposal({ title: "" });
+    const result = await committer.commitAndOpenPR(proposal, [...SAMPLE_FILES]);
+    expect(result.branch).toBe("proposal/efgh5678");
+  });
+
+  it("falls back to short-id when title is only special characters", async () => {
+    const calls: RecordedCall[] = [];
+    const committer = new ProposalGitCommitter({
+      rootDir: "/repo",
+      gitRunner: makeQueueRunner("git", happyGitResponses(), calls),
+      ghRunner: makeQueueRunner("gh", happyGhResponses(), calls),
+    });
+    const proposal = makeApprovedProposal({ title: "!!!@@@###" });
+    const result = await committer.commitAndOpenPR(proposal, [...SAMPLE_FILES]);
+    expect(result.branch).toBe("proposal/efgh5678");
+  });
+
+  it("caps slug at 40 chars when the title is long", async () => {
+    const calls: RecordedCall[] = [];
+    const committer = new ProposalGitCommitter({
+      rootDir: "/repo",
+      gitRunner: makeQueueRunner("git", happyGitResponses(), calls),
+      ghRunner: makeQueueRunner("gh", happyGhResponses(), calls),
+    });
+    const longTitle = "a".repeat(120);
+    const proposal = makeApprovedProposal({ title: longTitle });
+    const result = await committer.commitAndOpenPR(proposal, [...SAMPLE_FILES]);
+    // After prefix + short-id + dash, slug portion must be exactly 40 chars.
+    const slug = result.branch.replace(/^proposal\/efgh5678-/, "");
+    expect(slug.length).toBe(40);
+    expect(/^a+$/.test(slug)).toBe(true);
+  });
+});
+
+describe("ProposalGitCommitter — PR URL parsing", () => {
+  it("extracts the URL from a multi-line gh stdout", async () => {
+    const calls: RecordedCall[] = [];
+    const multiLine =
+      "Creating pull request for proposal/foo-bar into main in acme/repo\n\nhttps://github.com/acme/repo/pull/123\n";
+    const committer = new ProposalGitCommitter({
+      rootDir: "/repo",
+      gitRunner: makeQueueRunner("git", happyGitResponses(), calls),
+      ghRunner: makeQueueRunner("gh", [ok(multiLine)], calls),
+    });
+    const result = await committer.commitAndOpenPR(makeApprovedProposal(), [...SAMPLE_FILES]);
+    expect(result.prUrl).toBe("https://github.com/acme/repo/pull/123");
+  });
+
+  it("throws when stdout has no recognisable PR URL", async () => {
+    const calls: RecordedCall[] = [];
+    const committer = new ProposalGitCommitter({
+      rootDir: "/repo",
+      gitRunner: makeQueueRunner("git", happyGitResponses(), calls),
+      ghRunner: makeQueueRunner("gh", [ok("no url here\n")], calls),
+    });
+    await expect(
+      committer.commitAndOpenPR(makeApprovedProposal(), [...SAMPLE_FILES]),
+    ).rejects.toThrow(/could not parse PR URL/);
+  });
+});
+
+describe("ProposalGitCommitter — commit message truncation", () => {
+  it("truncates the subject with an ellipsis when > 72 chars", async () => {
+    const calls: RecordedCall[] = [];
+    const longTitle = "x".repeat(200);
+    const committer = new ProposalGitCommitter({
+      rootDir: "/repo",
+      gitRunner: makeQueueRunner("git", happyGitResponses(), calls),
+      ghRunner: makeQueueRunner("gh", happyGhResponses(), calls),
+    });
+
+    await committer.commitAndOpenPR(makeApprovedProposal({ title: longTitle }), [...SAMPLE_FILES]);
+    const commitMsg = calls[5].args[2];
+    // First line is the subject — must be exactly 72 chars and end with the ellipsis.
+    const subject = commitMsg.split("\n")[0];
+    expect(subject.length).toBe(72);
+    expect(subject.endsWith("…")).toBe(true);
+  });
+});
+
+describe("createProposalGitCommitter factory", () => {
+  it("returns a ProposalGitCommitter instance", () => {
+    const c = createProposalGitCommitter({ rootDir: "/repo" });
+    expect(c).toBeInstanceOf(ProposalGitCommitter);
+  });
+});

--- a/packages/core/src/engine/index.ts
+++ b/packages/core/src/engine/index.ts
@@ -99,6 +99,16 @@ export {
   ProposalGenerationError,
   type ProposalGeneratorDeps,
 } from "./proposal-generator";
+// Proposal git committer (Spec 55 §7.7)
+export {
+  createProposalGitCommitter,
+  type ProposalGhRunner,
+  type ProposalGitCommitResult,
+  ProposalGitCommitter,
+  type ProposalGitCommitterOptions,
+  type ProposalGitCommitterRunResult,
+  type ProposalGitRunner,
+} from "./proposal-git-committer";
 // Rule engine
 export {
   collectRules,

--- a/packages/core/src/engine/proposal-git-committer.ts
+++ b/packages/core/src/engine/proposal-git-committer.ts
@@ -1,0 +1,424 @@
+/**
+ * ProposalGitCommitter — Spec 55 §7.7 "Graduation: from disk to PR".
+ *
+ * Thin orchestrator that graduates the on-disk files produced by
+ * `ProposalFileWriter` into a reviewable GitHub PR. The boundary is
+ * intentionally narrow:
+ *
+ *   - Pre-conditions: `proposal.status === "approved"` and `writtenFiles`
+ *     is non-empty (the files actually written by the upstream writer).
+ *   - Side effects: a fresh local branch, a single commit on it, a push
+ *     to the configured remote, and a `gh pr create` invocation.
+ *   - Failure mode: throw loudly. We do NOT auto-merge, NOT auto-resolve
+ *     conflicts, and NOT skip hooks (`--no-verify` is forbidden).
+ *   - Composition: the caller decides when to invoke this — typically
+ *     from `ProposalEngine.onApproved`, after `ProposalFileWriter` has
+ *     resolved. We deliberately do NOT auto-wire into the engine so the
+ *     project keeps the option of staging or batching PRs.
+ *
+ * The default subprocess runners use `Bun.spawn`. Tests inject custom
+ * runners so they never touch the real `git`/`gh` binaries.
+ */
+
+import type { ProposalDefinition } from "../types/proposal";
+
+// ── Types ───────────────────────────────────────────────────
+
+export interface ProposalGitCommitterRunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/** Async runner for the `git` binary. Args are passed verbatim, no shell. */
+export type ProposalGitRunner = (
+  args: readonly string[],
+  options: { cwd: string },
+) => Promise<ProposalGitCommitterRunResult>;
+
+/** Async runner for the `gh` binary. Args are passed verbatim, no shell. */
+export type ProposalGhRunner = (
+  args: readonly string[],
+  options: { cwd: string },
+) => Promise<ProposalGitCommitterRunResult>;
+
+export interface ProposalGitCommitterOptions {
+  /** Absolute path to the repository root — used as cwd for every subprocess. */
+  rootDir: string;
+  /** Base branch the PR targets. Default: "main". */
+  baseBranch?: string;
+  /** Git remote name. Default: "origin". */
+  remote?: string;
+  /** Branch namespace prefix. Default: "proposal/". */
+  branchPrefix?: string;
+  /** Override the default branch namer. */
+  branchName?: (proposal: ProposalDefinition) => string;
+  /** Override the default commit message builder. */
+  commitMessage?: (proposal: ProposalDefinition, writtenFiles: readonly string[]) => string;
+  /** Override the default PR title. */
+  prTitle?: (proposal: ProposalDefinition) => string;
+  /** Override the default PR body. */
+  prBody?: (proposal: ProposalDefinition, writtenFiles: readonly string[]) => string;
+  /** Injectable for tests; default spawns real `git` via Bun.spawn. */
+  gitRunner?: ProposalGitRunner;
+  /** Injectable for tests; default spawns real `gh` via Bun.spawn. */
+  ghRunner?: ProposalGhRunner;
+  /** Structured logger. If provided, used only for non-fatal warnings. */
+  logger?: { warn?: (msg: string) => void; info?: (msg: string) => void };
+}
+
+export interface ProposalGitCommitResult {
+  branch: string;
+  prUrl: string;
+  commitSha: string;
+}
+
+// ── Constants ───────────────────────────────────────────────
+
+const DEFAULT_BASE_BRANCH = "main";
+const DEFAULT_REMOTE = "origin";
+const DEFAULT_BRANCH_PREFIX = "proposal/";
+const MAX_SUBJECT_LENGTH = 72;
+const MAX_SLUG_LENGTH = 40;
+const SHORT_ID_LENGTH = 8;
+const PR_URL_REGEX = /https:\/\/github\.com\/.+\/pull\/\d+/;
+
+// ── Helpers (pure) ──────────────────────────────────────────
+
+/** Read provenance from the loosely-typed sidecar attached by life-system. */
+function readSourceInsights(proposal: ProposalDefinition): readonly string[] {
+  // The InsightToProposal translator attaches `evidence` as a non-enumerable
+  // sidecar (see life-system/insight-to-proposal.ts). The same record may
+  // also carry an explicit `sourceInsights: string[]` field if a downstream
+  // capability decided to lift the provenance into a first-class slot.
+  const explicit = (proposal as { sourceInsights?: unknown }).sourceInsights;
+  if (Array.isArray(explicit)) {
+    return explicit.filter((id): id is string => typeof id === "string");
+  }
+  const evidence = (proposal as { evidence?: { context?: Record<string, unknown> } }).evidence;
+  const insightId = evidence?.context?.insightId;
+  if (typeof insightId === "string" && insightId.length > 0) {
+    return [insightId];
+  }
+  return [];
+}
+
+/** Truncate a single-line subject to at most {@link MAX_SUBJECT_LENGTH} chars. */
+function truncateSubject(subject: string): string {
+  if (subject.length <= MAX_SUBJECT_LENGTH) return subject;
+  // Reserve one slot for the ellipsis character. Using "…" (U+2026) keeps
+  // the byte budget tight vs. "..." (3 chars) so we lose minimal title.
+  return `${subject.slice(0, MAX_SUBJECT_LENGTH - 1)}…`;
+}
+
+/** Slugify a free-form title into a branch-safe segment. */
+function slugify(title: string, maxLength = MAX_SLUG_LENGTH): string {
+  const normalised = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (normalised.length === 0) return "";
+  if (normalised.length <= maxLength) return normalised;
+  // Trim any trailing dash created by the cap so we never emit `…-/`.
+  return normalised.slice(0, maxLength).replace(/-+$/, "");
+}
+
+function shortId(proposalId: string): string {
+  return proposalId.length <= SHORT_ID_LENGTH
+    ? proposalId
+    : proposalId.slice(proposalId.length - SHORT_ID_LENGTH);
+}
+
+function defaultBranchName(proposal: ProposalDefinition, prefix: string): string {
+  const sid = shortId(proposal.id);
+  const slug = slugify(proposal.title);
+  return slug.length === 0 ? `${prefix}${sid}` : `${prefix}${sid}-${slug}`;
+}
+
+function defaultCommitSubject(proposal: ProposalDefinition): string {
+  return truncateSubject(`feat(proposal): ${proposal.title}`);
+}
+
+function defaultCommitMessage(
+  proposal: ProposalDefinition,
+  _writtenFiles: readonly string[],
+): string {
+  const subject = defaultCommitSubject(proposal);
+  const trailers: string[] = [`Proposal-ID: ${proposal.id}`];
+  const insights = readSourceInsights(proposal);
+  if (insights.length > 0) {
+    trailers.push(`Source-Insights: ${insights.join(", ")}`);
+  }
+  const body = proposal.description?.trim();
+  // Conventional-commit-ish layout: subject, blank line, trailers, blank,
+  // optional body. The trailers form a parseable block for downstream tools.
+  const segments: string[] = [subject, "", trailers.join("\n")];
+  if (body && body.length > 0) {
+    segments.push("", body);
+  }
+  return segments.join("\n");
+}
+
+function defaultPrTitle(proposal: ProposalDefinition): string {
+  return defaultCommitSubject(proposal);
+}
+
+/** Path → repo-relative for body rendering. Falls back to absolute on mismatch. */
+function relativeToRoot(rootDir: string, absolutePath: string): string {
+  const root = rootDir.endsWith("/") ? rootDir : `${rootDir}/`;
+  return absolutePath.startsWith(root) ? absolutePath.slice(root.length) : absolutePath;
+}
+
+function defaultPrBody(
+  proposal: ProposalDefinition,
+  writtenFiles: readonly string[],
+  rootDir: string,
+): string {
+  const lines: string[] = [];
+  lines.push("## Proposal");
+  lines.push(`- ID: ${proposal.id}`);
+  lines.push(`- Status: ${proposal.status}`);
+  const insights = readSourceInsights(proposal);
+  if (insights.length > 0) {
+    lines.push(`- Source insights: ${insights.join(", ")}`);
+  }
+  lines.push("");
+  lines.push("## Changes");
+  if (proposal.changes.length === 0) {
+    lines.push("- (none)");
+  } else {
+    for (const change of proposal.changes) {
+      lines.push(`- ${change.target} / ${change.operation} / ${change.name}`);
+    }
+  }
+  lines.push("");
+  lines.push("## Files written");
+  for (const file of writtenFiles) {
+    lines.push(`- ${relativeToRoot(rootDir, file)}`);
+  }
+  const description = proposal.description?.trim();
+  if (description && description.length > 0) {
+    lines.push("");
+    lines.push("## Description");
+    lines.push(description);
+  }
+  lines.push("");
+  lines.push("🤖 Generated by LinchKit Evolution Engine (Spec 55 §7.7)");
+  return lines.join("\n");
+}
+
+/** Throw a uniformly-formatted error for a non-zero subprocess exit. */
+function failStep(stepName: string, result: ProposalGitCommitterRunResult): never {
+  throw new Error(`git/gh '${stepName}' failed (exit ${result.exitCode}): ${result.stderr.trim()}`);
+}
+
+// ── Default runners (Bun.spawn) ─────────────────────────────
+
+function makeDefaultRunner(bin: string): ProposalGitRunner {
+  return async (args, options) => {
+    const proc = Bun.spawn({
+      cmd: [bin, ...args],
+      cwd: options.cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    // Drain both streams concurrently to avoid the buffer-fill deadlock
+    // that bites every "read stdout then stderr" implementation.
+    const [stdout, stderr] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    const exitCode = await proc.exited;
+    return { stdout, stderr, exitCode };
+  };
+}
+
+const defaultGitRunner: ProposalGitRunner = makeDefaultRunner("git");
+const defaultGhRunner: ProposalGhRunner = makeDefaultRunner("gh");
+
+// ── ProposalGitCommitter ────────────────────────────────────
+
+export class ProposalGitCommitter {
+  private readonly rootDir: string;
+  private readonly baseBranch: string;
+  private readonly remote: string;
+  private readonly branchPrefix: string;
+  private readonly branchNamer: (proposal: ProposalDefinition) => string;
+  private readonly commitMessageBuilder: (
+    proposal: ProposalDefinition,
+    writtenFiles: readonly string[],
+  ) => string;
+  private readonly prTitleBuilder: (proposal: ProposalDefinition) => string;
+  private readonly prBodyBuilder: (
+    proposal: ProposalDefinition,
+    writtenFiles: readonly string[],
+  ) => string;
+  private readonly gitRunner: ProposalGitRunner;
+  private readonly ghRunner: ProposalGhRunner;
+  private readonly logger?: { warn?: (msg: string) => void; info?: (msg: string) => void };
+
+  constructor(options: ProposalGitCommitterOptions) {
+    this.rootDir = options.rootDir;
+    this.baseBranch = options.baseBranch ?? DEFAULT_BASE_BRANCH;
+    this.remote = options.remote ?? DEFAULT_REMOTE;
+    this.branchPrefix = options.branchPrefix ?? DEFAULT_BRANCH_PREFIX;
+    this.branchNamer = options.branchName ?? ((p) => defaultBranchName(p, this.branchPrefix));
+    this.commitMessageBuilder = options.commitMessage ?? defaultCommitMessage;
+    this.prTitleBuilder = options.prTitle ?? defaultPrTitle;
+    this.prBodyBuilder = options.prBody ?? ((p, files) => defaultPrBody(p, files, this.rootDir));
+    this.gitRunner = options.gitRunner ?? defaultGitRunner;
+    this.ghRunner = options.ghRunner ?? defaultGhRunner;
+    this.logger = options.logger;
+  }
+
+  /**
+   * Commit the given files to a new branch derived from the proposal,
+   * push to remote, and open a GitHub PR.
+   *
+   * Throws on:
+   *   - proposal.status !== "approved"
+   *   - empty writtenFiles
+   *   - any git/gh subprocess non-zero exit (except `git fetch`, which is
+   *     best-effort and only warns)
+   *   - branch already exists locally OR remotely
+   */
+  async commitAndOpenPR(
+    proposal: ProposalDefinition,
+    writtenFiles: readonly string[],
+  ): Promise<ProposalGitCommitResult> {
+    // ── Pre-conditions ──
+    if (proposal.status !== "approved") {
+      throw new Error(
+        `ProposalGitCommitter requires status "approved" — got "${proposal.status}" for proposal "${proposal.id}"`,
+      );
+    }
+    if (writtenFiles.length === 0) {
+      throw new Error(
+        `ProposalGitCommitter requires at least one written file for proposal "${proposal.id}"`,
+      );
+    }
+
+    const branch = this.branchNamer(proposal);
+    const cwdOpt = { cwd: this.rootDir };
+
+    // ── Step 1: git fetch (best-effort) ──
+    const fetchResult = await this.gitRunner(["fetch", this.remote, this.baseBranch], cwdOpt);
+    if (fetchResult.exitCode !== 0) {
+      this.logger?.warn?.(
+        `ProposalGitCommitter: git fetch ${this.remote} ${this.baseBranch} failed (exit ${fetchResult.exitCode}): ${fetchResult.stderr.trim()} — continuing`,
+      );
+    }
+
+    // ── Step 2: refuse if branch exists locally ──
+    const localCheck = await this.gitRunner(["rev-parse", "--verify", branch], cwdOpt);
+    if (localCheck.exitCode === 0) {
+      throw new Error(
+        `ProposalGitCommitter: branch already exists locally: "${branch}" (proposal "${proposal.id}")`,
+      );
+    }
+
+    // ── Step 3: refuse if branch exists on remote ──
+    const remoteCheck = await this.gitRunner(
+      ["ls-remote", "--exit-code", "--heads", this.remote, branch],
+      cwdOpt,
+    );
+    if (remoteCheck.exitCode === 0) {
+      throw new Error(
+        `ProposalGitCommitter: branch already exists on remote: "${this.remote}/${branch}" (proposal "${proposal.id}")`,
+      );
+    }
+
+    // ── Step 4: create branch from <remote>/<base>, fallback to <base> ──
+    const remoteRef = `${this.remote}/${this.baseBranch}`;
+    const checkoutFromRemote = await this.gitRunner(["checkout", "-b", branch, remoteRef], cwdOpt);
+    if (checkoutFromRemote.exitCode !== 0) {
+      // Remote ref may be missing (offline, fresh clone w/o tracking, ...);
+      // fall back to the local base branch before giving up.
+      const checkoutFromLocal = await this.gitRunner(
+        ["checkout", "-b", branch, this.baseBranch],
+        cwdOpt,
+      );
+      if (checkoutFromLocal.exitCode !== 0) {
+        failStep("checkout", checkoutFromLocal);
+      }
+    }
+
+    // ── Step 5: stage files explicitly (no -A / no .) ──
+    const addResult = await this.gitRunner(["add", "--", ...writtenFiles], cwdOpt);
+    if (addResult.exitCode !== 0) {
+      failStep("add", addResult);
+    }
+
+    // ── Step 6: commit ──
+    const commitMessage = this.commitMessageBuilder(proposal, writtenFiles);
+    const commitResult = await this.gitRunner(["commit", "-m", commitMessage], cwdOpt);
+    if (commitResult.exitCode !== 0) {
+      failStep("commit", commitResult);
+    }
+
+    // ── Step 7: capture commit SHA ──
+    const headResult = await this.gitRunner(["rev-parse", "HEAD"], cwdOpt);
+    if (headResult.exitCode !== 0) {
+      failStep("rev-parse HEAD", headResult);
+    }
+    const commitSha = headResult.stdout.trim();
+
+    // ── Step 8: push ──
+    const pushResult = await this.gitRunner(["push", "-u", this.remote, branch], cwdOpt);
+    if (pushResult.exitCode !== 0) {
+      failStep("push", pushResult);
+    }
+
+    // ── Step 9: open PR via gh ──
+    const prTitle = this.prTitleBuilder(proposal);
+    const prBody = this.prBodyBuilder(proposal, writtenFiles);
+    const prResult = await this.ghRunner(
+      [
+        "pr",
+        "create",
+        "--base",
+        this.baseBranch,
+        "--head",
+        branch,
+        "--title",
+        prTitle,
+        "--body",
+        prBody,
+      ],
+      cwdOpt,
+    );
+    if (prResult.exitCode !== 0) {
+      failStep("pr create", prResult);
+    }
+
+    const prUrl = extractPrUrl(prResult.stdout);
+    if (!prUrl) {
+      throw new Error(
+        `ProposalGitCommitter: could not parse PR URL from 'gh pr create' stdout: ${prResult.stdout.trim()}`,
+      );
+    }
+
+    return { branch, prUrl, commitSha };
+  }
+}
+
+/** Extract the GitHub PR URL from `gh pr create` stdout (last matching line). */
+function extractPrUrl(stdout: string): string | null {
+  const lines = stdout.split(/\r?\n/);
+  // Walk backwards so the URL on the final line wins, matching the gh CLI
+  // convention where any preceding noise (warnings, status messages) is
+  // irrelevant to the caller.
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i]?.trim();
+    if (!line) continue;
+    const match = line.match(PR_URL_REGEX);
+    if (match) return match[0];
+  }
+  return null;
+}
+
+export function createProposalGitCommitter(
+  options: ProposalGitCommitterOptions,
+): ProposalGitCommitter {
+  return new ProposalGitCommitter(options);
+}

--- a/packages/core/src/engine/proposal-git-committer.ts
+++ b/packages/core/src/engine/proposal-git-committer.ts
@@ -81,7 +81,9 @@ const DEFAULT_BRANCH_PREFIX = "proposal/";
 const MAX_SUBJECT_LENGTH = 72;
 const MAX_SLUG_LENGTH = 40;
 const SHORT_ID_LENGTH = 8;
-const PR_URL_REGEX = /https:\/\/github\.com\/.+\/pull\/\d+/;
+// Match owner/repo segments without slashes or whitespace so we never overrun
+// path boundaries on lines that contain unrelated trailing text or extra URLs.
+const PR_URL_REGEX = /https:\/\/github\.com\/[^\s/]+\/[^\s/]+\/pull\/\d+/;
 
 // ── Helpers (pure) ──────────────────────────────────────────
 
@@ -150,12 +152,14 @@ function defaultCommitMessage(
     trailers.push(`Source-Insights: ${insights.join(", ")}`);
   }
   const body = proposal.description?.trim();
-  // Conventional-commit-ish layout: subject, blank line, trailers, blank,
-  // optional body. The trailers form a parseable block for downstream tools.
-  const segments: string[] = [subject, "", trailers.join("\n")];
+  // Conventional Commits layout: subject, optional body, trailers — trailers
+  // MUST come last for `git interpret-trailers` and GitHub PR parsing to pick
+  // them up as metadata rather than free-form prose.
+  const segments: string[] = [subject];
   if (body && body.length > 0) {
     segments.push("", body);
   }
+  segments.push("", trailers.join("\n"));
   return segments.join("\n");
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -178,6 +178,13 @@ export type {
 export type { ProposalFileWriterOptions } from "./engine/proposal-file-writer";
 export type { ProposalGeneratorDeps } from "./engine/proposal-generator";
 export type {
+  ProposalGhRunner,
+  ProposalGitCommitResult,
+  ProposalGitCommitterOptions,
+  ProposalGitCommitterRunResult,
+  ProposalGitRunner,
+} from "./engine/proposal-git-committer";
+export type {
   RuleEvalInput,
   RuleEvalOptions,
   RuleEvalOutput,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -177,13 +177,7 @@ export type {
 } from "./engine/proposal-engine";
 export type { ProposalFileWriterOptions } from "./engine/proposal-file-writer";
 export type { ProposalGeneratorDeps } from "./engine/proposal-generator";
-export type {
-  ProposalGhRunner,
-  ProposalGitCommitResult,
-  ProposalGitCommitterOptions,
-  ProposalGitCommitterRunResult,
-  ProposalGitRunner,
-} from "./engine/proposal-git-committer";
+export type * from "./engine/proposal-git-committer";
 export type {
   RuleEvalInput,
   RuleEvalOptions,

--- a/packages/core/src/server-entry.ts
+++ b/packages/core/src/server-entry.ts
@@ -92,6 +92,15 @@ export {
   ProposalGenerationError,
   type ProposalGeneratorDeps,
 } from "./engine/proposal-generator";
+export {
+  createProposalGitCommitter,
+  type ProposalGhRunner,
+  type ProposalGitCommitResult,
+  ProposalGitCommitter,
+  type ProposalGitCommitterOptions,
+  type ProposalGitCommitterRunResult,
+  type ProposalGitRunner,
+} from "./engine/proposal-git-committer";
 
 export {
   collectRules,


### PR DESCRIPTION
## Summary

Closes the last gap in the Spec 55 evolution loop:

```
Proposal (approved)
  → ProposalFileWriter   (#366, Spec 55 §7.6) → on-disk TypeScript source
  → ProposalGitCommitter (THIS PR, Spec 55 §7.7) → branch + commit + push + PR
```

After #366 shipped, approved Proposals graduate from runtime state to actual TS source files. The files just sat there waiting for a human to `git add` + commit + open a PR. This PR closes that gap with a thin orchestrator that drives `git` and `gh` from a recorded Proposal.

## Public surface — `@linchkit/core`, semver-minor (additive)

```ts
import { createProposalGitCommitter } from "@linchkit/core";

const committer = createProposalGitCommitter({
  rootDir: process.cwd(),
  baseBranch: "main",        // default
  remote: "origin",          // default
  branchPrefix: "proposal/", // default
});

const { branch, prUrl, commitSha } = await committer.commitAndOpenPR(
  approvedProposal,
  writtenFilesFromProposalFileWriter,
);
```

- `ProposalGitCommitter` class + `createProposalGitCommitter()` factory
- `ProposalGitRunner` / `ProposalGhRunner` injectable for deterministic tests — default spawns real `git`/`gh` via `Bun.spawn` (no `node:child_process`)
- Customisable `branchName` / `commitMessage` / `prTitle` / `prBody` hooks
- Throws with actionable error on every failure mode: status not approved, empty `writtenFiles`, local branch collision, remote branch collision, push reject, `gh pr create` non-zero

## Composition (intentionally not auto-wired)

Per the issue's "Out of scope": no automatic wiring into `ProposalEngine.onApproved`. The caller composes the writer + committer themselves — keeps the engine policy-free, matches the §7.6 design.

```ts
const writer = createProposalFileWriter({ rootDir });
const committer = createProposalGitCommitter({ rootDir });

const engine = createProposalEngine({
  onApproved: async (proposal) => {
    const files = await writer.writeApprovedProposal(proposal);
    await committer.commitAndOpenPR(proposal, files);
  },
});
```

## Design defaults

| Aspect | Default | Customisable? |
|---|---|---|
| Branch name | `proposal/<short-id>-<slugified-title>` (slug capped 40 chars, fallback `proposal/<short-id>` for empty slug) | yes (`branchName` hook) |
| Commit subject | `feat(proposal): <title>` capped at 72 chars with U+2026 ellipsis | yes (`commitMessage` hook) |
| PR body | markdown with Proposal / Changes / Files written / Description sections | yes (`prBody` hook) |
| `git fetch` failure | best-effort: warn + continue | logger optional |
| Push reject | hard fail with stderr included | — |
| Branch collision (local OR remote) | hard fail before any mutation | — |

## Source-Insights provenance

`ProposalDefinition` has no first-class `sourceInsights` field. `life-system/insight-to-proposal.ts` attaches provenance via a non-enumerable sidecar at `evidence.context.insightId`. The committer reads first from a future explicit `sourceInsights: string[]` field (if a downstream cap promotes it) and falls back to the sidecar. Returns `[]` when neither exists → omits the `Source insights` PR section entirely.

## What's NOT included (intentional)

- **No auto-wiring into `ProposalEngine.onApproved`** — composition is the caller's choice
- **No merge / squash automation** — every Proposal PR must still pass human review (Spec 55 §7.x invariant + CLAUDE.md `AI Never Modifies Production Directly`)
- **No conflict resolution** — if push rejects (e.g., race with manual commit), fail loudly with stderr; don't auto-rebase
- **No `--no-verify`** — explicitly asserted in the success-path test; hooks must run
- **No new dependencies**

## Tests

`packages/core/__tests__/proposal-git-committer.test.ts` — **17 tests, 58 expectations, all passing**, runners mocked end-to-end (zero real `git` / `gh` subprocess in unit tests):

- Success path: 2-file approved Proposal → correct runner call order with expected args
- `status !== "approved"` → throws, no runner calls
- Empty `writtenFiles` → throws, no runner calls
- Local branch collision → throws, halts before any mutation
- Remote branch collision → throws, halts before any mutation
- `git push` non-zero → throws with stderr
- `gh pr create` non-zero → throws with stderr
- `git fetch` non-zero → warn + continue (no abort)
- Custom `branchName` / `commitMessage` / `prTitle` / `prBody` overrides honored
- Slug edge cases: empty title, special-char-only title, > 40 char title
- `gh pr create` multi-line stdout → URL extracted from last matching line
- Commit subject > 72 chars → truncated with U+2026

## Quality gates

| Gate | Command | Result |
|---|---|---|
| Biome | `bun run check` | clean (1 pre-existing biome schema info) |
| TypeScript | `bun run typecheck` | clean |
| Targeted | `bun test packages/core/__tests__/proposal-git-committer.test.ts` | **17 pass / 0 fail / 58 expect()** |
| Full suite | `bun test` | **5931 pass / 0 fail / 3 skip** (3 pre-existing Volcengine E2E skips, unrelated) |

## Cross-model review

Codex hit usage cap (resets ~21:06 today); Gemini-CLI piping denied by auto-mode harness for safety. Falling back to Gemini bot inline review on this PR — same pattern as #365 and #366. Will re-run Codex once cap resets if there's substantive bot feedback.

## Spec / docs

Spec 55 §7 — evolution loop end-to-end (umbrella unchanged). Spec 55 §7.7 implemented. No INDEX.md update needed (sub-issues track this directly).

Closes #367.

## Self-review checklist

- [x] Tests added and passing
- [x] `bun run check` green
- [x] `bun run typecheck` green
- [x] `bun test` green (no new failures)
- [x] Changeset entry — semver-minor, scope `@linchkit/core`
- [x] Spec 55 §7.7 referenced
- [x] Security review walked through — no auth/tenant/input-trust surfaces; subprocess args pass-through is from a recorded ProposalDefinition (caller-owned trust boundary, not user-input)
- [x] No new dependencies
- [x] No hardcoded secrets, no `any`, no `eval`, no `new Function`, no `node:child_process`
- [x] No `--no-verify` anywhere
- [x] Changes strictly within issue scope
- [x] Branch name follows `feat/` convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ProposalGitCommitter` to automate the creation of GitHub pull requests from approved proposals.
  * Supports customizable branch naming, commit messages, PR titles, and body content through override hooks.
  * Configurable base branch, remote, and branch prefix options.
  * Comprehensive test coverage for end-to-end PR creation workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laofahai/linchkit/pull/370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->