### PR TITLE
feat(core): rollback Insight→Proposal translator (Spec 55 §7.7)

### DIFF
--- a/.changeset/rollback-proposal-translator.md
+++ b/.changeset/rollback-proposal-translator.md
@@ -1,0 +1,30 @@
+---
+"@linchkit/core": minor
+---
+
+Add the rollback Insight→Proposal translator (Spec 55 §7.7 Phase 2, Slice A).
+
+A `rollback_candidate`-tagged anomaly Insight (emitted by `RollbackInsightEmitter`
+when a merged Proposal fails its successMetric) is now translated into a
+governance-safe `status:"draft"` rollback `ProposalDefinition`. The draft carries
+a single `target:"revert"` change (with a fixed, validation-safe name `"revert"`)
+and an inverse `successMetric`, then flows through the existing Insight→Proposal
+pipeline to the HUMAN approval gate. The translator only produces a draft — it
+never invokes `DeployRollbackOrchestrator`, performs Git operations, or
+auto-executes a rollback.
+
+Supporting changes:
+- `ProposalChangeTarget` gains a `"revert"` member.
+- Phase-1 validation (`validatePhase1` / `validateProposal`) now skips the
+  `MISSING_DEFINITION` requirement for `target:"revert"` changes (mirroring the
+  existing `delete` skip), so a definition-less rollback draft passes validation
+  and can reach the approval gate. The revert change name is a fixed
+  `NAME_PATTERN`-valid identifier; the proposalId being reverted is carried in the
+  change `diff` and the proposal's evidence sidecar (`evidence.context.revertProposalId`).
+- `ProposalFileWriter` skips `target:"revert"` changes (no source file to write)
+  with a warning, mirroring how it skips `delete` operations.
+- `insightTranslatorKey()` routes tagged anomalies to `anomaly:rollback_candidate`
+  without affecting ordinary anomaly insights.
+- The rollback evidence sidecar is now nested under `.context` and enumerable,
+  matching `schemaNoViewTranslator`, so `ProposalGitCommitter` recovers the source
+  insight id for the commit trailer / PR body and the sidecar survives `JSON.stringify`.

--- a/packages/core/__tests__/proposal-file-writer.test.ts
+++ b/packages/core/__tests__/proposal-file-writer.test.ts
@@ -521,6 +521,40 @@ describe("ProposalFileWriter formatter option", () => {
     // Whether Biome ran or not, the file must exist with valid generated code.
     expect(contents).toContain("defineRule(");
   });
+
+  it('skips a target:"revert" change (no file written) and warns (Spec 55 §7.7)', async () => {
+    const logs: Array<{ message: string; context?: Record<string, unknown> }> = [];
+    const logger = {
+      info: (message: string, context?: Record<string, unknown>) => {
+        logs.push({ message, context });
+      },
+      warn: (message: string, context?: Record<string, unknown>) => {
+        logs.push({ message, context });
+      },
+    };
+
+    const revertChange: ProposalChange = {
+      target: "revert",
+      operation: "update",
+      // Fixed, validation-safe name produced by rollbackCandidateTranslator; the
+      // proposalId being reverted is carried in `diff`, not in `name`.
+      name: "revert",
+      diff: 'Roll back merged proposal "proposal_abc".',
+    };
+
+    const writer = new ProposalFileWriter({ rootDir: tmpDir, logger });
+    const proposal = makeApprovedProposal({ changes: [revertChange] });
+
+    const written = await writer.writeApprovedProposal(proposal);
+
+    // Nothing was written for a revert change — it has no source file.
+    expect(written).toEqual([]);
+
+    const warning = logs.find((l) => l.message.includes("skipping revert change"));
+    expect(warning).toBeDefined();
+    expect(warning?.context?.target).toBe("revert");
+    expect(warning?.context?.name).toBe("revert");
+  });
 });
 
 /** A self-contained entity create — passes Phase 1 validation without registry. */

--- a/packages/core/__tests__/proposal-validation-phase1.test.ts
+++ b/packages/core/__tests__/proposal-validation-phase1.test.ts
@@ -308,6 +308,25 @@ describe("validatePhase1", () => {
     expect(result.status).toBe("failed");
     expect(result.errors.some((e) => e.code === "MISSING_DEFINITION")).toBe(true);
   });
+
+  it('passes a target:"revert" change despite having no definition (Spec 55 §7.7)', () => {
+    // A rollback Proposal carries a single definition-less revert change with a
+    // fixed, NAME_PATTERN-valid name. Phase-1 must NOT flag MISSING_DEFINITION
+    // or INVALID_NAME for it, or the draft can never reach the approval gate.
+    const result = validatePhase1({
+      changes: [
+        {
+          target: "revert",
+          operation: "update",
+          name: "revert",
+          diff: 'Roll back merged proposal "proposal_abc".',
+        },
+      ],
+    });
+
+    expect(result.status).toBe("passed");
+    expect(result.errors).toHaveLength(0);
+  });
 });
 
 // ── validatePhase1: duplicate detection ─────────────────

--- a/packages/core/src/__tests__/life-system/insight-to-proposal.test.ts
+++ b/packages/core/src/__tests__/life-system/insight-to-proposal.test.ts
@@ -300,6 +300,56 @@ describe("rollbackCandidateTranslator", () => {
     expect(await rollbackCandidateTranslator(structuralTagged, {})).toBeNull();
   });
 
+  it("does NOT throw and declines (null) for a malformed insight with undefined/null evidence", async () => {
+    // FINDING 1 regression guard: runtime Insights (deserialized from storage,
+    // or malformed) may carry an undefined/null `evidence` despite the type
+    // saying it is required. The translator must access it defensively and
+    // decline rather than throw a TypeError.
+    const undefinedEvidence = makeRollbackInsight({
+      evidence: undefined,
+    } as unknown as Partial<Insight>);
+    let result: unknown;
+    expect(() => {
+      result = rollbackCandidateTranslator(undefinedEvidence, {});
+    }).not.toThrow();
+    expect(await result).toBeNull();
+
+    const nullEvidence = makeRollbackInsight({
+      evidence: null,
+    } as unknown as Partial<Insight>);
+    expect(() => rollbackCandidateTranslator(nullEvidence, {})).not.toThrow();
+    expect(await rollbackCandidateTranslator(nullEvidence, {})).toBeNull();
+  });
+
+  it("falls back to insight.entity for capability when context.capability is absent", async () => {
+    // FINDING 2: a rollback must target the capability that owns the regressed
+    // proposal. When evidence.context.capability is missing/empty, the fallback
+    // prefers the insight's own entity over the generic DEFAULT_CAPABILITY.
+    const insight = makeRollbackInsight({
+      entity: "cap-purchase",
+      evidence: {
+        signals: [],
+        // No `capability` key — forces the fallback chain.
+        context: { proposalId: "proposal_abc", signalRef: "x" },
+      },
+    });
+    const proposal = await rollbackCandidateTranslator(insight, {
+      now: () => FROZEN_NOW,
+      idGenerator: () => "proposal_rollback_entity",
+    });
+    if (!proposal) throw new Error("expected proposal");
+
+    // Resolved from insight.entity, NOT the "evolution" default nor ctx override.
+    expect(proposal.capability).toBe("cap-purchase");
+    expect(proposal.impact.dependentsAffected).toEqual(["cap-purchase"]);
+    expect(proposal.title).toContain("cap-purchase");
+    expect(proposal.changes[0]?.diff).toContain("cap-purchase");
+
+    const sidecar = (proposal as unknown as { evidence: { context: { capability: string } } })
+      .evidence;
+    expect(sidecar.context.capability).toBe("cap-purchase");
+  });
+
   it("produces a draft that PASSES validateProposal() (reaches the approval gate)", async () => {
     // FINDING 1 regression guard: the draft revert Proposal must survive Phase-1
     // validation, otherwise submitProposal() never sets status "validated" and

--- a/packages/core/src/__tests__/life-system/insight-to-proposal.test.ts
+++ b/packages/core/src/__tests__/life-system/insight-to-proposal.test.ts
@@ -1,11 +1,21 @@
 import { describe, expect, it } from "bun:test";
 import {
+  createProposalGitCommitter,
+  type ProposalGhRunner,
+  type ProposalGitCommitterRunResult,
+  type ProposalGitRunner,
+} from "../../engine/proposal-git-committer";
+import { ROLLBACK_CANDIDATE_TAG } from "../../engine/rollback-insight-emitter";
+import { validateProposal } from "../../engine/validation-engine";
+import {
   createDefaultInsightTranslatorRegistry,
   createInsightTranslatorRegistry,
   insightTranslatorKey,
+  rollbackCandidateTranslator,
   schemaNoViewTranslator,
 } from "../../life-system/insight-to-proposal";
 import type { Insight } from "../../types/life-system";
+import type { ProposalDefinition } from "../../types/proposal";
 import type { ViewDefinition } from "../../types/view";
 
 const FROZEN_NOW = new Date("2026-05-07T00:00:00.000Z");
@@ -23,6 +33,35 @@ const makeStructuralInsight = (overrides: Partial<Insight> = {}): Insight => ({
   causality: "structural",
   entity: "purchase_request",
   createdAt: FROZEN_NOW,
+  ...overrides,
+});
+
+/**
+ * Fixture mirroring RollbackInsightEmitter's output: a `type:"anomaly"` insight
+ * tagged `rollback_candidate` carrying the failed-proposal evidence context.
+ */
+const makeRollbackInsight = (overrides: Partial<Insight> = {}): Insight => ({
+  id: "rollback-insight:proposal_abc",
+  type: "anomaly",
+  confidence: 0.9,
+  impact: "high",
+  evidence: {
+    signals: [],
+    context: {
+      proposalId: "proposal_abc",
+      capability: "cap-life-demo",
+      signalRef: "purchase_request:approval_latency",
+      baselineValue: 120,
+      targetValue: 60,
+      currentValue: 180,
+    },
+  },
+  summary:
+    'Merged proposal "proposal_abc" on capability "cap-life-demo" failed its successMetric. Rollback candidate.',
+  causality: "causal",
+  entity: "cap-life-demo",
+  createdAt: FROZEN_NOW,
+  tags: [ROLLBACK_CANDIDATE_TAG],
   ...overrides,
 });
 
@@ -46,6 +85,20 @@ describe("insightTranslatorKey", () => {
       causality: "correlational",
     };
     expect(insightTranslatorKey(insight)).toBe("anomaly");
+  });
+
+  it("routes rollback_candidate-tagged anomalies to a dedicated key", () => {
+    const insight = makeRollbackInsight();
+    expect(insightTranslatorKey(insight)).toBe("anomaly:rollback_candidate");
+  });
+
+  it("does NOT hijack ordinary anomaly insights that lack the tag (regression guard)", () => {
+    // Same anomaly shape, but no rollback_candidate tag — must stay bare.
+    const untagged = makeRollbackInsight({ tags: ["something_else"] });
+    expect(insightTranslatorKey(untagged)).toBe("anomaly");
+
+    const noTags = makeRollbackInsight({ tags: undefined });
+    expect(insightTranslatorKey(noTags)).toBe("anomaly");
   });
 });
 
@@ -125,6 +178,149 @@ describe("schemaNoViewTranslator", () => {
   });
 });
 
+describe("rollbackCandidateTranslator", () => {
+  it("emits a draft/major rollback proposal with an inverse successMetric", async () => {
+    const insight = makeRollbackInsight();
+    const proposal = await rollbackCandidateTranslator(insight, {
+      now: () => FROZEN_NOW,
+      idGenerator: () => "proposal_rollback_1",
+    });
+
+    expect(proposal).not.toBeNull();
+    if (!proposal) throw new Error("expected proposal");
+
+    expect(proposal.id).toBe("proposal_rollback_1");
+    expect(proposal.status).toBe("draft");
+    expect(proposal.changeType).toBe("major");
+    // Capability is resolved from evidence, not the default.
+    expect(proposal.capability).toBe("cap-life-demo");
+    expect(proposal.author).toEqual({
+      type: "ai",
+      id: "rollback-translator",
+      name: "Rollback Translator",
+    });
+    expect(proposal.createdAt).toBe(FROZEN_NOW);
+    expect(proposal.updatedAt).toBe(FROZEN_NOW);
+    expect(proposal.description).toBe(insight.summary);
+    expect(proposal.title).toContain("proposal_abc");
+    expect(proposal.title).toContain("cap-life-demo");
+
+    // Single revert change with a fixed, validation-safe name. The target
+    // proposalId is carried out-of-band (diff + evidence sidecar), not in `name`.
+    expect(proposal.changes).toHaveLength(1);
+    const change = proposal.changes[0];
+    if (!change) throw new Error("expected one change");
+    expect(change.target).toBe("revert");
+    expect(change.operation).toBe("update");
+    expect(change.name).toBe("revert");
+    // The proposalId being reverted survives in the human-readable diff.
+    expect(change.diff).toContain("proposal_abc");
+    // A revert carries no definition file.
+    expect(change.definition).toBeUndefined();
+
+    // INVERSE successMetric: baseline = regressed current, target = pre-merge baseline.
+    expect(proposal.successMetric).toBeDefined();
+    expect(proposal.successMetric?.insightRef).toBe(insight.id);
+    expect(proposal.successMetric?.signalRef).toBe("purchase_request:approval_latency");
+    expect(proposal.successMetric?.baselineValue).toBe(180); // was currentValue
+    expect(proposal.successMetric?.targetValue).toBe(120); // was baselineValue
+
+    // Conservative impact — only the reverted capability is re-affected.
+    expect(proposal.impact.dependentsAffected).toEqual(["cap-life-demo"]);
+    expect(proposal.impact.migrationRequired).toBe(false);
+
+    // Evidence sidecar traces back to the insight and the proposal being reverted.
+    // It mirrors schemaNoViewTranslator: provenance nested under `.context` and
+    // the sidecar enumerable so JSON.stringify / the git committer can read it.
+    const sidecar = (
+      proposal as unknown as {
+        evidence: {
+          context: {
+            revertProposalId: string;
+            insightId: string;
+            capability: string;
+            signalRef: string;
+          };
+        };
+      }
+    ).evidence;
+    expect(sidecar).toBeDefined();
+    expect(sidecar.context.revertProposalId).toBe("proposal_abc");
+    expect(sidecar.context.insightId).toBe(insight.id);
+    expect(sidecar.context.capability).toBe("cap-life-demo");
+    expect(sidecar.context.signalRef).toBe("purchase_request:approval_latency");
+
+    // Enumerability parity with schemaNoViewTranslator: the sidecar survives a
+    // JSON round-trip (a non-enumerable sidecar would be silently dropped).
+    const roundTripped = JSON.parse(JSON.stringify(proposal)) as {
+      evidence?: { context?: { insightId?: string } };
+    };
+    expect(roundTripped.evidence?.context?.insightId).toBe(insight.id);
+  });
+
+  it("honours ctx.now and ctx.idGenerator overrides (frozen-clock determinism)", async () => {
+    const altNow = new Date("2030-01-01T00:00:00.000Z");
+    const proposal = await rollbackCandidateTranslator(makeRollbackInsight(), {
+      now: () => altNow,
+      idGenerator: () => "proposal_frozen",
+    });
+    if (!proposal) throw new Error("expected proposal");
+    expect(proposal.id).toBe("proposal_frozen");
+    expect(proposal.createdAt).toBe(altNow);
+    expect(proposal.updatedAt).toBe(altNow);
+  });
+
+  it("declines (null) for an anomaly WITHOUT the rollback_candidate tag", async () => {
+    const untagged = makeRollbackInsight({ tags: ["other"] });
+    expect(await rollbackCandidateTranslator(untagged, {})).toBeNull();
+  });
+
+  it("declines (null) when evidence.context.proposalId is missing", async () => {
+    const missing = makeRollbackInsight({
+      evidence: {
+        signals: [],
+        context: { capability: "cap-life-demo", signalRef: "x" },
+      },
+    });
+    expect(await rollbackCandidateTranslator(missing, {})).toBeNull();
+  });
+
+  it("declines (null) when evidence.context.proposalId is an empty string", async () => {
+    const empty = makeRollbackInsight({
+      evidence: {
+        signals: [],
+        context: { proposalId: "", capability: "cap-life-demo" },
+      },
+    });
+    expect(await rollbackCandidateTranslator(empty, {})).toBeNull();
+  });
+
+  it("declines (null) for a non-anomaly insight even if tagged", async () => {
+    const structuralTagged = makeStructuralInsight({ tags: [ROLLBACK_CANDIDATE_TAG] });
+    expect(await rollbackCandidateTranslator(structuralTagged, {})).toBeNull();
+  });
+
+  it("produces a draft that PASSES validateProposal() (reaches the approval gate)", async () => {
+    // FINDING 1 regression guard: the draft revert Proposal must survive Phase-1
+    // validation, otherwise submitProposal() never sets status "validated" and
+    // approveProposal() can never run — freezing the draft forever. The fixed
+    // valid `name` plus the revert MISSING_DEFINITION skip make this pass.
+    const proposal = await rollbackCandidateTranslator(makeRollbackInsight(), {
+      now: () => FROZEN_NOW,
+      idGenerator: () => "proposal_rollback_validate",
+    });
+    if (!proposal) throw new Error("expected proposal");
+
+    const result = validateProposal({ proposal });
+    // No phase may report an error.
+    expect(result.passed).toBe(true);
+    const allErrors = result.phases.flatMap((p) => p.errors);
+    expect(allErrors).toEqual([]);
+    // Governance safety is untouched — the translator still emits a draft.
+    expect(proposal.status).toBe("draft");
+  });
+});
+
 describe("InsightTranslatorRegistry", () => {
   it("translates via the registered translator", async () => {
     const registry = createInsightTranslatorRegistry();
@@ -173,11 +369,88 @@ describe("InsightTranslatorRegistry", () => {
     expect(result?.id).toBe("proposal_default_1");
   });
 
+  it("default registry round-trips a rollback_candidate insight to a draft rollback proposal", async () => {
+    const registry = createDefaultInsightTranslatorRegistry();
+    expect(registry.has("anomaly:rollback_candidate")).toBe(true);
+
+    const rollbackInsight = makeRollbackInsight();
+    const result = await registry.translate(rollbackInsight, {
+      now: () => FROZEN_NOW,
+      idGenerator: () => "proposal_rollback_default",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe("proposal_rollback_default");
+    expect(result?.status).toBe("draft");
+    expect(result?.changeType).toBe("major");
+    expect(result?.changes[0]?.target).toBe("revert");
+    expect(result?.changes[0]?.name).toBe("revert");
+    expect(result?.successMetric?.insightRef).toBe(rollbackInsight.id);
+  });
+
   it("a translator that returns null does not throw and propagates null", async () => {
     const registry = createInsightTranslatorRegistry();
     registry.register("structural:schema_no_view", () => null);
     const insight = makeStructuralInsight();
     const result = await registry.translate(insight);
     expect(result).toBeNull();
+  });
+});
+
+describe("rollback proposal provenance (committer path)", () => {
+  // FINDING 2 regression guard: ProposalGitCommitter.readSourceInsights reads
+  // `evidence.context.insightId`. The rollback sidecar must nest under `.context`
+  // (enumerable) so the source insight is preserved in the commit/PR metadata.
+  const ok = (stdout = ""): ProposalGitCommitterRunResult => ({ stdout, stderr: "", exitCode: 0 });
+  const absent = (): ProposalGitCommitterRunResult => ({
+    stdout: "",
+    stderr: "not found",
+    exitCode: 1,
+  });
+
+  it("recovers the source insight id from the sidecar into the commit + PR body", async () => {
+    const insight = makeRollbackInsight();
+    const draft = await rollbackCandidateTranslator(insight, {
+      now: () => FROZEN_NOW,
+      idGenerator: () => "proposal_rollback_committer",
+    });
+    if (!draft) throw new Error("expected proposal");
+    // The committer only acts on an approved proposal; flip status for the test.
+    const proposal: ProposalDefinition = { ...draft, status: "approved" };
+    // The non-enumerable→enumerable sidecar is defined via Object.defineProperty,
+    // so the object spread above does NOT copy it — re-attach it onto the copy.
+    Object.defineProperty(proposal, "evidence", {
+      value: (draft as unknown as { evidence: unknown }).evidence,
+      enumerable: true,
+      writable: false,
+      configurable: false,
+    });
+
+    let capturedCommitMessage = "";
+    let capturedPrBody = "";
+    const gitRunner: ProposalGitRunner = async (args) => {
+      // Report both branch-existence probes as "absent" so the flow proceeds.
+      if (args[0] === "rev-parse" && args[1] === "--verify") return absent();
+      if (args[0] === "ls-remote") return absent();
+      if (args[0] === "rev-parse" && args[1] === "HEAD") return ok("deadbeef\n");
+      if (args[0] === "commit") {
+        const idx = args.indexOf("-m");
+        capturedCommitMessage = idx >= 0 ? (args[idx + 1] ?? "") : "";
+      }
+      return ok();
+    };
+    const ghRunner: ProposalGhRunner = async (args) => {
+      const idx = args.indexOf("--body");
+      capturedPrBody = idx >= 0 ? (args[idx + 1] ?? "") : "";
+      return ok("https://github.com/acme/linchkit/pull/123\n");
+    };
+
+    const committer = createProposalGitCommitter({ rootDir: "/repo", gitRunner, ghRunner });
+    await committer.commitAndOpenPR(proposal, ["/repo/file.ts"]);
+
+    // The originating insight id flows into both the commit trailer and PR body,
+    // proving provenance survived the (now nested + enumerable) sidecar.
+    expect(capturedCommitMessage).toContain(`Source-Insights: ${insight.id}`);
+    expect(capturedPrBody).toContain(insight.id);
   });
 });

--- a/packages/core/src/engine/proposal-file-writer.ts
+++ b/packages/core/src/engine/proposal-file-writer.ts
@@ -62,8 +62,17 @@ export interface ProposalFileWriterOptions {
 
 // ── Defaults ────────────────────────────────────────────────
 
+/**
+ * Change targets that materialise a source file on disk. `"revert"` is excluded
+ * because a rollback change (Spec 55 §7.7) has no definition file to write — it
+ * is skipped by `writeApprovedProposal` before any map lookup happens. Keeping
+ * the maps keyed by this `Exclude<…>` type preserves exhaustiveness over the
+ * writable targets without inventing a fake `"revert"` entry.
+ */
+type WritableChangeTarget = Exclude<ProposalChangeTarget, "revert">;
+
 /** Map a change target to its subdirectory (relative to `<cap>/src/`). */
-const TARGET_SUBDIR: Record<ProposalChangeTarget, string> = {
+const TARGET_SUBDIR: Record<WritableChangeTarget, string> = {
   entity: "entities",
   action: "actions",
   rule: "rules",
@@ -75,7 +84,7 @@ const TARGET_SUBDIR: Record<ProposalChangeTarget, string> = {
 };
 
 /** Map a change target to its file-name discriminator. */
-const TARGET_KIND_SUFFIX: Record<ProposalChangeTarget, string> = {
+const TARGET_KIND_SUFFIX: Record<WritableChangeTarget, string> = {
   entity: "entity",
   action: "action",
   rule: "rule",
@@ -87,7 +96,7 @@ const TARGET_KIND_SUFFIX: Record<ProposalChangeTarget, string> = {
 };
 
 /** Map a change target to its `defineXxx` factory name. */
-const TARGET_FACTORY: Record<ProposalChangeTarget, string> = {
+const TARGET_FACTORY: Record<WritableChangeTarget, string> = {
   entity: "defineEntity",
   action: "defineAction",
   rule: "defineRule",
@@ -214,9 +223,21 @@ function buildHeader(proposal: ProposalDefinition, change: ProposalChange): stri
   ].join("\n");
 }
 
+/** Narrow a change target to a writable one, throwing if it is `"revert"`. */
+function assertWritableTarget(target: ProposalChangeTarget): WritableChangeTarget {
+  if (target === "revert") {
+    // Unreachable in normal flow — writeApprovedProposal skips revert changes
+    // before any path/codegen resolution. Guards against future callers.
+    throw new Error(
+      'ProposalFileWriter: "revert" changes carry no source file and cannot be written',
+    );
+  }
+  return target;
+}
+
 /** Default codegen: import the matching `defineXxx` and re-emit the change. */
 function defaultCodegen(proposal: ProposalDefinition, change: ProposalChange): string {
-  const factory = TARGET_FACTORY[change.target];
+  const factory = TARGET_FACTORY[assertWritableTarget(change.target)];
   const definition = change.definition ?? { name: change.name };
   const header = buildHeader(proposal, change);
 
@@ -318,6 +339,17 @@ export class ProposalFileWriter {
 
     const written: string[] = [];
     for (const change of proposal.changes) {
+      // A revert change (Spec 55 §7.7 rollback loop) has no definition file to
+      // write — it instructs a separate human-approved deploy step to roll back
+      // the named proposal. Skip it here, mirroring the delete-operation skip.
+      if (change.target === "revert") {
+        this.logger?.warn?.(
+          `ProposalFileWriter: skipping revert change "${change.name}" — no source file to write; rollback is handled by the deploy pipeline`,
+          { proposalId: proposal.id, target: change.target, name: change.name },
+        );
+        continue;
+      }
+
       if (change.operation === "delete") {
         this.logger?.warn?.(
           `ProposalFileWriter: skipping delete operation for "${change.name}" — manual removal required`,
@@ -397,8 +429,9 @@ export class ProposalFileWriter {
       group = await resolveCapGroup(this.rootDir, capName);
       groupCache?.set(capName, group);
     }
-    const subdir = TARGET_SUBDIR[change.target];
-    const kindSuffix = TARGET_KIND_SUFFIX[change.target];
+    const writableTarget = assertWritableTarget(change.target);
+    const subdir = TARGET_SUBDIR[writableTarget];
+    const kindSuffix = TARGET_KIND_SUFFIX[writableTarget];
     // Include the change name so multiple changes of the same target kind
     // within one proposal don't collide on the same path.
     const safeName = change.name.replace(/[^a-zA-Z0-9_-]/g, "_");

--- a/packages/core/src/engine/validation-engine.ts
+++ b/packages/core/src/engine/validation-engine.ts
@@ -147,6 +147,13 @@ export function validatePhase1(options: {
     }
 
     if (change.operation === "delete") continue;
+    // A `target:"revert"` change (Spec 55 §7.7 rollback loop) intentionally
+    // carries no `definition` — it only names the proposal to roll back via its
+    // `diff`/evidence sidecar; the rollback is executed by a separate
+    // human-approved deploy step. Skip the MISSING_DEFINITION requirement (and
+    // the target-specific definition validation below) just as we skip deletes,
+    // so a governance-safe draft rollback Proposal can reach the approval gate.
+    if (change.target === "revert") continue;
     if (!change.definition) {
       errors.push({
         code: "MISSING_DEFINITION",

--- a/packages/core/src/life-system/index.ts
+++ b/packages/core/src/life-system/index.ts
@@ -48,6 +48,7 @@ export {
   createDefaultInsightTranslatorRegistry,
   createInsightTranslatorRegistry,
   insightTranslatorKey,
+  rollbackCandidateTranslator,
   schemaNoViewTranslator,
 } from "./insight-to-proposal";
 export type { MemoryEngineOptions } from "./memory-engine";

--- a/packages/core/src/life-system/insight-to-proposal.ts
+++ b/packages/core/src/life-system/insight-to-proposal.ts
@@ -10,9 +10,15 @@
  * registered later via capability extensions (mirrors `extensions.sensors`).
  */
 
+import { ROLLBACK_CANDIDATE_TAG } from "../engine/rollback-insight-emitter";
 import type { OntologyRegistry } from "../ontology/ontology-registry";
 import type { Insight, InsightEvidence, InsightType } from "../types/life-system";
-import type { ProposalAuthor, ProposalChange, ProposalDefinition } from "../types/proposal";
+import type {
+  ProposalAuthor,
+  ProposalChange,
+  ProposalDefinition,
+  SuccessMetric,
+} from "../types/proposal";
 import type { ViewDefinition } from "../types/view";
 
 // ── Translator key ──────────────────────────────────────────
@@ -23,8 +29,12 @@ import type { ViewDefinition } from "../types/view";
  *
  * - `structural` insights discriminate on `evidence.context.kind`
  *   (one of {@link import("../types/life-system").StructuralIssueKind}).
- * - Non-structural insights fall back to `Insight.type` alone for now;
- *   later slices may refine (e.g. anomaly + sensor name).
+ * - Insights tagged `rollback_candidate` (Spec 55 §7.7 Phase 2) discriminate
+ *   on that tag, yielding `\`${type}:rollback_candidate\`` (e.g.
+ *   `anomaly:rollback_candidate`) so a dedicated rollback translator handles
+ *   them WITHOUT hijacking ordinary anomaly insights.
+ * - All other non-structural insights fall back to `Insight.type` alone for
+ *   now; later slices may refine (e.g. anomaly + sensor name).
  */
 export type InsightTranslatorKey = string;
 
@@ -36,6 +46,12 @@ export function insightTranslatorKey(insight: Insight): InsightTranslatorKey {
       return `structural:${kind}`;
     }
     return "structural:unknown";
+  }
+  // Rollback-candidate insights route to a dedicated translator. The tag is the
+  // sole discriminator so ordinary `anomaly` insights (no tag) still key on the
+  // bare type and are unaffected.
+  if (insight.tags?.includes(ROLLBACK_CANDIDATE_TAG)) {
+    return `${insight.type}:${ROLLBACK_CANDIDATE_TAG}`;
   }
   return insight.type;
 }
@@ -261,6 +277,163 @@ export const schemaNoViewTranslator: InsightTranslator = (insight, ctx) => {
   return proposal;
 };
 
+/** Author stamped on rollback proposals so provenance is unambiguous. */
+const ROLLBACK_AUTHOR: ProposalAuthor = {
+  type: "ai",
+  id: "rollback-translator",
+  name: "Rollback Translator",
+};
+
+/**
+ * Fixed name for the single `target:"revert"` change a rollback Proposal carries.
+ *
+ * Must satisfy the validation engine's `NAME_PATTERN` (`/^[a-z][a-z0-9_]*$/`),
+ * so it deliberately does NOT embed the target proposalId (which may contain a
+ * colon or uppercase, e.g. `rollback-insight:proposal_abc`). The proposalId
+ * being reverted is carried in the change `diff` and the evidence sidecar's
+ * `context.revertProposalId` instead. A rollback Proposal always has exactly one
+ * revert change, so a constant name never collides under the DUPLICATE_CHANGE check.
+ */
+export const REVERT_CHANGE_NAME = "revert";
+
+/**
+ * Shape of the evidence context carried by a `rollback_candidate` Insight,
+ * as produced by {@link import("../engine/rollback-insight-emitter").RollbackInsightEmitter}.
+ * All numeric fields are optional because the upstream verifier may lack a
+ * post-merge measurement; only `proposalId` is required to translate.
+ */
+interface RollbackEvidenceContext {
+  proposalId?: unknown;
+  capability?: unknown;
+  signalRef?: unknown;
+  baselineValue?: unknown;
+  targetValue?: unknown;
+  currentValue?: unknown;
+}
+
+/** Narrow an `unknown` evidence field to a finite number, else `undefined`. */
+function numberOrUndefined(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Translator for `rollback_candidate`-tagged anomaly Insights (Spec 55 §7.7
+ * Phase 2). Emits a GOVERNANCE-SAFE `status: "draft"` rollback Proposal so the
+ * failed change flows through the normal Insight → Proposal pipeline to the
+ * HUMAN approval gate.
+ *
+ * This translator NEVER executes a rollback: it does not call
+ * DeployRollbackOrchestrator, does not touch Git, and does not auto-approve.
+ * It only materialises the intent to revert as a reviewable draft Proposal
+ * carrying a single `target: "revert"` change.
+ *
+ * The revert change uses the fixed, NAME_PATTERN-valid name {@link REVERT_CHANGE_NAME}
+ * so the draft passes Phase-1 validation (a `revert:<proposalId>` name would
+ * fail `INVALID_NAME` on the colon/uppercase). The target proposalId is carried
+ * out-of-band in the change `diff` and the evidence sidecar's
+ * `context.revertProposalId`, so the eventual rollback-execution / SHA-threading
+ * follow-up can still resolve which proposal to revert.
+ *
+ * Slice A does NOT thread the merged commit SHA — a separate follow-up resolves
+ * the actual SHA at deploy time.
+ *
+ * Returns `null` (declines) when the insight is not a tagged anomaly carrying a
+ * non-empty `evidence.context.proposalId`.
+ */
+export const rollbackCandidateTranslator: InsightTranslator = (insight, ctx) => {
+  // Defensive guard: only a tagged anomaly with a usable proposalId qualifies.
+  if (insight.type !== "anomaly") return null;
+  if (!insight.tags?.includes(ROLLBACK_CANDIDATE_TAG)) return null;
+
+  const context = insight.evidence.context as RollbackEvidenceContext;
+  const proposalId = context.proposalId;
+  if (typeof proposalId !== "string" || proposalId.length === 0) return null;
+
+  const now = ctx.now?.() ?? new Date();
+  const idGen = ctx.idGenerator ?? defaultIdGenerator;
+  const author = ctx.author ?? ROLLBACK_AUTHOR;
+
+  // Capability is resolved from evidence first, then the context override,
+  // then the shared default — keeping the rollback scoped to the failed change.
+  const capability =
+    typeof context.capability === "string" && context.capability.length > 0
+      ? context.capability
+      : (ctx.capability ?? DEFAULT_CAPABILITY);
+
+  const signalRef = typeof context.signalRef === "string" ? context.signalRef : undefined;
+  // The INVERSE successMetric reuses only the pre-merge baseline (→ new target)
+  // and the regressed current value (→ new baseline). The original targetValue
+  // is intentionally not extracted — it has no role in a rollback's metric.
+  const baselineValue = numberOrUndefined(context.baselineValue);
+  const currentValue = numberOrUndefined(context.currentValue);
+
+  const change: ProposalChange = {
+    target: "revert",
+    operation: "update",
+    // Fixed NAME_PATTERN-valid name; the target proposalId lives in `diff` and
+    // the evidence sidecar so the draft can pass Phase-1 validation.
+    name: REVERT_CHANGE_NAME,
+    diff: `Roll back merged proposal "${proposalId}" on capability "${capability}".`,
+  };
+
+  // INVERSE successMetric: the rollback succeeds when the metric returns from
+  // the regressed `currentValue` back toward the pre-merge `baselineValue`.
+  const successMetric: SuccessMetric = {
+    description: `Revert proposal "${proposalId}" should restore ${signalRef ?? "the metric"} toward its pre-merge baseline.`,
+    insightRef: insight.id,
+    signalRef,
+    baselineValue: currentValue,
+    targetValue: baselineValue,
+  };
+
+  const proposal: ProposalDefinition = {
+    id: idGen(),
+    title: `Roll back proposal "${proposalId}" on "${capability}"`,
+    description: insight.summary,
+    author,
+    capability,
+    changeType: "major",
+    changes: [change],
+    impact: {
+      schemasAffected: [],
+      actionsAffected: [],
+      rulesAffected: [],
+      // Conservative: a rollback only re-affects the capability it reverts.
+      dependentsAffected: [capability],
+      migrationRequired: false,
+    },
+    status: "draft",
+    successMetric,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  // Attach an evidence trace sidecar mirroring schemaNoViewTranslator's contract
+  // exactly: the provenance lives under `.context` (not flat) and the sidecar is
+  // enumerable so `JSON.stringify` and `ProposalGitCommitter.readSourceInsights`
+  // (which reads `evidence.context.insightId`) can both recover it. `context`
+  // also carries `revertProposalId` so the rollback-execution / SHA-threading
+  // follow-up can resolve which proposal to revert.
+  const evidence = cloneEvidence(insight.evidence);
+  const traceContext: Record<string, unknown> = {
+    ...evidence.context,
+    insightId: insight.id,
+    insightSummary: insight.summary,
+    insightCausality: insight.causality,
+    revertProposalId: proposalId,
+    capability,
+    signalRef,
+  };
+  Object.defineProperty(proposal, "evidence", {
+    value: { ...evidence, context: traceContext },
+    enumerable: true,
+    writable: false,
+    configurable: false,
+  });
+
+  return proposal;
+};
+
 // ── Default registry factory ────────────────────────────────
 
 /**
@@ -271,6 +444,7 @@ export const schemaNoViewTranslator: InsightTranslator = (insight, ctx) => {
 export function createDefaultInsightTranslatorRegistry(): InsightTranslatorRegistry {
   const registry = createInsightTranslatorRegistry();
   registry.register("structural:schema_no_view", schemaNoViewTranslator);
+  registry.register(`anomaly:${ROLLBACK_CANDIDATE_TAG}`, rollbackCandidateTranslator);
   return registry;
 }
 

--- a/packages/core/src/life-system/insight-to-proposal.ts
+++ b/packages/core/src/life-system/insight-to-proposal.ts
@@ -317,6 +317,18 @@ function numberOrUndefined(value: unknown): number | undefined {
 }
 
 /**
+ * Return the first candidate that is a non-empty string. Used to resolve a
+ * fallback chain (most specific → most generic) while skipping any candidate
+ * that is missing, empty, or not a string.
+ */
+function firstNonEmptyString(...candidates: unknown[]): string {
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.length > 0) return candidate;
+  }
+  return DEFAULT_CAPABILITY;
+}
+
+/**
  * Translator for `rollback_candidate`-tagged anomaly Insights (Spec 55 §7.7
  * Phase 2). Emits a GOVERNANCE-SAFE `status: "draft"` rollback Proposal so the
  * failed change flows through the normal Insight → Proposal pipeline to the
@@ -338,14 +350,19 @@ function numberOrUndefined(value: unknown): number | undefined {
  * the actual SHA at deploy time.
  *
  * Returns `null` (declines) when the insight is not a tagged anomaly carrying a
- * non-empty `evidence.context.proposalId`.
+ * non-empty `evidence.context.proposalId`. Malformed insights (e.g. an
+ * undefined/null `evidence`) decline rather than throw.
  */
 export const rollbackCandidateTranslator: InsightTranslator = (insight, ctx) => {
   // Defensive guard: only a tagged anomaly with a usable proposalId qualifies.
   if (insight.type !== "anomaly") return null;
   if (!insight.tags?.includes(ROLLBACK_CANDIDATE_TAG)) return null;
 
-  const context = insight.evidence.context as RollbackEvidenceContext;
+  // `evidence`/`evidence.context` are typed required, but runtime Insights
+  // (deserialized from storage, or malformed) may carry an undefined/null
+  // `evidence`. Access defensively so a malformed insight declines (returns
+  // null) instead of throwing a TypeError.
+  const context = (insight.evidence?.context ?? {}) as RollbackEvidenceContext;
   const proposalId = context.proposalId;
   if (typeof proposalId !== "string" || proposalId.length === 0) return null;
 
@@ -353,12 +370,15 @@ export const rollbackCandidateTranslator: InsightTranslator = (insight, ctx) => 
   const idGen = ctx.idGenerator ?? defaultIdGenerator;
   const author = ctx.author ?? ROLLBACK_AUTHOR;
 
-  // Capability is resolved from evidence first, then the context override,
-  // then the shared default — keeping the rollback scoped to the failed change.
-  const capability =
-    typeof context.capability === "string" && context.capability.length > 0
-      ? context.capability
-      : (ctx.capability ?? DEFAULT_CAPABILITY);
+  // Capability is resolved from the most specific source first so the rollback
+  // stays scoped to the capability that owns the regressed proposal:
+  //   evidence context → the insight's own entity → ctx override → shared default.
+  const capability = firstNonEmptyString(
+    context.capability,
+    insight.entity,
+    ctx.capability,
+    DEFAULT_CAPABILITY,
+  );
 
   const signalRef = typeof context.signalRef === "string" ? context.signalRef : undefined;
   // The INVERSE successMetric reuses only the pre-merge baseline (→ new target)

--- a/packages/core/src/types/proposal.ts
+++ b/packages/core/src/types/proposal.ts
@@ -48,7 +48,18 @@ export type ProposalChangeTarget =
   | "state"
   | "event"
   | "flow"
-  | "overlay";
+  | "overlay"
+  /**
+   * Revert a previously-merged Proposal (Spec 55 §7.7 Phase 2 rollback loop).
+   * A revert change carries no definition file; its `name` is a fixed,
+   * validation-safe identifier (`"revert"`) and the proposalId to roll back is
+   * carried in the change `diff` and the proposal's evidence sidecar
+   * (`evidence.context.revertProposalId`). Phase-1 validation skips the
+   * MISSING_DEFINITION requirement for these changes, and the on-disk
+   * ProposalFileWriter SKIPS them; the actual rollback is performed by a
+   * separate, human-approved deploy step.
+   */
+  | "revert";
 
 export type ProposalChangeOperation = "create" | "update" | "delete";
 


### PR DESCRIPTION
## Summary
Closes the Spec 55 §7.7 evolution loop: when `ProposalEffectVerifier` detects a merged Proposal's effect regressed (an `anomaly` Insight tagged `rollback_candidate` via `RollbackInsightEmitter`, #395), this translator turns it into a **governance-safe DRAFT revert Proposal**. The draft flows through the existing Proposal **validation → human approval** gate — there is no auto-execution and no git operation here (AI never modifies production directly).

## What changed
- **`insightTranslatorKey()`** keys tagged anomalies to `anomaly:rollback_candidate` (the tag is the sole discriminator; untagged anomalies keep their bare-`type` key and are untouched — regression-guarded).
- **`rollbackCandidateTranslator`** emits `status:"draft"` with one change `{target:"revert", operation:"update", name:"revert"}`. The target proposalId is carried in the change `diff` + the evidence sidecar (not in the name, which is the pattern-valid constant `"revert"`). The inverse `successMetric` returns the metric to its pre-merge baseline.
- **`ProposalChangeTarget`** gains `"revert"`; **`ProposalFileWriter`** skips revert changes (`WritableChangeTarget = Exclude<…,"revert">` keeps the codegen maps exhaustive — no fake entries).
- **`validatePhase1`** skips the `MISSING_DEFINITION` check for `target:"revert"` so the draft is approvable and actually reaches the human gate; the evidence sidecar is nested under `.context` (enumerable) so provenance (`insightId`, `revertProposalId`) survives into the eventual PR body.

## Review
- Claude adversarial review caught (and this branch fixes) a critical gap where the draft was permanently un-approvable (`validateProposal` rejected the `revert:<id>` name + missing definition).
- Cross-model review (gemini): no material issues.

## Tests
`bun run typecheck` clean; 47 translator/file-writer tests + a new `validateProposal`-passes test + a committer-provenance test + a phase-1 revert test (165 across the touched engines) — all green.

## Follow-up
- **SHA-threading (Slice B):** this slice names the target proposal only; a follow-up must thread the merged commit SHA so the deploy step can perform the actual `git revert` against the right commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)