### PR TITLE
chore(ci): guard Release workflow against Bun 1.2.18 teardown segfault

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,28 @@ jobs:
         run: bun run typecheck
 
       - name: Run tests
-        run: bun test
+        shell: bash
+        run: |
+          # Bun 1.2.18 occasionally segfaults during process teardown
+          # (panic 0x4A at exit) even when every test passes. Detect this
+          # specific pattern (non-zero exit + "0 fail" in summary) and
+          # treat it as success instead of failing the build.
+          # Mirrors the guard in ci.yml so the Release workflow does not
+          # block on the same Bun teardown crash.
+          set +e
+          OUTPUT=$(bun test 2>&1)
+          RC=$?
+          set -e
+          printf '%s\n' "$OUTPUT"
+          if [ "$RC" -eq 0 ]; then
+            exit 0
+          fi
+          if printf '%s\n' "$OUTPUT" | grep -qE '^[[:space:]]+0 fail$' \
+             && printf '%s\n' "$OUTPUT" | grep -qE '^[[:space:]]+[0-9]+ pass$'; then
+            echo "::warning::bun test exited $RC after reporting 0 failures — treating as success (known Bun teardown segfault)."
+            exit 0
+          fi
+          exit "$RC"
 
   release:
     name: Release


### PR DESCRIPTION
## Problem
The **Release** workflow (`.github/workflows/publish.yml`) has failed on **every push to main since 2026-05-16**, which:
- skips the gated `release` job, so the Changesets bot never updates its release PR (#174 has been frozen — 51 commits behind main, missing 4 changesets), and
- blocks all npm publishing.

## Root cause
The `quality` job ran a **bare `bun test`**. On Bun 1.2.18 the test process exits with **code 2 during teardown** (panic 0x4A at exit) *even when every test passes* (`6056 pass / 0 fail`). A bare step treats that non-zero exit as a build failure. The PR-CI workflow (`ci.yml`) already wraps `bun test` in a guard for exactly this; `publish.yml` did not.

Confirmed from CI log (run 26638825944: `6056 pass / 0 fail` immediately followed by `Process completed with exit code 2`) and reproduced locally (deterministic `EXIT=2` with 0 failures).

## Fix
Apply the **same guard `ci.yml` already uses** to the Release workflow's test step: capture the exit code, pass real failures through, and treat only the `(non-zero exit + "0 fail" + "N pass")` segfault pattern as success with a `::warning::`. Real test failures still fail the build. Byte-identical to the ci.yml guard for consistency.

Once merged, the next push to main re-runs the Release workflow with the guard, unblocking the `release` job and the Changesets PR.

## Follow-up (owner's call, not here)
The underlying bug is Bun 1.2.18's teardown crash. Pinning `bun-version` to a known-good fixed version (instead of `latest`) in both workflows, and revisiting when an upstream fix lands, would let both drop the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow test execution with improved output handling and conditional success logic based on test results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laofahai/linchkit/pull/400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->