### PR TITLE
chore(ci): add advisory Capability Lint job enforcing Spec 21 §9.1 (#122)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,37 @@ jobs:
             exit 0
           fi
           exit "$RC"
+
+  capability-lint:
+    name: Capability Lint
+    runs-on: ubuntu-latest
+    # Advisory gate for Spec 21 §9.1: surfaces non-compliant capabilities on
+    # every PR. This job is intentionally NOT in the branch-protection required
+    # checks — it reports (red X) without blocking merge. Promote it to a
+    # required check in branch protection to make §9.1 compliance mandatory.
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Lint all capabilities (metadata, import-boundary, tests)
+        shell: bash
+        run: |
+          # Run `linch lint-capability` over every addon capability. Fail this
+          # job if any capability violates a §9.1 gate so the regression is
+          # visible on the PR. All addons pass as of this job's introduction.
+          fail=0
+          for d in addons/*/cap-*/; do
+            if ! bun packages/cli/src/index.ts lint-capability "$d"; then
+              fail=1
+            fi
+          done
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::One or more capabilities failed lint-capability (Spec 21 §9.1)."
+          fi
+          exit "$fail"


### PR DESCRIPTION
## What

Adds a dedicated CI job (`Capability Lint`) that runs `linch lint-capability` over **every addon** on each PR — the automated-pipeline piece of Spec 21 §9.1. Checks: metadata completeness, `@linchkit/core` import-boundary, test existence.

All 29 addons pass as of #413, so the job is **green today** and only turns red if a future capability regresses §9.1.

## Blocking vs advisory (deliberate)

The job is **intentionally NOT in the branch-protection required checks** — it reports (red X) without blocking merge. This avoids any risk of a self-inflicted PR freeze (cf. #400) from an unforeseen CI-environment edge case, while still surfacing regressions on every PR.

**To make §9.1 mandatory:** add `Capability Lint` to the required status checks in branch protection (one setting, fully reversible). Left to the repo owner.

## Verification

- Ran the exact job loop locally → all 29 addons PASS (exit 0).
- `ci.yml` validated with a YAML parser (jobs: `quality`, `capability-lint`).
- The change is a single new job; the existing `Code Quality` job is untouched.

## Note

Cross-model review: the gemini **CLI** is quota-exhausted (~6h reset), so the cross-model pass is manual review + the gemini-code-assist / CodeRabbit PR bots (separate from the CLI quota).

Part of #122 (Spec 21 §9.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)