### PR TITLE
feat(core): honor capability.json at runtime with precedence over package.json (#122, Spec 21 §7.2)

### DIFF
--- a/packages/core/__tests__/capability/addon-scanner-manifest.test.ts
+++ b/packages/core/__tests__/capability/addon-scanner-manifest.test.ts
@@ -180,6 +180,39 @@ describe("scanAddonsPath — capability.json precedence (Spec 21 §7.2)", () => 
     expect(caps[0]?.trustLevel).not.toBe("official");
   });
 
+  test("an invalid code-declared trustLevel is dropped (not promoted)", async () => {
+    // SECURITY: a malicious JS addon hardcodes an UNKNOWN tier ("superadmin") on
+    // its code export. That string has no rank in TRUST_LEVEL_ORDER, so it must be
+    // rejected by the trustLevelEnum guard BEFORE clamping — the result is an
+    // ignored declaration (`undefined`), never the invalid string and never a
+    // silent promotion to `official`. The `as` cast simulates the untyped value a
+    // hand-written addon could inject past the type system.
+    makeAddon(root, {
+      packageName: "@linchkit/cap-x",
+      capabilityJson: false,
+      defExtra: { trustLevel: "superadmin" as unknown as string },
+    });
+
+    const caps = await scanAddonsPath([root]);
+    expect(caps).toHaveLength(1);
+    expect(caps[0]?.trustLevel).toBeUndefined();
+  });
+
+  test("an invalid package.json linchkit.trustLevel is ignored", async () => {
+    // The lowest-precedence declared source (package.json `linchkit`) carries an
+    // unknown tier ("root"). With no capability.json and no code-def tier, the
+    // guard rejects it and `trustLevel` is left undefined.
+    makeAddon(root, {
+      packageName: "linchkit-cap-y",
+      pkgLinchkit: { trustLevel: "root" },
+      capabilityJson: false,
+    });
+
+    const caps = await scanAddonsPath([root]);
+    expect(caps).toHaveLength(1);
+    expect(caps[0]?.trustLevel).toBeUndefined();
+  });
+
   test("a legitimately official code-declared tier is preserved", async () => {
     // `@linchkit/cap-baz` justifies `official`, so a code-def declaring `official`
     // is honored unchanged — the clamp ceiling equals the declared tier.

--- a/packages/core/__tests__/capability/addon-scanner-manifest.test.ts
+++ b/packages/core/__tests__/capability/addon-scanner-manifest.test.ts
@@ -1,0 +1,242 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { scanAddonsPath } from "../../src/capability/addon-scanner";
+
+/**
+ * Spec 21 §7.2: the boot-time scanner reads the standalone `capability.json`
+ * manifest with HIGHER precedence than `package.json`. These tests build real
+ * fixture directories on disk because the scanner uses dynamic `await import()`.
+ */
+
+const ROOTS: string[] = [];
+
+function makeRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "addon-scan-manifest-"));
+  ROOTS.push(root);
+  return root;
+}
+
+interface FixtureOptions {
+  /** Package name written to package.json (drives trust inference). */
+  packageName?: string;
+  /** package.json `linchkit` block. */
+  pkgLinchkit?: Record<string, unknown>;
+  /** capability.json contents. When `false`, no capability.json is written. */
+  capabilityJson?: Record<string, unknown> | false;
+  /** Raw capability.json text (overrides `capabilityJson`, for malformed JSON). */
+  capabilityJsonRaw?: string;
+  /** Extra fields merged into the default-exported CapabilityDefinition. */
+  defExtra?: Record<string, unknown>;
+}
+
+/**
+ * Create `{root}/{group}/cap-foo/` with a package.json, a tiny src/index.ts that
+ * default-exports a minimal CapabilityDefinition, and optionally a capability.json.
+ */
+function makeAddon(root: string, options: FixtureOptions = {}): void {
+  const {
+    packageName = "@linchkit/cap-foo",
+    pkgLinchkit,
+    capabilityJson,
+    capabilityJsonRaw,
+    defExtra = {},
+  } = options;
+
+  const capDir = join(root, "test-group", "cap-foo");
+  mkdirSync(join(capDir, "src"), { recursive: true });
+
+  const pkg: Record<string, unknown> = { name: packageName, main: "src/index.ts" };
+  if (pkgLinchkit) pkg.linchkit = pkgLinchkit;
+  writeFileSync(join(capDir, "package.json"), JSON.stringify(pkg));
+
+  const def = {
+    name: "cap-foo",
+    label: "Foo",
+    type: "standard",
+    category: "business",
+    version: "0.1.0",
+    ...defExtra,
+  };
+  writeFileSync(join(capDir, "src", "index.ts"), `export default ${JSON.stringify(def)};`);
+
+  if (capabilityJsonRaw !== undefined) {
+    writeFileSync(join(capDir, "capability.json"), capabilityJsonRaw);
+  } else if (capabilityJson !== false && capabilityJson !== undefined) {
+    writeFileSync(join(capDir, "capability.json"), JSON.stringify(capabilityJson));
+  }
+}
+
+/** A schema-valid capability.json payload with the given overrides applied. */
+function validManifest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    name: "@linchkit/cap-foo",
+    version: "0.1.0",
+    type: "standard",
+    category: "business",
+    label: "Foo",
+    ...overrides,
+  };
+}
+
+afterAll(() => {
+  for (const root of ROOTS) rmSync(root, { recursive: true, force: true });
+});
+
+describe("scanAddonsPath — capability.json precedence (Spec 21 §7.2)", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = makeRoot();
+  });
+
+  test("capability.json coreVersion overrides package.json coreVersion", async () => {
+    makeAddon(root, {
+      pkgLinchkit: { coreVersion: "^0.2.0" },
+      capabilityJson: validManifest({ linchkit: { coreVersion: ">=0.3.0" } }),
+    });
+
+    const caps = await scanAddonsPath([root]);
+    expect(caps).toHaveLength(1);
+    expect(caps[0]?.coreVersion).toBe(">=0.3.0");
+  });
+
+  test("falls back to package.json linchkit when no capability.json is present", async () => {
+    makeAddon(root, {
+      pkgLinchkit: { minCoreVersion: "^0.2.0" },
+      capabilityJson: false,
+    });
+
+    const caps = await scanAddonsPath([root]);
+    expect(caps).toHaveLength(1);
+    expect(caps[0]?.coreVersion).toBe("^0.2.0");
+  });
+
+  test("an explicit coreVersion on the code definition wins over both manifests", async () => {
+    makeAddon(root, {
+      defExtra: { coreVersion: ">=0.5.0" },
+      pkgLinchkit: { coreVersion: "^0.2.0" },
+      capabilityJson: validManifest({ linchkit: { coreVersion: ">=0.3.0" } }),
+    });
+
+    const caps = await scanAddonsPath([root]);
+    expect(caps).toHaveLength(1);
+    expect(caps[0]?.coreVersion).toBe(">=0.5.0");
+  });
+
+  test("a declared trustLevel is CLAMPED against the name-justified tier (anti-spoof)", async () => {
+    // `linchkit-cap-foo` infers `community`; declaring `official` must clamp
+    // back DOWN to `community` — a self-declaration can never raise standing.
+    makeAddon(root, {
+      packageName: "linchkit-cap-foo",
+      capabilityJson: {
+        name: "linchkit-cap-foo",
+        version: "0.1.0",
+        type: "standard",
+        category: "business",
+        label: "Foo",
+        trustLevel: "official",
+      },
+    });
+
+    const caps = await scanAddonsPath([root]);
+    expect(caps).toHaveLength(1);
+    expect(caps[0]?.trustLevel).toBe("community");
+    expect(caps[0]?.trustLevel).not.toBe("official");
+  });
+
+  test("a trustLevel hardcoded on the code export is CLAMPED (anti-spoof regression)", async () => {
+    // SECURITY: a malicious addon ships `trustLevel: "official"` directly on its
+    // code export (src/index.ts default), with NO capability.json declaring trust.
+    // `linchkit-cap-foo` only justifies `community`, so the spoofed tier must be
+    // clamped DOWN to `community` — the clamp must NOT be skipped just because the
+    // tier was declared on the code-def rather than a manifest.
+    makeAddon(root, {
+      packageName: "linchkit-cap-foo",
+      capabilityJson: false,
+      defExtra: { trustLevel: "official" },
+    });
+
+    const caps = await scanAddonsPath([root]);
+    expect(caps).toHaveLength(1);
+    expect(caps[0]?.trustLevel).toBe("community");
+    expect(caps[0]?.trustLevel).not.toBe("official");
+  });
+
+  test("package.json linchkit.trustLevel is used as a fallback AND clamped", async () => {
+    // No capability.json and no code-def trustLevel — the declared tier comes
+    // from package.json's `linchkit` block (§7.2 lowest-precedence fallback) and
+    // is still clamped: `linchkit-cap-bar` justifies only `community`.
+    makeAddon(root, {
+      packageName: "linchkit-cap-bar",
+      pkgLinchkit: { trustLevel: "official" },
+      capabilityJson: false,
+    });
+
+    const caps = await scanAddonsPath([root]);
+    expect(caps).toHaveLength(1);
+    expect(caps[0]?.trustLevel).toBe("community");
+    expect(caps[0]?.trustLevel).not.toBe("official");
+  });
+
+  test("a legitimately official code-declared tier is preserved", async () => {
+    // `@linchkit/cap-baz` justifies `official`, so a code-def declaring `official`
+    // is honored unchanged — the clamp ceiling equals the declared tier.
+    makeAddon(root, {
+      packageName: "@linchkit/cap-baz",
+      capabilityJson: false,
+      defExtra: { trustLevel: "official" },
+    });
+
+    const caps = await scanAddonsPath([root]);
+    expect(caps).toHaveLength(1);
+    expect(caps[0]?.trustLevel).toBe("official");
+  });
+
+  test("copies dependencies from capability.json when the code-def omits them", async () => {
+    makeAddon(root, {
+      capabilityJson: validManifest({ dependencies: ["@linchkit/cap-auth"] }),
+    });
+
+    const caps = await scanAddonsPath([root]);
+    expect(caps).toHaveLength(1);
+    expect(caps[0]?.dependencies).toEqual(["@linchkit/cap-auth"]);
+  });
+
+  test("malformed capability.json (invalid JSON) does not drop the addon", async () => {
+    makeAddon(root, {
+      pkgLinchkit: { coreVersion: "^0.2.0" },
+      capabilityJsonRaw: "{ this is not valid json",
+    });
+
+    const caps = await scanAddonsPath([root]);
+    // Addon still loaded; coreVersion falls back to package.json; no throw.
+    expect(caps).toHaveLength(1);
+    expect(caps[0]?.name).toBe("cap-foo");
+    expect(caps[0]?.coreVersion).toBe("^0.2.0");
+  });
+
+  test("schema-invalid capability.json does not drop the addon", async () => {
+    makeAddon(root, {
+      pkgLinchkit: { coreVersion: "^0.2.0" },
+      // Missing required fields (type/category/version) → fails validation.
+      capabilityJson: { name: "@linchkit/cap-foo", label: "Foo" },
+    });
+
+    const caps = await scanAddonsPath([root]);
+    expect(caps).toHaveLength(1);
+    expect(caps[0]?.name).toBe("cap-foo");
+    expect(caps[0]?.coreVersion).toBe("^0.2.0");
+  });
+
+  test("regression: capability with neither manifest leaves coreVersion/trustLevel undefined", async () => {
+    makeAddon(root, { capabilityJson: false });
+
+    const caps = await scanAddonsPath([root]);
+    expect(caps).toHaveLength(1);
+    expect(caps[0]?.coreVersion).toBeUndefined();
+    expect(caps[0]?.trustLevel).toBeUndefined();
+    expect(caps[0]?.dependencies).toBeUndefined();
+  });
+});

--- a/packages/core/src/capability/addon-scanner.ts
+++ b/packages/core/src/capability/addon-scanner.ts
@@ -2,7 +2,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 import type { CapabilityDefinition } from "../types/capability";
 import { type CapabilityMetadata, validateCapabilityMetadata } from "../types/capability-metadata";
-import type { TrustLevel } from "../types/trust";
+import { type TrustLevel, trustLevelEnum } from "../types/trust";
 import { coreVersionRangeOf, type MetadataCompatibility } from "./compatibility";
 import { computeEffectiveTrust } from "./trust";
 
@@ -55,8 +55,10 @@ export function loadCapabilityManifest(capPath: string): CapabilityMetadata | nu
  *   (b) the standalone `capability.json` manifest — HIGHER than package.json;
  *   (c) the `package.json` `linchkit` field — fallback.
  * A declared `trustLevel` from ANY source (code-def, capability.json, or
- * package.json `linchkit`) is always clamped via `computeEffectiveTrust`
- * (anti-spoof: a declaration can only LOWER standing, never raise it).
+ * package.json `linchkit`) is first runtime-validated against the canonical
+ * `trustLevelEnum` and then clamped via `computeEffectiveTrust` (anti-spoof: a
+ * declaration can only LOWER standing, never raise it; an invalid tier is
+ * ignored entirely rather than leaking into permission checks).
  */
 export async function scanAddonsPath(addonsPaths: string[]): Promise<CapabilityDefinition[]> {
   const capabilities: CapabilityDefinition[] = [];
@@ -121,18 +123,45 @@ export async function scanAddonsPath(addonsPaths: string[]): Promise<CapabilityD
             // Trust tier (Spec 21 / #122) — the anti-spoof clamp applies to EVERY declared
             // tier regardless of source. Precedence for the declared value:
             // code-def > capability.json > package.json `linchkit`. Whichever we take is
-            // then ALWAYS clamped via computeEffectiveTrust. The clamp runs even when the
-            // tier was hardcoded on the code export — otherwise a malicious addon could
-            // ship `trustLevel: "official"` in src/index.ts and bypass the clamp entirely.
-            const declaredTrust =
+            // first runtime-VALIDATED against the canonical `trustLevelEnum`, then ALWAYS
+            // clamped via computeEffectiveTrust. Validation matters because only the
+            // manifest tier is Zod-checked upstream — `def.trustLevel` (code export) and
+            // `pkgJson.linchkit?.trustLevel` (package.json) are untrusted strings cast to
+            // `TrustLevel`. An unknown tier (e.g. "superadmin") has no rank in
+            // TRUST_LEVEL_ORDER, so it would make the clamp comparison misbehave and could
+            // leak an invalid trust level into runtime permission checks. The clamp also
+            // runs even when the tier was hardcoded on the code export — otherwise a
+            // malicious addon could ship `trustLevel: "official"` in src/index.ts and
+            // bypass the clamp entirely.
+            const rawDeclared =
               def.trustLevel ?? manifest?.trustLevel ?? pkgJson.linchkit?.trustLevel;
-            if (declaredTrust !== undefined) {
-              // Clamp ceiling is inferred from the canonical publish name, NOT the short
-              // runtime `def.name` (e.g. "cap-auth") which carries no scope/prefix and would
-              // mis-infer every addon as `unverified`. Prefer the manifest name (higher
-              // priority per §7.2), then package.json's name. Mirrors install.ts/publish.ts.
-              const canonicalName = manifest?.name ?? pkgJson.name ?? def.name;
-              def.trustLevel = computeEffectiveTrust({ name: canonicalName, declaredTrust });
+            if (rawDeclared !== undefined) {
+              const parsed = trustLevelEnum.safeParse(rawDeclared);
+              if (parsed.success) {
+                // Clamp ceiling is inferred from the canonical publish name, NOT the short
+                // runtime `def.name` (e.g. "cap-auth") which carries no scope/prefix and
+                // would mis-infer every addon as `unverified`. Prefer the manifest name
+                // (higher priority per §7.2), then package.json's name. Mirrors
+                // install.ts/publish.ts.
+                const canonicalName = manifest?.name ?? pkgJson.name ?? def.name;
+                def.trustLevel = computeEffectiveTrust({
+                  name: canonicalName,
+                  declaredTrust: parsed.data,
+                });
+              } else {
+                console.warn(
+                  `[linchkit] Ignoring invalid declared trustLevel "${String(rawDeclared)}" for capability "${def.name}"`,
+                );
+                // Defensive: if the invalid value came from the code export, do not let it
+                // survive on the runtime definition (it would otherwise reach permission
+                // checks unclamped).
+                if (
+                  def.trustLevel !== undefined &&
+                  !trustLevelEnum.safeParse(def.trustLevel).success
+                ) {
+                  def.trustLevel = undefined;
+                }
+              }
             }
 
             // Dependencies declared in capability.json fill in when the code-def

--- a/packages/core/src/capability/addon-scanner.ts
+++ b/packages/core/src/capability/addon-scanner.ts
@@ -1,7 +1,44 @@
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 import type { CapabilityDefinition } from "../types/capability";
+import { type CapabilityMetadata, validateCapabilityMetadata } from "../types/capability-metadata";
+import type { TrustLevel } from "../types/trust";
 import { coreVersionRangeOf, type MetadataCompatibility } from "./compatibility";
+import { computeEffectiveTrust } from "./trust";
+
+/**
+ * Load and validate the standalone `capability.json` manifest for a capability
+ * directory (Spec 21 §7.2).
+ *
+ * Mirrors the loader used by `linch install`: read → JSON.parse → validate
+ * against `capabilityMetadataSchema`. Returns `null` (never throws) when the
+ * file is absent, unreadable, invalid JSON, or fails schema validation — the
+ * caller falls back to `package.json` metadata. An invalid-but-present manifest
+ * is reported via `console.warn` so authors notice the typo without losing the
+ * addon (graceful degradation).
+ */
+export function loadCapabilityManifest(capPath: string): CapabilityMetadata | null {
+  const manifestPath = join(capPath, "capability.json");
+  if (!existsSync(manifestPath)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(manifestPath, "utf-8"));
+    const result = validateCapabilityMetadata(raw);
+    if (result.success) return result.data;
+    const reason = result.errors
+      .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+      .join("; ");
+    console.warn(
+      `[linchkit] Ignoring invalid capability.json at ${manifestPath}: ${reason}; falling back to package.json`,
+    );
+    return null;
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[linchkit] Ignoring invalid capability.json at ${manifestPath}: ${reason}; falling back to package.json`,
+    );
+    return null;
+  }
+}
 
 /**
  * Scan addon_path directories for capability packages.
@@ -11,6 +48,15 @@ import { coreVersionRangeOf, type MetadataCompatibility } from "./compatibility"
  *
  * Each cap-* directory is imported and its default export is
  * expected to be a CapabilityDefinition (or a factory that returns one).
+ *
+ * Declared metadata (coreVersion / trustLevel / dependencies) is resolved with
+ * the following precedence, highest first (Spec 21 §7.2):
+ *   (a) a value hardcoded on the code-exported definition — author wins;
+ *   (b) the standalone `capability.json` manifest — HIGHER than package.json;
+ *   (c) the `package.json` `linchkit` field — fallback.
+ * A declared `trustLevel` from ANY source (code-def, capability.json, or
+ * package.json `linchkit`) is always clamped via `computeEffectiveTrust`
+ * (anti-spoof: a declaration can only LOWER standing, never raise it).
  */
 export async function scanAddonsPath(addonsPaths: string[]): Promise<CapabilityDefinition[]> {
   const capabilities: CapabilityDefinition[] = [];
@@ -40,9 +86,14 @@ export async function scanAddonsPath(addonsPaths: string[]): Promise<CapabilityD
         try {
           const pkg = await import(join(capPath, "package.json"));
           const pkgJson = (pkg.default ?? pkg) as {
+            name?: string;
             main?: string;
-            linchkit?: MetadataCompatibility;
+            linchkit?: MetadataCompatibility & { trustLevel?: TrustLevel };
           };
+          // Standalone manifest (Spec 21 §7.2) — HIGHER priority than
+          // package.json. Loaded defensively: a malformed manifest is logged
+          // and ignored (null) so the addon still boots from package.json.
+          const manifest = loadCapabilityManifest(capPath);
           const mainEntry = pkgJson.main ?? "src/index.ts";
           const mod = await import(join(capPath, mainEntry));
           const capDef = mod.default ?? mod;
@@ -54,16 +105,44 @@ export async function scanAddonsPath(addonsPaths: string[]): Promise<CapabilityD
             // a TypeError that this try/catch would silently swallow, dropping
             // the addon. The copy is a plain extensible object we own.
             const def = { ...(capDef as CapabilityDefinition) };
-            // Populate the boot-time compatibility range (Spec 21 / #122) from
-            // the addon's `package.json` `linchkit` block (coreVersion ??
-            // minVersion ?? minCoreVersion). The runtime definition rarely
-            // declares `coreVersion` itself, so without this the boot check in
-            // `enforceCoreCompatibility` would see `undefined` for every addon.
+
+            // Populate the boot-time compatibility range (Spec 21 / #122).
+            // Precedence: code-def `coreVersion` (if set) > capability.json
+            // `linchkit` > package.json `linchkit`. The runtime definition
+            // rarely declares `coreVersion` itself, so without this the boot
+            // check in `enforceCoreCompatibility` would see `undefined`.
             // A range declared explicitly on the definition still wins.
             if (def.coreVersion === undefined) {
-              const range = coreVersionRangeOf(pkgJson.linchkit);
+              const range =
+                coreVersionRangeOf(manifest?.linchkit) ?? coreVersionRangeOf(pkgJson.linchkit);
               if (range !== undefined) def.coreVersion = range;
             }
+
+            // Trust tier (Spec 21 / #122) — the anti-spoof clamp applies to EVERY declared
+            // tier regardless of source. Precedence for the declared value:
+            // code-def > capability.json > package.json `linchkit`. Whichever we take is
+            // then ALWAYS clamped via computeEffectiveTrust. The clamp runs even when the
+            // tier was hardcoded on the code export — otherwise a malicious addon could
+            // ship `trustLevel: "official"` in src/index.ts and bypass the clamp entirely.
+            const declaredTrust =
+              def.trustLevel ?? manifest?.trustLevel ?? pkgJson.linchkit?.trustLevel;
+            if (declaredTrust !== undefined) {
+              // Clamp ceiling is inferred from the canonical publish name, NOT the short
+              // runtime `def.name` (e.g. "cap-auth") which carries no scope/prefix and would
+              // mis-infer every addon as `unverified`. Prefer the manifest name (higher
+              // priority per §7.2), then package.json's name. Mirrors install.ts/publish.ts.
+              const canonicalName = manifest?.name ?? pkgJson.name ?? def.name;
+              def.trustLevel = computeEffectiveTrust({ name: canonicalName, declaredTrust });
+            }
+
+            // Dependencies declared in capability.json fill in when the code-def
+            // does not list its own. package.json is intentionally NOT a fallback here:
+            // capability dependencies live only in capability.json (§7.2), whereas
+            // package.json's top-level `dependencies` are npm packages — a different concept.
+            if (def.dependencies === undefined && manifest?.dependencies !== undefined) {
+              def.dependencies = manifest.dependencies;
+            }
+
             capabilities.push(def);
           }
         } catch {


### PR DESCRIPTION
## What

`capability.json` (the standalone capability manifest, Spec 21 §7.2) was already **generated** by `linch create capability` and **validated** by `linch install`, but the boot-time addon scanner (`scanAddonsPath`) only ever read the `linchkit` field of `package.json`. The manifest was never honored at runtime — closing that gap.

## Changes

`packages/core/src/capability/addon-scanner.ts`:
- New `loadCapabilityManifest(capPath)` — reads + validates `capability.json` via the existing core `validateCapabilityMetadata`. Returns `null` (never throws) when absent/unreadable/invalid; an invalid-but-present manifest is `console.warn`-logged and the addon **still boots from package.json** (graceful degradation, never silently dropped).
- Declared metadata (`coreVersion`, `trustLevel`, `dependencies`) is resolved with the spec precedence **code-def > capability.json > package.json**.
- **Anti-spoof:** every declared `trustLevel` — from the code export, capability.json, or the package.json `linchkit` block — is clamped via `computeEffectiveTrust` against the name-justified ceiling. A manifest (or a hardcoded code export) can only **lower** a capability's standing, never spoof a higher tier. Capability `dependencies` fall back from capability.json only (package.json's top-level `dependencies` are npm packages, not capability deps).

## Tests

`packages/core/__tests__/capability/addon-scanner-manifest.test.ts` (new, 11 cases over real on-disk fixtures + dynamic import): precedence, package.json fallback, code-def-wins, **anti-spoof clamp of a code-hardcoded `official` tier on a community-named package**, package.json `linchkit.trustLevel` fallback+clamp, and malformed-manifest graceful degradation.

## Cross-model review

Reviewed via Gemini. It flagged a **HIGH** anti-spoof bypass (the original code skipped the clamp when `trustLevel` was hardcoded on the code export) and a spec-precedence gap (no package.json fallback for trustLevel). Both fixed and covered by the new security regression tests. Low/medium type-hygiene notes also applied (no `as any`).

## Notes

- Local `bun run check` exits 1 from a pre-existing Biome version drift (CI's `bunx biome check .` is clean) — unrelated to this change.
- One unrelated test (`ProposalFileWriter > default Biome formatter`) is a flaky 5s subprocess timeout under the same local Biome drift; it passes on retry and is green in CI.

Part of #122 (Spec 21 ecosystem lifecycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for addon manifest validation and precedence handling.

* **New Features**
  * Addons now support `capability.json` configuration files for enhanced metadata control.
  * Improved security through enhanced trust level validation and clamping mechanisms for addons.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laofahai/linchkit/pull/411?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->