### PR TITLE
feat(adapter): cap-adapter-a2a skeleton (Spec 15 §6.5, #89 S1)

### DIFF
--- a/addons/adapter-a2a/cap-adapter-a2a/README.md
+++ b/addons/adapter-a2a/cap-adapter-a2a/README.md
@@ -1,0 +1,3 @@
+# @linchkit/cap-adapter-a2a
+
+A2A (Agent-to-Agent) protocol adapter for LinchKit (Spec 15 §6.5) — it will expose the Command Layer over the A2A protocol so external agents can discover and invoke LinchKit Actions. **Status: SKELETON.** This package currently registers only a no-op `a2a` transport (start/stop) and a minimal config schema; the real protocol logic — Agent Card publication, JSON-RPC handling, and the task/message-send lifecycle — is intentionally deferred to later slices pending an owner decision. Tracked by issue #89 (slice S1).

--- a/addons/adapter-a2a/cap-adapter-a2a/__tests__/capability.test.ts
+++ b/addons/adapter-a2a/cap-adapter-a2a/__tests__/capability.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { capAdapterA2aConfig } from "../src/config";
+import { createCapAdapterA2a } from "../src/factory";
+
+describe("createCapAdapterA2a", () => {
+  test("returns a valid CapabilityDefinition", () => {
+    const cap = createCapAdapterA2a();
+
+    expect(cap).toBeDefined();
+    expect(cap.name).toBe("cap-adapter-a2a");
+    expect(cap.label).toBe("A2A Server");
+    expect(cap.version).toBe("0.0.1");
+  });
+
+  test("has correct type and category metadata", () => {
+    const cap = createCapAdapterA2a();
+
+    expect(cap.type).toBe("adapter");
+    expect(cap.category).toBe("integration");
+  });
+
+  test("registers the a2a transport in extensions", () => {
+    const cap = createCapAdapterA2a();
+
+    expect(cap.extensions).toBeDefined();
+    expect(cap.extensions?.transports).toBeDefined();
+    expect(cap.extensions?.transports).toHaveLength(1);
+
+    const transport = cap.extensions?.transports?.[0];
+    expect(transport?.name).toBe("a2a");
+    expect(transport?.label).toBe("Agent-to-Agent Protocol");
+    expect(typeof transport?.factory).toBe("function");
+  });
+
+  test("declares network:outbound system permission", () => {
+    const cap = createCapAdapterA2a();
+
+    expect(cap.systemPermissions).toContain("network:outbound");
+  });
+
+  test("accepts declarative config options", () => {
+    const cap = createCapAdapterA2a({ config: { enabled: true, port: 4444 } });
+
+    expect(cap).toBeDefined();
+    expect(cap.name).toBe("cap-adapter-a2a");
+    const transport = cap.extensions?.transports?.[0];
+    expect(typeof transport?.factory).toBe("function");
+  });
+});
+
+describe("capAdapterA2aConfig", () => {
+  test("parses its defaults", () => {
+    const parsed = capAdapterA2aConfig.schema.parse({});
+
+    expect(parsed.enabled).toBe(false);
+    expect(parsed.port).toBe(3003);
+    expect(parsed.basePath).toBe("/a2a");
+  });
+
+  test("is bound to the cap-adapter-a2a namespace", () => {
+    expect(capAdapterA2aConfig.name).toBe("cap-adapter-a2a");
+  });
+});

--- a/addons/adapter-a2a/cap-adapter-a2a/package.json
+++ b/addons/adapter-a2a/cap-adapter-a2a/package.json
@@ -21,7 +21,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "minCoreVersion": "^0.1.0",
+    "minCoreVersion": "^0.2.0",
     "type": "adapter",
     "category": "integration"
   }

--- a/addons/adapter-a2a/cap-adapter-a2a/package.json
+++ b/addons/adapter-a2a/cap-adapter-a2a/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@linchkit/cap-adapter-a2a",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "files": [
+    "src/",
+    "package.json",
+    "README.md"
+  ],
+  "scripts": {
+    "test": "bun test"
+  },
+  "peerDependencies": {
+    "@linchkit/core": "^0.2.0"
+  },
+  "devDependencies": {
+    "@linchkit/core": "workspace:*",
+    "@linchkit/devtools": "workspace:*",
+    "typescript": "^6.0.2"
+  },
+  "linchkit": {
+    "minCoreVersion": "^0.1.0",
+    "type": "adapter",
+    "category": "integration"
+  }
+}

--- a/addons/adapter-a2a/cap-adapter-a2a/src/a2a-transport.ts
+++ b/addons/adapter-a2a/cap-adapter-a2a/src/a2a-transport.ts
@@ -1,0 +1,61 @@
+/**
+ * a2a-transport — TransportAdapterDefinition for the A2A protocol.
+ *
+ * SKELETON slice (issue #89, Spec 15 §6.5): the factory returns a no-op
+ * lifecycle handle so the capability can be loaded and wired into the
+ * transport pipeline without yet speaking the A2A protocol.
+ *
+ * The factory is declarative on purpose — when it later dispatches inbound
+ * agent messages to Actions it will route them through `ctx.commandLayer.execute`
+ * (the sole write entry point), never bypassing the CommandLayer middleware.
+ */
+
+import type { TransportAdapterDefinition, TransportContext } from "@linchkit/core";
+import { capAdapterA2aConfig } from "./config";
+
+/**
+ * The A2A transport definition registered via `extensions.transports`.
+ *
+ * `start`/`stop` are currently no-ops. Real protocol wiring is deferred —
+ * see the TODO inside the factory.
+ */
+export const a2aTransport: TransportAdapterDefinition = {
+  name: "a2a",
+  label: "Agent-to-Agent Protocol",
+  factory: (ctx: TransportContext) => {
+    // Read config from the typed accessor (env resolved, validated, frozen).
+    const cfg = capAdapterA2aConfig.from(ctx);
+
+    return {
+      start: async () => {
+        // TODO(#89 S2+): publish the Agent Card, mount the JSON-RPC endpoint
+        // (message/send, tasks/get, tasks/cancel) under `cfg.basePath`, and
+        // dispatch inbound agent messages to Actions via `ctx.commandLayer.execute`.
+        // The skeleton intentionally does not open a port or speak the protocol.
+        console.log(
+          `[cap-adapter-a2a] A2A transport is a no-op skeleton (enabled=${cfg.enabled}, basePath=${cfg.basePath}, port=${cfg.port}). Protocol logic deferred to a later slice (#89).`,
+        );
+      },
+      stop: async () => {
+        // No resources are held by the skeleton transport.
+      },
+    };
+  },
+  config: {
+    enabled: {
+      type: "boolean",
+      default: false,
+      description: "Enable the A2A transport adapter",
+    },
+    port: {
+      type: "number",
+      default: 3003,
+      description: "Port for the A2A HTTP server",
+    },
+    basePath: {
+      type: "string",
+      default: "/a2a",
+      description: "Base path the A2A endpoints are mounted under",
+    },
+  },
+};

--- a/addons/adapter-a2a/cap-adapter-a2a/src/capability.ts
+++ b/addons/adapter-a2a/cap-adapter-a2a/src/capability.ts
@@ -1,0 +1,12 @@
+/**
+ * Capability definition for cap-adapter-a2a
+ *
+ * Static, zero-config export of the A2A adapter capability. It mirrors the
+ * parametrized `createCapAdapterA2a` factory with default options so the two
+ * stay in sync. SKELETON slice — see factory.ts and issue #89.
+ */
+
+import type { CapabilityDefinition } from "@linchkit/core";
+import { createCapAdapterA2a } from "./factory";
+
+export const capAdapterA2a: CapabilityDefinition = createCapAdapterA2a();

--- a/addons/adapter-a2a/cap-adapter-a2a/src/config.ts
+++ b/addons/adapter-a2a/cap-adapter-a2a/src/config.ts
@@ -1,0 +1,16 @@
+/**
+ * cap-adapter-a2a configuration schema
+ *
+ * Declares config keys for the A2A (Agent-to-Agent) protocol transport adapter.
+ * Minimal for the SKELETON slice — real protocol options arrive in later slices.
+ * See Spec 15 §6.5 and issue #89.
+ */
+
+import { defineConfigSchema } from "@linchkit/core/config";
+import { z } from "zod";
+
+export const capAdapterA2aConfig = defineConfigSchema("cap-adapter-a2a", {
+  enabled: z.boolean().default(false).describe("Enable the A2A transport adapter"),
+  port: z.coerce.number().default(3003).describe("Port for the A2A HTTP server"),
+  basePath: z.string().default("/a2a").describe("Base path the A2A endpoints are mounted under"),
+});

--- a/addons/adapter-a2a/cap-adapter-a2a/src/factory.ts
+++ b/addons/adapter-a2a/cap-adapter-a2a/src/factory.ts
@@ -1,0 +1,56 @@
+/**
+ * createCapAdapterA2a — Factory that produces the A2A adapter capability.
+ *
+ * SKELETON slice (issue #89, Spec 15 §6.5): returns a CapabilityDefinition with
+ * the no-op `a2a` transport registered in `extensions.transports`. Real protocol
+ * logic (Agent Card, JSON-RPC, task/message lifecycle) is deferred to later slices.
+ *
+ * Usage:
+ * ```ts
+ * import { createCapAdapterA2a } from "@linchkit/cap-adapter-a2a";
+ *
+ * const capA2a = createCapAdapterA2a({
+ *   config: { enabled: true, port: 3003 },
+ * });
+ * ```
+ */
+
+import type { CapabilityDefinition } from "@linchkit/core";
+import { defineCapability } from "@linchkit/core";
+import type { z } from "zod";
+import { a2aTransport } from "./a2a-transport";
+import { capAdapterA2aConfig } from "./config";
+
+export interface CapAdapterA2aOptions {
+  /** Declarative configuration — validated by capAdapterA2aConfig schema */
+  config?: Partial<z.infer<typeof capAdapterA2aConfig.schema>>;
+}
+
+/**
+ * Create the A2A adapter capability.
+ *
+ * Registers the no-op A2A transport. When the protocol is implemented the
+ * transport factory will wire inbound agent messages to the CommandLayer.
+ */
+export function createCapAdapterA2a(options?: CapAdapterA2aOptions): CapabilityDefinition {
+  return defineCapability({
+    name: "cap-adapter-a2a",
+    label: "A2A Server",
+    description:
+      "Exposes LinchKit actions over the Agent-to-Agent (A2A) protocol (Spec 15 §6.5). SKELETON — protocol logic deferred to a later slice (#89).",
+    type: "adapter",
+    category: "integration",
+    version: "0.0.1",
+
+    configSchema: capAdapterA2aConfig.schema,
+    config: options?.config,
+
+    dependencies: [],
+
+    extensions: {
+      transports: [a2aTransport],
+    },
+
+    systemPermissions: ["network:outbound"],
+  });
+}

--- a/addons/adapter-a2a/cap-adapter-a2a/src/index.ts
+++ b/addons/adapter-a2a/cap-adapter-a2a/src/index.ts
@@ -1,0 +1,21 @@
+/**
+ * @linchkit/cap-adapter-a2a — A2A (Agent-to-Agent) protocol adapter
+ *
+ * Exposes the LinchKit Command Layer over the A2A protocol (Spec 15 §6.5).
+ * SKELETON slice (#89): a no-op transport plus config schema; protocol logic
+ * is deferred to later slices.
+ */
+
+// Transport definition
+export { a2aTransport } from "./a2a-transport";
+// Static capability export
+export { capAdapterA2a } from "./capability";
+// Config schema
+export { capAdapterA2aConfig } from "./config";
+// Factory
+export type { CapAdapterA2aOptions } from "./factory";
+export { createCapAdapterA2a } from "./factory";
+
+import { capAdapterA2a } from "./capability";
+
+export default capAdapterA2a;

--- a/addons/adapter-a2a/cap-adapter-a2a/tsconfig.json
+++ b/addons/adapter-a2a/cap-adapter-a2a/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "composite": true,
+    "baseUrl": ".",
+    "paths": {
+      "@linchkit/core": ["../../../packages/core/src"],
+      "@linchkit/core/config": ["../../../packages/core/src/config/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "__tests__/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
First slice (S1) of #89 — scaffold the **Agent-to-Agent (A2A)** protocol adapter capability (Spec 15 §6.5), following the OCA addon model and mirroring `cap-adapter-mcp`'s structure exactly.

**SKELETON only** — no protocol logic, **no external dependencies**. The `a2a` transport's `start`/`stop` are no-ops (start logs a notice). This lets the capability load and register cleanly while the real protocol work is sliced separately.

## What's here
- `addons/adapter-a2a/cap-adapter-a2a/` — `package.json` (no runtime deps), `tsconfig.json`, `README`, `src/{capability,factory,config,a2a-transport,index}.ts`, `__tests__/capability.test.ts`.
- `defineCapability({ type: "adapter", category: "integration", systemPermissions: ["network:outbound"] })` with `a2aTransport` via `extensions.transports` and a config schema (`enabled`/`port`/`basePath`).

## Deferred (later slices, see issue #89 plan)
- Agent Card (`/.well-known/agent.json`), JSON-RPC envelope (`message/send`, `tasks/get`, `tasks/cancel`), task-lifecycle mapping over `executionLogger`, peer registry/auth. Inbound agent messages will dispatch through `ctx.commandLayer.execute` (sole write entry) — never bypassing the CommandLayer.
- **Owner decision pending:** whether to extend core's `ExecutionChannel`/`ActionExposure` with an `a2a` channel (additive) vs reusing `mcp`. The skeleton needs neither yet.

## Review
Cross-model (gemini): "no material issues — valid skeleton". typecheck + 7 tests + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)