### PR TITLE
fix(ai-eval): harden eval-runner — typecheck coverage + state_flow wiring (#393, #394)

### DIFF
--- a/.changeset/eval-runner-hardening.md
+++ b/.changeset/eval-runner-hardening.md
@@ -1,0 +1,6 @@
+---
+"@linchkit/devtools": patch
+"@linchkit/cap-ai-provider": patch
+---
+
+Wire pattern-detector `state_flow` fixtures and bring eval-runner adapters into typecheck (#393, #394). `PatternExecLogInput` gains optional top-level `recordId` / `stateTransition` fields the detector reads for state-flow analysis, and the pattern-detector scenario adapter now maps them (plus fixes an invalid `ActorType` cast and a `PatternDetectorConfig` argument mismatch). Root `tsconfig.json` now includes `addons/*/cap-*/eval-runner/**` so `bun run typecheck` validates the scenario adapters going forward.

--- a/addons/ai-provider/cap-ai-provider/__tests__/eval-runner/anomaly-detector-scenario.test.ts
+++ b/addons/ai-provider/cap-ai-provider/__tests__/eval-runner/anomaly-detector-scenario.test.ts
@@ -233,7 +233,7 @@ describe("createAnomalyDetectorScenario.replayFromBaseline", () => {
       { now: NOW },
     );
     const live = await scenario.runLive(fx);
-    const replayed = await scenario.replayFromBaseline(fx, undefined);
+    const replayed = await scenario.replayFromBaseline(fx, null);
     expect(replayed).toEqual(live);
   });
 });

--- a/addons/ai-provider/cap-ai-provider/__tests__/eval-runner/intent-scenario.test.ts
+++ b/addons/ai-provider/cap-ai-provider/__tests__/eval-runner/intent-scenario.test.ts
@@ -337,9 +337,12 @@ describe("createIntentScenario.replayFromBaseline", () => {
     };
   }
 
-  it("returns the recorded entry by fixture id on the happy path", () => {
+  it("returns the recorded entry by fixture id on the happy path", async () => {
     const fx = recordedFixture();
-    const out = scenario.replayFromBaseline(fx, baselineFor(fx));
+    // `replayFromBaseline` is typed `Promise<TOutput>` by the ScenarioAdapter
+    // contract; the intent adapter happens to resolve synchronously. `await`
+    // narrows the union so the recorded fields can be asserted directly.
+    const out = await scenario.replayFromBaseline(fx, baselineFor(fx));
     expect(out.action).toBe("create_purchase_request");
     expect(out.explanation).toBe("replayed");
   });

--- a/addons/ai-provider/cap-ai-provider/__tests__/eval-runner/pattern-detector-scenario.test.ts
+++ b/addons/ai-provider/cap-ai-provider/__tests__/eval-runner/pattern-detector-scenario.test.ts
@@ -12,7 +12,10 @@ import type {
   PatternFixtureContext,
   PatternFixtureInput,
 } from "@linchkit/devtools";
-import { createPatternDetectorScenario } from "../../eval-runner/pattern-detector-scenario";
+import {
+  coerceEnabledPatterns,
+  createPatternDetectorScenario,
+} from "../../eval-runner/pattern-detector-scenario";
 
 function makeEntry(
   id: string,
@@ -146,6 +149,37 @@ describe("createPatternDetectorScenario.runLive", () => {
     const out = await scenario.runLive(fx);
     // No single currency dominates at 90% confidence
     expect(out.every((p) => p.type !== "default_value")).toBe(true);
+  });
+});
+
+describe("coerceEnabledPatterns", () => {
+  it("returns undefined when patterns is undefined (use detector defaults)", () => {
+    expect(coerceEnabledPatterns(undefined)).toBeUndefined();
+  });
+
+  it("passes through valid PatternType members unchanged", () => {
+    const valid = ["state_flow", "default_value", "repetitive_action"];
+    expect(coerceEnabledPatterns(valid)).toEqual([
+      "state_flow",
+      "default_value",
+      "repetitive_action",
+    ]);
+  });
+
+  it("accepts an empty array (explicitly disables all patterns)", () => {
+    expect(coerceEnabledPatterns([])).toEqual([]);
+  });
+
+  it("throws on an unknown pattern name, listing the offender and valid set", () => {
+    expect(() => coerceEnabledPatterns(["stateflow"])).toThrow(
+      /Unknown pattern type\(s\) in fixture enabledPatterns: stateflow\. Valid: /,
+    );
+  });
+
+  it("lists every offending name when multiple are unknown", () => {
+    expect(() => coerceEnabledPatterns(["state_flow", "bogus", "typo"])).toThrow(
+      /Unknown pattern type\(s\) in fixture enabledPatterns: bogus, typo\./,
+    );
   });
 });
 

--- a/addons/ai-provider/cap-ai-provider/__tests__/eval-runner/pattern-detector-scenario.test.ts
+++ b/addons/ai-provider/cap-ai-provider/__tests__/eval-runner/pattern-detector-scenario.test.ts
@@ -165,7 +165,7 @@ describe("createPatternDetectorScenario.replayFromBaseline", () => {
       config: { minOccurrences: 5, minConfidence: 0.7 },
     });
     const live = await scenario.runLive(fx);
-    const replayed = await scenario.replayFromBaseline(fx, undefined);
+    const replayed = await scenario.replayFromBaseline(fx, null);
     // PatternDetector uses Date.now() for insight IDs, so IDs differ across calls.
     // Verify structural equivalence (same types, entities, confidence) instead.
     const strip = (items: typeof live) => items.map(({ id: _, ...rest }) => rest);

--- a/addons/ai-provider/cap-ai-provider/__tests__/eval-runner/pattern-detector-state-flow.test.ts
+++ b/addons/ai-provider/cap-ai-provider/__tests__/eval-runner/pattern-detector-state-flow.test.ts
@@ -1,0 +1,113 @@
+/**
+ * End-to-end regression guard for pattern-detector `state_flow` fixtures
+ * (Issue #393).
+ *
+ * Loads the committed `state_flow` fixtures from disk, runs each through the
+ * production pattern-detector scenario adapter, and applies every fixture's
+ * own `expected.matchers` via the matcher registry. This proves the adapter
+ * maps the top-level `recordId` / `stateTransition` fields the detector reads
+ * for state-flow analysis — without these the matchers can never pass, which
+ * is exactly the regression #393 fixes.
+ */
+
+import { describe, expect, it } from "bun:test";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  createMatcherRegistry,
+  type EvalFixture,
+  loadFixtures,
+  type MatcherResult,
+  type PatternEvalOutput,
+  type PatternFixtureContext,
+  type PatternFixtureInput,
+  registerPatternMatchers,
+} from "@linchkit/devtools";
+import { createPatternDetectorScenario } from "../../eval-runner/pattern-detector-scenario";
+
+const FIXTURES_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../eval/fixtures/pattern-detector/state_flow",
+);
+
+const scenario = createPatternDetectorScenario();
+
+/**
+ * `pd-sf-5` (two_flows) cannot pass under the current detector algorithm and is
+ * excluded here (flagged in #393, not forced). `detectStateFlowPatterns` emits
+ * at most ONE state_flow insight per entity — the single dominant path, and
+ * only when its frequency clears `minConfidence`. The fixture splits 5 records
+ * down `draft→approved` and 5 down `draft→rejected` under the same `request`
+ * entity, so the dominant path is 50% (< the 0.7 threshold) and no state_flow
+ * insight is produced. Asserting "two distinct state_flow patterns" requires a
+ * per-path enumeration the detector does not implement; changing that is out of
+ * scope for the adapter-wiring fix.
+ */
+const CANNOT_PASS_FIXTURE_IDS = new Set(["pd-sf-5"]);
+
+// `registerPatternMatchers` accepts the scenario-agnostic `MatcherRegistry`
+// (i.e. `MatcherRegistry<unknown>`), so the registry is created untyped and the
+// `PatternEvalOutput` is passed to `invoke` (whose `output` param is `unknown`).
+function makeRegistry() {
+  const registry = createMatcherRegistry();
+  registerPatternMatchers(registry);
+  return registry;
+}
+
+async function runFixtureMatchers(
+  fx: EvalFixture<PatternFixtureInput, PatternFixtureContext>,
+): Promise<MatcherResult[]> {
+  const output: PatternEvalOutput = await scenario.runLive(fx);
+  const registry = makeRegistry();
+  return fx.expected.matchers.map((m) => registry.invoke(m, output));
+}
+
+describe("pattern-detector state_flow fixtures (Issue #393)", () => {
+  it("loads every committed state_flow fixture from disk", async () => {
+    const fixtures = await loadFixtures<PatternFixtureInput, PatternFixtureContext>({
+      fixturesDir: FIXTURES_DIR,
+      scenario: "pattern-detector",
+    });
+    // 4 positive flows (pd-sf-1/4/5/6) + 2 negatives (pd-sf-2/3).
+    expect(fixtures.length).toBe(6);
+    expect(fixtures.every((f) => f.expected.matchers.length > 0)).toBe(true);
+  });
+
+  it("every supported state_flow fixture passes all of its strict matchers", async () => {
+    const fixtures = (
+      await loadFixtures<PatternFixtureInput, PatternFixtureContext>({
+        fixturesDir: FIXTURES_DIR,
+        scenario: "pattern-detector",
+      })
+    ).filter((f) => !CANNOT_PASS_FIXTURE_IDS.has(f.id));
+
+    // pd-sf-1, pd-sf-2, pd-sf-3, pd-sf-4, pd-sf-6 (pd-sf-5 is flagged above).
+    expect(fixtures.length).toBe(5);
+
+    for (const fx of fixtures) {
+      const results = await runFixtureMatchers(fx);
+      const strictFailures = results.filter((r) => r.strict && !r.passed);
+      expect({ fixture: fx.id, failures: strictFailures }).toEqual({
+        fixture: fx.id,
+        failures: [],
+      });
+    }
+  });
+
+  it("multi_step_flow (pd-sf-4) detects a single state_flow pattern", async () => {
+    const fixtures = await loadFixtures<PatternFixtureInput, PatternFixtureContext>({
+      fixturesDir: FIXTURES_DIR,
+      scenario: "pattern-detector",
+      fixtureFilter: "pd-sf-4",
+    });
+    expect(fixtures.length).toBe(1);
+    const fx = fixtures[0];
+    if (!fx) throw new Error("pd-sf-4 fixture not found");
+
+    const output = await scenario.runLive(fx);
+    const stateFlow = output.filter((p) => p.type === "state_flow");
+    expect(stateFlow.length).toBe(1);
+    // 6 contracts all follow draft→reviewed→approved→closed → 100% confidence.
+    expect(stateFlow[0]?.confidence).toBe(1);
+  });
+});

--- a/addons/ai-provider/cap-ai-provider/__tests__/eval-runner/watcher-engine-scenario.test.ts
+++ b/addons/ai-provider/cap-ai-provider/__tests__/eval-runner/watcher-engine-scenario.test.ts
@@ -231,7 +231,7 @@ describe("createWatcherEngineScenario.replayFromBaseline", () => {
       ],
     });
     const live = await scenario.runLive(fx);
-    const replayed = await scenario.replayFromBaseline(fx, undefined);
+    const replayed = await scenario.replayFromBaseline(fx, null);
     expect(replayed).toEqual(live);
   });
 });

--- a/addons/ai-provider/cap-ai-provider/__tests__/eval/fixtures/pattern-detector/state_flow/basic_state_flow.json
+++ b/addons/ai-provider/cap-ai-provider/__tests__/eval/fixtures/pattern-detector/state_flow/basic_state_flow.json
@@ -11,10 +11,18 @@
         "entity": "order",
         "capability": "cap-order",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "submitted", "recordId": "ord-001" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-20T08:00:00Z",
-        "actor": { "id": "user-alice", "type": "user" }
+        "actor": {
+          "id": "user-alice",
+          "type": "user"
+        },
+        "recordId": "ord-001",
+        "stateTransition": {
+          "from": "draft",
+          "to": "submitted"
+        }
       },
       {
         "id": "e-sf1-2",
@@ -22,10 +30,18 @@
         "entity": "order",
         "capability": "cap-order",
         "status": "succeeded",
-        "input": { "fromState": "submitted", "toState": "approved", "recordId": "ord-001" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-20T10:00:00Z",
-        "actor": { "id": "user-alice", "type": "user" }
+        "actor": {
+          "id": "user-alice",
+          "type": "user"
+        },
+        "recordId": "ord-001",
+        "stateTransition": {
+          "from": "submitted",
+          "to": "approved"
+        }
       },
       {
         "id": "e-sf1-3",
@@ -33,10 +49,18 @@
         "entity": "order",
         "capability": "cap-order",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "submitted", "recordId": "ord-002" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-21T09:00:00Z",
-        "actor": { "id": "user-bob", "type": "user" }
+        "actor": {
+          "id": "user-bob",
+          "type": "user"
+        },
+        "recordId": "ord-002",
+        "stateTransition": {
+          "from": "draft",
+          "to": "submitted"
+        }
       },
       {
         "id": "e-sf1-4",
@@ -44,10 +68,18 @@
         "entity": "order",
         "capability": "cap-order",
         "status": "succeeded",
-        "input": { "fromState": "submitted", "toState": "approved", "recordId": "ord-002" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-21T11:00:00Z",
-        "actor": { "id": "user-bob", "type": "user" }
+        "actor": {
+          "id": "user-bob",
+          "type": "user"
+        },
+        "recordId": "ord-002",
+        "stateTransition": {
+          "from": "submitted",
+          "to": "approved"
+        }
       },
       {
         "id": "e-sf1-5",
@@ -55,10 +87,18 @@
         "entity": "order",
         "capability": "cap-order",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "submitted", "recordId": "ord-003" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-22T08:00:00Z",
-        "actor": { "id": "user-carol", "type": "user" }
+        "actor": {
+          "id": "user-carol",
+          "type": "user"
+        },
+        "recordId": "ord-003",
+        "stateTransition": {
+          "from": "draft",
+          "to": "submitted"
+        }
       },
       {
         "id": "e-sf1-6",
@@ -66,10 +106,18 @@
         "entity": "order",
         "capability": "cap-order",
         "status": "succeeded",
-        "input": { "fromState": "submitted", "toState": "approved", "recordId": "ord-003" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-22T10:00:00Z",
-        "actor": { "id": "user-carol", "type": "user" }
+        "actor": {
+          "id": "user-carol",
+          "type": "user"
+        },
+        "recordId": "ord-003",
+        "stateTransition": {
+          "from": "submitted",
+          "to": "approved"
+        }
       },
       {
         "id": "e-sf1-7",
@@ -77,10 +125,18 @@
         "entity": "order",
         "capability": "cap-order",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "submitted", "recordId": "ord-004" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-23T09:00:00Z",
-        "actor": { "id": "user-alice", "type": "user" }
+        "actor": {
+          "id": "user-alice",
+          "type": "user"
+        },
+        "recordId": "ord-004",
+        "stateTransition": {
+          "from": "draft",
+          "to": "submitted"
+        }
       },
       {
         "id": "e-sf1-8",
@@ -88,10 +144,18 @@
         "entity": "order",
         "capability": "cap-order",
         "status": "succeeded",
-        "input": { "fromState": "submitted", "toState": "approved", "recordId": "ord-004" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-23T11:00:00Z",
-        "actor": { "id": "user-alice", "type": "user" }
+        "actor": {
+          "id": "user-alice",
+          "type": "user"
+        },
+        "recordId": "ord-004",
+        "stateTransition": {
+          "from": "submitted",
+          "to": "approved"
+        }
       },
       {
         "id": "e-sf1-9",
@@ -99,10 +163,18 @@
         "entity": "order",
         "capability": "cap-order",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "submitted", "recordId": "ord-005" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-24T08:00:00Z",
-        "actor": { "id": "user-bob", "type": "user" }
+        "actor": {
+          "id": "user-bob",
+          "type": "user"
+        },
+        "recordId": "ord-005",
+        "stateTransition": {
+          "from": "draft",
+          "to": "submitted"
+        }
       },
       {
         "id": "e-sf1-10",
@@ -110,10 +182,18 @@
         "entity": "order",
         "capability": "cap-order",
         "status": "succeeded",
-        "input": { "fromState": "submitted", "toState": "approved", "recordId": "ord-005" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-24T10:00:00Z",
-        "actor": { "id": "user-bob", "type": "user" }
+        "actor": {
+          "id": "user-bob",
+          "type": "user"
+        },
+        "recordId": "ord-005",
+        "stateTransition": {
+          "from": "submitted",
+          "to": "approved"
+        }
       }
     ],
     "config": {
@@ -121,11 +201,23 @@
       "minConfidence": 0.7
     }
   },
-  "context": { "now": "2026-05-24T10:00:00Z" },
+  "context": {
+    "now": "2026-05-24T10:00:00Z"
+  },
   "expected": {
     "matchers": [
-      { "name": "pattern_count_min", "args": { "value": 1 } },
-      { "name": "pattern_type_includes", "args": { "value": "state_flow" } }
+      {
+        "name": "pattern_count_min",
+        "args": {
+          "value": 1
+        }
+      },
+      {
+        "name": "pattern_type_includes",
+        "args": {
+          "value": "state_flow"
+        }
+      }
     ]
   }
 }

--- a/addons/ai-provider/cap-ai-provider/__tests__/eval/fixtures/pattern-detector/state_flow/flow_same_entity.json
+++ b/addons/ai-provider/cap-ai-provider/__tests__/eval/fixtures/pattern-detector/state_flow/flow_same_entity.json
@@ -11,10 +11,18 @@
         "entity": "purchase_request",
         "capability": "cap-purchase",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "submitted", "recordId": "pr-001" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-20T08:00:00Z",
-        "actor": { "id": "user-alice", "type": "user" }
+        "actor": {
+          "id": "user-alice",
+          "type": "user"
+        },
+        "recordId": "pr-001",
+        "stateTransition": {
+          "from": "draft",
+          "to": "submitted"
+        }
       },
       {
         "id": "e-sf6-2",
@@ -22,10 +30,18 @@
         "entity": "purchase_request",
         "capability": "cap-purchase",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "submitted", "recordId": "pr-002" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-20T14:00:00Z",
-        "actor": { "id": "user-bob", "type": "user" }
+        "actor": {
+          "id": "user-bob",
+          "type": "user"
+        },
+        "recordId": "pr-002",
+        "stateTransition": {
+          "from": "draft",
+          "to": "submitted"
+        }
       },
       {
         "id": "e-sf6-3",
@@ -33,10 +49,18 @@
         "entity": "purchase_request",
         "capability": "cap-purchase",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "submitted", "recordId": "pr-003" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-21T09:00:00Z",
-        "actor": { "id": "user-carol", "type": "user" }
+        "actor": {
+          "id": "user-carol",
+          "type": "user"
+        },
+        "recordId": "pr-003",
+        "stateTransition": {
+          "from": "draft",
+          "to": "submitted"
+        }
       },
       {
         "id": "e-sf6-4",
@@ -44,10 +68,18 @@
         "entity": "purchase_request",
         "capability": "cap-purchase",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "submitted", "recordId": "pr-004" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-22T10:00:00Z",
-        "actor": { "id": "user-alice", "type": "user" }
+        "actor": {
+          "id": "user-alice",
+          "type": "user"
+        },
+        "recordId": "pr-004",
+        "stateTransition": {
+          "from": "draft",
+          "to": "submitted"
+        }
       },
       {
         "id": "e-sf6-5",
@@ -55,10 +87,18 @@
         "entity": "purchase_request",
         "capability": "cap-purchase",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "submitted", "recordId": "pr-005" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-23T09:00:00Z",
-        "actor": { "id": "user-dave", "type": "user" }
+        "actor": {
+          "id": "user-dave",
+          "type": "user"
+        },
+        "recordId": "pr-005",
+        "stateTransition": {
+          "from": "draft",
+          "to": "submitted"
+        }
       },
       {
         "id": "e-sf6-6",
@@ -66,10 +106,18 @@
         "entity": "purchase_request",
         "capability": "cap-purchase",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "submitted", "recordId": "pr-006" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-24T09:00:00Z",
-        "actor": { "id": "user-bob", "type": "user" }
+        "actor": {
+          "id": "user-bob",
+          "type": "user"
+        },
+        "recordId": "pr-006",
+        "stateTransition": {
+          "from": "draft",
+          "to": "submitted"
+        }
       }
     ],
     "config": {
@@ -77,12 +125,29 @@
       "minConfidence": 0.7
     }
   },
-  "context": { "now": "2026-05-24T10:00:00Z" },
+  "context": {
+    "now": "2026-05-24T10:00:00Z"
+  },
   "expected": {
     "matchers": [
-      { "name": "pattern_count_min", "args": { "value": 1 } },
-      { "name": "pattern_type_includes", "args": { "value": "state_flow" } },
-      { "name": "pattern_entity_equals", "args": { "value": "purchase_request" } }
+      {
+        "name": "pattern_count_min",
+        "args": {
+          "value": 1
+        }
+      },
+      {
+        "name": "pattern_type_includes",
+        "args": {
+          "value": "state_flow"
+        }
+      },
+      {
+        "name": "pattern_entity_equals",
+        "args": {
+          "value": "purchase_request"
+        }
+      }
     ]
   }
 }

--- a/addons/ai-provider/cap-ai-provider/__tests__/eval/fixtures/pattern-detector/state_flow/multi_step_flow.json
+++ b/addons/ai-provider/cap-ai-provider/__tests__/eval/fixtures/pattern-detector/state_flow/multi_step_flow.json
@@ -11,10 +11,18 @@
         "entity": "contract",
         "capability": "cap-contract",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "reviewed", "recordId": "ctr-001" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-20T08:00:00Z",
-        "actor": { "id": "user-alice", "type": "user" }
+        "actor": {
+          "id": "user-alice",
+          "type": "user"
+        },
+        "recordId": "ctr-001",
+        "stateTransition": {
+          "from": "draft",
+          "to": "reviewed"
+        }
       },
       {
         "id": "e-sf4-2",
@@ -22,10 +30,18 @@
         "entity": "contract",
         "capability": "cap-contract",
         "status": "succeeded",
-        "input": { "fromState": "reviewed", "toState": "approved", "recordId": "ctr-001" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-20T12:00:00Z",
-        "actor": { "id": "user-alice", "type": "user" }
+        "actor": {
+          "id": "user-alice",
+          "type": "user"
+        },
+        "recordId": "ctr-001",
+        "stateTransition": {
+          "from": "reviewed",
+          "to": "approved"
+        }
       },
       {
         "id": "e-sf4-3",
@@ -33,10 +49,18 @@
         "entity": "contract",
         "capability": "cap-contract",
         "status": "succeeded",
-        "input": { "fromState": "approved", "toState": "closed", "recordId": "ctr-001" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-20T16:00:00Z",
-        "actor": { "id": "user-alice", "type": "user" }
+        "actor": {
+          "id": "user-alice",
+          "type": "user"
+        },
+        "recordId": "ctr-001",
+        "stateTransition": {
+          "from": "approved",
+          "to": "closed"
+        }
       },
       {
         "id": "e-sf4-4",
@@ -44,10 +68,18 @@
         "entity": "contract",
         "capability": "cap-contract",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "reviewed", "recordId": "ctr-002" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-21T08:00:00Z",
-        "actor": { "id": "user-bob", "type": "user" }
+        "actor": {
+          "id": "user-bob",
+          "type": "user"
+        },
+        "recordId": "ctr-002",
+        "stateTransition": {
+          "from": "draft",
+          "to": "reviewed"
+        }
       },
       {
         "id": "e-sf4-5",
@@ -55,10 +87,18 @@
         "entity": "contract",
         "capability": "cap-contract",
         "status": "succeeded",
-        "input": { "fromState": "reviewed", "toState": "approved", "recordId": "ctr-002" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-21T12:00:00Z",
-        "actor": { "id": "user-bob", "type": "user" }
+        "actor": {
+          "id": "user-bob",
+          "type": "user"
+        },
+        "recordId": "ctr-002",
+        "stateTransition": {
+          "from": "reviewed",
+          "to": "approved"
+        }
       },
       {
         "id": "e-sf4-6",
@@ -66,10 +106,18 @@
         "entity": "contract",
         "capability": "cap-contract",
         "status": "succeeded",
-        "input": { "fromState": "approved", "toState": "closed", "recordId": "ctr-002" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-21T16:00:00Z",
-        "actor": { "id": "user-bob", "type": "user" }
+        "actor": {
+          "id": "user-bob",
+          "type": "user"
+        },
+        "recordId": "ctr-002",
+        "stateTransition": {
+          "from": "approved",
+          "to": "closed"
+        }
       },
       {
         "id": "e-sf4-7",
@@ -77,10 +125,18 @@
         "entity": "contract",
         "capability": "cap-contract",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "reviewed", "recordId": "ctr-003" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-22T09:00:00Z",
-        "actor": { "id": "user-carol", "type": "user" }
+        "actor": {
+          "id": "user-carol",
+          "type": "user"
+        },
+        "recordId": "ctr-003",
+        "stateTransition": {
+          "from": "draft",
+          "to": "reviewed"
+        }
       },
       {
         "id": "e-sf4-8",
@@ -88,10 +144,18 @@
         "entity": "contract",
         "capability": "cap-contract",
         "status": "succeeded",
-        "input": { "fromState": "reviewed", "toState": "approved", "recordId": "ctr-003" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-22T13:00:00Z",
-        "actor": { "id": "user-carol", "type": "user" }
+        "actor": {
+          "id": "user-carol",
+          "type": "user"
+        },
+        "recordId": "ctr-003",
+        "stateTransition": {
+          "from": "reviewed",
+          "to": "approved"
+        }
       },
       {
         "id": "e-sf4-9",
@@ -99,10 +163,18 @@
         "entity": "contract",
         "capability": "cap-contract",
         "status": "succeeded",
-        "input": { "fromState": "approved", "toState": "closed", "recordId": "ctr-003" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-22T17:00:00Z",
-        "actor": { "id": "user-carol", "type": "user" }
+        "actor": {
+          "id": "user-carol",
+          "type": "user"
+        },
+        "recordId": "ctr-003",
+        "stateTransition": {
+          "from": "approved",
+          "to": "closed"
+        }
       },
       {
         "id": "e-sf4-10",
@@ -110,10 +182,18 @@
         "entity": "contract",
         "capability": "cap-contract",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "reviewed", "recordId": "ctr-004" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-23T08:00:00Z",
-        "actor": { "id": "user-alice", "type": "user" }
+        "actor": {
+          "id": "user-alice",
+          "type": "user"
+        },
+        "recordId": "ctr-004",
+        "stateTransition": {
+          "from": "draft",
+          "to": "reviewed"
+        }
       },
       {
         "id": "e-sf4-11",
@@ -121,10 +201,18 @@
         "entity": "contract",
         "capability": "cap-contract",
         "status": "succeeded",
-        "input": { "fromState": "reviewed", "toState": "approved", "recordId": "ctr-004" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-23T12:00:00Z",
-        "actor": { "id": "user-alice", "type": "user" }
+        "actor": {
+          "id": "user-alice",
+          "type": "user"
+        },
+        "recordId": "ctr-004",
+        "stateTransition": {
+          "from": "reviewed",
+          "to": "approved"
+        }
       },
       {
         "id": "e-sf4-12",
@@ -132,10 +220,18 @@
         "entity": "contract",
         "capability": "cap-contract",
         "status": "succeeded",
-        "input": { "fromState": "approved", "toState": "closed", "recordId": "ctr-004" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-23T16:00:00Z",
-        "actor": { "id": "user-alice", "type": "user" }
+        "actor": {
+          "id": "user-alice",
+          "type": "user"
+        },
+        "recordId": "ctr-004",
+        "stateTransition": {
+          "from": "approved",
+          "to": "closed"
+        }
       },
       {
         "id": "e-sf4-13",
@@ -143,10 +239,18 @@
         "entity": "contract",
         "capability": "cap-contract",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "reviewed", "recordId": "ctr-005" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-24T08:00:00Z",
-        "actor": { "id": "user-bob", "type": "user" }
+        "actor": {
+          "id": "user-bob",
+          "type": "user"
+        },
+        "recordId": "ctr-005",
+        "stateTransition": {
+          "from": "draft",
+          "to": "reviewed"
+        }
       },
       {
         "id": "e-sf4-14",
@@ -154,10 +258,18 @@
         "entity": "contract",
         "capability": "cap-contract",
         "status": "succeeded",
-        "input": { "fromState": "reviewed", "toState": "approved", "recordId": "ctr-005" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-24T11:00:00Z",
-        "actor": { "id": "user-bob", "type": "user" }
+        "actor": {
+          "id": "user-bob",
+          "type": "user"
+        },
+        "recordId": "ctr-005",
+        "stateTransition": {
+          "from": "reviewed",
+          "to": "approved"
+        }
       },
       {
         "id": "e-sf4-15",
@@ -165,10 +277,18 @@
         "entity": "contract",
         "capability": "cap-contract",
         "status": "succeeded",
-        "input": { "fromState": "approved", "toState": "closed", "recordId": "ctr-005" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-24T15:00:00Z",
-        "actor": { "id": "user-bob", "type": "user" }
+        "actor": {
+          "id": "user-bob",
+          "type": "user"
+        },
+        "recordId": "ctr-005",
+        "stateTransition": {
+          "from": "approved",
+          "to": "closed"
+        }
       },
       {
         "id": "e-sf4-16",
@@ -176,10 +296,18 @@
         "entity": "contract",
         "capability": "cap-contract",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "reviewed", "recordId": "ctr-006" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-24T16:00:00Z",
-        "actor": { "id": "user-carol", "type": "user" }
+        "actor": {
+          "id": "user-carol",
+          "type": "user"
+        },
+        "recordId": "ctr-006",
+        "stateTransition": {
+          "from": "draft",
+          "to": "reviewed"
+        }
       },
       {
         "id": "e-sf4-17",
@@ -187,10 +315,18 @@
         "entity": "contract",
         "capability": "cap-contract",
         "status": "succeeded",
-        "input": { "fromState": "reviewed", "toState": "approved", "recordId": "ctr-006" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-24T17:00:00Z",
-        "actor": { "id": "user-carol", "type": "user" }
+        "actor": {
+          "id": "user-carol",
+          "type": "user"
+        },
+        "recordId": "ctr-006",
+        "stateTransition": {
+          "from": "reviewed",
+          "to": "approved"
+        }
       },
       {
         "id": "e-sf4-18",
@@ -198,10 +334,18 @@
         "entity": "contract",
         "capability": "cap-contract",
         "status": "succeeded",
-        "input": { "fromState": "approved", "toState": "closed", "recordId": "ctr-006" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-24T18:00:00Z",
-        "actor": { "id": "user-carol", "type": "user" }
+        "actor": {
+          "id": "user-carol",
+          "type": "user"
+        },
+        "recordId": "ctr-006",
+        "stateTransition": {
+          "from": "approved",
+          "to": "closed"
+        }
       }
     ],
     "config": {
@@ -209,11 +353,23 @@
       "minConfidence": 0.7
     }
   },
-  "context": { "now": "2026-05-24T19:00:00Z" },
+  "context": {
+    "now": "2026-05-24T19:00:00Z"
+  },
   "expected": {
     "matchers": [
-      { "name": "pattern_count_min", "args": { "value": 1 } },
-      { "name": "pattern_type_includes", "args": { "value": "state_flow" } }
+      {
+        "name": "pattern_count_min",
+        "args": {
+          "value": 1
+        }
+      },
+      {
+        "name": "pattern_type_includes",
+        "args": {
+          "value": "state_flow"
+        }
+      }
     ]
   }
 }

--- a/addons/ai-provider/cap-ai-provider/__tests__/eval/fixtures/pattern-detector/state_flow/partial_state_flow.json
+++ b/addons/ai-provider/cap-ai-provider/__tests__/eval/fixtures/pattern-detector/state_flow/partial_state_flow.json
@@ -11,10 +11,18 @@
         "entity": "order",
         "capability": "cap-order",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "submitted", "recordId": "ord-101" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-21T08:00:00Z",
-        "actor": { "id": "user-alice", "type": "user" }
+        "actor": {
+          "id": "user-alice",
+          "type": "user"
+        },
+        "recordId": "ord-101",
+        "stateTransition": {
+          "from": "draft",
+          "to": "submitted"
+        }
       },
       {
         "id": "e-sf3-2",
@@ -22,10 +30,18 @@
         "entity": "order",
         "capability": "cap-order",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "submitted", "recordId": "ord-102" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-21T14:00:00Z",
-        "actor": { "id": "user-bob", "type": "user" }
+        "actor": {
+          "id": "user-bob",
+          "type": "user"
+        },
+        "recordId": "ord-102",
+        "stateTransition": {
+          "from": "draft",
+          "to": "submitted"
+        }
       },
       {
         "id": "e-sf3-3",
@@ -33,10 +49,18 @@
         "entity": "order",
         "capability": "cap-order",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "submitted", "recordId": "ord-103" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-22T09:00:00Z",
-        "actor": { "id": "user-carol", "type": "user" }
+        "actor": {
+          "id": "user-carol",
+          "type": "user"
+        },
+        "recordId": "ord-103",
+        "stateTransition": {
+          "from": "draft",
+          "to": "submitted"
+        }
       },
       {
         "id": "e-sf3-4",
@@ -44,10 +68,18 @@
         "entity": "order",
         "capability": "cap-order",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "submitted", "recordId": "ord-104" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-23T10:00:00Z",
-        "actor": { "id": "user-alice", "type": "user" }
+        "actor": {
+          "id": "user-alice",
+          "type": "user"
+        },
+        "recordId": "ord-104",
+        "stateTransition": {
+          "from": "draft",
+          "to": "submitted"
+        }
       }
     ],
     "config": {
@@ -55,11 +87,23 @@
       "minConfidence": 0.7
     }
   },
-  "context": { "now": "2026-05-24T10:00:00Z" },
+  "context": {
+    "now": "2026-05-24T10:00:00Z"
+  },
   "expected": {
     "matchers": [
-      { "name": "pattern_count", "args": { "value": 0 } },
-      { "name": "pattern_type_absent", "args": { "value": "state_flow" } }
+      {
+        "name": "pattern_count",
+        "args": {
+          "value": 0
+        }
+      },
+      {
+        "name": "pattern_type_absent",
+        "args": {
+          "value": "state_flow"
+        }
+      }
     ]
   }
 }

--- a/addons/ai-provider/cap-ai-provider/__tests__/eval/fixtures/pattern-detector/state_flow/two_flows.json
+++ b/addons/ai-provider/cap-ai-provider/__tests__/eval/fixtures/pattern-detector/state_flow/two_flows.json
@@ -11,10 +11,18 @@
         "entity": "request",
         "capability": "cap-request",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "approved", "recordId": "req-001" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-20T08:00:00Z",
-        "actor": { "id": "user-alice", "type": "user" }
+        "actor": {
+          "id": "user-alice",
+          "type": "user"
+        },
+        "recordId": "req-001",
+        "stateTransition": {
+          "from": "draft",
+          "to": "approved"
+        }
       },
       {
         "id": "e-sf5-2",
@@ -22,10 +30,18 @@
         "entity": "request",
         "capability": "cap-request",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "approved", "recordId": "req-002" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-20T12:00:00Z",
-        "actor": { "id": "user-alice", "type": "user" }
+        "actor": {
+          "id": "user-alice",
+          "type": "user"
+        },
+        "recordId": "req-002",
+        "stateTransition": {
+          "from": "draft",
+          "to": "approved"
+        }
       },
       {
         "id": "e-sf5-3",
@@ -33,10 +49,18 @@
         "entity": "request",
         "capability": "cap-request",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "approved", "recordId": "req-003" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-21T09:00:00Z",
-        "actor": { "id": "user-bob", "type": "user" }
+        "actor": {
+          "id": "user-bob",
+          "type": "user"
+        },
+        "recordId": "req-003",
+        "stateTransition": {
+          "from": "draft",
+          "to": "approved"
+        }
       },
       {
         "id": "e-sf5-4",
@@ -44,10 +68,18 @@
         "entity": "request",
         "capability": "cap-request",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "approved", "recordId": "req-004" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-22T10:00:00Z",
-        "actor": { "id": "user-carol", "type": "user" }
+        "actor": {
+          "id": "user-carol",
+          "type": "user"
+        },
+        "recordId": "req-004",
+        "stateTransition": {
+          "from": "draft",
+          "to": "approved"
+        }
       },
       {
         "id": "e-sf5-5",
@@ -55,10 +87,18 @@
         "entity": "request",
         "capability": "cap-request",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "approved", "recordId": "req-005" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-23T09:00:00Z",
-        "actor": { "id": "user-alice", "type": "user" }
+        "actor": {
+          "id": "user-alice",
+          "type": "user"
+        },
+        "recordId": "req-005",
+        "stateTransition": {
+          "from": "draft",
+          "to": "approved"
+        }
       },
       {
         "id": "e-sf5-6",
@@ -66,10 +106,18 @@
         "entity": "request",
         "capability": "cap-request",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "rejected", "recordId": "req-011" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-20T09:00:00Z",
-        "actor": { "id": "user-dave", "type": "user" }
+        "actor": {
+          "id": "user-dave",
+          "type": "user"
+        },
+        "recordId": "req-011",
+        "stateTransition": {
+          "from": "draft",
+          "to": "rejected"
+        }
       },
       {
         "id": "e-sf5-7",
@@ -77,10 +125,18 @@
         "entity": "request",
         "capability": "cap-request",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "rejected", "recordId": "req-012" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-21T08:00:00Z",
-        "actor": { "id": "user-dave", "type": "user" }
+        "actor": {
+          "id": "user-dave",
+          "type": "user"
+        },
+        "recordId": "req-012",
+        "stateTransition": {
+          "from": "draft",
+          "to": "rejected"
+        }
       },
       {
         "id": "e-sf5-8",
@@ -88,10 +144,18 @@
         "entity": "request",
         "capability": "cap-request",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "rejected", "recordId": "req-013" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-21T14:00:00Z",
-        "actor": { "id": "user-eve", "type": "user" }
+        "actor": {
+          "id": "user-eve",
+          "type": "user"
+        },
+        "recordId": "req-013",
+        "stateTransition": {
+          "from": "draft",
+          "to": "rejected"
+        }
       },
       {
         "id": "e-sf5-9",
@@ -99,10 +163,18 @@
         "entity": "request",
         "capability": "cap-request",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "rejected", "recordId": "req-014" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-22T09:00:00Z",
-        "actor": { "id": "user-dave", "type": "user" }
+        "actor": {
+          "id": "user-dave",
+          "type": "user"
+        },
+        "recordId": "req-014",
+        "stateTransition": {
+          "from": "draft",
+          "to": "rejected"
+        }
       },
       {
         "id": "e-sf5-10",
@@ -110,10 +182,18 @@
         "entity": "request",
         "capability": "cap-request",
         "status": "succeeded",
-        "input": { "fromState": "draft", "toState": "rejected", "recordId": "req-015" },
+        "input": {},
         "tenantId": "tenant-1",
         "timestamp": "2026-05-23T10:00:00Z",
-        "actor": { "id": "user-eve", "type": "user" }
+        "actor": {
+          "id": "user-eve",
+          "type": "user"
+        },
+        "recordId": "req-015",
+        "stateTransition": {
+          "from": "draft",
+          "to": "rejected"
+        }
       }
     ],
     "config": {
@@ -121,11 +201,23 @@
       "minConfidence": 0.7
     }
   },
-  "context": { "now": "2026-05-24T10:00:00Z" },
+  "context": {
+    "now": "2026-05-24T10:00:00Z"
+  },
   "expected": {
     "matchers": [
-      { "name": "pattern_count_min", "args": { "value": 2 } },
-      { "name": "pattern_type_includes", "args": { "value": "state_flow" } }
+      {
+        "name": "pattern_count_min",
+        "args": {
+          "value": 2
+        }
+      },
+      {
+        "name": "pattern_type_includes",
+        "args": {
+          "value": "state_flow"
+        }
+      }
     ]
   }
 }

--- a/addons/ai-provider/cap-ai-provider/eval-runner/pattern-detector-scenario.ts
+++ b/addons/ai-provider/cap-ai-provider/eval-runner/pattern-detector-scenario.ts
@@ -48,12 +48,22 @@ function coerceActorType(type: string): ActorType {
 
 /**
  * Narrow the fixture's `enabledPatterns: string[]` to the detector's
- * `PatternType[]`. Unknown names are dropped rather than silently widened,
- * so a typo in a fixture cannot enable an undefined detector branch.
+ * `PatternType[]`. Fail loud on unknown names: a fixture typo (e.g.
+ * `"stateflow"` instead of `"state_flow"`) would otherwise silently drop the
+ * pattern and yield a false-green eval. `undefined` is passed through
+ * unchanged — that path means "use the detector defaults" and is legitimate.
  */
-function coerceEnabledPatterns(patterns: string[] | undefined): PatternType[] | undefined {
+export function coerceEnabledPatterns(patterns: string[] | undefined): PatternType[] | undefined {
   if (!patterns) return undefined;
-  return patterns.filter((p): p is PatternType => (PATTERN_TYPES as readonly string[]).includes(p));
+  const valid = PATTERN_TYPES as readonly string[];
+  const unknown = patterns.filter((p) => !valid.includes(p));
+  if (unknown.length > 0) {
+    throw new Error(
+      `Unknown pattern type(s) in fixture enabledPatterns: ${unknown.join(", ")}. ` +
+        `Valid: ${PATTERN_TYPES.join(", ")}`,
+    );
+  }
+  return patterns as PatternType[];
 }
 
 async function runPatternDetector(

--- a/addons/ai-provider/cap-ai-provider/eval-runner/pattern-detector-scenario.ts
+++ b/addons/ai-provider/cap-ai-provider/eval-runner/pattern-detector-scenario.ts
@@ -6,14 +6,55 @@
  * serialisable PatternInsight objects. No baseline file required.
  */
 
+import type { ActorType } from "@linchkit/core";
 import { InMemoryExecutionLogger } from "@linchkit/core/server";
 import type {
   PatternEvalOutput,
+  PatternExecLogInput,
   PatternFixtureContext,
   PatternFixtureInput,
   ScenarioAdapter,
 } from "@linchkit/devtools";
-import { PatternDetector } from "../src/pattern-detector";
+import {
+  PatternDetector,
+  type PatternDetectorConfig,
+  type PatternType,
+} from "../src/pattern-detector";
+
+/** Core `ActorType` literals — used to narrow fixture-supplied actor types. */
+const ACTOR_TYPES: readonly ActorType[] = ["human", "ai", "system", "worker", "timer", "external"];
+
+/** Detector `PatternType` literals — used to narrow fixture-supplied pattern names. */
+const PATTERN_TYPES: readonly PatternType[] = [
+  "repetitive_action",
+  "default_value",
+  "validation_pattern",
+  "state_flow",
+  "timing",
+];
+
+/**
+ * Coerce a fixture-supplied actor type string to a valid core `ActorType`.
+ *
+ * Fixtures author actors as plain `{ id, type }` JSON, so `type` is an
+ * unconstrained string. Map the common `"user"` alias to the canonical
+ * `"human"` actor, pass through any valid `ActorType`, and fall back to
+ * `"system"` for anything else so the logger always receives a valid `Actor`.
+ */
+function coerceActorType(type: string): ActorType {
+  if (type === "user") return "human";
+  return (ACTOR_TYPES as readonly string[]).includes(type) ? (type as ActorType) : "system";
+}
+
+/**
+ * Narrow the fixture's `enabledPatterns: string[]` to the detector's
+ * `PatternType[]`. Unknown names are dropped rather than silently widened,
+ * so a typo in a fixture cannot enable an undefined detector branch.
+ */
+function coerceEnabledPatterns(patterns: string[] | undefined): PatternType[] | undefined {
+  if (!patterns) return undefined;
+  return patterns.filter((p): p is PatternType => (PATTERN_TYPES as readonly string[]).includes(p));
+}
 
 async function runPatternDetector(
   input: PatternFixtureInput,
@@ -21,7 +62,7 @@ async function runPatternDetector(
 ): Promise<PatternEvalOutput> {
   const logger = new InMemoryExecutionLogger();
 
-  for (const entry of input.entries) {
+  for (const entry of input.entries as PatternExecLogInput[]) {
     logger.log({
       id: entry.id,
       action: entry.action,
@@ -30,7 +71,13 @@ async function runPatternDetector(
       status: entry.status,
       input: entry.input,
       tenantId: entry.tenantId,
-      actor: { id: entry.actor.id, type: entry.actor.type as "user" | "system" | "ai" },
+      actor: { id: entry.actor.id, type: coerceActorType(entry.actor.type), groups: [] },
+      // `recordId` + `stateTransition` are top-level fields the detector reads
+      // for state_flow analysis (it groups transitions by `entity::recordId`).
+      // Map them straight through; they are `undefined` for non-state-flow
+      // fixtures, which the detector skips.
+      recordId: entry.recordId,
+      stateTransition: entry.stateTransition,
       startedAt: new Date(entry.timestamp),
       duration: 0,
     });
@@ -42,11 +89,20 @@ async function runPatternDetector(
   // default to a very large lookback so fixed-date fixture entries always stay
   // in-window regardless of when the test runs. Build a NEW config object —
   // never mutate the caller's `input.config` (fixtures may be reused).
+  //
+  // Only copy keys the fixture actually set: the detector merges this over its
+  // own DEFAULT_CONFIG, so an explicit `undefined` here would clobber a default
+  // (e.g. `enabledPatterns`) rather than fall back to it.
   const config = input.config ?? {};
-  const detector = new PatternDetector({
-    ...config,
+  const detectorConfig: PatternDetectorConfig = {
     lookbackDays: config.lookbackDays ?? 3650,
-  });
+  };
+  if (config.minOccurrences !== undefined) detectorConfig.minOccurrences = config.minOccurrences;
+  if (config.minConfidence !== undefined) detectorConfig.minConfidence = config.minConfidence;
+  if (config.maxExamples !== undefined) detectorConfig.maxExamples = config.maxExamples;
+  const enabledPatterns = coerceEnabledPatterns(config.enabledPatterns);
+  if (enabledPatterns !== undefined) detectorConfig.enabledPatterns = enabledPatterns;
+  const detector = new PatternDetector(detectorConfig);
 
   const insights = await detector.detect(logger);
   if (!insights || insights.length === 0) return [];

--- a/packages/devtools/src/ai-eval/types.ts
+++ b/packages/devtools/src/ai-eval/types.ts
@@ -310,6 +310,19 @@ export interface PatternExecLogInput {
   tenantId?: string;
   timestamp: string;
   actor: { id: string; type: string };
+  /**
+   * Record this entry mutated. Required (alongside `stateTransition`) for the
+   * detector's `state_flow` analysis, which groups transitions by
+   * `entity::recordId` to reconstruct per-record state paths. Optional so
+   * non-state-flow fixtures stay valid.
+   */
+  recordId?: string;
+  /**
+   * The state change this entry performed (`from` → `to`). The detector reads
+   * this top-level field directly — see `PatternDetector.detectStateFlowPatterns`
+   * in `@linchkit/cap-ai-provider`. Optional so non-state-flow fixtures stay valid.
+   */
+  stateTransition?: { from: string; to: string };
 }
 
 /** Input shape for pattern-detector eval fixtures. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -82,6 +82,8 @@
     "addons/*/cap-*/ui/**/*.tsx",
     "addons/*/cap-*/ui-kit/src/**/*.ts",
     "addons/*/cap-*/ui-kit/src/**/*.tsx",
+    "addons/*/cap-*/eval-runner/**/*.ts",
+    "addons/*/cap-*/__tests__/eval-runner/**/*.ts",
     "e2e/**/*.ts"
   ],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
Two follow-ups from #383 review.

**#394 — eval-runner now typechecked.** Added `addons/*/cap-*/eval-runner/**` to the tsconfig `include`, so `bun run typecheck` validates the scenario adapters (the #383 missing-`await` slipped past CI because they were invisible to `tsc`). Fixed the 2 surfaced type errors in `pattern-detector-scenario.ts`: ActorType coercion (`user`→`human` + `groups`) and PatternDetectorConfig narrowing (`enabledPatterns` string[]→PatternType[]); plus 3 `replayFromBaseline(fx, undefined→null)` and one async intent test.

**#393 — state_flow transitions wired.** Added `recordId?` + `stateTransition?{from,to}` to `PatternExecLogInput` and mapped them through the pattern-detector adapter so `detectStateFlowPatterns` receives them. 5 state_flow fixtures now pass their matchers; new `pattern-detector-state-flow.test.ts` locks it. `pd-sf-5` (two_flows) documented as `CANNOT_PASS` — needs detector per-path enumeration (out of scope).

## Tests
devtools ai-eval 84 pass; cap-ai-provider 233 pass / 3 skip; full suite 6140 / 0 fail; typecheck clean (now covers eval-runner).

## Cross-model review
Gemini: LGTM. One Low follow-up suggestion — `coerceEnabledPatterns` silently drops unknown pattern names (a fixture typo could disable all patterns → false-green eval); worth a warn/fail in a later pass.

Closes #393. Closes #394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)