### PR TITLE
feat(cap-ai-provider): accurate post-drain token/cost accounting for the streaming path (#350)

### DIFF
--- a/.changeset/ai-tracing-stream-accounting.md
+++ b/.changeset/ai-tracing-stream-accounting.md
@@ -1,0 +1,30 @@
+---
+"@linchkit/cap-ai-provider": minor
+---
+
+Accurate streaming-path token/cost accounting for AI tracing (Spec 69 Phase 3,
+follow-up to PR-1).
+
+`completeStream()` previously recorded only a zero-token, best-effort `partial`
+generation at stream OPEN — usage / cost / completion text are unknown until the
+Vercel AI SDK stream fully drains. It now wraps the SDK `textStream` and records
+exactly ONE token-accurate generation when the stream finishes:
+
+- A CLEAN drain records a `partial: false` / `status: "ok"` generation with the
+  correct `inputTokens` / `outputTokens` (read from the SDK's post-drain
+  `totalUsage` accessor), cost (computed with the SAME `CostEstimator` the
+  completion path uses), full completion text (from the SDK `text` accessor,
+  falling back to the accumulated chunks), and latency.
+- An ABORTING / erroring stream records a single `partial: true` /
+  `status: "error"` record (zero tokens, partial text captured so far) and
+  re-throws the original error to the consumer.
+- A parent `AITrace` now wraps the stream (mirroring the completion path) so the
+  trace's token/cost rollup is correct, with the sampling decision resolved once
+  and threaded into the child generation.
+
+The finish-hook recording is STRICTLY non-throwing: any tracing failure
+(including awaiting the SDK usage/text promises) is swallowed and logged once,
+and the wrapped stream yields the same chunks in the same order — a tracing
+failure can never break or alter the consumer's stream, output, or timing. The
+SDK runner is now reachable through the existing `runStreamText` injectable test
+seam.

--- a/addons/ai-provider/cap-ai-provider/__tests__/ai-service.stream-tracing.test.ts
+++ b/addons/ai-provider/cap-ai-provider/__tests__/ai-service.stream-tracing.test.ts
@@ -1,0 +1,516 @@
+/**
+ * Streaming-path tracing tests for createAIService (Spec 69 Phase 3, P3).
+ *
+ * Exercises the real `completeStream()` path using an injected fake
+ * `runStreamText` runner (no network), plus a fake tracer (setObservability)
+ * and an in-memory sink (setAITraceSink) reset in afterEach.
+ *
+ * The streaming path now records token-ACCURATE accounting once the stream
+ * finishes draining (instead of the zero-token partial-at-open of PR-1):
+ *  - a CLEAN drain records exactly ONE `partial: false` / `status: "ok"`
+ *    generation with correct input/output tokens, cost, and completion text;
+ *  - an ABORTING / erroring stream records ONE `partial: true` /
+ *    `status: "error"` record and re-throws to the consumer WITHOUT the tracing
+ *    layer ever throwing on its own;
+ *  - the parent trace token/cost rollup matches the recorded generation;
+ *  - a sink that THROWS never breaks the consumer's stream;
+ *  - sampling rate 0 records nothing.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import type {
+  AIServiceConfig,
+  Observability,
+  Span,
+  SpanAttributes,
+  SpanAttributeValue,
+  SpanStatus,
+  StartSpanOptions,
+  Tracer,
+} from "@linchkit/core/server";
+import {
+  InMemoryAITraceStore,
+  resetAITraceSink,
+  resetObservability,
+  setAITraceSink,
+  setObservability,
+} from "@linchkit/core/server";
+import { type AIServiceInternals, createAIService, type StreamTextLike } from "../src/ai-service";
+import { resetTracingWarnLatch } from "../src/ai-tracing";
+
+// ── Fake tracer ──────────────────────────────────────────
+
+class FakeSpan implements Span {
+  attributes: SpanAttributes = {};
+  status: SpanStatus = { code: "unset" };
+  exceptions: string[] = [];
+  ended = false;
+  setAttribute(key: string, value: SpanAttributeValue): this {
+    this.attributes[key] = value;
+    return this;
+  }
+  setAttributes(attrs: SpanAttributes): this {
+    Object.assign(this.attributes, attrs);
+    return this;
+  }
+  recordException(error: Error | string): this {
+    this.exceptions.push(error instanceof Error ? error.message : error);
+    return this;
+  }
+  setStatus(status: SpanStatus): this {
+    this.status = status;
+    return this;
+  }
+  end(): void {
+    this.ended = true;
+  }
+  isRecording(): boolean {
+    return !this.ended;
+  }
+}
+
+class FakeTracer implements Tracer {
+  spans: { name: string; span: FakeSpan; options?: StartSpanOptions }[] = [];
+  startSpan(name: string, options?: StartSpanOptions): Span {
+    const span = new FakeSpan();
+    if (options?.attributes) span.setAttributes(options.attributes);
+    this.spans.push({ name, span, options });
+    return span;
+  }
+}
+
+// ── Fake stream runner (no network) ──────────────────────
+
+/**
+ * Build a fake {@link StreamTextLike}: yields the given chunks lazily, then
+ * resolves `totalUsage` / `text` ONLY after the stream is fully drained
+ * (mirroring the SDK's "automatically consumes the stream" accessors). The
+ * usage promise resolves with the concatenated chunks counted as a sanity check
+ * is left to the caller — the runner just reports the configured usage.
+ */
+function fakeStream(args: {
+  chunks: string[];
+  usage: { inputTokens?: number; outputTokens?: number };
+  /** Optionally make `text` reject to prove the chunk-accumulation fallback. */
+  textRejects?: boolean;
+}): StreamTextLike {
+  let drained = false;
+  const fullText = args.chunks.join("");
+  return {
+    textStream: (async function* () {
+      for (const c of args.chunks) {
+        yield c;
+      }
+      drained = true;
+    })(),
+    get totalUsage() {
+      return Promise.resolve(args.usage);
+    },
+    get text() {
+      if (args.textRejects) return Promise.reject(new Error("text accessor unavailable"));
+      // Resolve only when the stream actually drained — asserts ordering.
+      return drained
+        ? Promise.resolve(fullText)
+        : Promise.reject(new Error("text read before drain"));
+    },
+  };
+}
+
+/**
+ * A fake stream that throws partway through iteration (simulates an abort or a
+ * mid-stream provider error). The consumer's `for await` surfaces the throw.
+ */
+function erroringStream(args: {
+  chunksBeforeError: string[];
+  errorMessage: string;
+}): StreamTextLike {
+  return {
+    textStream: (async function* () {
+      for (const c of args.chunksBeforeError) {
+        yield c;
+      }
+      throw new Error(args.errorMessage);
+    })(),
+    get totalUsage() {
+      // Should NEVER be awaited on the error path — usage is unknown.
+      return Promise.reject(new Error("totalUsage must not be read on the error path"));
+    },
+    get text() {
+      return Promise.reject(new Error("text must not be read on the error path"));
+    },
+  };
+}
+
+function streamInternals(stream: StreamTextLike): AIServiceInternals {
+  return {
+    getModel: async () => ({ id: "fake-model" }),
+    runStreamText: () => stream,
+  };
+}
+
+/** Drain an async iterable into the concatenated string. */
+async function drain(textStream: AsyncIterable<string>): Promise<string> {
+  let out = "";
+  for await (const chunk of textStream) out += chunk;
+  return out;
+}
+
+/**
+ * The fire-and-forget finish recording runs in a microtask after the consumer
+ * finishes draining. Yield to the event loop so the recording settles before
+ * assertions read the sink.
+ */
+async function flushMicrotasks(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+// ── Config ───────────────────────────────────────────────
+
+const config: AIServiceConfig = {
+  defaultProvider: "anthropic",
+  providers: {
+    anthropic: {
+      defaultModel: "claude-haiku-4-5-20251001",
+      models: { fast: "claude-haiku-4-5-20251001" },
+    },
+  },
+};
+
+// ── Harness ──────────────────────────────────────────────
+
+let tracer: FakeTracer;
+let sink: InMemoryAITraceStore;
+
+beforeEach(() => {
+  tracer = new FakeTracer();
+  sink = new InMemoryAITraceStore();
+  setObservability({ tracer, meter: noopMeterPassthrough() } as Observability);
+  setAITraceSink(sink);
+  resetTracingWarnLatch();
+});
+
+afterEach(() => {
+  resetObservability();
+  resetAITraceSink();
+});
+
+function noopMeterPassthrough() {
+  return {
+    createCounter: () => ({ add: () => {} }),
+    createHistogram: () => ({ record: () => {} }),
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────
+
+describe("createAIService streaming tracing — clean drain", () => {
+  it("records exactly one accurate partial:false generation after the stream drains", async () => {
+    const ai = createAIService(
+      config,
+      streamInternals(
+        fakeStream({
+          chunks: ["Hello", " ", "world"],
+          usage: { inputTokens: 13, outputTokens: 9 },
+        }),
+      ),
+    );
+
+    const stream = await ai.completeStream?.({
+      messages: [{ role: "user", content: "say hi" }],
+      model: "fast",
+      trace: { origin: "eval" },
+    });
+    expect(stream).toBeDefined();
+    if (!stream) return;
+
+    // No generation is recorded at stream OPEN — accounting waits for drain.
+    expect(sink.size).toBe(0);
+
+    const text = await drain(stream.textStream);
+    expect(text).toBe("Hello world");
+    await flushMicrotasks();
+
+    // Exactly one generation, with ACCURATE tokens/cost/completion.
+    expect(sink.size).toBe(1);
+    const gen = sink.query()[0];
+    expect(gen?.partial).toBe(false);
+    expect(gen?.status).toBe("ok");
+    expect(gen?.model).toBe("claude-haiku-4-5-20251001");
+    expect(gen?.provider).toBe("anthropic");
+    expect(gen?.inputTokens).toBe(13);
+    expect(gen?.outputTokens).toBe(9);
+    // eval origin keeps the completion verbatim.
+    expect(gen?.completion).toBe("Hello world");
+    // Cost computed from the SAME estimator the completion path uses.
+    expect(typeof gen?.cost).toBe("number");
+    expect(gen?.cost).toBeGreaterThan(0);
+    expect(gen?.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("rolls the accurate usage/cost up to the parent trace", async () => {
+    const ai = createAIService(
+      config,
+      streamInternals(fakeStream({ chunks: ["abc"], usage: { inputTokens: 20, outputTokens: 5 } })),
+    );
+    const stream = await ai.completeStream?.({
+      messages: [{ role: "user", content: "x" }],
+      trace: { origin: "eval" },
+    });
+    if (!stream) throw new Error("no stream");
+    await drain(stream.textStream);
+    await flushMicrotasks();
+
+    const traces = sink.queryTraces();
+    expect(traces).toHaveLength(1);
+    const gen = sink.query()[0];
+    expect(traces[0]?.traceId).toBe(gen?.traceId);
+    expect(traces[0]?.inputTokens).toBe(20);
+    expect(traces[0]?.outputTokens).toBe(5);
+    expect(traces[0]?.cost).toBe(gen?.cost ?? 0);
+    // Parent finalized as ok.
+    expect(traces[0]?.endedAt).toBeDefined();
+    expect(traces[0]?.status).toBe("ok");
+  });
+
+  it("opens a generation span with accurate token attributes after drain", async () => {
+    const ai = createAIService(
+      config,
+      streamInternals(fakeStream({ chunks: ["hi"], usage: { inputTokens: 4, outputTokens: 2 } })),
+    );
+    const stream = await ai.completeStream?.({
+      messages: [{ role: "user", content: "x" }],
+      trace: { origin: "eval" },
+    });
+    if (!stream) throw new Error("no stream");
+    await drain(stream.textStream);
+    await flushMicrotasks();
+
+    const spanEntry = tracer.spans.find((s) => s.name === "linchkit.ai.generation");
+    expect(spanEntry).toBeDefined();
+    expect(spanEntry?.span.ended).toBe(true);
+    expect(spanEntry?.span.status.code).toBe("ok");
+    expect(spanEntry?.span.attributes["linchkit.ai.input_tokens"]).toBe(4);
+    expect(spanEntry?.span.attributes["linchkit.ai.output_tokens"]).toBe(2);
+    expect(spanEntry?.span.attributes["linchkit.ai.partial"]).toBe(false);
+  });
+
+  it("falls back to accumulated chunks when the SDK text accessor rejects", async () => {
+    const ai = createAIService(
+      config,
+      streamInternals(
+        fakeStream({
+          chunks: ["part-A", "part-B"],
+          usage: { inputTokens: 3, outputTokens: 3 },
+          textRejects: true,
+        }),
+      ),
+    );
+    const stream = await ai.completeStream?.({
+      messages: [{ role: "user", content: "x" }],
+      trace: { origin: "eval" },
+    });
+    if (!stream) throw new Error("no stream");
+    const text = await drain(stream.textStream);
+    expect(text).toBe("part-Apart-B");
+    await flushMicrotasks();
+
+    const gen = sink.query()[0];
+    expect(gen?.status).toBe("ok");
+    expect(gen?.partial).toBe(false);
+    // Tokens still accurate; completion falls back to accumulated chunks.
+    expect(gen?.inputTokens).toBe(3);
+    expect(gen?.completion).toBe("part-Apart-B");
+  });
+
+  it("coerces undefined provider usage fields to zero", async () => {
+    const ai = createAIService(config, streamInternals(fakeStream({ chunks: ["z"], usage: {} })));
+    const stream = await ai.completeStream?.({
+      messages: [{ role: "user", content: "x" }],
+      trace: { origin: "eval" },
+    });
+    if (!stream) throw new Error("no stream");
+    await drain(stream.textStream);
+    await flushMicrotasks();
+
+    const gen = sink.query()[0];
+    expect(gen?.inputTokens).toBe(0);
+    expect(gen?.outputTokens).toBe(0);
+  });
+});
+
+describe("createAIService streaming tracing — abort / error", () => {
+  it("records a single partial:true error generation and re-throws to the consumer", async () => {
+    const ai = createAIService(
+      config,
+      streamInternals(
+        erroringStream({ chunksBeforeError: ["start"], errorMessage: "stream exploded" }),
+      ),
+    );
+    const stream = await ai.completeStream?.({
+      messages: [{ role: "user", content: "x" }],
+      trace: { origin: "eval" },
+    });
+    if (!stream) throw new Error("no stream");
+
+    // The consumer's iteration surfaces the stream's own error (tracing does
+    // NOT swallow it).
+    await expect(drain(stream.textStream)).rejects.toThrow("stream exploded");
+    await flushMicrotasks();
+
+    expect(sink.size).toBe(1);
+    const gen = sink.query()[0];
+    expect(gen?.partial).toBe(true);
+    expect(gen?.status).toBe("error");
+    expect(gen?.error).toContain("stream exploded");
+    expect(gen?.inputTokens).toBe(0);
+    expect(gen?.outputTokens).toBe(0);
+    // Completion holds the chunks received before the error.
+    expect(gen?.completion).toBe("start");
+    // Parent trace finalized as error.
+    expect(sink.queryTraces()[0]?.status).toBe("error");
+  });
+
+  it("a consumer that stops early (return) finalizes the parent trace without throwing", async () => {
+    const ai = createAIService(
+      config,
+      streamInternals(
+        fakeStream({ chunks: ["a", "b", "c"], usage: { inputTokens: 1, outputTokens: 1 } }),
+      ),
+    );
+    const stream = await ai.completeStream?.({
+      messages: [{ role: "user", content: "x" }],
+      trace: { origin: "eval" },
+    });
+    if (!stream) throw new Error("no stream");
+
+    // Consume only the first chunk, then break — the wrapper generator's
+    // `return()` runs its `finally` clean-up without throwing into the consumer.
+    let first: string | undefined;
+    for await (const chunk of stream.textStream) {
+      first = chunk;
+      break;
+    }
+    expect(first).toBe("a");
+    await flushMicrotasks();
+
+    // Early break does not drain the stream, so NO generation is recorded
+    // (usage is unknown — awaiting it could hang).
+    expect(sink.size).toBe(0);
+    // ...but the parent trace MUST still be finalized: an opened `startTrace`
+    // without a matching `endTrace` would leak an open trace forever. The
+    // `finally` ends it as "ok" (no error occurred, the consumer just stopped).
+    const trace = sink.queryTraces()[0];
+    expect(trace).toBeDefined();
+    expect(trace?.status).toBe("ok");
+    expect(trace?.endedAt).toBeDefined();
+  });
+
+  it("finalizes the parent trace as error when stream acquisition throws", async () => {
+    // The parent trace is opened BEFORE the stream is acquired. If acquisition
+    // throws (SDK import rejects / streamText throws synchronously), the
+    // consumer never gets a stream to drain, so the wrapper's own finalizer can
+    // never run — executeStream must finalize the parent itself.
+    const ai = createAIService(config, {
+      getModel: async () => ({ id: "fake-model" }),
+      runStreamText: () => {
+        throw new Error("streamText boom");
+      },
+    });
+
+    await expect(
+      ai.completeStream?.({
+        messages: [{ role: "user", content: "x" }],
+        trace: { origin: "eval" },
+      }),
+    ).rejects.toThrow("streamText boom");
+
+    // No generation recorded (the stream never started)...
+    expect(sink.size).toBe(0);
+    // ...but the opened parent trace MUST be finalized as error, not leaked open.
+    const trace = sink.queryTraces()[0];
+    expect(trace).toBeDefined();
+    expect(trace?.status).toBe("error");
+    expect(trace?.endedAt).toBeDefined();
+  });
+});
+
+describe("createAIService streaming tracing — robustness", () => {
+  it("a sink that THROWS never breaks the consumer's stream", async () => {
+    setAITraceSink({
+      startTrace: () => {
+        throw new Error("sink.startTrace boom");
+      },
+      endTrace: () => {
+        throw new Error("sink.endTrace boom");
+      },
+      recordGeneration: () => {
+        throw new Error("sink.recordGeneration boom");
+      },
+      query: () => {
+        throw new Error("nope");
+      },
+      queryTraces: () => {
+        throw new Error("nope");
+      },
+      get size() {
+        return 0;
+      },
+      clear: () => {},
+    });
+
+    const ai = createAIService(
+      config,
+      streamInternals(
+        fakeStream({ chunks: ["ok", "!"], usage: { inputTokens: 2, outputTokens: 1 } }),
+      ),
+    );
+    const stream = await ai.completeStream?.({ messages: [{ role: "user", content: "x" }] });
+    if (!stream) throw new Error("no stream");
+    // The stream drains to the full output despite every sink method throwing.
+    const text = await drain(stream.textStream);
+    expect(text).toBe("ok!");
+    await flushMicrotasks();
+  });
+
+  it("a tracer that THROWS never breaks the consumer's stream", async () => {
+    setObservability({
+      tracer: {
+        startSpan: () => {
+          throw new Error("tracer boom");
+        },
+      },
+      meter: noopMeterPassthrough(),
+    } as Observability);
+
+    const ai = createAIService(
+      config,
+      streamInternals(fakeStream({ chunks: ["ok"], usage: { inputTokens: 2, outputTokens: 1 } })),
+    );
+    const stream = await ai.completeStream?.({
+      messages: [{ role: "user", content: "x" }],
+      trace: { origin: "eval" },
+    });
+    if (!stream) throw new Error("no stream");
+    const text = await drain(stream.textStream);
+    expect(text).toBe("ok");
+    await flushMicrotasks();
+    // Sink still recorded despite the tracer span failing (span + record are
+    // isolated from each other).
+    expect(sink.size).toBe(1);
+    expect(sink.query()[0]?.outputTokens).toBe(1);
+  });
+
+  it("sampling rate 0 records nothing for a stream", async () => {
+    const ai = createAIService(config, {
+      ...streamInternals(fakeStream({ chunks: ["x"], usage: { inputTokens: 1, outputTokens: 1 } })),
+      sampling: { rate: 0 },
+    });
+    const stream = await ai.completeStream?.({ messages: [{ role: "user", content: "x" }] });
+    if (!stream) throw new Error("no stream");
+    const text = await drain(stream.textStream);
+    expect(text).toBe("x");
+    await flushMicrotasks();
+    expect(sink.size).toBe(0);
+    expect(tracer.spans).toHaveLength(0);
+  });
+});

--- a/addons/ai-provider/cap-ai-provider/__tests__/ai-service.stream-tracing.test.ts
+++ b/addons/ai-provider/cap-ai-provider/__tests__/ai-service.stream-tracing.test.ts
@@ -336,6 +336,45 @@ describe("createAIService streaming tracing — clean drain", () => {
     expect(gen?.inputTokens).toBe(0);
     expect(gen?.outputTokens).toBe(0);
   });
+
+  it("records a successful generation with 0 tokens when totalUsage rejects after a clean drain", async () => {
+    // A clean drain is a SUCCESS even if the usage accessor is unavailable (some
+    // providers omit usage on streams). The generation must still be recorded
+    // (0 tokens) and the parent trace ended "ok" — NOT dropped + marked errored.
+    const ai = createAIService(config, {
+      getModel: async () => ({ id: "fake-model" }),
+      runStreamText: () => ({
+        textStream: (async function* () {
+          yield "a";
+          yield "b";
+        })(),
+        get totalUsage() {
+          return Promise.reject(new Error("usage unavailable"));
+        },
+        get text() {
+          return Promise.resolve("ab");
+        },
+      }),
+    });
+    const stream = await ai.completeStream?.({
+      messages: [{ role: "user", content: "x" }],
+      trace: { origin: "eval" },
+    });
+    if (!stream) throw new Error("no stream");
+    const text = await drain(stream.textStream);
+    expect(text).toBe("ab");
+    await flushMicrotasks();
+
+    expect(sink.size).toBe(1);
+    const gen = sink.query()[0];
+    expect(gen?.status).toBe("ok");
+    expect(gen?.partial).toBe(false);
+    expect(gen?.inputTokens).toBe(0);
+    expect(gen?.outputTokens).toBe(0);
+    expect(gen?.completion).toBe("ab");
+    // Parent finalized "ok" despite the usage rejection.
+    expect(sink.queryTraces()[0]?.status).toBe("ok");
+  });
 });
 
 describe("createAIService streaming tracing — abort / error", () => {

--- a/addons/ai-provider/cap-ai-provider/src/ai-service.ts
+++ b/addons/ai-provider/cap-ai-provider/src/ai-service.ts
@@ -995,9 +995,20 @@ function recordStreamFinish(args: {
   // and forget: nothing awaits this and the stream's output is already done.
   void (async () => {
     try {
-      const usage = await result.totalUsage;
-      const inputTokens = usage.inputTokens ?? 0;
-      const outputTokens = usage.outputTokens ?? 0;
+      // The stream drained cleanly, so this is a SUCCESS regardless of whether
+      // the usage accessor is available. Isolate the usage await so a rejected /
+      // undefined `totalUsage` falls back to 0 tokens instead of skipping the
+      // record entirely and marking the parent errored (some providers omit
+      // usage on streams). `usage?.` guards a null/undefined resolution too.
+      let inputTokens = 0;
+      let outputTokens = 0;
+      try {
+        const usage = await result.totalUsage;
+        inputTokens = usage?.inputTokens ?? 0;
+        outputTokens = usage?.outputTokens ?? 0;
+      } catch {
+        // totalUsage unavailable/rejected — keep 0 tokens; still record below.
+      }
       // Prefer the SDK's authoritative final text; fall back to the text we
       // accumulated from the chunks if the accessor is unavailable.
       let completion = outcome.streamedText;

--- a/addons/ai-provider/cap-ai-provider/src/ai-service.ts
+++ b/addons/ai-provider/cap-ai-provider/src/ai-service.ts
@@ -31,9 +31,44 @@ import type {
   AIToolCall,
   AITraceSamplingConfig,
 } from "@linchkit/core";
-import { fallbackTraceId, openParentTrace, recordGeneration, recordSuccess } from "./ai-tracing";
+import {
+  fallbackTraceId,
+  logTracingError,
+  openParentTrace,
+  type ParentTraceHandle,
+  recordGeneration,
+  recordSuccess,
+} from "./ai-tracing";
 import { CostEstimator } from "./cost-estimator";
 import { AIResponseCache } from "./response-cache";
+
+/**
+ * The subset of the Vercel AI SDK `streamText` result the streaming path reads
+ * for accurate post-drain accounting. Each accessor is a `PromiseLike` that the
+ * SDK resolves only AFTER the stream fully drains (it "automatically consumes
+ * the stream"), so we MUST await them only once the consumer has finished
+ * iterating `textStream` — never before, or we would consume the stream out
+ * from under the consumer.
+ *
+ * Mirrors `StreamTextResult` (ai@6) `usage` / `totalUsage` / `text` /
+ * `finishReason` accessors; declared structurally so tests can inject a fake
+ * without depending on the SDK's generic result type.
+ */
+export interface StreamTextLike {
+  /** Text delta stream the consumer iterates. */
+  readonly textStream: AsyncIterable<string>;
+  /**
+   * Total token usage across all steps, resolved after drain. `totalUsage`
+   * sums multi-step usage; fields may be `undefined` when a provider omits
+   * them (coerced to 0 at the call site, mirroring the completion path).
+   */
+  readonly totalUsage: PromiseLike<{
+    inputTokens?: number;
+    outputTokens?: number;
+  }>;
+  /** Full generated text, resolved after drain. */
+  readonly text: PromiseLike<string>;
+}
 
 /**
  * Internal generation runners — the seam between the service and the Vercel AI
@@ -54,6 +89,13 @@ export interface AIServiceInternals {
   runGenerateObject?: (args: AnyGenerateResult) => Promise<AnyGenerateResult>;
   /** Run a text generation. Defaults to `ai.generateText`. */
   runGenerateText?: (args: AnyGenerateResult) => Promise<AnyGenerateResult>;
+  /**
+   * Run a streaming text generation. Defaults to `ai.streamText`. Returns a
+   * result exposing the consumer's `textStream` plus post-drain `totalUsage` /
+   * `text` accessors (see {@link StreamTextLike}). SYNCHRONOUS like the SDK's
+   * `streamText` — it returns a result object immediately and streams lazily.
+   */
+  runStreamText?: (args: AnyGenerateResult) => StreamTextLike;
   /**
    * Trace sampling config. Applied at every span/record call. Defaults to
    * recording everything; set `{ rate: 0 }` to disable tracing entirely
@@ -114,7 +156,7 @@ export function createAIService(
     defaultProvider: config.defaultProvider,
     providerNames: Object.keys(config.providers),
     complete: (options) => executeWithFallback(config, options, costEstimator, cache, internals),
-    completeStream: (options) => executeStream(config, options, internals),
+    completeStream: (options) => executeStream(config, options, costEstimator, internals),
   };
 }
 
@@ -702,11 +744,23 @@ async function executeCompletion(
 
 /**
  * Execute a streaming completion request.
- * Returns an async iterable of text chunks using Vercel AI SDK's streamText.
+ *
+ * Returns an async iterable of text chunks backed by the Vercel AI SDK's
+ * `streamText`. Token usage, cost, and the full completion text are only known
+ * AFTER the stream fully drains (the SDK's `totalUsage` / `text` accessors are
+ * `PromiseLike`s that "automatically consume the stream" and resolve only once
+ * iteration finishes — see {@link StreamTextLike}). So we do NOT record at
+ * stream open; instead we wrap `textStream` and record exactly one ACCURATE
+ * generation when the consumer finishes draining it (`partial: false`,
+ * `status: "ok"`, correct tokens/cost/completion/latency). If the consumer
+ * aborts or the stream errors before draining, we record a single
+ * `partial: true` / `status: "error"` record instead. Either way the recording
+ * is strictly non-throwing and never alters the consumer's stream or timing.
  */
 async function executeStream(
   config: AIServiceConfig,
   options: AICompletionOptions,
+  costEstimator: CostEstimator,
   internals?: AIServiceInternals,
 ): Promise<AIStreamResult> {
   const startTime = Date.now();
@@ -745,44 +799,247 @@ async function executeStream(
     ? internals.getModel(effectiveConfig, resolved)
     : getLanguageModel(effectiveConfig, resolved));
 
-  const { streamText } = await import("ai");
+  // Open the parent trace ONCE (mirrors the completion path) so the stream's
+  // generation lands under a parent and the trace's token/cost rollup is
+  // correct. The sampling decision is resolved here and threaded into the
+  // child generation via `forcedSampled` so a fractional rate rolls once.
+  // Non-throwing — an inert handle is returned on failure.
+  const parent = openParentTrace(resolvedOptions.trace, { sampling: internals?.sampling });
 
-  const result = streamText({
-    model,
-    messages: resolvedOptions.messages,
-    temperature: resolvedOptions.temperature ?? 0,
-    maxOutputTokens,
-    abortSignal: resolvedOptions.timeout ? AbortSignal.timeout(resolvedOptions.timeout) : undefined,
-  });
+  try {
+    // Use the injectable runner (test seam); default to the SDK's `streamText`,
+    // which is SYNCHRONOUS — it returns a result object immediately and streams
+    // lazily as the consumer iterates `textStream`.
+    let result: StreamTextLike;
+    if (internals?.runStreamText) {
+      result = internals.runStreamText({
+        model,
+        messages: resolvedOptions.messages,
+        temperature: resolvedOptions.temperature ?? 0,
+        maxOutputTokens,
+        abortSignal: resolvedOptions.timeout
+          ? AbortSignal.timeout(resolvedOptions.timeout)
+          : undefined,
+      });
+    } else {
+      const { streamText } = await import("ai");
+      result = streamText({
+        model,
+        messages: resolvedOptions.messages,
+        temperature: resolvedOptions.temperature ?? 0,
+        maxOutputTokens,
+        abortSignal: resolvedOptions.timeout
+          ? AbortSignal.timeout(resolvedOptions.timeout)
+          : undefined,
+      }) as StreamTextLike;
+    }
 
-  // Streaming limitation (PR-1): usage / cost / completion text are only known
-  // after the stream fully drains, which happens in the caller. Record a
-  // best-effort PARTIAL generation at stream open so the trace is not lost;
-  // token-accurate streaming accounting is deferred to a later PR. Non-throwing.
-  recordGeneration({
-    // Fall back to a FRESH unique id per call (never the model name) so
-    // untraced streams stay isolated instead of all sharing one static traceId.
-    traceId: resolvedOptions.trace?.traceId ?? fallbackTraceId(),
-    context: resolvedOptions.trace,
-    model: resolved.modelId,
-    provider: resolved.provider,
-    messages: resolvedOptions.messages,
-    completion: "",
-    inputTokens: 0,
-    outputTokens: 0,
-    latencyMs: Date.now() - startTime,
-    temperature: resolvedOptions.temperature,
-    responseFormat: "text",
-    partial: true,
-    status: "partial",
-    startedAt: startTime,
-    endedAt: Date.now(),
-    sampling: internals?.sampling,
-  });
+    return {
+      // Wrap the SDK stream so accounting is recorded once iteration finishes —
+      // accurate on a clean drain, partial/error on an abort. The wrapper yields
+      // the SAME chunks in the SAME order, so the consumer sees identical output.
+      textStream: instrumentStreamText({
+        result,
+        costEstimator,
+        resolved,
+        options: resolvedOptions,
+        startTime,
+        parent,
+        sampling: internals?.sampling,
+      }),
+      model: resolved.modelId,
+      provider: resolved.provider,
+    };
+  } catch (error) {
+    // Acquiring the stream failed AFTER the parent trace was opened (the `ai`
+    // import rejected, or `streamText` / the injected runner threw
+    // synchronously). The consumer never receives a stream to drain, so
+    // `instrumentStreamText`'s own finalizer can never run — finalize the parent
+    // here so the opened trace is never left without a matching end, then
+    // re-throw to the caller. `parent.end` is non-throwing.
+    parent.end("error");
+    throw error;
+  }
+}
 
-  return {
-    textStream: result.textStream,
-    model: resolved.modelId,
-    provider: resolved.provider,
-  };
+/** Inputs for {@link instrumentStreamText}. */
+interface InstrumentStreamInput {
+  /** The SDK (or fake) stream result exposing `textStream` + post-drain usage. */
+  readonly result: StreamTextLike;
+  readonly costEstimator: CostEstimator;
+  readonly resolved: ResolvedModel;
+  readonly options: AICompletionOptions;
+  /** Stream-open wall-clock epoch ms (latency baseline). */
+  readonly startTime: number;
+  /**
+   * Parent trace handle (from `openParentTrace`). Carries the trace id +
+   * sampling decision threaded into the child generation, plus the non-throwing
+   * `end()` finalizer called once the stream finishes (success or error).
+   */
+  readonly parent: ParentTraceHandle;
+  /** Sampling config (only consulted for the standalone fallback path). */
+  readonly sampling?: AITraceSamplingConfig;
+}
+
+/**
+ * Wrap an SDK text stream so token-accurate accounting is recorded exactly
+ * once when the stream finishes.
+ *
+ * On a clean drain: await `totalUsage` + `text` (resolved only after the stream
+ * is fully consumed), compute cost with the SAME estimator the completion path
+ * uses, and record ONE accurate `partial: false` / `status: "ok"` generation.
+ *
+ * On abort / error before draining: record ONE `partial: true` /
+ * `status: "error"` generation, then re-throw so the consumer's iteration still
+ * surfaces the error (we instrument, we never swallow the stream's own error).
+ *
+ * The recording itself is wrapped in {@link recordStreamFinish} so a tracing
+ * failure is swallowed and never affects the consumer's stream.
+ */
+async function* instrumentStreamText(input: InstrumentStreamInput): AsyncGenerator<string> {
+  const { result } = input;
+  let fullText = "";
+  // Tracks whether the clean-drain or error path already finalized the trace, so
+  // the `finally` below only handles the third case: a consumer that abandons
+  // the stream early (`break`/`return` without an error).
+  let settled = false;
+  try {
+    for await (const chunk of result.textStream) {
+      fullText += chunk;
+      yield chunk;
+    }
+    // Clean drain — the usage / text accessors are now resolved. Capture the
+    // drain-completion time HERE (not after awaiting the post-drain
+    // usage/text promises in the recorder) so `latencyMs` reflects how long the
+    // stream actually took, not extra time the SDK spends resolving accounting.
+    const endedAt = Date.now();
+    settled = true;
+    recordStreamFinish({ input, outcome: { kind: "done", streamedText: fullText, endedAt } });
+  } catch (error) {
+    // The stream itself failed (or the consumer's `break`/`return` triggered an
+    // AbortSignal that the SDK surfaced as a throw). Record a partial/error
+    // generation, then re-throw the ORIGINAL error so the consumer still sees
+    // it — tracing must not swallow the stream's own failure.
+    settled = true;
+    recordStreamFinish({
+      input,
+      outcome: { kind: "error", error, partialText: fullText },
+    });
+    throw error;
+  } finally {
+    // The consumer abandoned the stream early (`break`/`return` with no error),
+    // so neither the clean-drain nor the error path ran. Do NOT record a
+    // generation: `totalUsage` / `text` never resolve on a non-drained stream,
+    // so awaiting them could hang the fire-and-forget recorder forever. But DO
+    // finalize the parent trace so a `startTrace` is never left without a
+    // matching `endTrace` (an open-trace leak). `parent.end` is non-throwing.
+    if (!settled) {
+      input.parent.end("ok");
+    }
+  }
+}
+
+/** Outcome of draining a stream, passed to {@link recordStreamFinish}. */
+type StreamFinishOutcome =
+  | { kind: "done"; streamedText: string; endedAt: number }
+  | { kind: "error"; error: unknown; partialText: string };
+
+/**
+ * Record the final generation for a finished stream. STRICTLY non-throwing —
+ * any failure (including awaiting the SDK usage/text promises) is swallowed and
+ * logged once via the tracing wrapper, so a tracing failure can NEVER break or
+ * alter the consumer's stream. Runs AFTER the consumer has finished iterating,
+ * so awaiting `totalUsage` / `text` here never consumes the stream out from
+ * under the consumer.
+ */
+function recordStreamFinish(args: {
+  input: InstrumentStreamInput;
+  outcome: StreamFinishOutcome;
+}): void {
+  const { input, outcome } = args;
+  const { result, costEstimator, resolved, options, startTime, parent, sampling } = input;
+
+  if (outcome.kind === "error") {
+    // Abort / stream error before a clean drain — usage is unknown, so record a
+    // single partial/error generation with zero tokens (mirrors the completion
+    // error path). Synchronous so it cannot stall or throw asynchronously.
+    const endedAt = Date.now();
+    recordGeneration({
+      traceId: parent.traceId,
+      context: options.trace,
+      model: resolved.modelId,
+      provider: resolved.provider,
+      messages: options.messages,
+      completion: outcome.partialText,
+      inputTokens: 0,
+      outputTokens: 0,
+      latencyMs: endedAt - startTime,
+      temperature: options.temperature,
+      responseFormat: "text",
+      partial: true,
+      status: "error",
+      error: outcome.error instanceof Error ? outcome.error.message : String(outcome.error),
+      startedAt: startTime,
+      endedAt,
+      sampling,
+      forcedSampled: parent.sampled,
+    });
+    // Finalize the parent trace as errored (non-throwing).
+    parent.end("error");
+    return;
+  }
+
+  // Clean drain — await the post-drain usage/text accessors, compute cost, and
+  // record ONE accurate generation. The await is wrapped so a rejected/throwing
+  // accessor is swallowed (the consumer's stream has already completed). Fire
+  // and forget: nothing awaits this and the stream's output is already done.
+  void (async () => {
+    try {
+      const usage = await result.totalUsage;
+      const inputTokens = usage.inputTokens ?? 0;
+      const outputTokens = usage.outputTokens ?? 0;
+      // Prefer the SDK's authoritative final text; fall back to the text we
+      // accumulated from the chunks if the accessor is unavailable.
+      let completion = outcome.streamedText;
+      try {
+        completion = await result.text;
+      } catch {
+        // Keep the accumulated text — recordGeneration below is still accurate
+        // on tokens/cost even if the SDK text accessor rejects.
+      }
+      // Use the drain-completion time captured in `instrumentStreamText` so
+      // latency excludes the time spent awaiting the post-drain usage/text
+      // promises above.
+      const endedAt = outcome.endedAt;
+      recordGeneration({
+        traceId: parent.traceId,
+        context: options.trace,
+        model: resolved.modelId,
+        provider: resolved.provider,
+        messages: options.messages,
+        completion,
+        inputTokens,
+        outputTokens,
+        cost: costEstimator.estimateCost(resolved.modelId, inputTokens, outputTokens),
+        latencyMs: endedAt - startTime,
+        temperature: options.temperature,
+        responseFormat: "text",
+        partial: false,
+        status: "ok",
+        startedAt: startTime,
+        endedAt,
+        sampling,
+        forcedSampled: parent.sampled,
+      });
+      // Finalize the parent trace as ok (non-throwing).
+      parent.end("ok");
+    } catch (err) {
+      // Awaiting usage/text rejected (or recordGeneration's own guard somehow
+      // escaped). Swallow — a tracing failure must never escape into the
+      // consumer's already-completed stream. Log once via the tracing latch.
+      logTracingError("stream-finish", err);
+      // Still finalize the parent so the trace does not leak open.
+      parent.end("error");
+    }
+  })();
 }

--- a/addons/ai-provider/cap-ai-provider/src/ai-tracing.ts
+++ b/addons/ai-provider/cap-ai-provider/src/ai-tracing.ts
@@ -412,8 +412,14 @@ export function recordSuccess(params: {
 
 let warnedOnce = false;
 
-/** Log a tracing failure once per process at warn level, then go quiet. */
-function logTracingError(stage: string, err: unknown): void {
+/**
+ * Log a tracing failure once per process at warn level, then go quiet.
+ *
+ * Exported so other tracing call sites (e.g. the streaming finish-hook in
+ * `ai-service.ts`) share the SAME once-only latch — a single noisy stage must
+ * not let a sibling stage re-arm the warning.
+ */
+export function logTracingError(stage: string, err: unknown): void {
   if (warnedOnce) return;
   warnedOnce = true;
   const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## What

Spec 69 P3 follow-up to #402. The streaming path previously recorded a **zero-token `partial` generation at stream OPEN**. The Vercel AI SDK's `totalUsage` / `text` accessors are `PromiseLike`s that resolve only **after** the stream drains, so `executeStream` now wraps `result.textStream` in an async generator that records exactly **one** generation when iteration finishes.

## Behaviour

| Terminal case | Recorded | Parent trace |
|---|---|---|
| **Clean drain** | one `partial:false` / `status:"ok"` generation — accurate input/output tokens, cost (same `CostEstimator` as the completion path), completion text | `end("ok")` |
| **Abort / mid-stream error** | one `partial:true` / `status:"error"` generation (zero tokens, partial text); original error re-thrown to the consumer | `end("error")` |
| **Early break/return (no error)** | none — `totalUsage` never resolves on a non-drained stream, so it is **not** awaited (would hang) | `finally` → `end("ok")` (no open-trace leak) |

The finish recording is **strictly non-throwing** and runs *after* the consumer's stream completes, so a tracing failure can never break or alter the stream. Sampling is decided **once** on the parent and threaded into the child generation via `forcedSampled`.

## Review hardening (cross-model R1 → R2)

Two issues flagged in cross-model review and fixed:

1. **Parent-trace leak on acquisition failure** — `executeStream` now wraps stream acquisition + return in a `try/catch`; if the `ai` import rejects or `streamText`/the injected runner throws *after* the parent trace opened, the `catch` calls `parent.end("error")` then re-throws, so the trace is never left open. (Drain errors happen lazily *inside* the returned generator, after `executeStream` returns, so they remain handled by the generator's own paths — no double-end; guarded by a `settled` flag.)
2. **Inflated latency** — `latencyMs` now uses the drain-completion timestamp captured immediately after the `for await` loop, not the time after awaiting the post-drain `totalUsage`/`text` promises.

(R1 also suggested a hang-timeout on the fire-and-forget usage await; skipped deliberately — on a clean drain `totalUsage` is resolved by the same stream-finish event that ended `textStream` (absent usage fields coerce to 0), so the guarded state is contradictory under the real SDK. Adding a timer + magic constant for it would be YAGNI.)

## Tests

`bun test packages/core/src/observability/ addons/ai-provider/cap-ai-provider/__tests__/` → **329 pass / 0 fail**. New `ai-service.stream-tracing.test.ts` (11 tests): one accurate `partial:false` generation w/ correct tokens/cost/completion, parent rollup, span attributes, text-accessor-reject fallback, undefined-usage coercion, abort → single `partial:true`/error + re-throw, **early break finalizes the parent trace (endedAt set) without recording**, **acquisition-throw finalizes the parent as error**, throwing sink/tracer don't break the stream, sampling rate 0 records nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)