### PR TITLE
feat(core): thread merged commit SHA into the rollback loop (#375, Spec 55 §7.7)

### DIFF
--- a/.changeset/rollback-sha-threading.md
+++ b/.changeset/rollback-sha-threading.md
@@ -1,0 +1,21 @@
+---
+"@linchkit/core": minor
+---
+
+Thread the merged commit SHA end-to-end through the rollback Insight→Proposal
+loop (Spec 55 §7.7), so a rollback executor can `git revert` the exact regressed
+commit instead of only naming the proposal.
+
+The SHA originates from `ProposalGitCommitter.commitAndOpenPR` (`commitSha`) and
+now flows: outcome payload (`ProposalOutcomePayload.mergedSha`, finally wiring
+the previously-orphaned `resolveMergedSha` capture) → effect-verification record
+and signal (`EffectVerificationRecord.mergedSha`) → rollback Insight evidence
+(`evidence.context.mergedSha`) → the revert `ProposalChange.revertSha` stamped by
+`rollbackCandidateTranslator`.
+
+Adds a pure, side-effect-free consumption helper
+`rollbackInputFromProposal(proposal)` that maps an APPROVED revert proposal to a
+`DeployRollbackOrchestrator` `RollbackInput`. It declines (returns `null`) for
+non-approved proposals or a missing SHA and never auto-executes — the rollback
+proposal stays `status: "draft"` and only graduates through the human approval
+gate.

--- a/packages/core/__tests__/barrel-public-surface.test.ts
+++ b/packages/core/__tests__/barrel-public-surface.test.ts
@@ -373,6 +373,7 @@ const EXPECTED_SERVER_EXPORTS = [
   "resolveDependencies",
   "resolveFieldMasking",
   "resolveIntent",
+  "rollbackInputFromProposal",
   "rollbackInsightId",
   "sanitizeAIOutput",
   "sanitizePII",

--- a/packages/core/__tests__/deployment-rollback.test.ts
+++ b/packages/core/__tests__/deployment-rollback.test.ts
@@ -5,7 +5,9 @@ import {
   type RollbackGhRunner,
   type RollbackGitRunner,
   type RollbackRunResult,
+  rollbackInputFromProposal,
 } from "../src/deployment/rollback-orchestrator";
+import type { ProposalDefinition } from "../src/types/proposal";
 
 const REPO_DIR = "/tmp/fake-repo";
 const BASE_SHA = "abc123def4567890abcdef1234567890abcdef12";
@@ -568,5 +570,75 @@ describe("DeployRollbackOrchestrator — custom options", () => {
     const result = await orch.orchestrate({ commitSha: BASE_SHA });
     expect(result.branch).toMatch(/^revert\//);
     expect(result.prUrl).toBe(FAKE_PR_URL);
+  });
+});
+
+// ── rollbackInputFromProposal (Spec 55 §7.7 consumption point) ──────────────
+
+describe("rollbackInputFromProposal", () => {
+  const FIXED_NOW = new Date("2026-05-29T00:00:00.000Z");
+
+  function makeRevertProposal(overrides: Partial<ProposalDefinition> = {}): ProposalDefinition {
+    return {
+      id: "proposal_rollback_1",
+      title: 'Roll back proposal "proposal_abc"',
+      description: "Rollback candidate.",
+      author: { type: "ai", id: "rollback-translator", name: "Rollback Translator" },
+      capability: "cap-life-demo",
+      changeType: "major",
+      changes: [{ target: "revert", operation: "update", name: "revert", revertSha: BASE_SHA }],
+      impact: {
+        schemasAffected: [],
+        actionsAffected: [],
+        rulesAffected: [],
+        dependentsAffected: ["cap-life-demo"],
+        migrationRequired: false,
+      },
+      status: "approved",
+      createdAt: FIXED_NOW,
+      updatedAt: FIXED_NOW,
+      ...overrides,
+    };
+  }
+
+  it("extracts a RollbackInput from an approved revert proposal carrying revertSha", () => {
+    const input = rollbackInputFromProposal(makeRevertProposal());
+    expect(input).not.toBeNull();
+    expect(input?.commitSha).toBe(BASE_SHA);
+  });
+
+  it("threads optional title/body extras through", () => {
+    const input = rollbackInputFromProposal(makeRevertProposal(), {
+      titleOverride: "manual rollback",
+      bodyNote: "approved by ops",
+    });
+    expect(input?.titleOverride).toBe("manual rollback");
+    expect(input?.bodyNote).toBe("approved by ops");
+  });
+
+  it("declines (null) when the proposal is not approved — governance gate", () => {
+    // The whole point of Slice B: a draft must NEVER feed an execution.
+    expect(rollbackInputFromProposal(makeRevertProposal({ status: "draft" }))).toBeNull();
+    expect(rollbackInputFromProposal(makeRevertProposal({ status: "validated" }))).toBeNull();
+  });
+
+  it("declines (null) when the revert change has no revertSha", () => {
+    const noSha = makeRevertProposal({
+      changes: [{ target: "revert", operation: "update", name: "revert" }],
+    });
+    expect(rollbackInputFromProposal(noSha)).toBeNull();
+  });
+
+  it("declines (null) when there is no revert change", () => {
+    const noRevert = makeRevertProposal({
+      changes: [{ target: "view", operation: "create", name: "x" }],
+    });
+    expect(rollbackInputFromProposal(noRevert)).toBeNull();
+  });
+
+  it("does not throw on a proposal with empty changes", () => {
+    const empty = makeRevertProposal({ changes: [] });
+    expect(() => rollbackInputFromProposal(empty)).not.toThrow();
+    expect(rollbackInputFromProposal(empty)).toBeNull();
   });
 });

--- a/packages/core/__tests__/proposal-effect-verifier.test.ts
+++ b/packages/core/__tests__/proposal-effect-verifier.test.ts
@@ -341,6 +341,35 @@ describe("ProposalEffectVerifier", () => {
       expect(p.rollback_candidate).toBe(true);
       expect(p.proposalId).toBe("prop-xyz-00000001");
     });
+
+    it("threads mergedSha from the merged outcome payload into the record and failed signal", async () => {
+      // Slice B: the merged commit SHA captured at graduation must survive the
+      // outcome → effect-verification hop so it can reach the rollback translator.
+      const store = makeStore();
+      await store.recordSignal(
+        makeMergedSignal({
+          mergedSha: "cafebabe9999",
+          successMetric: {
+            description: "test",
+            baselineValue: 50,
+            targetValue: 80,
+            signalRef: "cap-task",
+          },
+        }),
+      );
+      await store.updateBaseline(makeBaseline("cap-task", "value", 40));
+      const verifier = new ProposalEffectVerifier({ store });
+      const results = await verifier.verifyAll();
+      const record = results[0];
+      if (!record) throw new Error("expected one verification record");
+      expect(record.mergedSha).toBe("cafebabe9999");
+
+      const failedSignals = await store.getSignals({ entity: "proposal:effect:failed" });
+      const failedSignal = failedSignals[0];
+      if (!failedSignal) throw new Error("expected one failed signal");
+      const p = failedSignal.payload as EffectVerificationPayload;
+      expect(p.mergedSha).toBe("cafebabe9999");
+    });
   });
 
   // ── verifyAll — decreasing goals ──────────────────────────────────────────

--- a/packages/core/__tests__/proposal-outcome-recorder.test.ts
+++ b/packages/core/__tests__/proposal-outcome-recorder.test.ts
@@ -144,6 +144,44 @@ describe("ProposalOutcomeRecorder", () => {
       expect(payload.outcome).toBe("merged");
       expect(payload.proposalId).toBe("proposal-test-abc123");
     });
+
+    it("stamps mergedSha onto the merged payload (Spec 55 §7.7 rollback loop)", async () => {
+      // Slice B: the commitSha returned by ProposalGitCommitter is the SHA source
+      // and enters the rollback chain here, on the merged outcome payload.
+      const store = new InMemoryMemoryStore();
+      const recorder = new ProposalOutcomeRecorder({ store });
+      const proposal = makeProposal({ status: "committed" });
+
+      await recorder.recordOutcome(proposal, "merged", { mergedSha: "abc1234def" });
+
+      const payload = extractPayload(await firstSignal(store));
+      expect(payload.mergedSha).toBe("abc1234def");
+    });
+
+    it("leaves mergedSha undefined on a merged payload when none supplied", async () => {
+      const store = new InMemoryMemoryStore();
+      const recorder = new ProposalOutcomeRecorder({ store });
+      const proposal = makeProposal({ status: "committed" });
+
+      await recorder.recordOutcome(proposal, "merged");
+
+      const payload = extractPayload(await firstSignal(store));
+      expect(payload.mergedSha).toBeUndefined();
+    });
+
+    it("ignores mergedSha for a non-merged outcome and warns", async () => {
+      const store = new InMemoryMemoryStore();
+      const warnings: string[] = [];
+      const logger = { warn: (msg: string) => warnings.push(msg) } as unknown as Logger;
+      const recorder = new ProposalOutcomeRecorder({ store, logger });
+      const proposal = makeProposal();
+
+      await recorder.recordOutcome(proposal, "accepted", { mergedSha: "abc1234def" });
+
+      const payload = extractPayload(await firstSignal(store));
+      expect(payload.mergedSha).toBeUndefined();
+      expect(warnings.some((w) => w.includes("ignoring mergedSha"))).toBe(true);
+    });
   });
 
   describe("recordOutcome — withdrawn", () => {

--- a/packages/core/__tests__/rollback-insight-emitter.test.ts
+++ b/packages/core/__tests__/rollback-insight-emitter.test.ts
@@ -135,6 +135,26 @@ describe("RollbackInsightEmitter", () => {
       });
     });
 
+    it("threads mergedSha from the payload into the insight evidence context", async () => {
+      // Slice B: the merged commit SHA must survive the verifier → emitter hop so
+      // the rollback translator can stamp it on the revert change's revertSha.
+      const store = makeStore();
+      await store.recordSignal(makeFailedSignal({ mergedSha: "deadbeef1234" }));
+      const emitter = new RollbackInsightEmitter({ store });
+      const insight = first(await emitter.emitAll());
+
+      expect(insight.evidence.context).toMatchObject({ mergedSha: "deadbeef1234" });
+    });
+
+    it("carries mergedSha=undefined when the payload had no SHA", async () => {
+      const store = makeStore();
+      await store.recordSignal(makeFailedSignal());
+      const emitter = new RollbackInsightEmitter({ store });
+      const insight = first(await emitter.emitAll());
+
+      expect((insight.evidence.context as { mergedSha?: string }).mergedSha).toBeUndefined();
+    });
+
     it("sets deterministic confidence/impact/causality/createdAt", async () => {
       const store = makeStore();
       await store.recordSignal(makeFailedSignal());

--- a/packages/core/src/__tests__/life-system/insight-to-proposal.test.ts
+++ b/packages/core/src/__tests__/life-system/insight-to-proposal.test.ts
@@ -425,8 +425,8 @@ describe("rollbackCandidateTranslator", () => {
     expect(proposal.status).toBe("draft");
   });
 
-  it("ignores a non-string/empty mergedSha (no revertSha stamped)", async () => {
-    for (const bad of ["", 12345, null]) {
+  it("ignores a non-string/empty/whitespace mergedSha (no revertSha stamped)", async () => {
+    for (const bad of ["", "   ", 12345, null]) {
       const insight = makeRollbackInsight({
         evidence: {
           signals: [],

--- a/packages/core/src/__tests__/life-system/insight-to-proposal.test.ts
+++ b/packages/core/src/__tests__/life-system/insight-to-proposal.test.ts
@@ -369,6 +369,77 @@ describe("rollbackCandidateTranslator", () => {
     // Governance safety is untouched — the translator still emits a draft.
     expect(proposal.status).toBe("draft");
   });
+
+  it("stamps revertSha on the revert change from evidence.context.mergedSha", async () => {
+    // Slice B: the merged commit SHA threaded end-to-end (committer → outcome →
+    // effect-verifier → rollback Insight) lands on the typed revertSha field so a
+    // rollback executor can `git revert` the EXACT commit, not just name the proposal.
+    const sha = "abc1234def5678";
+    const insight = makeRollbackInsight({
+      evidence: {
+        signals: [],
+        context: {
+          proposalId: "proposal_abc",
+          capability: "cap-life-demo",
+          signalRef: "purchase_request:approval_latency",
+          baselineValue: 120,
+          targetValue: 60,
+          currentValue: 180,
+          mergedSha: sha,
+        },
+      },
+    });
+    const proposal = await rollbackCandidateTranslator(insight, {
+      now: () => FROZEN_NOW,
+      idGenerator: () => "proposal_rollback_sha",
+    });
+    if (!proposal) throw new Error("expected proposal");
+
+    const change = proposal.changes[0];
+    if (!change) throw new Error("expected one change");
+    expect(change.revertSha).toBe(sha);
+    // The SHA also surfaces in the human-readable diff for reviewers.
+    expect(change.diff).toContain(sha);
+    // ...and is mirrored on the evidence sidecar for provenance.
+    const sidecar = (proposal as unknown as { evidence: { context: { revertSha?: string } } })
+      .evidence;
+    expect(sidecar.context.revertSha).toBe(sha);
+    // Governance unchanged — stamping a SHA never auto-executes anything.
+    expect(proposal.status).toBe("draft");
+  });
+
+  it("omits revertSha when evidence carries no mergedSha (still a valid draft)", async () => {
+    // The upstream chain may lack a SHA (out-of-band merge / pre-SHA-capture).
+    // The draft must still be produced, just without the optional revertSha.
+    const proposal = await rollbackCandidateTranslator(makeRollbackInsight(), {
+      now: () => FROZEN_NOW,
+      idGenerator: () => "proposal_rollback_no_sha",
+    });
+    if (!proposal) throw new Error("expected proposal");
+
+    const change = proposal.changes[0];
+    if (!change) throw new Error("expected one change");
+    // Absent rather than an empty string, so consumers can branch on undefined.
+    expect(change.revertSha).toBeUndefined();
+    expect("revertSha" in change).toBe(false);
+    expect(proposal.status).toBe("draft");
+  });
+
+  it("ignores a non-string/empty mergedSha (no revertSha stamped)", async () => {
+    for (const bad of ["", 12345, null]) {
+      const insight = makeRollbackInsight({
+        evidence: {
+          signals: [],
+          context: { proposalId: "proposal_abc", capability: "cap-life-demo", mergedSha: bad },
+        },
+      });
+      const proposal = await rollbackCandidateTranslator(insight, {
+        idGenerator: () => "proposal_rollback_bad_sha",
+      });
+      if (!proposal) throw new Error("expected proposal");
+      expect(proposal.changes[0]?.revertSha).toBeUndefined();
+    }
+  });
 });
 
 describe("InsightTranslatorRegistry", () => {

--- a/packages/core/src/deployment/index.ts
+++ b/packages/core/src/deployment/index.ts
@@ -77,6 +77,7 @@ export {
   type RollbackInput,
   type RollbackResult,
   type RollbackRunResult,
+  rollbackInputFromProposal,
 } from "./rollback-orchestrator";
 export {
   type DeployArtifact,

--- a/packages/core/src/deployment/rollback-orchestrator.ts
+++ b/packages/core/src/deployment/rollback-orchestrator.ts
@@ -446,7 +446,12 @@ export function rollbackInputFromProposal(
   extras: { titleOverride?: string; bodyNote?: string } = {},
 ): RollbackInput | null {
   // Governance gate: only an approved Proposal may feed a rollback execution.
-  if (proposal.status !== "approved") return null;
+  // Defensive against null/malformed input (this is a consumption point that may
+  // receive deserialized/untrusted Proposals): a missing proposal or a
+  // non-array `changes` declines rather than throwing a TypeError.
+  if (!proposal || proposal.status !== "approved" || !Array.isArray(proposal.changes)) {
+    return null;
+  }
 
   const revertChange = proposal.changes.find((change) => change.target === "revert");
   const commitSha = revertChange?.revertSha;

--- a/packages/core/src/deployment/rollback-orchestrator.ts
+++ b/packages/core/src/deployment/rollback-orchestrator.ts
@@ -20,6 +20,7 @@
  */
 
 import type { Logger } from "../types/logger";
+import type { ProposalDefinition } from "../types/proposal";
 
 // ── Types ────────────────────────────────────────────────────────────────
 
@@ -412,4 +413,48 @@ export function createDeployRollbackOrchestrator(
   options: DeployRollbackOrchestratorOptions,
 ): DeployRollbackOrchestrator {
   return new DeployRollbackOrchestrator(options);
+}
+
+// ── Proposal → RollbackInput bridge (Spec 55 §7.7 consumption point) ───────
+
+/**
+ * Resolve the {@link RollbackInput} for a HUMAN-APPROVED rollback Proposal,
+ * reading the merged commit SHA threaded onto its `target:"revert"` change
+ * (`change.revertSha`) by `rollbackCandidateTranslator`.
+ *
+ * This is the explicit CONSUMPTION POINT for the SHA threaded end-to-end
+ * (`ProposalGitCommitter.commitSha` → outcome `mergedSha` → effect-verification
+ * → rollback Insight evidence → revert `change.revertSha`). It is a PURE,
+ * side-effect-free extractor — it does NOT call {@link
+ * DeployRollbackOrchestrator.orchestrate}, touch Git, or auto-execute anything.
+ * A caller deliberately invokes `orchestrate(rollbackInputFromProposal(p))`
+ * only AFTER the rollback Proposal has cleared the human approval gate, keeping
+ * the "AI Never Modifies Production Directly" guarantee intact.
+ *
+ * Returns `null` (declines, never throws) when:
+ *   - the proposal is not yet `status: "approved"` (governance gate not passed);
+ *   - it carries no `target:"revert"` change;
+ *   - that change has no usable `revertSha` (the upstream chain lacked a SHA —
+ *     a human must supply one before a rollback can run).
+ *
+ * @param proposal A rollback Proposal produced by `rollbackCandidateTranslator`.
+ * @param extras Optional passthrough for {@link RollbackInput.titleOverride} /
+ *   {@link RollbackInput.bodyNote}.
+ */
+export function rollbackInputFromProposal(
+  proposal: ProposalDefinition,
+  extras: { titleOverride?: string; bodyNote?: string } = {},
+): RollbackInput | null {
+  // Governance gate: only an approved Proposal may feed a rollback execution.
+  if (proposal.status !== "approved") return null;
+
+  const revertChange = proposal.changes.find((change) => change.target === "revert");
+  const commitSha = revertChange?.revertSha;
+  if (typeof commitSha !== "string" || commitSha.trim().length === 0) return null;
+
+  return {
+    commitSha: commitSha.trim(),
+    titleOverride: extras.titleOverride,
+    bodyNote: extras.bodyNote,
+  };
 }

--- a/packages/core/src/engine/proposal-effect-verifier.ts
+++ b/packages/core/src/engine/proposal-effect-verifier.ts
@@ -57,6 +57,14 @@ export interface EffectVerificationRecord {
   currentValue: number | undefined;
   result: EffectVerificationResult;
   verifiedAt: string;
+  /**
+   * Merged commit SHA of the proposal under verification (Spec 55 §7.7 rollback
+   * loop). Threaded forward from the merged outcome payload's `mergedSha` so a
+   * downstream rollback `target:"revert"` change can carry the EXACT commit to
+   * `git revert`. Undefined when the merge predates SHA capture or happened
+   * out-of-band.
+   */
+  mergedSha?: string;
 }
 
 /** Payload written to MemoryStore for each verification signal. */
@@ -192,6 +200,9 @@ export class ProposalEffectVerifier {
       currentValue,
       result,
       verifiedAt,
+      // Thread the merged commit SHA forward so the rollback loop can revert the
+      // exact commit. Absent on out-of-band merges / pre-SHA-capture payloads.
+      mergedSha: payload.mergedSha,
     };
 
     await this.emitVerificationSignal(record);

--- a/packages/core/src/engine/proposal-outcome-recorder.ts
+++ b/packages/core/src/engine/proposal-outcome-recorder.ts
@@ -58,6 +58,16 @@ export interface ProposalOutcomePayload {
   rejectionReason?: string;
   /** Carried through for Phase 2 ProposalEffectVerifier. */
   successMetric?: ProposalDefinition["successMetric"];
+  /**
+   * Merged commit SHA of the graduated proposal (Spec 55 §7.7 rollback loop).
+   *
+   * Populated for the "merged" outcome from the `commitSha` that
+   * `ProposalGitCommitter.commitAndOpenPR` returns. Threaded forward through the
+   * effect-verification → rollback-insight → translator chain so a rollback
+   * `target:"revert"` change can carry the EXACT commit to `git revert`. Absent
+   * when the merge happened out-of-band or predates SHA capture.
+   */
+  mergedSha?: string;
   /** ISO-8601 — when the outcome was recorded. */
   outcomeAt: string;
   /** ISO-8601 — when the Proposal was originally created. */
@@ -71,6 +81,17 @@ export interface ProposalOutcomeRecorderOptions {
   store: MemoryStore;
   /** Optional structured logger. */
   logger?: Logger;
+}
+
+/** Per-call extras for {@link ProposalOutcomeRecorder.recordOutcome}. */
+export interface RecordOutcomeOptions {
+  /**
+   * Merged commit SHA, supplied for the "merged" outcome from the `commitSha`
+   * that `ProposalGitCommitter.commitAndOpenPR` returns. Threaded onto the
+   * outcome payload so the rollback loop can later revert the exact commit.
+   * Ignored (with a warning) for non-"merged" outcomes.
+   */
+  mergedSha?: string;
 }
 
 // ── ProposalOutcomeRecorder ──────────────────────────────────
@@ -90,9 +111,19 @@ export class ProposalOutcomeRecorder {
    * Writes a Signal of type `proposal.outcome.<outcome>` to the configured
    * store. The signal carries enough context for future Insight generators to
    * compute per-generator acceptance ratios without re-fetching the Proposal.
+   *
+   * For the "merged" outcome, pass `{ mergedSha }` (the `commitSha` returned by
+   * `ProposalGitCommitter.commitAndOpenPR`) so the rollback loop can later
+   * revert the exact commit. A `mergedSha` on a non-"merged" outcome is ignored
+   * with a warning.
    */
-  async recordOutcome(proposal: ProposalDefinition, outcome: ProposalOutcomeType): Promise<void> {
+  async recordOutcome(
+    proposal: ProposalDefinition,
+    outcome: ProposalOutcomeType,
+    options: RecordOutcomeOptions = {},
+  ): Promise<void> {
     const now = new Date();
+    const mergedSha = this.resolveMergedSha(proposal.id, outcome, options.mergedSha);
     const payload: ProposalOutcomePayload = {
       proposalId: proposal.id,
       outcome,
@@ -103,6 +134,7 @@ export class ProposalOutcomeRecorder {
       approvedBy: outcome === "accepted" ? proposal.approvedBy : undefined,
       rejectionReason: outcome === "rejected" ? proposal.rejectionReason : undefined,
       successMetric: proposal.successMetric,
+      mergedSha,
       outcomeAt: now.toISOString(),
       proposalCreatedAt: proposal.createdAt.toISOString(),
     };
@@ -120,6 +152,31 @@ export class ProposalOutcomeRecorder {
       `ProposalOutcomeRecorder: recorded "${outcome}" for proposal "${proposal.id}"`,
       { proposalId: proposal.id, outcome, capability: proposal.capability },
     );
+  }
+
+  /**
+   * Resolve the `mergedSha` to stamp onto the outcome payload.
+   *
+   * - "merged" outcome: returns the supplied SHA verbatim (or `undefined` when
+   *   the caller did not provide one — e.g. an out-of-band merge).
+   * - Any other outcome: a SHA is meaningless, so it is dropped and a warning is
+   *   logged. The SHA only describes a graduated commit, which exists solely for
+   *   the "merged" outcome.
+   */
+  private resolveMergedSha(
+    proposalId: string,
+    outcome: ProposalOutcomeType,
+    mergedSha: string | undefined,
+  ): string | undefined {
+    if (outcome === "merged") {
+      return mergedSha;
+    }
+    if (mergedSha !== undefined) {
+      this.logger?.warn?.(
+        `ProposalOutcomeRecorder: ignoring mergedSha for non-"merged" outcome "${outcome}" on proposal "${proposalId}"`,
+      );
+    }
+    return undefined;
   }
 
   /**

--- a/packages/core/src/engine/proposal-outcome-recorder.ts
+++ b/packages/core/src/engine/proposal-outcome-recorder.ts
@@ -169,7 +169,10 @@ export class ProposalOutcomeRecorder {
     mergedSha: string | undefined,
   ): string | undefined {
     if (outcome === "merged") {
-      return mergedSha;
+      // Trim and drop empty/whitespace-only values so only a real SHA is stored
+      // (and never propagated downstream as a junk revertSha).
+      const trimmed = mergedSha?.trim();
+      return trimmed && trimmed.length > 0 ? trimmed : undefined;
     }
     if (mergedSha !== undefined) {
       this.logger?.warn?.(

--- a/packages/core/src/engine/rollback-insight-emitter.ts
+++ b/packages/core/src/engine/rollback-insight-emitter.ts
@@ -160,6 +160,7 @@ function buildRollbackInsight(
     targetValue,
     currentValue,
     verifiedAt,
+    mergedSha,
   } = payload;
 
   // Robust date: fall back to the originating Signal's timestamp when verifiedAt
@@ -204,6 +205,10 @@ function buildRollbackInsight(
         baselineValue,
         targetValue,
         currentValue,
+        // Carry the merged commit SHA so the rollback translator can stamp it on
+        // the revert change (Spec 55 §7.7). Undefined when the upstream verifier
+        // had no SHA (out-of-band merge / pre-SHA-capture proposal).
+        mergedSha,
       },
     },
     summary,

--- a/packages/core/src/exports/server/deployment.ts
+++ b/packages/core/src/exports/server/deployment.ts
@@ -61,6 +61,7 @@ export {
   type RollingUpdatePhase,
   type RollingUpdateResult,
   type RollingUpdateRollbackResult,
+  rollbackInputFromProposal,
   type ShutdownHook,
   type ShutdownPhase,
   type ShutdownStatus,

--- a/packages/core/src/life-system/insight-to-proposal.ts
+++ b/packages/core/src/life-system/insight-to-proposal.ts
@@ -318,9 +318,16 @@ interface RollbackEvidenceContext {
   mergedSha?: unknown;
 }
 
-/** Narrow an `unknown` evidence field to a non-empty string, else `undefined`. */
+/**
+ * Narrow an `unknown` evidence field to a non-empty string, else `undefined`.
+ * Trims first so a whitespace-only value (e.g. `"   "`) is treated as absent and
+ * the returned SHA never carries surrounding whitespace (which would otherwise
+ * produce a malformed `(commit    )` diff and a junk sidecar value).
+ */
 function nonEmptyStringOrUndefined(value: unknown): string | undefined {
-  return typeof value === "string" && value.length > 0 ? value : undefined;
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 /** Narrow an `unknown` evidence field to a finite number, else `undefined`. */

--- a/packages/core/src/life-system/insight-to-proposal.ts
+++ b/packages/core/src/life-system/insight-to-proposal.ts
@@ -309,6 +309,18 @@ interface RollbackEvidenceContext {
   baselineValue?: unknown;
   targetValue?: unknown;
   currentValue?: unknown;
+  /**
+   * Merged commit SHA of the regressed proposal (Spec 55 §7.7), threaded by
+   * {@link import("../engine/rollback-insight-emitter").RollbackInsightEmitter}
+   * from the effect-verification signal. Optional — absent on out-of-band
+   * merges or proposals that predate SHA capture.
+   */
+  mergedSha?: unknown;
+}
+
+/** Narrow an `unknown` evidence field to a non-empty string, else `undefined`. */
+function nonEmptyStringOrUndefined(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
 /** Narrow an `unknown` evidence field to a finite number, else `undefined`. */
@@ -343,11 +355,16 @@ function firstNonEmptyString(...candidates: unknown[]): string {
  * so the draft passes Phase-1 validation (a `revert:<proposalId>` name would
  * fail `INVALID_NAME` on the colon/uppercase). The target proposalId is carried
  * out-of-band in the change `diff` and the evidence sidecar's
- * `context.revertProposalId`, so the eventual rollback-execution / SHA-threading
- * follow-up can still resolve which proposal to revert.
+ * `context.revertProposalId`, so a rollback executor can resolve which proposal
+ * to revert.
  *
- * Slice A does NOT thread the merged commit SHA — a separate follow-up resolves
- * the actual SHA at deploy time.
+ * When the rollback Insight evidence carries `context.mergedSha` (threaded from
+ * `ProposalGitCommitter` → outcome → effect-verifier → RollbackInsightEmitter),
+ * that SHA is stamped on the revert change's typed `revertSha` field so
+ * `DeployRollbackOrchestrator` can `git revert` the EXACT commit. The SHA is
+ * OPTIONAL — when absent the draft is still produced and a human reviewer must
+ * supply the SHA before a rollback can execute. Stamping the SHA NEVER triggers
+ * auto-execution: the proposal remains `status: "draft"`.
  *
  * Returns `null` (declines) when the insight is not a tagged anomaly carrying a
  * non-empty `evidence.context.proposalId`. Malformed insights (e.g. an
@@ -387,13 +404,24 @@ export const rollbackCandidateTranslator: InsightTranslator = (insight, ctx) => 
   const baselineValue = numberOrUndefined(context.baselineValue);
   const currentValue = numberOrUndefined(context.currentValue);
 
+  // The merged commit SHA of the regressed proposal, threaded from the
+  // effect-verification signal via the rollback Insight evidence. When present,
+  // it is stamped on the revert change so DeployRollbackOrchestrator can
+  // `git revert` the EXACT commit instead of only naming the proposal.
+  const revertSha = nonEmptyStringOrUndefined(context.mergedSha);
+
   const change: ProposalChange = {
     target: "revert",
     operation: "update",
     // Fixed NAME_PATTERN-valid name; the target proposalId lives in `diff` and
     // the evidence sidecar so the draft can pass Phase-1 validation.
     name: REVERT_CHANGE_NAME,
-    diff: `Roll back merged proposal "${proposalId}" on capability "${capability}".`,
+    diff: revertSha
+      ? `Roll back merged proposal "${proposalId}" (commit ${revertSha}) on capability "${capability}".`
+      : `Roll back merged proposal "${proposalId}" on capability "${capability}".`,
+    // Optional typed slot the rollback executor reads; omitted when the upstream
+    // chain lacked a SHA so the field never carries an empty string.
+    ...(revertSha ? { revertSha } : {}),
   };
 
   // INVERSE successMetric: the rollback succeeds when the metric returns from
@@ -443,6 +471,9 @@ export const rollbackCandidateTranslator: InsightTranslator = (insight, ctx) => 
     revertProposalId: proposalId,
     capability,
     signalRef,
+    // Mirror the SHA on the sidecar so provenance survives even if a consumer
+    // reads the evidence trace rather than the typed change field.
+    revertSha,
   };
   Object.defineProperty(proposal, "evidence", {
     value: { ...evidence, context: traceContext },

--- a/packages/core/src/types/proposal.ts
+++ b/packages/core/src/types/proposal.ts
@@ -93,6 +93,22 @@ export interface ProposalChange {
   definition?: ChangeDefinition;
   /** Human-readable diff description (for updates) */
   diff?: string;
+  /**
+   * The merged commit SHA to revert (Spec 55 §7.7 rollback loop).
+   *
+   * Only meaningful on a `target:"revert"` change. Carries the commit SHA of
+   * the regressed proposal — captured when that proposal graduated to a PR via
+   * `ProposalGitCommitter` and threaded through the
+   * outcome → effect-verification → rollback-insight → translator chain — so a
+   * rollback executor (`DeployRollbackOrchestrator`) can `git revert` the
+   * CORRECT commit instead of only naming the reverted proposal.
+   *
+   * Optional: the upstream chain may lack the SHA (e.g. the original proposal
+   * predates SHA capture, or merged out-of-band). When absent, the rollback
+   * draft is still produced and the human reviewer must supply the SHA before
+   * a rollback can execute. This field NEVER triggers auto-execution.
+   */
+  revertSha?: string;
 }
 
 // ── Impact analysis ──────────────────────────────────────


### PR DESCRIPTION
## What

Slice B of the rollback-Insight→Proposal work (#375). **Slice A** produced a draft revert Proposal that only *named* the regressed proposal — a rollback executor had no commit to act on. This slice threads the **merged commit SHA end-to-end** so an approved rollback can `git revert` the **exact** commit:

```
ProposalGitCommitter.commitSha
  → ProposalOutcomePayload.mergedSha            (merged outcome only)
  → EffectVerificationRecord.mergedSha + signal
  → rollback Insight evidence.context.mergedSha
  → revert ProposalChange.revertSha             (typed slot) + diff text + sidecar
  → rollbackInputFromProposal()                 (pure extractor, human-gated)
```

## Changes

- **`types/proposal.ts`** — optional `ProposalChange.revertSha` (meaningful only on a `target:"revert"` change).
- **`proposal-outcome-recorder.ts`** — `recordOutcome(p, outcome, { mergedSha })` + private `resolveMergedSha`: passes the SHA through for `"merged"`, **drops it with a warning** for any other outcome. _(Also implements `resolveMergedSha`, which was referenced but unimplemented on the branch — fixes a baseline compile error.)_
- **`proposal-effect-verifier.ts` / `rollback-insight-emitter.ts`** — carry `mergedSha` forward onto the record/signal and into the rollback Insight evidence.
- **`insight-to-proposal.ts`** — `rollbackCandidateTranslator` stamps `revertSha` from `evidence.context.mergedSha` (**omitted when absent**, never an empty string), mentions it in the human-readable `diff`, and mirrors it on the evidence sidecar.
- **`rollback-orchestrator.ts`** — new pure `rollbackInputFromProposal(proposal, extras?)`, the explicit **consumption point**. Returns `null` (never throws) unless the proposal is `status:"approved"` **and** carries a revert change with a usable SHA. It does **not** call `orchestrate` / touch git.

## Governance

The "AI Never Modifies Production Directly" invariant is preserved: the translator still emits `status:"draft"`, stamping a SHA **never** auto-executes anything, and `rollbackInputFromProposal` refuses any proposal that has not cleared the human approval gate. A caller deliberately runs `orchestrate(rollbackInputFromProposal(p))` only *after* approval.

## Tests

Full `bun test packages/core` → **3807 pass / 0 fail**. New coverage: translator stamps `revertSha` from evidence (+ surfaces it in diff + sidecar); omits it when absent (`"revertSha" in change === false`); ignores non-string/empty SHA; emitter & verifier thread `mergedSha`; recorder stamps it on merged / drops+warns on non-merged; `rollbackInputFromProposal` extracts the SHA, threads title/body extras, and declines for non-approved / no-`revertSha` / no-revert-change. New `rollbackInputFromProposal` added to the server barrel allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)