### PR TITLE
fix(core): recognize "view" capability category + bring all addons to §9.1 compliance (#122)

### DIFF
--- a/addons/adapter-mcp/cap-mcp-ui/__tests__/capability.test.ts
+++ b/addons/adapter-mcp/cap-mcp-ui/__tests__/capability.test.ts
@@ -1,0 +1,32 @@
+/**
+ * cap-mcp-ui capability shape tests.
+ *
+ * Importing the package entry also runs its side-effect `registerAdminRoute`
+ * call, so we additionally assert the admin route it is supposed to register.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { getAdminRoutes } from "@linchkit/cap-adapter-ui/route-registry";
+import { capMcpUi } from "../src";
+
+describe("capMcpUi", () => {
+  it("declares the expected identity fields", () => {
+    expect(capMcpUi.name).toBe("cap-mcp-ui");
+    expect(capMcpUi.type).toBe("standard");
+    expect(capMcpUi.category).toBe("system");
+    expect(capMcpUi.version).toBe("0.1.0");
+  });
+
+  it("depends on the UI shell and the MCP adapter", () => {
+    expect(capMcpUi.dependencies).toEqual(
+      expect.arrayContaining(["cap-adapter-ui", "cap-adapter-mcp"]),
+    );
+  });
+
+  it("registers the MCP admin route on import", () => {
+    const route = getAdminRoutes().find((r) => r.id === "mcp");
+    expect(route).toBeDefined();
+    expect(route?.path).toBe("/admin/mcp");
+    expect(route?.capability).toBe("cap-adapter-mcp");
+  });
+});

--- a/addons/chatter/cap-chatter-ui/__tests__/capability.test.ts
+++ b/addons/chatter/cap-chatter-ui/__tests__/capability.test.ts
@@ -1,0 +1,32 @@
+/**
+ * cap-chatter-ui capability shape tests.
+ *
+ * Importing the package entry also runs its side-effect `registerRecordPanel`
+ * call, so we additionally assert the record-detail panel it should register.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { getRecordPanels } from "@linchkit/cap-adapter-ui/panel-registry";
+import { capChatterUi } from "../src";
+
+describe("capChatterUi", () => {
+  it("declares the expected identity fields", () => {
+    expect(capChatterUi.name).toBe("cap-chatter-ui");
+    expect(capChatterUi.type).toBe("standard");
+    expect(capChatterUi.category).toBe("system");
+    expect(capChatterUi.version).toBe("0.1.0");
+  });
+
+  it("depends on the UI shell and the chatter capability", () => {
+    expect(capChatterUi.dependencies).toEqual(
+      expect.arrayContaining(["cap-adapter-ui", "cap-chatter"]),
+    );
+  });
+
+  it("registers the chatter record-detail panel on import", () => {
+    const panel = getRecordPanels().find((p) => p.id === "chatter");
+    expect(panel).toBeDefined();
+    expect(panel?.slot).toBe("record-detail-tab");
+    expect(panel?.capability).toBe("cap-chatter");
+  });
+});

--- a/addons/demo/cap-life-demo/package.json
+++ b/addons/demo/cap-life-demo/package.json
@@ -10,5 +10,10 @@
   },
   "peerDependencies": {
     "@linchkit/core": "workspace:*"
+  },
+  "linchkit": {
+    "minCoreVersion": "^0.2.0",
+    "type": "standard",
+    "category": "system"
   }
 }

--- a/addons/demo/cap-life-demo/package.json
+++ b/addons/demo/cap-life-demo/package.json
@@ -12,7 +12,7 @@
     "@linchkit/core": "workspace:*"
   },
   "linchkit": {
-    "minCoreVersion": "^0.2.0",
+    "coreVersion": "^0.2.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/demo/cap-purchase-demo/package.json
+++ b/addons/demo/cap-purchase-demo/package.json
@@ -9,7 +9,7 @@
     "@linchkit/core": "workspace:*"
   },
   "linchkit": {
-    "minCoreVersion": "^0.2.0",
+    "coreVersion": "^0.2.0",
     "type": "standard",
     "category": "business"
   }

--- a/addons/demo/cap-purchase-demo/package.json
+++ b/addons/demo/cap-purchase-demo/package.json
@@ -7,5 +7,10 @@
   "types": "src/index.ts",
   "peerDependencies": {
     "@linchkit/core": "workspace:*"
+  },
+  "linchkit": {
+    "minCoreVersion": "^0.2.0",
+    "type": "standard",
+    "category": "business"
   }
 }

--- a/docs/specs/01_capability_structure.md
+++ b/docs/specs/01_capability_structure.md
@@ -187,6 +187,7 @@ business
   business.sales           — 销售
   business.project         — 项目管理
 ui
+view
 utility
 starter
 ```
@@ -200,6 +201,7 @@ starter
 | `integration` | 外部系统集成 | network.external | **cap-adapter-server (HTTP/GraphQL)**, cap-adapter-mcp, cap-adapter-a2a, cap-adapter-ag-ui, sms, email, payment |
 | `business` | 业务模块 | 无 | 采购管理, 库存管理, HR |
 | `ui` | UI 增强 | 无 | **cap-adapter-ui (shell)**, cap-admin, dashboard, report, gantt view |
+| `view` | UI 视图渲染能力 | 无 | cap-view-calendar, cap-view-kanban, cap-view-timeline |
 | `utility` | 通用工具 | 无 | import-export, tag, comment |
 | `starter` | 启动包 | 无 | starter-business, starter-saas |
 
@@ -219,7 +221,7 @@ Capability 可以声明需要的系统级权限，安装时用户确认：
 | `process.spawn` | 启动子进程 | 极少数 |
 
 安全原则：
-- `business` / `utility` / `ui` 类 Capability 默认无系统权限
+- `business` / `utility` / `ui` / `view` 类 Capability 默认无系统权限
 - `infrastructure` / `integration` 类显式声明需要的权限
 - AI 生成的 Capability 不能声明系统权限（必须人工添加）
 - 安装时提示用户确认权限

--- a/docs/specs/21_capability_ecosystem.md
+++ b/docs/specs/21_capability_ecosystem.md
@@ -84,7 +84,9 @@ linchkit-cap-*                    ← 社区能力
 ```
 
 Capability 类型：standard, bridge, adapter
-分类：system, infrastructure, integration, business, ui, utility, starter
+分类：system, infrastructure, integration, business, ui, view, utility, starter
+
+> `view` 是 UI 视图渲染类能力（calendar / kanban / timeline）的专用分类。
 
 ### 2.2 M0-M1：主仓库内独立包
 

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -22,6 +22,7 @@ const VALID_CATEGORIES = [
   "infrastructure",
   "integration",
   "ui",
+  "view",
   "utility",
   "starter",
 ] as const;

--- a/packages/core/__tests__/capability-metadata.test.ts
+++ b/packages/core/__tests__/capability-metadata.test.ts
@@ -275,6 +275,7 @@ describe("capabilityMetadataSchema", () => {
       "integration",
       "business",
       "ui",
+      "view",
       "utility",
       "starter",
     ]) {

--- a/packages/core/src/types/capability-metadata.ts
+++ b/packages/core/src/types/capability-metadata.ts
@@ -19,6 +19,8 @@ export const capabilityCategoryEnum = z.enum([
   "integration",
   "business",
   "ui",
+  // Category for UI view-renderer capabilities (calendar / kanban / timeline).
+  "view",
   "utility",
   "starter",
 ]);

--- a/packages/devtools/src/methodology/capability-lint.ts
+++ b/packages/devtools/src/methodology/capability-lint.ts
@@ -325,7 +325,9 @@ function isIgnoredDir(name: string): boolean {
  * existing full-content regexes still span newlines for multi-line imports.
  */
 function stripComments(content: string): string {
-  return content.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+  return content
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
 }
 
 /**

--- a/packages/devtools/src/methodology/capability-lint.ts
+++ b/packages/devtools/src/methodology/capability-lint.ts
@@ -325,9 +325,7 @@ function isIgnoredDir(name: string): boolean {
  * existing full-content regexes still span newlines for multi-line imports.
  */
 function stripComments(content: string): string {
-  return content
-    .replace(/\/\*[\s\S]*?\*\//g, "")
-    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+  return content.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/[^\n]*/g, "$1");
 }
 
 /**


### PR DESCRIPTION
## What

Dogfooding the new `linch lint-capability` (#412) across **all 29 addons** surfaced 7 failures. This fixes all of them so every shipped capability passes the Spec 21 §9.1 gates — and fixes a **latent install bug** along the way.

## Root causes & fixes

1. **Latent `linch install` bug (the important one).** `cap-view-calendar` / `cap-view-kanban` / `cap-view-timeline` declare `category: "view"`. The runtime `CapabilityCategory` type is open (`… | (string & {})`) so it accepts this, but `capabilityCategoryEnum` — which `validateCapabilityMetadata` (hence `linch install`) uses — did **not** list `"view"`. So installing any view capability would fail metadata validation today. Added `"view"` to:
   - `capabilityCategoryEnum` (`packages/core/src/types/capability-metadata.ts`),
   - `VALID_CATEGORIES` in the `linch create capability` command (so `--category view` scaffolds),
   - the documented taxonomy in `docs/specs/01_capability_structure.md` and `21_capability_ecosystem.md`.
2. **Demos missing static metadata.** `cap-life-demo` / `cap-purchase-demo` had no `linchkit` block in `package.json` (type/category lived only in code). Added a block mirroring each demo's runtime definition.
3. **UI capabilities missing tests.** `cap-mcp-ui` / `cap-chatter-ui` had no test file. Added a real metadata smoke test to each — asserts identity (name/type/category/version), declared dependencies, and the admin route / record panel each registers on import (not filler).

## Verification

- `lint-capability` over all 29 addons → **29/29 PASS**.
- `bunx tsc --noEmit` → clean.
- Targeted suites (capability-metadata, create-capability, adapter-mcp, chatter) → green; the new tests pass.

## Notes

- The full `bun test` reports a phantom non-zero exit from the **known flaky `ProposalFileWriter > default Biome formatter` test** (a 5s subprocess timeout under the local Biome version drift; passes on retry, unrelated to this change). CI handles it via the #400 exit-code guard + clean Biome. No named test of this change fails.
- Cross-model review: the gemini **CLI** is quota-exhausted (resets in ~6h), so the cross-model pass is the **gemini-code-assist + CodeRabbit PR bots** (separate from the CLI quota) plus a manual review — which itself caught the `create.ts VALID_CATEGORIES` consistency gap (now fixed).

Part of #122 (Spec 21 §9.1 quality assurance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new "view" capability category for UI view-rendering capabilities (e.g., calendar, kanban, timeline).

* **Documentation**
  * Updated capability structure and ecosystem documentation to include the new "view" category.

* **Tests**
  * Added capability validation test suites for MCP and Chatter integrations.

* **Chores**
  * Updated package metadata configurations with new linchkit settings.
  * Minor code refactoring for improved maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laofahai/linchkit/pull/413?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->