### PR TITLE
feat(cap-migration): DB-querying appliedMigrationsReader for MigrationCoordinator (#72)

### DIFF
--- a/.changeset/migration-applied-reader.md
+++ b/.changeset/migration-applied-reader.md
@@ -1,0 +1,18 @@
+---
+"@linchkit/cap-migration": minor
+---
+
+Add the DB-querying `appliedMigrationsReader` so the core `MigrationCoordinator`
+(Spec 12 §5) is usable end-to-end.
+
+`createAppliedMigrationsReader({ db, migrationsDir? })` returns a
+`() => Promise<ReadonlySet<string>>` of the migration tags actually applied to a
+target database. It queries drizzle-orm's default migrations table
+(`drizzle.__drizzle_migrations`, parameterized via `sql.identifier` — no
+string-built SQL), maps each row's `created_at` (epoch ms == journal `when`) back
+to its tag via `<migrationsDir>/meta/_journal.json`, returns an empty set on a
+fresh DB / missing table, and skips rows with no matching journal entry.
+
+Also adds `createDbMigrationCoordinator({ db, repoDir, ... })`, a convenience that
+wires a `MigrationCoordinator` with this reader plus `runMigrations` (forward) and
+`runReverseMigration` (reverse) so callers get a ready-to-use coordinator.

--- a/addons/migration/cap-migration/__tests__/applied-reader.test.ts
+++ b/addons/migration/cap-migration/__tests__/applied-reader.test.ts
@@ -1,0 +1,175 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createAppliedMigrationsReader, type MigrationStateDb } from "../src/applied-reader";
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+/**
+ * A fixture journal mirroring drizzle's `meta/_journal.json` shape. Each entry's
+ * `when` is what drizzle-orm writes into `__drizzle_migrations.created_at`
+ * (`folderMillis`), and `tag` is the migration id the coordinator partitions on.
+ */
+const JOURNAL = {
+  version: "7",
+  dialect: "postgresql",
+  entries: [
+    { idx: 0, version: "7", when: 1775376040980, tag: "0000_melted_gateway", breakpoints: true },
+    { idx: 1, version: "7", when: 1775733762343, tag: "0001_greedy_king", breakpoints: true },
+    { idx: 2, version: "7", when: 1777128126634, tag: "0002_loving_kang", breakpoints: true },
+  ],
+};
+
+let migrationsDir: string;
+
+beforeAll(async () => {
+  const root = await mkdtemp(join(tmpdir(), "cap-migration-reader-"));
+  migrationsDir = join(root, "drizzle", "migrations");
+  await Bun.write(join(migrationsDir, "meta", "_journal.json"), JSON.stringify(JOURNAL, null, 2));
+});
+
+afterAll(async () => {
+  // migrationsDir = <root>/drizzle/migrations — clean up the whole temp root.
+  await rm(join(migrationsDir, "..", ".."), { recursive: true, force: true });
+});
+
+// ── Fake DB helpers ─────────────────────────────────────────────────────────
+
+/**
+ * A fake `MigrationStateDb` whose `execute` returns canned object rows
+ * (`{ created_at }`), mimicking drizzle/postgres.js. `created_at` is a STRING
+ * because the column is `bigint` and postgres.js returns bigints as strings.
+ */
+function dbWithRows(...createdAt: Array<string | number | bigint>): MigrationStateDb {
+  return {
+    execute: (async () =>
+      createdAt.map((value) => ({ created_at: value }))) as MigrationStateDb["execute"],
+  };
+}
+
+/** A fake DB whose `execute` rejects with a given PG SQLSTATE code. */
+function dbThrowing(code: string): MigrationStateDb {
+  return {
+    execute: (async () => {
+      const err = new Error(`relation does not exist`) as Error & { code: string };
+      err.code = code;
+      throw err;
+    }) as MigrationStateDb["execute"],
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe("createAppliedMigrationsReader — maps DB rows → tags via journal", () => {
+  it("maps each applied created_at to its journal tag", async () => {
+    const reader = createAppliedMigrationsReader({
+      db: dbWithRows("1775376040980", "1775733762343"),
+      migrationsDir,
+    });
+    const applied = await reader();
+    expect([...applied].sort()).toEqual(["0000_melted_gateway", "0001_greedy_king"]);
+  });
+
+  it("tolerates created_at as number or bigint, not only string", async () => {
+    const reader = createAppliedMigrationsReader({
+      db: dbWithRows(1775376040980, 1777128126634n),
+      migrationsDir,
+    });
+    const applied = await reader();
+    expect([...applied].sort()).toEqual(["0000_melted_gateway", "0002_loving_kang"]);
+  });
+
+  it("returns the full applied set when every row matches", async () => {
+    const reader = createAppliedMigrationsReader({
+      db: dbWithRows("1775376040980", "1775733762343", "1777128126634"),
+      migrationsDir,
+    });
+    const applied = await reader();
+    expect(applied.size).toBe(3);
+  });
+});
+
+describe("createAppliedMigrationsReader — missing table → empty set", () => {
+  it("returns empty set on undefined_table (42P01)", async () => {
+    const reader = createAppliedMigrationsReader({ db: dbThrowing("42P01"), migrationsDir });
+    const applied = await reader();
+    expect(applied.size).toBe(0);
+  });
+
+  it("returns empty set on invalid_schema_name (3F000)", async () => {
+    const reader = createAppliedMigrationsReader({ db: dbThrowing("3F000"), migrationsDir });
+    const applied = await reader();
+    expect(applied.size).toBe(0);
+  });
+
+  it("re-throws DB errors that are NOT a missing table", async () => {
+    const reader = createAppliedMigrationsReader({ db: dbThrowing("08006"), migrationsDir });
+    await expect(reader()).rejects.toThrow();
+  });
+});
+
+describe("createAppliedMigrationsReader — unmatched rows are skipped", () => {
+  it("skips a created_at with no matching journal entry", async () => {
+    const reader = createAppliedMigrationsReader({
+      // 1775376040980 matches 0000; 9999999999999 + the malformed entries don't.
+      db: dbWithRows("1775376040980", "9999999999999", "not-a-number", ""),
+      migrationsDir,
+    });
+    const applied = await reader();
+    expect([...applied]).toEqual(["0000_melted_gateway"]);
+  });
+
+  it("returns empty set when no row matches any journal entry", async () => {
+    const reader = createAppliedMigrationsReader({
+      db: dbWithRows("1", "2", "3"),
+      migrationsDir,
+    });
+    const applied = await reader();
+    expect(applied.size).toBe(0);
+  });
+});
+
+describe("createAppliedMigrationsReader — journal handling", () => {
+  it("returns empty set when the journal is missing (never throws)", async () => {
+    const reader = createAppliedMigrationsReader({
+      db: dbWithRows("1775376040980"),
+      migrationsDir: join(tmpdir(), "cap-migration-no-such-dir-xyz"),
+    });
+    const applied = await reader();
+    expect(applied.size).toBe(0);
+  });
+
+  it("returns empty set when the journal is malformed (never throws)", async () => {
+    const root = await mkdtemp(join(tmpdir(), "cap-migration-bad-journal-"));
+    const badDir = join(root, "drizzle", "migrations");
+    await Bun.write(join(badDir, "meta", "_journal.json"), "{ this is not json");
+    try {
+      const reader = createAppliedMigrationsReader({
+        db: dbWithRows("1775376040980"),
+        migrationsDir: badDir,
+      });
+      const applied = await reader();
+      expect(applied.size).toBe(0);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not query the journal when the DB reports nothing applied", async () => {
+    const reader = createAppliedMigrationsReader({ db: dbWithRows(), migrationsDir });
+    const applied = await reader();
+    expect(applied.size).toBe(0);
+  });
+});
+
+describe("createAppliedMigrationsReader — positional tuple rows", () => {
+  it("reads created_at from positional [value] rows too", async () => {
+    const db: MigrationStateDb = {
+      execute: (async () => [["1775376040980"], ["1775733762343"]]) as MigrationStateDb["execute"],
+    };
+    const reader = createAppliedMigrationsReader({ db, migrationsDir });
+    const applied = await reader();
+    expect([...applied].sort()).toEqual(["0000_melted_gateway", "0001_greedy_king"]);
+  });
+});

--- a/addons/migration/cap-migration/src/applied-reader.ts
+++ b/addons/migration/cap-migration/src/applied-reader.ts
@@ -1,0 +1,285 @@
+/**
+ * Applied-migrations reader
+ *
+ * Builds the `appliedMigrationsReader` that the core `MigrationCoordinator`
+ * (Spec 12 §5) requires: a `() => Promise<ReadonlySet<string>>` returning the
+ * migration TAGS actually applied to the target database.
+ *
+ * The coordinator is intentionally DB-agnostic and has NO default reader (it
+ * throws when omitted), because the on-disk drizzle journal lists *generated*
+ * migrations, not *applied* ones. The genuinely-applied set lives in the DB, so
+ * this DB-querying reader belongs in cap-migration (which holds the db handle).
+ *
+ * How applied state is stored
+ * ---------------------------
+ * `runMigrations(db)` (db-migrate.ts) calls drizzle-orm's
+ * `migrate(db, { migrationsFolder })` with NO `migrationsTable`/`migrationsSchema`
+ * override, so drizzle-orm uses its defaults:
+ *
+ *   schema = "drizzle", table = "__drizzle_migrations"
+ *     columns: id SERIAL PRIMARY KEY, hash text NOT NULL, created_at bigint
+ *
+ * (verified against drizzle-orm 0.45.1 `pg-core/dialect` `migrate()`.)
+ *
+ * Each applied row's `created_at` is set to the migration's `folderMillis`, which
+ * drizzle-orm's `readMigrationFiles` reads verbatim from the journal entry's
+ * `when` field. So a row's `created_at` (epoch ms) maps 1:1 back to the journal
+ * entry whose `when` equals it, and that entry's `tag` is the migration id the
+ * coordinator partitions on.
+ *
+ * Mapping approach
+ * ----------------
+ *   1. SELECT created_at FROM drizzle.__drizzle_migrations  (parameterless,
+ *      identifiers via drizzle `sql.identifier` — no string-built SQL).
+ *      Fresh DB / table never created → return an EMPTY set (never throw).
+ *   2. Read `<migrationsDir>/meta/_journal.json`; build `when(ms) → tag`.
+ *   3. For each row, look up its `created_at` in the map; collect the tag.
+ *      Rows with no matching journal entry are skipped (best-effort). A
+ *      missing/malformed journal yields an empty set (never throws).
+ */
+
+import { join, resolve } from "node:path";
+import {
+  createMigrationCoordinator,
+  type MigrationCoordinator,
+  type MigrationCoordinatorOptions,
+} from "@linchkit/core/server";
+import { sql } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import { runMigrations, runReverseMigration } from "./db-migrate";
+
+/** Schema drizzle-orm's pg migrator uses by default (no override in runMigrations). */
+const MIGRATIONS_SCHEMA = "drizzle";
+/** Table drizzle-orm's pg migrator uses by default. */
+const MIGRATIONS_TABLE = "__drizzle_migrations";
+
+/** Default migrations folder — mirrors `runMigrations` / drizzle.config. */
+const DEFAULT_MIGRATIONS_DIR = "./drizzle/migrations";
+
+/**
+ * PostgreSQL `SQLSTATE` codes meaning "the applied-state table can't exist yet",
+ * which we treat as "nothing applied" rather than an error:
+ *   42P01 — undefined_table (the table does not exist)
+ *   3F000 — invalid_schema_name (the `drizzle` schema does not exist)
+ */
+const MISSING_TABLE_SQLSTATES = new Set(["42P01", "3F000"]);
+
+/**
+ * The minimal database surface this reader needs: a Drizzle `execute` that runs a
+ * parameterized `sql` query and resolves to the result rows. `PostgresJsDatabase`
+ * satisfies this structurally, and tests can supply a tiny fake. Kept narrow so
+ * the reader never reaches for anything but a read query.
+ */
+export interface MigrationStateDb {
+  execute: PostgresJsDatabase["execute"];
+}
+
+export interface AppliedMigrationsReaderOptions {
+  /** Drizzle database handle (or any `{ execute }` matching `MigrationStateDb`). */
+  db: MigrationStateDb;
+  /**
+   * Migrations folder containing `meta/_journal.json`.
+   * Default: "./drizzle/migrations" (matches `runMigrations`).
+   */
+  migrationsDir?: string;
+}
+
+/** Shape of a journal entry we rely on (`meta/_journal.json` → `entries[]`). */
+interface JournalEntry {
+  when: number;
+  tag: string;
+}
+
+/**
+ * Narrow an unknown PG driver error to its `SQLSTATE`/`code`, if present.
+ * postgres.js surfaces it as `err.code`; node-postgres also uses `code`.
+ */
+function pgErrorCode(err: unknown): string | undefined {
+  if (typeof err === "object" && err !== null && "code" in err) {
+    const code = (err as { code: unknown }).code;
+    return typeof code === "string" ? code : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Normalize a `created_at` cell to epoch milliseconds. The column is `bigint`, so
+ * postgres.js returns it as a string by default; be tolerant of number/bigint too.
+ * Returns `undefined` for values that can't be a finite integer epoch.
+ */
+function toEpochMs(value: unknown): number | undefined {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : undefined;
+  }
+  if (typeof value === "bigint") {
+    return Number(value);
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.length === 0 || !/^-?\d+$/.test(trimmed)) return undefined;
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Read `<migrationsDir>/meta/_journal.json` and build a `when(epoch ms) → tag`
+ * map. Returns an empty map if the journal is missing or malformed (never throws)
+ * so a journal problem degrades to "nothing matched" rather than a crash.
+ */
+async function readJournalWhenToTag(migrationsDir: string): Promise<Map<number, string>> {
+  const map = new Map<number, string>();
+  const journalPath = join(migrationsDir, "meta", "_journal.json");
+  try {
+    const file = Bun.file(journalPath);
+    if (!(await file.exists())) return map;
+    const parsed: unknown = await file.json();
+    if (typeof parsed !== "object" || parsed === null || !("entries" in parsed)) {
+      return map;
+    }
+    const entries = (parsed as { entries: unknown }).entries;
+    if (!Array.isArray(entries)) return map;
+    for (const entry of entries) {
+      if (typeof entry !== "object" || entry === null) continue;
+      const when = (entry as Partial<JournalEntry>).when;
+      const tag = (entry as Partial<JournalEntry>).tag;
+      if (typeof when === "number" && Number.isFinite(when) && typeof tag === "string") {
+        map.set(when, tag);
+      }
+    }
+  } catch {
+    // Malformed JSON / read error → best-effort empty map (never throw).
+    return new Map<number, string>();
+  }
+  return map;
+}
+
+/**
+ * Query the applied rows' `created_at` values from drizzle's migrations table.
+ * Returns an empty array when the table/schema does not exist yet (fresh DB).
+ * Re-throws any other DB error so genuine failures are not silently swallowed.
+ */
+async function readAppliedCreatedAt(db: MigrationStateDb): Promise<unknown[]> {
+  try {
+    // Identifiers via `sql.identifier` (not string concatenation); no user input.
+    const rows = await db.execute(
+      sql`select created_at from ${sql.identifier(MIGRATIONS_SCHEMA)}.${sql.identifier(
+        MIGRATIONS_TABLE,
+      )}`,
+    );
+    return Array.isArray(rows) ? rows : [...(rows as Iterable<unknown>)];
+  } catch (err) {
+    if (MISSING_TABLE_SQLSTATES.has(pgErrorCode(err) ?? "")) {
+      return [];
+    }
+    throw err;
+  }
+}
+
+/**
+ * Extract `created_at` from a result row, tolerating either object rows
+ * (`{ created_at }`) or positional tuples (`[created_at]`).
+ */
+function rowCreatedAt(row: unknown): unknown {
+  if (Array.isArray(row)) return row[0];
+  if (typeof row === "object" && row !== null && "created_at" in row) {
+    return (row as { created_at: unknown }).created_at;
+  }
+  return undefined;
+}
+
+/**
+ * Build the coordinator's `appliedMigrationsReader`.
+ *
+ * Returns `() => Promise<ReadonlySet<string>>` resolving to the set of migration
+ * tags applied to `db`. Inject the result into
+ * `MigrationCoordinatorOptions.appliedMigrationsReader`.
+ *
+ * @example
+ *   import { createMigrationCoordinator } from "@linchkit/core/server";
+ *   import { createAppliedMigrationsReader, runMigrations } from "@linchkit/cap-migration";
+ *
+ *   const coordinator = createMigrationCoordinator({
+ *     repoDir: process.cwd(),
+ *     appliedMigrationsReader: createAppliedMigrationsReader({ db }),
+ *     forwardApply: () => runMigrations(db),
+ *     // sqlExecutor: (sqlPath) => runReverseMigration(db, { sqlPath }),
+ *   });
+ */
+export function createAppliedMigrationsReader(
+  options: AppliedMigrationsReaderOptions,
+): () => Promise<ReadonlySet<string>> {
+  const { db } = options;
+  const migrationsDir = options.migrationsDir ?? DEFAULT_MIGRATIONS_DIR;
+
+  return async (): Promise<ReadonlySet<string>> => {
+    const rows = await readAppliedCreatedAt(db);
+    if (rows.length === 0) return new Set<string>();
+
+    const whenToTag = await readJournalWhenToTag(migrationsDir);
+    if (whenToTag.size === 0) return new Set<string>();
+
+    const applied = new Set<string>();
+    for (const row of rows) {
+      const ms = toEpochMs(rowCreatedAt(row));
+      if (ms === undefined) continue;
+      const tag = whenToTag.get(ms);
+      // Skip rows whose created_at has no matching journal entry (best-effort).
+      if (tag !== undefined) applied.add(tag);
+    }
+    return applied;
+  };
+}
+
+export interface DbMigrationCoordinatorOptions
+  extends Omit<
+    MigrationCoordinatorOptions,
+    "appliedMigrationsReader" | "forwardApply" | "sqlExecutor"
+  > {
+  /** Drizzle database handle the reader/runners operate against. */
+  db: PostgresJsDatabase;
+}
+
+/**
+ * Construct a `MigrationCoordinator` fully wired to a Drizzle database:
+ *   - `appliedMigrationsReader` ← `createAppliedMigrationsReader({ db, ... })`
+ *   - `forwardApply`            ← `runMigrations(db)`
+ *   - `sqlExecutor`             ← `runReverseMigration(db, { sqlPath })`
+ *
+ * This is the ready-to-use entry point so callers don't have to hand-wire the
+ * three DB-aware injections themselves. The reader's journal dir is resolved as
+ * `<repoDir>/<migrationsDir>` to match how the coordinator joins those paths;
+ * `runMigrations` is given the same absolute folder so DB and on-disk stay in
+ * sync. Any other coordinator option (dryRun, allowIrreversible, classifyRelease,
+ * dirReader, logger, clock) passes through unchanged.
+ *
+ * @example
+ *   import { createDatabase } from "@linchkit/core/server";
+ *   import { createDbMigrationCoordinator } from "@linchkit/cap-migration";
+ *
+ *   const db = createDatabase({ url: process.env.DATABASE_URL! });
+ *   const coordinator = createDbMigrationCoordinator({ db, repoDir: process.cwd() });
+ *   const preflight = await coordinator.preFlight();
+ */
+export function createDbMigrationCoordinator(
+  options: DbMigrationCoordinatorOptions,
+): MigrationCoordinator {
+  const { db, ...coordinatorOptions } = options;
+  const migrationsDir = coordinatorOptions.migrationsDir ?? "drizzle/migrations";
+  // Resolve robustly via node:path: an absolute migrationsDir is honored as-is,
+  // a relative one is joined onto repoDir (resolve handles trailing slashes and
+  // the absolute-path case), keeping the reader's journal dir and the
+  // forward-apply folder in lock-step with how the coordinator joins paths.
+  const absoluteMigrationsDir = resolve(coordinatorOptions.repoDir, migrationsDir);
+
+  return createMigrationCoordinator({
+    ...coordinatorOptions,
+    appliedMigrationsReader: createAppliedMigrationsReader({
+      db,
+      migrationsDir: absoluteMigrationsDir,
+    }),
+    forwardApply: () => runMigrations(db, { migrationsFolder: absoluteMigrationsDir }),
+    sqlExecutor: (sqlPath) => runReverseMigration(db, { sqlPath }),
+  });
+}

--- a/addons/migration/cap-migration/src/index.ts
+++ b/addons/migration/cap-migration/src/index.ts
@@ -5,6 +5,14 @@
  * version registry, Drizzle DB migration runner, and legacy data import tools.
  */
 
+// ── Applied-migrations reader (Spec 12 §5 — coordinator wiring) ─────
+export {
+  type AppliedMigrationsReaderOptions,
+  createAppliedMigrationsReader,
+  createDbMigrationCoordinator,
+  type DbMigrationCoordinatorOptions,
+  type MigrationStateDb,
+} from "./applied-reader";
 // ── Version compatibility (spec 38) ────────────────────────
 export type {
   BreakingChange,


### PR DESCRIPTION
## What

Wires core's `MigrationCoordinator` (Spec 12 §5) end-to-end. The coordinator **requires** an injected `appliedMigrationsReader: () => Promise<ReadonlySet<string>>` returning the migration **tags actually applied to the DB** — it has no default and throws if omitted, because the on-disk drizzle journal lists *generated* migrations, not *applied* ones (PR #398). This PR implements that reader in `cap-migration`, which holds the db handle.

## How applied state maps to tags

`runMigrations` calls drizzle-orm's `migrate(db, { migrationsFolder })` with no table/schema override → drizzle uses its defaults: schema `drizzle`, table `__drizzle_migrations` (`id` / `hash` / `created_at:bigint`). Each applied row's `created_at` is set to the migration's `folderMillis`, which drizzle reads verbatim from the journal entry's `when`. So a row's `created_at` (epoch ms) maps 1:1 back to the journal entry whose `when` equals it, and that entry's `tag` is the migration id the coordinator partitions on.

## API

- **`createAppliedMigrationsReader({ db, migrationsDir? })`** — queries `drizzle.__drizzle_migrations` via `sql.identifier` (parameterized, **no string-built SQL, no user input**), builds a `when→tag` map from `<migrationsDir>/meta/_journal.json`, and returns the applied tag set.
  - Fresh DB / missing table → empty set (SQLSTATE `42P01` undefined_table / `3F000` invalid_schema_name); **any other DB error re-throws** (genuine failures not swallowed).
  - Missing/malformed journal → empty set (best-effort, never throws). Rows with no matching journal entry are skipped.
  - `created_at` coerced from `string | number | bigint` to a finite epoch (postgres.js returns `bigint` columns as strings).
- **`createDbMigrationCoordinator({ db, repoDir, ... })`** — convenience wrapper wiring the reader + `runMigrations` (forward) + `runReverseMigration` (reverse). Migrations dir resolved via `node:path` `resolve()` (absolute honored, relative joined onto `repoDir`).

## Tests

`bun test addons/migration/` → **12 pass / 0 fail**. Covers: object & positional-tuple rows, string/number/bigint `created_at`, fresh-DB empty set, missing-table SQLSTATEs vs re-thrown errors, missing/malformed journal, unmatched rows skipped.

## Review

Cross-model review (gemini) LGTM-with-nits → fixed the flagged path-concatenation fragility by switching `${repoDir}/${migrationsDir}` and the journal path to `node:path` `resolve()`/`join()` (handles absolute paths + trailing slashes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)