### PR TITLE
feat(adapter): cap-adapter-ag-ui skeleton (Spec 15 §6.5, #89 S5)

### DIFF
--- a/addons/adapter-ag-ui/cap-adapter-ag-ui/README.md
+++ b/addons/adapter-ag-ui/cap-adapter-ag-ui/README.md
@@ -11,7 +11,7 @@ issue [#89](https://github.com/laofahai/linchkit/issues/89).
 
 ## Peer Dependencies
 
-- `@linchkit/core` ^0.1.0
+- `@linchkit/core` ^0.2.0
 
 ## Links
 

--- a/addons/adapter-ag-ui/cap-adapter-ag-ui/README.md
+++ b/addons/adapter-ag-ui/cap-adapter-ag-ui/README.md
@@ -1,0 +1,18 @@
+# @linchkit/cap-adapter-ag-ui
+
+AG-UI (Agent-User Interaction) protocol adapter for LinchKit (Spec 15 §6.5). AG-UI is the
+CopilotKit team's open standard for bidirectional, real-time communication between an AI agent
+and a frontend UI over SSE — enabling AI-assisted form filling, Human-in-the-Loop approval
+(AI submits a Proposal → UI renders it → user confirms), and live streaming of agent progress.
+**Status: SKELETON** — this package currently ships only the capability/transport scaffold; the
+real AG-UI logic (SSE event encoder, run-session, and `aiService.completeStream` wiring) is
+deferred to later slices pending an owner decision. The transport is a no-op `start`/`stop`. See
+issue [#89](https://github.com/laofahai/linchkit/issues/89).
+
+## Peer Dependencies
+
+- `@linchkit/core` ^0.1.0
+
+## Links
+
+- [Repository](https://github.com/laofahai/linchkit)

--- a/addons/adapter-ag-ui/cap-adapter-ag-ui/__tests__/capability.test.ts
+++ b/addons/adapter-ag-ui/cap-adapter-ag-ui/__tests__/capability.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { capAdapterAgUi } from "../src/capability";
+import { capAdapterAgUiConfig } from "../src/config";
+import { createCapAdapterAgUi } from "../src/factory";
+
+describe("cap-adapter-ag-ui capability", () => {
+  test("static export is a valid CapabilityDefinition", () => {
+    expect(capAdapterAgUi).toBeDefined();
+    expect(capAdapterAgUi.name).toBe("cap-adapter-ag-ui");
+    expect(capAdapterAgUi.label).toBe("AG-UI Server");
+    expect(capAdapterAgUi.version).toBe("0.0.1");
+  });
+
+  test("has correct type and category metadata", () => {
+    expect(capAdapterAgUi.type).toBe("adapter");
+    expect(capAdapterAgUi.category).toBe("integration");
+  });
+
+  test("registers the agui transport in extensions", () => {
+    expect(capAdapterAgUi.extensions).toBeDefined();
+    expect(capAdapterAgUi.extensions?.transports).toHaveLength(1);
+
+    const transport = capAdapterAgUi.extensions?.transports?.[0];
+    expect(transport?.name).toBe("agui");
+    expect(transport?.label).toBe("AG-UI (Agent-User Interaction)");
+    expect(typeof transport?.factory).toBe("function");
+  });
+
+  test("declares network:outbound system permission", () => {
+    expect(capAdapterAgUi.systemPermissions).toContain("network:outbound");
+  });
+});
+
+describe("createCapAdapterAgUi", () => {
+  test("returns a valid CapabilityDefinition", () => {
+    const cap = createCapAdapterAgUi();
+
+    expect(cap).toBeDefined();
+    expect(cap.name).toBe("cap-adapter-ag-ui");
+    expect(cap.type).toBe("adapter");
+    expect(cap.category).toBe("integration");
+  });
+
+  test("registers the agui transport with a callable factory", () => {
+    const cap = createCapAdapterAgUi();
+
+    const transport = cap.extensions?.transports?.[0];
+    expect(transport?.name).toBe("agui");
+    expect(typeof transport?.factory).toBe("function");
+  });
+});
+
+describe("capAdapterAgUiConfig", () => {
+  test("parses defaults when given an empty object", () => {
+    const parsed = capAdapterAgUiConfig.schema.parse({});
+
+    expect(parsed.enabled).toBe(false);
+    expect(parsed.basePath).toBe("/ag-ui");
+    expect(parsed.port).toBe(3003);
+  });
+});

--- a/addons/adapter-ag-ui/cap-adapter-ag-ui/package.json
+++ b/addons/adapter-ag-ui/cap-adapter-ag-ui/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@linchkit/cap-adapter-ag-ui",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "files": [
+    "src/",
+    "package.json",
+    "README.md"
+  ],
+  "scripts": {
+    "test": "bun test"
+  },
+  "peerDependencies": {
+    "@linchkit/core": "^0.2.0"
+  },
+  "devDependencies": {
+    "@linchkit/core": "workspace:*",
+    "@linchkit/devtools": "workspace:*",
+    "typescript": "^6.0.2"
+  },
+  "linchkit": {
+    "minCoreVersion": "^0.1.0",
+    "type": "adapter",
+    "category": "integration"
+  }
+}

--- a/addons/adapter-ag-ui/cap-adapter-ag-ui/package.json
+++ b/addons/adapter-ag-ui/cap-adapter-ag-ui/package.json
@@ -21,7 +21,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "minCoreVersion": "^0.1.0",
+    "minCoreVersion": "^0.2.0",
     "type": "adapter",
     "category": "integration"
   }

--- a/addons/adapter-ag-ui/cap-adapter-ag-ui/src/ag-ui-transport.ts
+++ b/addons/adapter-ag-ui/cap-adapter-ag-ui/src/ag-ui-transport.ts
@@ -1,0 +1,56 @@
+/**
+ * AG-UI transport definition for cap-adapter-ag-ui (SKELETON).
+ *
+ * Extracted from capability.ts so the capability definition stays declarative,
+ * mirroring cap-adapter-mcp's mcp-transport.ts. The factory currently returns a
+ * no-op lifecycle; the real AG-UI runtime is deferred to later slices.
+ */
+
+import type { TransportAdapterDefinition, TransportContext } from "@linchkit/core";
+import { capAdapterAgUiConfig } from "./config";
+
+/**
+ * AG-UI transport — Agent ↔ frontend bidirectional streaming over SSE
+ * (CopilotKit open standard, Spec 15 §6.5).
+ *
+ * TODO(#89 S6+): implement the real transport — wire the SSE event encoder,
+ * the per-connection run-session, and `ctx.aiService.completeStream(...)` so the
+ * agent can stream tokens / tool calls / Human-in-the-Loop Proposal prompts to
+ * the UI. For now `start`/`stop` are no-ops so the capability loads cleanly.
+ */
+export const agUiTransport: TransportAdapterDefinition = {
+  name: "agui",
+  label: "AG-UI (Agent-User Interaction)",
+  factory: (ctx: TransportContext) => {
+    // Read config from typed accessor (env resolved, validated, frozen).
+    // Read here (not used yet) to mirror cap-adapter-mcp's factory shape and to
+    // surface config validation errors at registration time.
+    const _cfg = capAdapterAgUiConfig.from(ctx);
+
+    return {
+      start: async () => {
+        // no-op skeleton — real SSE run-session wiring lands in a later slice.
+      },
+      stop: async () => {
+        // no-op skeleton
+      },
+    };
+  },
+  config: {
+    enabled: {
+      type: "boolean",
+      default: false,
+      description: "Enable the AG-UI transport",
+    },
+    basePath: {
+      type: "string",
+      default: "/ag-ui",
+      description: "Base path for the AG-UI SSE endpoint mounted on the main HTTP server",
+    },
+    port: {
+      type: "number",
+      default: 3003,
+      description: "Port for a standalone AG-UI HTTP server (only used when not mounted)",
+    },
+  },
+};

--- a/addons/adapter-ag-ui/cap-adapter-ag-ui/src/capability.ts
+++ b/addons/adapter-ag-ui/cap-adapter-ag-ui/src/capability.ts
@@ -1,0 +1,28 @@
+/**
+ * Capability definition for cap-adapter-ag-ui (SKELETON).
+ *
+ * Registers the AG-UI transport (Spec 15 §6.5). Transport factory logic lives
+ * in ag-ui-transport.ts to keep this file declarative, mirroring cap-adapter-mcp.
+ * The parametrized factory lives in factory.ts. Real AG-UI logic is deferred
+ * to later slices (#89).
+ */
+
+import { defineCapability } from "@linchkit/core";
+import { agUiTransport } from "./ag-ui-transport";
+import { capAdapterAgUiConfig } from "./config";
+
+export const capAdapterAgUi = defineCapability({
+  name: "cap-adapter-ag-ui",
+  label: "AG-UI Server",
+  type: "adapter",
+  category: "integration",
+  version: "0.0.1",
+
+  configSchema: capAdapterAgUiConfig.schema,
+
+  extensions: {
+    transports: [agUiTransport],
+  },
+
+  systemPermissions: ["network:outbound"],
+});

--- a/addons/adapter-ag-ui/cap-adapter-ag-ui/src/capability.ts
+++ b/addons/adapter-ag-ui/cap-adapter-ag-ui/src/capability.ts
@@ -1,28 +1,12 @@
 /**
  * Capability definition for cap-adapter-ag-ui (SKELETON).
  *
- * Registers the AG-UI transport (Spec 15 §6.5). Transport factory logic lives
- * in ag-ui-transport.ts to keep this file declarative, mirroring cap-adapter-mcp.
- * The parametrized factory lives in factory.ts. Real AG-UI logic is deferred
- * to later slices (#89).
+ * Registers the AG-UI transport (Spec 15 §6.5). The parametrized factory lives
+ * in factory.ts; this static export simply invokes it with defaults so the two
+ * never diverge (mirroring cap-adapter-a2a). Real AG-UI logic is deferred to
+ * later slices (#89).
  */
 
-import { defineCapability } from "@linchkit/core";
-import { agUiTransport } from "./ag-ui-transport";
-import { capAdapterAgUiConfig } from "./config";
+import { createCapAdapterAgUi } from "./factory";
 
-export const capAdapterAgUi = defineCapability({
-  name: "cap-adapter-ag-ui",
-  label: "AG-UI Server",
-  type: "adapter",
-  category: "integration",
-  version: "0.0.1",
-
-  configSchema: capAdapterAgUiConfig.schema,
-
-  extensions: {
-    transports: [agUiTransport],
-  },
-
-  systemPermissions: ["network:outbound"],
-});
+export const capAdapterAgUi = createCapAdapterAgUi();

--- a/addons/adapter-ag-ui/cap-adapter-ag-ui/src/config.ts
+++ b/addons/adapter-ag-ui/cap-adapter-ag-ui/src/config.ts
@@ -1,0 +1,22 @@
+/**
+ * cap-adapter-ag-ui configuration schema
+ *
+ * Declares config keys for the AG-UI (Agent-User Interaction) transport adapter.
+ * SKELETON — only the minimal connection fields are defined for now; richer
+ * options (auth, run-session limits, streaming knobs) arrive with later slices.
+ */
+
+import { defineConfigSchema } from "@linchkit/core/config";
+import { z } from "zod";
+
+export const capAdapterAgUiConfig = defineConfigSchema("cap-adapter-ag-ui", {
+  enabled: z.boolean().default(false).describe("Enable the AG-UI transport"),
+  basePath: z
+    .string()
+    .default("/ag-ui")
+    .describe("Base path for the AG-UI SSE endpoint mounted on the main HTTP server"),
+  port: z.coerce
+    .number()
+    .default(3003)
+    .describe("Port for a standalone AG-UI HTTP server (only used when not mounted)"),
+});

--- a/addons/adapter-ag-ui/cap-adapter-ag-ui/src/factory.ts
+++ b/addons/adapter-ag-ui/cap-adapter-ag-ui/src/factory.ts
@@ -1,0 +1,54 @@
+/**
+ * createCapAdapterAgUi — Factory that produces the AG-UI adapter capability (SKELETON).
+ *
+ * Returns a CapabilityDefinition with the AG-UI transport registered in
+ * extensions.transports. Mirrors cap-adapter-mcp's createCapAdapterMcp shape.
+ * The transport is currently a no-op; real logic arrives in later slices (#89).
+ *
+ * Usage:
+ * ```ts
+ * import { createCapAdapterAgUi } from '@linchkit/cap-adapter-ag-ui'
+ *
+ * const capAgUi = createCapAdapterAgUi()
+ * ```
+ */
+
+import type { CapabilityDefinition } from "@linchkit/core";
+import { defineCapability } from "@linchkit/core";
+import type { z } from "zod";
+import { agUiTransport } from "./ag-ui-transport";
+import { capAdapterAgUiConfig } from "./config";
+
+export interface CapAdapterAgUiOptions {
+  /** Declarative configuration — validated by capAdapterAgUiConfig schema */
+  config?: Partial<z.infer<typeof capAdapterAgUiConfig.schema>>;
+}
+
+/**
+ * Create the AG-UI adapter capability.
+ *
+ * SKELETON: wires the AG-UI transport definition into the capability but does
+ * not yet implement the SSE run-session. See ag-ui-transport.ts TODO(#89 S6+).
+ */
+export function createCapAdapterAgUi(options?: CapAdapterAgUiOptions): CapabilityDefinition {
+  return defineCapability({
+    name: "cap-adapter-ag-ui",
+    label: "AG-UI Server",
+    description:
+      "Exposes LinchKit to a frontend AI agent via the AG-UI SSE protocol (Spec 15 §6.5, skeleton)",
+    type: "adapter",
+    category: "integration",
+    version: "0.0.1",
+
+    configSchema: capAdapterAgUiConfig.schema,
+    config: options?.config,
+
+    dependencies: [],
+
+    extensions: {
+      transports: [agUiTransport],
+    },
+
+    systemPermissions: ["network:outbound"],
+  });
+}

--- a/addons/adapter-ag-ui/cap-adapter-ag-ui/src/index.ts
+++ b/addons/adapter-ag-ui/cap-adapter-ag-ui/src/index.ts
@@ -1,0 +1,16 @@
+/**
+ * @linchkit/cap-adapter-ag-ui — AG-UI adapter (SKELETON)
+ *
+ * AG-UI (Agent-User Interaction) protocol adapter — CopilotKit open standard for
+ * bidirectional, real-time agent ↔ frontend communication over SSE (Spec 15 §6.5).
+ * Only the capability/transport scaffold is implemented; real logic is deferred (#89).
+ */
+
+export type { TransportAdapterDefinition } from "@linchkit/core";
+// AG-UI transport definition
+export { agUiTransport } from "./ag-ui-transport";
+export { capAdapterAgUi } from "./capability";
+// Config schema
+export { capAdapterAgUiConfig } from "./config";
+export type { CapAdapterAgUiOptions } from "./factory";
+export { createCapAdapterAgUi } from "./factory";

--- a/addons/adapter-ag-ui/cap-adapter-ag-ui/tsconfig.json
+++ b/addons/adapter-ag-ui/cap-adapter-ag-ui/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun-types"]
+  },
+  "include": ["src", "__tests__"]
+}


### PR DESCRIPTION
## Summary
Slice S5 of #89 — scaffold the **AG-UI** (Agent-User Interaction; CopilotKit open standard, SSE agent↔frontend) protocol adapter capability (Spec 15 §6.5), mirroring `cap-adapter-mcp`'s structure.

**SKELETON only** — no SSE/run-session logic, **no external dependencies**. The `agui` transport's `start`/`stop` are no-ops. Independent of the a2a skeleton (#403): separate addon group, separate files — no conflict.

## What's here
- `addons/adapter-ag-ui/cap-adapter-ag-ui/` — `package.json` (no runtime deps), `tsconfig.json`, `README`, `src/{capability,factory,config,ag-ui-transport,index}.ts`, `__tests__/capability.test.ts`.
- `defineCapability({ type: "adapter", category: "integration", systemPermissions: ["network:outbound"] })` with `agUiTransport` via `extensions.transports` and a config schema (`enabled`/`basePath`/`port`).

## Deferred (later slices)
- SSE event encoder (`RUN_STARTED`/`TEXT_MESSAGE_*`/`TOOL_CALL_*`/`STATE_DELTA`/`RUN_FINISHED`), per-connection run-session driving `ctx.aiService.completeStream(...)`, TOOL_CALL → `ctx.commandLayer.execute`, Human-in-the-Loop Proposal/approval streaming, and the `cap-ag-ui-ui` React client.

## Review
Cross-model: validated against the identical-pattern a2a skeleton (gemini: "valid skeleton") + direct review of this package's factory/transport. typecheck + 7 tests + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)