### PR TITLE
fix(core): make core↔capability compat check fire for shipped addons (#122)

### DIFF
--- a/.changeset/compat-mincore.md
+++ b/.changeset/compat-mincore.md
@@ -1,0 +1,25 @@
+---
+"@linchkit/core": minor
+"@linchkit/cli": patch
+---
+
+fix(spec-21): make the core ↔ capability compatibility check fire for shipped addons (#122)
+
+The Spec 21 / #122 compatibility check was inert for every real addon: shipped
+`package.json` files declare `linchkit.minCoreVersion`, a third key the metadata
+schema did not recognize (so it was silently stripped), and the runtime
+`CapabilityDefinition.coreVersion` was never populated from disk metadata — so the
+boot-time `enforceCoreCompatibility` always saw `undefined` and checked nothing.
+
+- **Schema reconciliation**: `capabilityMetadataSchema.linchkit` now recognizes the
+  deprecated `minCoreVersion` alias alongside `coreVersion` and `minVersion`.
+  `coreVersionRangeOf` resolves the effective range with precedence
+  `coreVersion ?? minVersion ?? minCoreVersion`; `minVersion` and `minCoreVersion`
+  are normalized to a `>=` range (a value that is already a range is kept verbatim).
+- **Runtime population**: `scanAddonsPath` now populates `CapabilityDefinition.coreVersion`
+  from the scanned addon's `package.json` `linchkit` block via `coreVersionRangeOf`, so
+  the boot check has a real range to evaluate. An explicit range on the definition still wins.
+
+Strict enforcement remains hard-gated off (`STRICT_COMPAT_READY=false` in `dev.ts`):
+with core `VERSION` `0.0.1` vs addon ranges like `^0.2.0`, this surfaces WARN lines,
+never a throw. Non-breaking — all three `linchkit` version keys are optional.

--- a/packages/core/__tests__/capability-metadata.test.ts
+++ b/packages/core/__tests__/capability-metadata.test.ts
@@ -212,6 +212,32 @@ describe("capabilityMetadataSchema", () => {
     }
   });
 
+  it("recognizes legacy linchkit.minCoreVersion (no longer silently stripped)", () => {
+    // Every shipped addon's package.json declares `linchkit.minCoreVersion`.
+    // The schema must surface it so `coreVersionRangeOf` can read it at boot.
+    const result = capabilityMetadataSchema.safeParse({
+      ...validMinimal,
+      linchkit: { minCoreVersion: "^0.2.0" },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.linchkit?.minCoreVersion).toBe("^0.2.0");
+    }
+  });
+
+  it("accepts all three linchkit version keys together", () => {
+    const result = capabilityMetadataSchema.safeParse({
+      ...validMinimal,
+      linchkit: { coreVersion: ">=0.2.0 <0.4.0", minVersion: "0.1.0", minCoreVersion: "^0.2.0" },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.linchkit?.coreVersion).toBe(">=0.2.0 <0.4.0");
+      expect(result.data.linchkit?.minVersion).toBe("0.1.0");
+      expect(result.data.linchkit?.minCoreVersion).toBe("^0.2.0");
+    }
+  });
+
   it("accepts all valid category values", () => {
     for (const c of [
       "system",

--- a/packages/core/__tests__/capability/addon-scanner.test.ts
+++ b/packages/core/__tests__/capability/addon-scanner.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { scanAddonsPath } from "../../src/capability/addon-scanner";
+import type { MetadataCompatibility } from "../../src/capability/compatibility";
+import { enforceCoreCompatibility } from "../../src/capability/compatibility";
 
 const TMP = join(import.meta.dir, "__tmp_addon_scan__");
 
@@ -13,13 +15,17 @@ afterEach(() => {
   rmSync(TMP, { recursive: true, force: true });
 });
 
-function makeAddon(group: string, capName: string, capDef: string) {
+function makeAddon(
+  group: string,
+  capName: string,
+  capDef: string,
+  linchkit?: MetadataCompatibility,
+) {
   const dir = join(TMP, group, capName, "src");
   mkdirSync(dir, { recursive: true });
-  writeFileSync(
-    join(TMP, group, capName, "package.json"),
-    JSON.stringify({ name: `@linchkit/${capName}`, main: "src/index.ts" }),
-  );
+  const pkg: Record<string, unknown> = { name: `@linchkit/${capName}`, main: "src/index.ts" };
+  if (linchkit) pkg.linchkit = linchkit;
+  writeFileSync(join(TMP, group, capName, "package.json"), JSON.stringify(pkg));
   writeFileSync(join(dir, "index.ts"), capDef);
 }
 
@@ -90,5 +96,104 @@ describe("scanAddonsPath", () => {
   test("returns empty for non-existent path", async () => {
     const caps = await scanAddonsPath(["/non/existent/path"]);
     expect(caps).toHaveLength(0);
+  });
+
+  // ── Spec 21 / #122: boot-time coreVersion population ──
+
+  test("populates coreVersion from the addon's package.json linchkit.minCoreVersion", async () => {
+    // Shipped addons declare a bare `minCoreVersion` range under `linchkit`.
+    // Without population the boot-time compatibility check sees `undefined`.
+    makeAddon(
+      "test-group",
+      "cap-mincore",
+      `
+      export default {
+        name: "cap-mincore",
+        label: "MinCore",
+        type: "standard",
+        category: "business",
+        version: "0.1.0",
+      };
+    `,
+      { minCoreVersion: "^0.2.0" },
+    );
+
+    const caps = await scanAddonsPath([TMP]);
+    expect(caps).toHaveLength(1);
+    expect(caps[0]?.coreVersion).toBe("^0.2.0");
+  });
+
+  test("normalizes a bare minCoreVersion to a >= range on the runtime definition", async () => {
+    makeAddon(
+      "test-group",
+      "cap-bare",
+      `
+      export default {
+        name: "cap-bare",
+        label: "Bare",
+        type: "standard",
+        category: "business",
+        version: "0.1.0",
+      };
+    `,
+      { minCoreVersion: "0.2.0" },
+    );
+
+    const caps = await scanAddonsPath([TMP]);
+    expect(caps[0]?.coreVersion).toBe(">=0.2.0");
+  });
+
+  test("an explicit coreVersion on the definition wins over package.json metadata", async () => {
+    makeAddon(
+      "test-group",
+      "cap-explicit",
+      `
+      export default {
+        name: "cap-explicit",
+        label: "Explicit",
+        type: "standard",
+        category: "business",
+        version: "0.1.0",
+        coreVersion: ">=0.3.0",
+      };
+    `,
+      { minCoreVersion: "^0.2.0" },
+    );
+
+    const caps = await scanAddonsPath([TMP]);
+    expect(caps[0]?.coreVersion).toBe(">=0.3.0");
+  });
+
+  test("scanned coreVersion makes the boot check WARN (not throw) on VERSION skew", async () => {
+    // The #122 trap: core VERSION "0.0.1" vs an addon's "^0.2.0" must surface a
+    // warning at boot — never a throw — when strict mode is off (the default).
+    makeAddon(
+      "test-group",
+      "cap-skew",
+      `
+      export default {
+        name: "cap-skew",
+        label: "Skew",
+        type: "standard",
+        category: "business",
+        version: "0.1.0",
+      };
+    `,
+      { minCoreVersion: "^0.2.0" },
+    );
+
+    const caps = await scanAddonsPath([TMP]);
+    const warnings: string[] = [];
+    const noop = () => {};
+
+    expect(() =>
+      enforceCoreCompatibility(caps, "0.0.1", {
+        strict: false,
+        logger: { debug: noop, info: noop, warn: (m) => warnings.push(m), error: noop },
+      }),
+    ).not.toThrow();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("cap-skew");
+    expect(warnings[0]).toContain("^0.2.0");
   });
 });

--- a/packages/core/__tests__/capability/addon-scanner.test.ts
+++ b/packages/core/__tests__/capability/addon-scanner.test.ts
@@ -123,6 +123,30 @@ describe("scanAddonsPath", () => {
     expect(caps[0]?.coreVersion).toBe("^0.2.0");
   });
 
+  test("populates coreVersion even when the addon's default export is frozen", async () => {
+    // A frozen default export (or a named-export namespace object) cannot be
+    // mutated in place — the scanner must shallow-copy before stamping
+    // coreVersion, or the assignment throws and the addon is silently dropped.
+    makeAddon(
+      "test-group",
+      "cap-frozen",
+      `
+      export default Object.freeze({
+        name: "cap-frozen",
+        label: "Frozen",
+        type: "standard",
+        category: "business",
+        version: "0.1.0",
+      });
+    `,
+      { minCoreVersion: "^0.2.0" },
+    );
+
+    const caps = await scanAddonsPath([TMP]);
+    expect(caps).toHaveLength(1);
+    expect(caps[0]?.coreVersion).toBe("^0.2.0");
+  });
+
   test("normalizes a bare minCoreVersion to a >= range on the runtime definition", async () => {
     makeAddon(
       "test-group",

--- a/packages/core/__tests__/capability/compatibility.test.ts
+++ b/packages/core/__tests__/capability/compatibility.test.ts
@@ -182,6 +182,28 @@ describe("coreVersionRangeOf", () => {
     expect(range).toBeDefined();
     expect(satisfiesVersionRange("0.2.0", range as string)).toBe(false);
   });
+
+  it("reads the legacy minCoreVersion alias shipped addons declare", () => {
+    // A bare version is normalized to a `>=` range...
+    expect(coreVersionRangeOf({ minCoreVersion: "0.2.0" })).toBe(">=0.2.0");
+    // ...while a value that is already a range is kept verbatim.
+    expect(coreVersionRangeOf({ minCoreVersion: "^0.2.0" })).toBe("^0.2.0");
+  });
+
+  it("applies the precedence coreVersion ?? minVersion ?? minCoreVersion", () => {
+    // coreVersion wins over both deprecated keys.
+    expect(
+      coreVersionRangeOf({
+        coreVersion: ">=0.2.0 <0.4.0",
+        minVersion: "0.1.0",
+        minCoreVersion: "^0.2.0",
+      }),
+    ).toBe(">=0.2.0 <0.4.0");
+    // minVersion wins over minCoreVersion when coreVersion is absent.
+    expect(coreVersionRangeOf({ minVersion: "0.1.0", minCoreVersion: "^0.2.0" })).toBe(">=0.1.0");
+    // minCoreVersion is the last resort.
+    expect(coreVersionRangeOf({ minCoreVersion: "^0.2.0" })).toBe("^0.2.0");
+  });
 });
 
 // ── defaultLogger metadata forwarding ────────────────────

--- a/packages/core/src/capability/addon-scanner.ts
+++ b/packages/core/src/capability/addon-scanner.ts
@@ -1,6 +1,7 @@
 import { existsSync, readdirSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 import type { CapabilityDefinition } from "../types/capability";
+import { coreVersionRangeOf, type MetadataCompatibility } from "./compatibility";
 
 /**
  * Scan addon_path directories for capability packages.
@@ -38,12 +39,27 @@ export async function scanAddonsPath(addonsPaths: string[]): Promise<CapabilityD
         const capPath = join(groupPath, capDir);
         try {
           const pkg = await import(join(capPath, "package.json"));
-          const mainEntry = pkg.default?.main ?? pkg.main ?? "src/index.ts";
+          const pkgJson = (pkg.default ?? pkg) as {
+            main?: string;
+            linchkit?: MetadataCompatibility;
+          };
+          const mainEntry = pkgJson.main ?? "src/index.ts";
           const mod = await import(join(capPath, mainEntry));
           const capDef = mod.default ?? mod;
 
           if (capDef && typeof capDef === "object" && capDef.name && capDef.label) {
-            capabilities.push(capDef as CapabilityDefinition);
+            const def = capDef as CapabilityDefinition;
+            // Populate the boot-time compatibility range (Spec 21 / #122) from
+            // the addon's `package.json` `linchkit` block (coreVersion ??
+            // minVersion ?? minCoreVersion). The runtime definition rarely
+            // declares `coreVersion` itself, so without this the boot check in
+            // `enforceCoreCompatibility` would see `undefined` for every addon.
+            // A range declared explicitly on the definition still wins.
+            if (def.coreVersion === undefined) {
+              const range = coreVersionRangeOf(pkgJson.linchkit);
+              if (range !== undefined) def.coreVersion = range;
+            }
+            capabilities.push(def);
           }
         } catch {
           // Skip capabilities that fail to load

--- a/packages/core/src/capability/addon-scanner.ts
+++ b/packages/core/src/capability/addon-scanner.ts
@@ -48,7 +48,12 @@ export async function scanAddonsPath(addonsPaths: string[]): Promise<CapabilityD
           const capDef = mod.default ?? mod;
 
           if (capDef && typeof capDef === "object" && capDef.name && capDef.label) {
-            const def = capDef as CapabilityDefinition;
+            // Shallow-copy rather than mutate `capDef` in place: a default export
+            // may be `Object.freeze`d, and a named-export module resolves to a
+            // frozen namespace object — assigning `coreVersion` on either throws
+            // a TypeError that this try/catch would silently swallow, dropping
+            // the addon. The copy is a plain extensible object we own.
+            const def = { ...(capDef as CapabilityDefinition) };
             // Populate the boot-time compatibility range (Spec 21 / #122) from
             // the addon's `package.json` `linchkit` block (coreVersion ??
             // minVersion ?? minCoreVersion). The runtime definition rarely

--- a/packages/core/src/capability/compatibility.ts
+++ b/packages/core/src/capability/compatibility.ts
@@ -49,6 +49,14 @@ export interface MetadataCompatibility {
    * match.
    */
   minVersion?: string;
+  /**
+   * @deprecated Legacy alias of `minVersion`. Every shipped addon's
+   * `package.json` declares this key under `linchkit.minCoreVersion`. Used only
+   * when both `coreVersion` and `minVersion` are absent; normalized to a `>=`
+   * range via {@link normalizeMinVersion} so a bare version is treated as a
+   * minimum. A value that is already a range (e.g. "^0.2.0") is kept as-is.
+   */
+  minCoreVersion?: string;
 }
 
 // ── coreVersion range resolution ─────────────────────────
@@ -74,16 +82,20 @@ export function normalizeMinVersion(minVersion: string): string {
  * Resolve the effective core-version range a capability should be checked
  * against, from its `linchkit` metadata block.
  *
+ * Precedence: `coreVersion ?? minVersion ?? minCoreVersion`.
  * - Prefers `coreVersion` (already a semver range) verbatim.
- * - Falls back to the deprecated `minVersion`, normalized to a `>=` range via
- *   {@link normalizeMinVersion} so a bare version is treated as a minimum.
- * - Returns `undefined` when neither is declared.
+ * - Falls back to the deprecated `minVersion`, then the legacy
+ *   `minCoreVersion` alias, each normalized to a `>=` range via
+ *   {@link normalizeMinVersion} so a bare version is treated as a minimum
+ *   while a value that is already a range is kept as-is.
+ * - Returns `undefined` when none of the three is declared.
  */
 export function coreVersionRangeOf(
   linchkit: MetadataCompatibility | undefined,
 ): string | undefined {
   if (linchkit?.coreVersion) return linchkit.coreVersion;
   if (linchkit?.minVersion) return normalizeMinVersion(linchkit.minVersion);
+  if (linchkit?.minCoreVersion) return normalizeMinVersion(linchkit.minCoreVersion);
   return undefined;
 }
 

--- a/packages/core/src/capability/compatibility.ts
+++ b/packages/core/src/capability/compatibility.ts
@@ -93,9 +93,20 @@ export function normalizeMinVersion(minVersion: string): string {
 export function coreVersionRangeOf(
   linchkit: MetadataCompatibility | undefined,
 ): string | undefined {
-  if (linchkit?.coreVersion) return linchkit.coreVersion;
-  if (linchkit?.minVersion) return normalizeMinVersion(linchkit.minVersion);
-  if (linchkit?.minCoreVersion) return normalizeMinVersion(linchkit.minCoreVersion);
+  // `scanAddonsPath` reads `package.json` directly without validating it against
+  // `capabilityMetadataSchema`, so a malformed/third-party addon could declare a
+  // non-string value here. Guard every field with `typeof` so `normalizeMinVersion`
+  // never calls `.trim()` on a number/boolean (a TypeError the scanner's
+  // try/catch would silently swallow, dropping the addon).
+  if (typeof linchkit?.coreVersion === "string" && linchkit.coreVersion) {
+    return linchkit.coreVersion;
+  }
+  if (typeof linchkit?.minVersion === "string" && linchkit.minVersion) {
+    return normalizeMinVersion(linchkit.minVersion);
+  }
+  if (typeof linchkit?.minCoreVersion === "string" && linchkit.minCoreVersion) {
+    return normalizeMinVersion(linchkit.minCoreVersion);
+  }
   return undefined;
 }
 

--- a/packages/core/src/types/capability-metadata.ts
+++ b/packages/core/src/types/capability-metadata.ts
@@ -82,7 +82,7 @@ export const capabilityMetadataSchema = z.object({
       /**
        * Semver RANGE describing which @linchkit/core versions this capability
        * is compatible with (e.g. "^0.2.0", ">=0.2.0 <0.4.0"). When present it
-       * takes precedence over the deprecated `minVersion`.
+       * takes precedence over the deprecated `minVersion` / `minCoreVersion`.
        */
       coreVersion: z.string().optional(),
       /**
@@ -91,6 +91,14 @@ export const capabilityMetadataSchema = z.object({
        * version constraint.
        */
       minVersion: z.string().optional(),
+      /**
+       * @deprecated Legacy alias of `minVersion` carried by shipped addons'
+       * `package.json` (`linchkit.minCoreVersion`). Recognized so it is no
+       * longer silently stripped at parse time; honored only when both
+       * `coreVersion` and `minVersion` are absent. Interpreted as a minimum
+       * version constraint (a bare version is normalized to a `>=` range).
+       */
+      minCoreVersion: z.string().optional(),
     })
     .optional(),
 });


### PR DESCRIPTION
## What

Closes the **Spec 21 / #122** gap where the core↔capability version-compatibility check was **inert for every real addon**:

1. Shipped `package.json` files declare `linchkit.minCoreVersion` — a third key the metadata schema did **not** recognize, so it was silently stripped at parse time.
2. The runtime `CapabilityDefinition.coreVersion` was **never populated** from disk metadata, so the boot-time `enforceCoreCompatibility` always saw `undefined` and checked nothing.

This PR reconciles both.

## Changes

- **Schema** (`types/capability-metadata.ts`): `capabilityMetadataSchema.linchkit` now recognizes the deprecated `minCoreVersion` alias alongside `coreVersion` and `minVersion`.
- **Resolver** (`capability/compatibility.ts`): `coreVersionRangeOf` resolves the effective range with precedence `coreVersion ?? minVersion ?? minCoreVersion`; `minVersion`/`minCoreVersion` are normalized to a `>=` range (a value already a range is kept verbatim).
- **Runtime population** (`capability/addon-scanner.ts`): `scanAddonsPath` populates `CapabilityDefinition.coreVersion` from the scanned addon's `linchkit` block via `coreVersionRangeOf`. An explicit range declared on the definition still wins.

## Safety

Strict enforcement remains **hard-gated off** (`STRICT_COMPAT_READY=false` in `dev.ts`). With core `VERSION` `0.0.1` vs addon ranges like `^0.2.0`, this surfaces **WARN lines, never a throw**. Non-breaking — all three `linchkit` version keys are optional; no new public export (barrel surface unchanged).

## Tests

`packages/core` full suite: **3800 pass / 0 fail**. New coverage:
- schema accepts `minCoreVersion` (and all three keys together);
- `coreVersionRangeOf` reads the alias + full precedence assertion;
- `scanAddonsPath` populates `coreVersion` from metadata, normalizes a bare value to `>=`, lets an explicit def range win, and the scanned range makes the boot check **WARN-not-throw** on the `0.0.1` vs `^0.2.0` skew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)