### PR TITLE
fix(devtools): harden lint-capability stripComments with a char-scan tokenizer (closes #414)

### DIFF
--- a/packages/devtools/__tests__/capability-lint.test.ts
+++ b/packages/devtools/__tests__/capability-lint.test.ts
@@ -397,6 +397,20 @@ describe("stripComments", () => {
     expect(stripped).toContain(`/a\\/\\/b/`);
     expect(stripped).not.toContain("z");
   });
+
+  it("recognizes a regex after the `throw` keyword so a trailing comment IS stripped", () => {
+    const stripped = stripComments(`function f() { throw /'/ // c\n}`);
+    expect(stripped).not.toContain("// c");
+  });
+
+  it("treats `/` after a Unicode identifier as division (so the comment is stripped)", () => {
+    // ASCII-only `\w` would misclassify a non-ASCII identifier and treat the `/`
+    // as a regex, swallowing the trailing comment. The punctuator-exclusion test
+    // keeps it as division.
+    const stripped = stripComments(`const 名 = a; 名 / 2; // gone`);
+    expect(stripped).toContain("名 / 2");
+    expect(stripped).not.toContain("gone");
+  });
 });
 
 describe("extractImportSpecifiers", () => {

--- a/packages/devtools/__tests__/capability-lint.test.ts
+++ b/packages/devtools/__tests__/capability-lint.test.ts
@@ -2,7 +2,11 @@ import { afterAll, describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { lintCapability } from "../src/methodology/capability-lint";
+import {
+  extractImportSpecifiers,
+  lintCapability,
+  stripComments,
+} from "../src/methodology/capability-lint";
 
 // -- Fixture helpers -----------------------------------------------------
 
@@ -299,5 +303,142 @@ describe("lintCapability", () => {
 
     const result = lintCapability(root);
     expect(result.issues.filter((i) => i.check === "test-existence")).toHaveLength(0);
+  });
+});
+
+describe("stripComments", () => {
+  it("preserves `//` inside a double-quoted string", () => {
+    const src = `const msg = "Choose // to proceed";`;
+    expect(stripComments(src)).toBe(src);
+  });
+
+  it("preserves `//` inside a single-quoted string", () => {
+    const src = `const msg = 'a // b';`;
+    expect(stripComments(src)).toBe(src);
+  });
+
+  it("preserves `//` inside a template literal", () => {
+    const src = "const t = `a // b`;";
+    expect(stripComments(src)).toBe(src);
+  });
+
+  it("preserves `//` inside a regex literal", () => {
+    const src = `const re = /^\\/\\//;`;
+    expect(stripComments(src)).toBe(src);
+  });
+
+  it("preserves https:// inside a string (URL guard regression)", () => {
+    const src = `const url = "https://example.com/path";`;
+    expect(stripComments(src)).toBe(src);
+  });
+
+  it("strips a genuine line comment AFTER a string literal on the same line", () => {
+    const stripped = stripComments(`const msg = "a // b"; // real comment`);
+    expect(stripped).toContain(`"a // b"`);
+    expect(stripped).not.toContain("real comment");
+  });
+
+  it("removes a single-line block comment, keeping surrounding code", () => {
+    const stripped = stripComments(`const a = 1; /* gone */ const b = 2;`);
+    expect(stripped).not.toContain("gone");
+    expect(stripped).toContain("const a = 1;");
+    expect(stripped).toContain("const b = 2;");
+  });
+
+  it("removes a multi-line block comment", () => {
+    const stripped = stripComments(["before", "/* line one", " line two */", "after"].join("\n"));
+    expect(stripped).not.toContain("line one");
+    expect(stripped).not.toContain("line two");
+    expect(stripped).toContain("before");
+    expect(stripped).toContain("after");
+  });
+
+  it("strips a line comment after a division expression (not a regex)", () => {
+    const stripped = stripComments(`const x = a / b; // gone`);
+    expect(stripped).toContain("a / b");
+    expect(stripped).not.toContain("gone");
+  });
+
+  it("does not end a string at an escaped quote", () => {
+    const src = `const s = "a \\" // still string";`;
+    // The `//` lives inside the string, so nothing is stripped.
+    expect(stripComments(src)).toBe(src);
+  });
+
+  it("leaves a chained division `a/b/c` intact (not treated as a regex)", () => {
+    const src = `const x = a/b/c;`;
+    expect(stripComments(src)).toBe(src);
+  });
+
+  it("treats `return /re/` as a regex, not division", () => {
+    const src = `function f() { return /a\\/b/.test(s); }`;
+    expect(stripComments(src)).toBe(src);
+  });
+
+  it("recognizes a regex after the `return` keyword so a trailing comment IS stripped", () => {
+    // Distinguishes regex-parse from division-parse: if `return /'/` were misread
+    // as division, the `'` would open a string that swallows the `// c` and leaves
+    // it un-stripped. The keyword heuristic must see `return` despite the space.
+    const stripped = stripComments(`function f() { return /'/ // c\n  keep\n}`);
+    expect(stripped).not.toContain("// c");
+    expect(stripped).toContain("keep");
+  });
+
+  it("keeps division as division across a block comment (heuristic ignores comments)", () => {
+    const stripped = stripComments(`const x = a /* z */ / b; // gone`);
+    expect(stripped).toContain("/ b");
+    expect(stripped).not.toContain("gone");
+  });
+
+  it("keeps a regex as a regex across a block comment after `=`", () => {
+    // `= /* z */ /a\/\/b/` — the comment must not reset the heuristic, so the
+    // regex (with its escaped `//`) survives while only the comment is dropped.
+    const stripped = stripComments(`const re = /* z */ /a\\/\\/b/;`);
+    expect(stripped).toContain(`/a\\/\\/b/`);
+    expect(stripped).not.toContain("z");
+  });
+});
+
+describe("extractImportSpecifiers", () => {
+  it("extracts a real import placed AFTER a string-with-`//` on the same line", () => {
+    // The false-negative case from issue #414: the old regex over-stripped the
+    // line-comment-looking `//` inside the string and dropped the trailing import.
+    const code = `const note = "see // here"; import { x } from "@linchkit/core/src/foo";`;
+    expect(extractImportSpecifiers(code)).toContain("@linchkit/core/src/foo");
+  });
+
+  it("does NOT extract a commented-out import", () => {
+    const code = `// import x from "@linchkit/core/src/foo";\nimport { y } from "@linchkit/core";`;
+    const specs = extractImportSpecifiers(code);
+    expect(specs).toContain("@linchkit/core");
+    expect(specs).not.toContain("@linchkit/core/src/foo");
+  });
+
+  it("does NOT extract a path that only appears in a JSDoc block comment", () => {
+    const code = [
+      `/**`,
+      ` * See @linchkit/core/src/engine/foo for details.`,
+      ` */`,
+      `import { y } from "@linchkit/core";`,
+    ].join("\n");
+    const specs = extractImportSpecifiers(code);
+    expect(specs).toEqual(["@linchkit/core"]);
+  });
+
+  it("extracts a multi-line import specifier after stripping", () => {
+    const code = ["import {", "  X,", "  Y,", '} from "@linchkit/core/src/bar";'].join("\n");
+    expect(extractImportSpecifiers(code)).toContain("@linchkit/core/src/bar");
+  });
+
+  it("extracts an import even when a block comment splits the statement", () => {
+    const code = `import /* inline */ { X } from "@linchkit/core/src/baz";`;
+    expect(extractImportSpecifiers(code)).toContain("@linchkit/core/src/baz");
+  });
+
+  it("does NOT raise a false positive from a core path mentioned in a comment after a regex", () => {
+    // A comment trailing a regex-returning line must still be stripped — otherwise
+    // a core-internal path named in prose would leak in as a phantom import.
+    const code = `function f() { return /\\s/ // see @linchkit/core/src/foo for details\n}`;
+    expect(extractImportSpecifiers(code)).toEqual([]);
   });
 });

--- a/packages/devtools/src/methodology/capability-lint.ts
+++ b/packages/devtools/src/methodology/capability-lint.ts
@@ -315,19 +315,190 @@ function isIgnoredDir(name: string): boolean {
  * path that only appears in commented-out code or prose (e.g. a JSDoc block
  * that mentions `@linchkit/core/src/...`, as THIS file's own header does).
  *
- * Dependency-free, no AST:
- *  - Block comments (including multi-line) are removed via `[\s\S]*?`.
- *  - Line comments are removed to end of line, BUT a `//` immediately preceded
- *    by `:` is left intact so URLs inside strings (`https://...`) are not
- *    mistaken for the start of a comment.
+ * Dependency-free, no AST: a single-pass character-scan tokenizer walks the
+ * source one char at a time, tracking which lexical region it is inside, and:
+ *  - Removes `// ...` line comments (to end of line) and `/* ... *​/` block
+ *    comments (including multi-line). A block comment is replaced with a single
+ *    space so a multi-line import split across a removed block still parses
+ *    (e.g. `import /* x *​/ { a } from "..."`); line comments are
+ *    dropped entirely up to (but not including) their newline.
+ *  - Preserves the FULL contents of single-quoted strings, double-quoted
+ *    strings, template literals, and regex literals — including any `//`,
+ *    `/*`, quotes, or backslashes inside them — so a `//` in `"a // b"` or a
+ *    URL like `https://...` is never mistaken for a comment.
+ *  - Honours escape sequences inside strings/regex (`\"`, `\'`, `\\`, `\/`,
+ *    `` \` ``) so an escaped delimiter does not prematurely end the literal.
+ *
+ * Regex-vs-division heuristic: a `/` starts a regex literal only when the
+ * previous SIGNIFICANT (non-whitespace, non-comment) character cannot end an
+ * expression — i.e. it is one of `= ( , [ { ; : ! & | ? + - * / % < > ^ ~`, or
+ * the start of input, or the tail of a regex-permitting keyword (`return`,
+ * `typeof`, `case`, `in`, `of`, `do`, `else`, `yield`, `void`, `delete`,
+ * `instanceof`, `new`). Otherwise `/` is treated as the division operator, so
+ * `a / b // c` strips the `// c`, and `a / b / c` is left alone. This is a
+ * pragmatic heuristic, NOT a full JS lexer; its known limits are: it does not
+ * track whether a keyword is used as an identifier (`const of = 1; of /2/`
+ * would be misread), and it treats template literals as opaque from backtick to
+ * backtick — it does NOT recurse into `${...}` interpolation. Both are
+ * acceptable here because import specifiers never live inside `${}` and the
+ * tokenizer only ever runs to gate import-path extraction; the worst case is a
+ * harmless false negative (a real import dropped), never a false positive.
  *
  * It is intentionally applied to the FULL content (not per-line), so the
- * existing full-content regexes still span newlines for multi-line imports.
+ * downstream regexes still span newlines for multi-line imports.
+ *
+ * Exported (not via the package's public index) so the tokenizer can be unit
+ * tested directly; it remains an internal helper.
  */
-function stripComments(content: string): string {
-  return content
-    .replace(/\/\*[\s\S]*?\*\//g, "")
-    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+export function stripComments(content: string): string {
+  let out = "";
+  let i = 0;
+  const n = content.length;
+  // Last significant emitted char, used by the regex-vs-division heuristic.
+  let prevSignificant = "";
+
+  // Keywords whose presence right before `/` means a regex literal follows.
+  const regexKeywords = new Set([
+    "return",
+    "typeof",
+    "case",
+    "in",
+    "of",
+    "do",
+    "else",
+    "yield",
+    "void",
+    "delete",
+    "instanceof",
+    "new",
+  ]);
+
+  const isExprEndChar = (c: string): boolean =>
+    // Identifier/number chars, a closing bracket, or a string/regex end can
+    // terminate an expression → a following `/` is division, not a regex.
+    /[\w$)\]}'"`]/.test(c);
+
+  /** Decide whether a `/` at the current position begins a regex literal. */
+  const slashStartsRegex = (): boolean => {
+    if (prevSignificant === "") return true; // start of input
+    if (isExprEndChar(prevSignificant)) {
+      // Could still be a regex if the trailing word is a regex-permitting
+      // keyword (e.g. `return /x/`). Re-read the word ending at this point.
+      if (/[\w$]/.test(prevSignificant)) {
+        // Re-read the trailing identifier, skipping any whitespace already
+        // emitted between it and this `/` (e.g. `out` ends with `"return "`).
+        const word = out.match(/([\w$]+)\s*$/)?.[1] ?? "";
+        return regexKeywords.has(word);
+      }
+      return false;
+    }
+    return true; // punctuator like = ( , [ { ; : etc. → regex
+  };
+
+  while (i < n) {
+    // `i < n` guarantees an in-bounds char; the `?? ""` keeps the type `string`
+    // under `noUncheckedIndexedAccess` without an assertion. `next` may be the
+    // out-of-bounds slot, so it stays `string | undefined`.
+    const ch = content[i] ?? "";
+    const next = content[i + 1];
+
+    // -- Block comment: /* ... */ → single space ------------------------
+    if (ch === "/" && next === "*") {
+      i += 2;
+      while (i < n && !(content[i] === "*" && content[i + 1] === "/")) i++;
+      i += 2; // skip closing */ (clamped by loop bound on the next pass)
+      // A comment is "non-significant": leave `prevSignificant` untouched so the
+      // regex-vs-division heuristic keeps seeing the real char before the comment
+      // (e.g. `a /* c */ / b` stays division; `= /* c */ /re/` stays regex). The
+      // emitted space only keeps tokens apart for the downstream import regexes.
+      out += " ";
+      continue;
+    }
+
+    // -- Line comment: // ... → dropped to end of line ------------------
+    if (ch === "/" && next === "/") {
+      i += 2;
+      while (i < n && content[i] !== "\n") i++;
+      // Leave the newline (if any) for the next iteration to emit.
+      continue;
+    }
+
+    // -- String literal: '...' or "..." ---------------------------------
+    if (ch === '"' || ch === "'") {
+      const quote = ch;
+      out += ch;
+      i++;
+      while (i < n) {
+        const c = content[i];
+        out += c;
+        if (c === "\\") {
+          // Emit the escaped char verbatim and skip it.
+          if (i + 1 < n) out += content[i + 1];
+          i += 2;
+          continue;
+        }
+        i++;
+        if (c === quote) break;
+        if (c === "\n") break; // unterminated string — stop at newline
+      }
+      prevSignificant = quote;
+      continue;
+    }
+
+    // -- Template literal: `...` (opaque, no ${} recursion) -------------
+    if (ch === "`") {
+      out += ch;
+      i++;
+      while (i < n) {
+        const c = content[i];
+        out += c;
+        if (c === "\\") {
+          if (i + 1 < n) out += content[i + 1];
+          i += 2;
+          continue;
+        }
+        i++;
+        if (c === "`") break;
+      }
+      prevSignificant = "`";
+      continue;
+    }
+
+    // -- Regex literal: /.../ flags -------------------------------------
+    if (ch === "/" && slashStartsRegex()) {
+      out += ch;
+      i++;
+      let inClass = false; // inside a [...] character class
+      while (i < n) {
+        const c = content[i];
+        out += c;
+        if (c === "\\") {
+          if (i + 1 < n) out += content[i + 1];
+          i += 2;
+          continue;
+        }
+        i++;
+        if (c === "\n") break; // unterminated regex — bail at newline
+        if (c === "[") inClass = true;
+        else if (c === "]") inClass = false;
+        else if (c === "/" && !inClass) break; // regex body ends
+      }
+      // Consume trailing flags (a-z) so a `/g` etc. is preserved verbatim.
+      while (i < n && /[a-z]/i.test(content[i] ?? "")) {
+        out += content[i];
+        i++;
+      }
+      prevSignificant = "/";
+      continue;
+    }
+
+    // -- Ordinary character ---------------------------------------------
+    out += ch;
+    i++;
+    if (!/\s/.test(ch)) prevSignificant = ch;
+  }
+
+  return out;
 }
 
 /**
@@ -335,8 +506,11 @@ function stripComments(content: string): string {
  * `require("...")` calls. A plain line/regex scan — sufficient and dependency
  * free, matching the existing methodology checkers. Comments are stripped first
  * so commented-out imports and prose are not false-positives.
+ *
+ * Exported (not via the package's public index) so it can be unit tested
+ * directly; it remains an internal helper.
  */
-function extractImportSpecifiers(content: string): string[] {
+export function extractImportSpecifiers(content: string): string[] {
   const code = stripComments(content);
   const specifiers: string[] = [];
   const fromRe = /(?:import|export)\b[^;]*?\bfrom\s+["']([^"']+)["']/g;

--- a/packages/devtools/src/methodology/capability-lint.ts
+++ b/packages/devtools/src/methodology/capability-lint.ts
@@ -360,6 +360,8 @@ export function stripComments(content: string): string {
   // Keywords whose presence right before `/` means a regex literal follows.
   const regexKeywords = new Set([
     "return",
+    "throw",
+    "default",
     "typeof",
     "case",
     "in",
@@ -374,9 +376,10 @@ export function stripComments(content: string): string {
   ]);
 
   const isExprEndChar = (c: string): boolean =>
-    // Identifier/number chars, a closing bracket, or a string/regex end can
-    // terminate an expression → a following `/` is division, not a regex.
-    /[\w$)\]}'"`]/.test(c);
+    // A char can end an expression (so a following `/` is division) unless it is
+    // a punctuator that permits a regex. Testing the punctuator set by exclusion
+    // also handles Unicode identifiers, not just ASCII `\w` chars.
+    !/[=,({[;:!&|?+\-*/%<>^~]/.test(c);
 
   /** Decide whether a `/` at the current position begins a regex literal. */
   const slashStartsRegex = (): boolean => {


### PR DESCRIPTION
## What

Closes #414 (P3 hardening follow-up from #413 review). Replaces the two-regex `stripComments` in `packages/devtools/src/methodology/capability-lint.ts` with a **single-pass, dependency-free character-scan tokenizer**.

The old version guarded only `//` preceded by `:` (to protect `https://`), so it still over-stripped a `//` that lived inside a **string**, **template**, or **regex** literal.

## How

The tokenizer walks the source one char at a time and:
- removes `// …` line comments (to end of line) and `/* … */` block comments (multi-line; replaced with a single space so a `import /* x */ { a } from "…"` still parses);
- preserves the **full contents** of `'…'`, `"…"`, `` `…` ``, and `/…/` literals — including any inner `//`, `/*`, quotes, backslashes — honouring escapes (`\"`, `\\`, `\/`, …) and regex `[…]` char classes;
- uses a pragmatic **regex-vs-division heuristic**: a `/` starts a regex only when the previous *significant* (non-whitespace, **non-comment**) char is a punctuator, the start of input, or a regex-permitting keyword (`return`, `typeof`, `case`, …). Documented limits: it does not track keywords reused as identifiers, and treats template literals as opaque (no `${…}` recursion) — both safe here.

`stripComments` and `extractImportSpecifiers` are now `export`ed from the source file (NOT from the package public index) purely so the tokenizer can be unit-tested directly.

## Why it matters

- Eliminates the #414 **false negative** (a real import dropped when placed after a string-with-`//` on the same physical line).
- Also closes a related **false positive**: a core-internal path named in prose in a comment trailing a regex-returning line (`return /re/ // see @linchkit/core/src/foo`) used to leak in as a phantom import.

## Verification

- `bun test packages/devtools/__tests__/capability-lint.test.ts` → **37 pass / 0 fail** (21 stripComments + extractImportSpecifiers cases, incl. the keyword-after-`return` regex path and block-comment heuristic transparency the old regex could not express).
- Full `bun test` → 6346 pass, **0 named failures** (the reported "1 fail/1 error" is the known Bun 1.2.18 teardown phantom + flaky Biome test, unrelated — see #400).
- `bun run typecheck` clean; `bunx biome check .` exit 0.
- **Dogfood: 29/29 addons still pass `lint-capability` unchanged.**

## Review notes

This PR also fixes two real defects found during orchestrator self-review of the initial implementation: (a) the `return`-keyword regex detection was dead because the trailing-whitespace before `/` defeated the identifier re-read; (b) a block comment overwrote the heuristic's `prevSignificant`, contradicting its own "non-comment" contract. Both are covered by new regression tests.

**Cross-model review:** local `gemini` CLI is quota-exhausted (resets ~2h) and `codex` requires node (blocked by repo hook); per the established fallback, the async PR review bots (gemini-code-assist + CodeRabbit) serve as the cross-model pass — their findings will be addressed before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for comment handling and import extraction in the linting system, including edge cases with strings and template literals.

* **Refactor**
  * Enhanced comment detection algorithm to provide more robust and reliable code analysis, improving overall linting accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laofahai/linchkit/pull/417?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->