### PR TITLE
feat(devtools): lint-capability — enforce real tests + core-version declaration; align addon coreVersion (#122)

### DIFF
--- a/addons/adapter-a2a/cap-adapter-a2a/package.json
+++ b/addons/adapter-a2a/cap-adapter-a2a/package.json
@@ -21,7 +21,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "minCoreVersion": "^0.2.0",
+    "coreVersion": "^0.2.0",
     "type": "adapter",
     "category": "integration"
   }

--- a/addons/adapter-ag-ui/cap-adapter-ag-ui/package.json
+++ b/addons/adapter-ag-ui/cap-adapter-ag-ui/package.json
@@ -21,7 +21,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "minCoreVersion": "^0.2.0",
+    "coreVersion": "^0.2.0",
     "type": "adapter",
     "category": "integration"
   }

--- a/addons/adapter-mcp/cap-adapter-mcp/package.json
+++ b/addons/adapter-mcp/cap-adapter-mcp/package.json
@@ -24,7 +24,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "minCoreVersion": "^0.1.0",
+    "coreVersion": "^0.2.0",
     "type": "adapter",
     "category": "integration"
   }

--- a/addons/adapter-mcp/cap-mcp-ui/package.json
+++ b/addons/adapter-mcp/cap-mcp-ui/package.json
@@ -26,7 +26,7 @@
     "@linchkit/cap-adapter-mcp": "workspace:*"
   },
   "linchkit": {
-    "minCoreVersion": "^0.1.0",
+    "coreVersion": "^0.2.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/adapter-server/cap-adapter-server/package.json
+++ b/addons/adapter-server/cap-adapter-server/package.json
@@ -34,7 +34,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "minCoreVersion": "^0.1.0",
+    "coreVersion": "^0.2.0",
     "type": "adapter",
     "category": "integration"
   }

--- a/addons/adapter-ui/cap-adapter-ui/package.json
+++ b/addons/adapter-ui/cap-adapter-ui/package.json
@@ -71,7 +71,7 @@
     "autoprefixer": "^10.4.27"
   },
   "linchkit": {
-    "minCoreVersion": "^0.1.0",
+    "coreVersion": "^0.2.0",
     "type": "adapter",
     "category": "integration"
   }

--- a/addons/ai-provider/cap-ai-provider/package.json
+++ b/addons/ai-provider/cap-ai-provider/package.json
@@ -27,7 +27,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "minCoreVersion": "^0.1.0",
+    "coreVersion": "^0.2.0",
     "type": "adapter",
     "category": "integration"
   }

--- a/addons/audit/cap-audit-ui/package.json
+++ b/addons/audit/cap-audit-ui/package.json
@@ -24,7 +24,7 @@
     "@linchkit/cap-adapter-ui": "workspace:*"
   },
   "linchkit": {
-    "minCoreVersion": "^0.2.0",
+    "coreVersion": "^0.2.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/auth/cap-auth-better-auth/package.json
+++ b/addons/auth/cap-auth-better-auth/package.json
@@ -26,7 +26,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "minCoreVersion": "^0.1.0",
+    "coreVersion": "^0.2.0",
     "type": "adapter",
     "category": "system"
   }

--- a/addons/auth/cap-auth/package.json
+++ b/addons/auth/cap-auth/package.json
@@ -37,7 +37,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "minCoreVersion": "^0.1.0",
+    "coreVersion": "^0.2.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/cache-redis/cap-cache-redis/package.json
+++ b/addons/cache-redis/cap-cache-redis/package.json
@@ -28,7 +28,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "minCoreVersion": "^0.1.0",
+    "coreVersion": "^0.2.0",
     "type": "standard",
     "category": "system",
     "autoInstall": false

--- a/addons/chatter/cap-chatter-ui/package.json
+++ b/addons/chatter/cap-chatter-ui/package.json
@@ -25,7 +25,7 @@
     "@linchkit/ui-kit": "workspace:*"
   },
   "linchkit": {
-    "minCoreVersion": "^0.1.0",
+    "coreVersion": "^0.2.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/chatter/cap-chatter/package.json
+++ b/addons/chatter/cap-chatter/package.json
@@ -27,7 +27,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "minCoreVersion": "^0.1.0",
+    "coreVersion": "^0.2.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/file-storage/cap-file-storage/package.json
+++ b/addons/file-storage/cap-file-storage/package.json
@@ -26,7 +26,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "minCoreVersion": "^0.1.0",
+    "coreVersion": "^0.2.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/flow-restate/cap-flow-restate/package.json
+++ b/addons/flow-restate/cap-flow-restate/package.json
@@ -23,7 +23,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "minCoreVersion": "^0.1.0",
+    "coreVersion": "^0.2.0",
     "type": "standard",
     "category": "infrastructure"
   }

--- a/addons/keyboard-shortcuts/cap-keyboard-shortcuts/package.json
+++ b/addons/keyboard-shortcuts/cap-keyboard-shortcuts/package.json
@@ -25,7 +25,7 @@
     "@linchkit/core": "workspace:*"
   },
   "linchkit": {
-    "minCoreVersion": "^0.2.0",
+    "coreVersion": "^0.2.0",
     "type": "standard",
     "category": "system",
     "autoInstall": false

--- a/addons/migration/cap-migration/package.json
+++ b/addons/migration/cap-migration/package.json
@@ -17,7 +17,7 @@
     "@linchkit/core": "workspace:*"
   },
   "linchkit": {
-    "minCoreVersion": "^0.1.0",
+    "coreVersion": "^0.2.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/notification/cap-notification/package.json
+++ b/addons/notification/cap-notification/package.json
@@ -25,7 +25,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "minCoreVersion": "^0.1.0",
+    "coreVersion": "^0.2.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/observability/cap-observability-otel/package.json
+++ b/addons/observability/cap-observability-otel/package.json
@@ -37,7 +37,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "minCoreVersion": "^0.2.0",
+    "coreVersion": "^0.2.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/permission/cap-permission/package.json
+++ b/addons/permission/cap-permission/package.json
@@ -20,7 +20,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "minCoreVersion": "^0.1.0",
+    "coreVersion": "^0.2.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/search/cap-search-ui/package.json
+++ b/addons/search/cap-search-ui/package.json
@@ -27,7 +27,7 @@
     "@linchkit/cap-search": "workspace:*"
   },
   "linchkit": {
-    "minCoreVersion": "^0.2.0",
+    "coreVersion": "^0.2.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/search/cap-search/package.json
+++ b/addons/search/cap-search/package.json
@@ -28,7 +28,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "minCoreVersion": "^0.1.0",
+    "coreVersion": "^0.2.0",
     "type": "standard",
     "category": "system"
   }

--- a/addons/theme/cap-theme/package.json
+++ b/addons/theme/cap-theme/package.json
@@ -27,7 +27,7 @@
     "@linchkit/cap-adapter-ui": "workspace:*"
   },
   "linchkit": {
-    "minCoreVersion": "^0.2.0",
+    "coreVersion": "^0.2.0",
     "type": "standard",
     "category": "system",
     "autoInstall": false

--- a/addons/vector/cap-vector-pgvector/package.json
+++ b/addons/vector/cap-vector-pgvector/package.json
@@ -26,7 +26,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "minCoreVersion": "^0.2.0",
+    "coreVersion": "^0.2.0",
     "type": "standard",
     "category": "system",
     "autoInstall": false

--- a/addons/view-calendar/cap-view-calendar/package.json
+++ b/addons/view-calendar/cap-view-calendar/package.json
@@ -31,7 +31,7 @@
     "typescript": "^6.0.2"
   },
   "linchkit": {
-    "minCoreVersion": "^0.2.0",
+    "coreVersion": "^0.2.0",
     "type": "standard",
     "category": "view",
     "autoInstall": false

--- a/addons/view-kanban/cap-view-kanban/package.json
+++ b/addons/view-kanban/cap-view-kanban/package.json
@@ -32,7 +32,7 @@
     "@linchkit/cap-adapter-ui": "workspace:*"
   },
   "linchkit": {
-    "minCoreVersion": "^0.2.0",
+    "coreVersion": "^0.2.0",
     "type": "standard",
     "category": "view",
     "autoInstall": false

--- a/addons/view-timeline/cap-view-timeline/package.json
+++ b/addons/view-timeline/cap-view-timeline/package.json
@@ -28,7 +28,7 @@
     "@linchkit/cap-adapter-ui": "workspace:*"
   },
   "linchkit": {
-    "minCoreVersion": "^0.2.0",
+    "coreVersion": "^0.2.0",
     "type": "standard",
     "category": "view",
     "autoInstall": false

--- a/packages/devtools/__tests__/capability-lint.test.ts
+++ b/packages/devtools/__tests__/capability-lint.test.ts
@@ -33,6 +33,24 @@ const VALID_CAPABILITY_JSON = {
   label: "Sample Capability",
 };
 
+/**
+ * A package.json that satisfies the core-version check: declares
+ * `@linchkit/core` as a peerDependency and a matching `coreVersion`. Used by
+ * fixtures that exercise OTHER checks and must otherwise be fully clean.
+ */
+function writeCorePackageJson(root: string, coreRange = "^0.2.0"): void {
+  writeFile(
+    root,
+    "package.json",
+    JSON.stringify({
+      name: "@linchkit/cap-sample",
+      version: "1.0.0",
+      peerDependencies: { "@linchkit/core": coreRange },
+      linchkit: { coreVersion: coreRange },
+    }),
+  );
+}
+
 afterAll(() => {
   for (const root of tmpRoots) {
     rmSync(root, { recursive: true, force: true });
@@ -45,6 +63,7 @@ describe("lintCapability", () => {
   it("returns ok for a clean capability (valid manifest + core barrel import + test)", () => {
     const root = makeCapDir();
     writeFile(root, "capability.json", JSON.stringify(VALID_CAPABILITY_JSON));
+    writeCorePackageJson(root);
     writeFile(root, "src/index.ts", `import { defineEntity } from "@linchkit/core";\nexport {};\n`);
     writeFile(
       root,
@@ -65,7 +84,8 @@ describe("lintCapability", () => {
       JSON.stringify({
         name: "@linchkit/cap-fallback",
         version: "1.0.0",
-        linchkit: { type: "adapter", category: "integration", minCoreVersion: "^0.1.0" },
+        peerDependencies: { "@linchkit/core": "^0.2.0" },
+        linchkit: { type: "adapter", category: "integration", coreVersion: "^0.2.0" },
       }),
     );
     writeFile(
@@ -158,6 +178,7 @@ describe("lintCapability", () => {
   it("does NOT flag the bare @linchkit/core barrel or public subpath imports", () => {
     const root = makeCapDir();
     writeFile(root, "capability.json", JSON.stringify(VALID_CAPABILITY_JSON));
+    writeCorePackageJson(root);
     writeFile(
       root,
       "src/index.ts",
@@ -178,6 +199,7 @@ describe("lintCapability", () => {
   it("does NOT flag a deep import that only appears in comments", () => {
     const root = makeCapDir();
     writeFile(root, "capability.json", JSON.stringify(VALID_CAPABILITY_JSON));
+    writeCorePackageJson(root);
     writeFile(
       root,
       "src/index.ts",
@@ -303,6 +325,256 @@ describe("lintCapability", () => {
 
     const result = lintCapability(root);
     expect(result.issues.filter((i) => i.check === "test-existence")).toHaveLength(0);
+  });
+
+  // -- Check 3 (executable test content) -------------------------------
+
+  it("accepts a test file containing a real it(...) block", () => {
+    const root = makeCapDir();
+    writeFile(root, "capability.json", JSON.stringify(VALID_CAPABILITY_JSON));
+    writeFile(root, "src/index.ts", `import { x } from "@linchkit/core";\nexport {};\n`);
+    writeFile(
+      root,
+      "src/real.test.ts",
+      `import { expect, it } from "bun:test";\nit("does a thing", () => expect(1).toBe(1));\n`,
+    );
+
+    const result = lintCapability(root);
+    expect(result.issues.filter((i) => i.check === "test-existence")).toHaveLength(0);
+  });
+
+  it("fails the basic-test check for an empty test file (no executable test)", () => {
+    const root = makeCapDir();
+    writeFile(root, "capability.json", JSON.stringify(VALID_CAPABILITY_JSON));
+    writeCorePackageJson(root);
+    writeFile(root, "src/index.ts", `import { x } from "@linchkit/core";\nexport {};\n`);
+    // File exists and matches the *.test.ts pattern but contains no test call.
+    writeFile(root, "src/empty.test.ts", `export {};\n`);
+
+    const result = lintCapability(root);
+    expect(result.ok).toBe(false);
+    const testIssues = result.issues.filter((i) => i.check === "test-existence");
+    expect(testIssues).toHaveLength(1);
+    expect(testIssues[0]?.level).toBe("error");
+    expect(testIssues[0]?.message).toContain("executable test");
+  });
+
+  it("fails the basic-test check when the only test() call is commented out", () => {
+    const root = makeCapDir();
+    writeFile(root, "capability.json", JSON.stringify(VALID_CAPABILITY_JSON));
+    writeCorePackageJson(root);
+    writeFile(root, "src/index.ts", `import { x } from "@linchkit/core";\nexport {};\n`);
+    writeFile(
+      root,
+      "src/commented.test.ts",
+      [
+        `import { test } from "bun:test";`,
+        `// test("disabled", () => {});`,
+        `/* test("also disabled", () => {}); */`,
+        `export {};`,
+      ].join("\n"),
+    );
+
+    const result = lintCapability(root);
+    const testIssues = result.issues.filter((i) => i.check === "test-existence");
+    expect(testIssues).toHaveLength(1);
+    expect(testIssues[0]?.level).toBe("error");
+  });
+
+  it("accepts test.only(...) and describe(...) member forms as executable tests", () => {
+    const root = makeCapDir();
+    writeFile(root, "capability.json", JSON.stringify(VALID_CAPABILITY_JSON));
+    writeFile(root, "src/index.ts", `import { x } from "@linchkit/core";\nexport {};\n`);
+    writeFile(
+      root,
+      "src/member.test.ts",
+      `import { describe, test } from "bun:test";\ndescribe("suite", () => { test.only("x", () => {}); });\n`,
+    );
+
+    const result = lintCapability(root);
+    expect(result.issues.filter((i) => i.check === "test-existence")).toHaveLength(0);
+  });
+
+  // -- Check 4 (core version declaration consistency) ------------------
+
+  it("passes when peerDep and coreVersion are present and consistent", () => {
+    const root = makeCapDir();
+    writeFile(
+      root,
+      "package.json",
+      JSON.stringify({
+        name: "@linchkit/cap-cv",
+        version: "1.0.0",
+        peerDependencies: { "@linchkit/core": "^0.2.0" },
+        linchkit: { type: "standard", category: "business", coreVersion: "^0.2.0" },
+      }),
+    );
+    writeFile(root, "src/index.ts", `import { x } from "@linchkit/core";\nexport {};\n`);
+    writeFile(root, "src/a.test.ts", `import { test } from "bun:test";\ntest("a", () => {});\n`);
+
+    const result = lintCapability(root);
+    expect(result.issues.filter((i) => i.check === "core-version")).toHaveLength(0);
+    expect(result.ok).toBe(true);
+  });
+
+  it("errors when peerDep ^0.2.0 does not equal coreVersion ^0.1.0 (mismatch)", () => {
+    const root = makeCapDir();
+    writeFile(
+      root,
+      "package.json",
+      JSON.stringify({
+        name: "@linchkit/cap-cv",
+        version: "1.0.0",
+        peerDependencies: { "@linchkit/core": "^0.2.0" },
+        linchkit: { type: "standard", category: "business", coreVersion: "^0.1.0" },
+      }),
+    );
+    writeFile(root, "src/index.ts", `import { x } from "@linchkit/core";\nexport {};\n`);
+    writeFile(root, "src/a.test.ts", `import { test } from "bun:test";\ntest("a", () => {});\n`);
+
+    const result = lintCapability(root);
+    expect(result.ok).toBe(false);
+    const cv = result.issues.filter((i) => i.check === "core-version" && i.level === "error");
+    expect(cv).toHaveLength(1);
+    expect(cv[0]?.message).toContain("^0.2.0");
+    expect(cv[0]?.message).toContain("^0.1.0");
+  });
+
+  it("errors when @linchkit/core is missing from peerDependencies", () => {
+    const root = makeCapDir();
+    writeFile(
+      root,
+      "package.json",
+      JSON.stringify({
+        name: "@linchkit/cap-cv",
+        version: "1.0.0",
+        // No peerDependencies block at all.
+        linchkit: { type: "standard", category: "business", coreVersion: "^0.2.0" },
+      }),
+    );
+    writeFile(root, "src/index.ts", `import { x } from "@linchkit/core";\nexport {};\n`);
+    writeFile(root, "src/a.test.ts", `import { test } from "bun:test";\ntest("a", () => {});\n`);
+
+    const result = lintCapability(root);
+    expect(result.ok).toBe(false);
+    const cv = result.issues.filter((i) => i.check === "core-version" && i.level === "error");
+    expect(cv.some((i) => i.message.includes("peerDependencies"))).toBe(true);
+  });
+
+  it("errors when no coreVersion is declared anywhere", () => {
+    const root = makeCapDir();
+    writeFile(
+      root,
+      "package.json",
+      JSON.stringify({
+        name: "@linchkit/cap-cv",
+        version: "1.0.0",
+        peerDependencies: { "@linchkit/core": "^0.2.0" },
+        linchkit: { type: "standard", category: "business" },
+      }),
+    );
+    writeFile(root, "src/index.ts", `import { x } from "@linchkit/core";\nexport {};\n`);
+    writeFile(root, "src/a.test.ts", `import { test } from "bun:test";\ntest("a", () => {});\n`);
+
+    const result = lintCapability(root);
+    expect(result.ok).toBe(false);
+    const cv = result.issues.filter((i) => i.check === "core-version" && i.level === "error");
+    expect(cv.some((i) => i.message.includes("No core-version range declared"))).toBe(true);
+  });
+
+  it("skips the equality check when peerDep is workspace:* (only requires coreVersion)", () => {
+    const root = makeCapDir();
+    writeFile(
+      root,
+      "package.json",
+      JSON.stringify({
+        name: "@linchkit/cap-cv",
+        version: "1.0.0",
+        peerDependencies: { "@linchkit/core": "workspace:*" },
+        linchkit: { type: "standard", category: "business", coreVersion: "^0.2.0" },
+      }),
+    );
+    writeFile(root, "src/index.ts", `import { x } from "@linchkit/core";\nexport {};\n`);
+    writeFile(root, "src/a.test.ts", `import { test } from "bun:test";\ntest("a", () => {});\n`);
+
+    const result = lintCapability(root);
+    // No equality error despite the value differing from a concrete range.
+    expect(result.issues.filter((i) => i.check === "core-version")).toHaveLength(0);
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts deprecated minCoreVersion with a migration warning (no error)", () => {
+    const root = makeCapDir();
+    writeFile(
+      root,
+      "package.json",
+      JSON.stringify({
+        name: "@linchkit/cap-cv",
+        version: "1.0.0",
+        peerDependencies: { "@linchkit/core": "^0.2.0" },
+        linchkit: { type: "standard", category: "business", minCoreVersion: "^0.2.0" },
+      }),
+    );
+    writeFile(root, "src/index.ts", `import { x } from "@linchkit/core";\nexport {};\n`);
+    writeFile(root, "src/a.test.ts", `import { test } from "bun:test";\ntest("a", () => {});\n`);
+
+    const result = lintCapability(root);
+    const cv = result.issues.filter((i) => i.check === "core-version");
+    expect(cv).toHaveLength(1);
+    expect(cv[0]?.level).toBe("warning");
+    expect(cv[0]?.message).toContain("minCoreVersion");
+    // A warning does not fail the lint.
+    expect(result.ok).toBe(true);
+  });
+
+  it("errors when a deprecated-only minCoreVersion mismatches a concrete peerDep", () => {
+    const root = makeCapDir();
+    writeFile(
+      root,
+      "package.json",
+      JSON.stringify({
+        name: "@linchkit/cap-cv",
+        version: "1.0.0",
+        peerDependencies: { "@linchkit/core": "^0.2.0" },
+        linchkit: { type: "standard", category: "business", minCoreVersion: "^0.1.0" },
+      }),
+    );
+    writeFile(root, "src/index.ts", `import { x } from "@linchkit/core";\nexport {};\n`);
+    writeFile(root, "src/a.test.ts", `import { test } from "bun:test";\ntest("a", () => {});\n`);
+
+    const result = lintCapability(root);
+    expect(result.ok).toBe(false);
+    // Both the deprecation warning AND the mismatch error are reported.
+    const cv = result.issues.filter((i) => i.check === "core-version");
+    expect(cv.some((i) => i.level === "warning")).toBe(true);
+    expect(cv.some((i) => i.level === "error" && i.message.includes("mismatch"))).toBe(true);
+  });
+
+  it("prefers capability.json coreVersion over package.json linchkit.coreVersion", () => {
+    const root = makeCapDir();
+    // capability.json declares ^0.2.0 (the precedence source) and matches peerDep.
+    writeFile(
+      root,
+      "capability.json",
+      JSON.stringify({ ...VALID_CAPABILITY_JSON, coreVersion: "^0.2.0" }),
+    );
+    // package.json's linchkit.coreVersion intentionally differs; it must be ignored.
+    writeFile(
+      root,
+      "package.json",
+      JSON.stringify({
+        name: "@linchkit/cap-cv",
+        version: "1.0.0",
+        peerDependencies: { "@linchkit/core": "^0.2.0" },
+        linchkit: { coreVersion: "^0.9.0" },
+      }),
+    );
+    writeFile(root, "src/index.ts", `import { x } from "@linchkit/core";\nexport {};\n`);
+    writeFile(root, "src/a.test.ts", `import { test } from "bun:test";\ntest("a", () => {});\n`);
+
+    const result = lintCapability(root);
+    expect(result.issues.filter((i) => i.check === "core-version")).toHaveLength(0);
+    expect(result.ok).toBe(true);
   });
 });
 

--- a/packages/devtools/__tests__/capability-lint.test.ts
+++ b/packages/devtools/__tests__/capability-lint.test.ts
@@ -553,10 +553,11 @@ describe("lintCapability", () => {
   it("prefers capability.json coreVersion over package.json linchkit.coreVersion", () => {
     const root = makeCapDir();
     // capability.json declares ^0.2.0 (the precedence source) and matches peerDep.
+    // Per capabilityMetadataSchema, coreVersion is nested under `linchkit`.
     writeFile(
       root,
       "capability.json",
-      JSON.stringify({ ...VALID_CAPABILITY_JSON, coreVersion: "^0.2.0" }),
+      JSON.stringify({ ...VALID_CAPABILITY_JSON, linchkit: { coreVersion: "^0.2.0" } }),
     );
     // package.json's linchkit.coreVersion intentionally differs; it must be ignored.
     writeFile(

--- a/packages/devtools/src/methodology/capability-lint.ts
+++ b/packages/devtools/src/methodology/capability-lint.ts
@@ -251,7 +251,11 @@ const TEST_FILE_RE = /\.(test|spec)\.(ts|tsx)$/;
  * never counts. The `\b` anchor avoids matching identifiers like `submit(` or
  * `unit(`.
  */
-const EXECUTABLE_TEST_RE = /\b(?:Bun\.test\s*\(|(?:test|it|describe)\s*(?:\(|\.))/;
+// Match an executable test call: `test(` / `it(` / `describe(` / `Bun.test(`,
+// or a member call like `test.only(` / `it.each(`. Requiring the trailing `(`
+// after a `.member` avoids false positives on strings/paths such as
+// `"test.ts"` or `"./test.helper"` (stripComments preserves string contents).
+const EXECUTABLE_TEST_RE = /\b(?:Bun\.test\s*\(|(?:test|it|describe)\s*(?:\(|\.\s*\w+\s*\())/;
 
 function checkTestExistence(root: string): CapabilityLintIssue[] {
   const testFiles = collectTestFiles(root);
@@ -420,7 +424,11 @@ function checkCoreVersion(root: string): CapabilityLintIssue[] {
 
   // 3. Equality check — only when the peerDep is a concrete range. workspace:*
   //    resolves locally and cannot be compared, so it is skipped.
-  if (typeof peerCore === "string" && peerCore.length > 0 && !WORKSPACE_PROTOCOL_RE.test(peerCore)) {
+  if (
+    typeof peerCore === "string" &&
+    peerCore.length > 0 &&
+    !WORKSPACE_PROTOCOL_RE.test(peerCore)
+  ) {
     if (peerCore !== effectiveRange) {
       issues.push({
         check: "core-version",
@@ -448,14 +456,29 @@ interface DeclaredCoreVersion {
  * wins; otherwise fall back to `package.json` `linchkit.coreVersion`, then the
  * deprecated `package.json` `linchkit.minCoreVersion`.
  */
-function resolveDeclaredCoreVersion(root: string, pkg: Record<string, unknown>): DeclaredCoreVersion {
+function resolveDeclaredCoreVersion(
+  root: string,
+  pkg: Record<string, unknown>,
+): DeclaredCoreVersion {
   const capabilityJsonPath = join(root, "capability.json");
   if (existsSync(capabilityJsonPath)) {
     const parsed = readJson(capabilityJsonPath);
     if (!parsed.error && typeof parsed.value === "object" && parsed.value !== null) {
-      const cv = (parsed.value as Record<string, unknown>).coreVersion;
+      const capObj = parsed.value as Record<string, unknown>;
+      // capabilityMetadataSchema nests the compat fields under `linchkit`
+      // (linchkit.coreVersion / linchkit.minCoreVersion). Read the nested block
+      // first; accept a top-level value as a backward-compatible fallback.
+      const capBlock =
+        typeof capObj.linchkit === "object" && capObj.linchkit !== null
+          ? (capObj.linchkit as Record<string, unknown>)
+          : {};
+      const cv = capBlock.coreVersion ?? capObj.coreVersion;
       if (typeof cv === "string" && cv.length > 0) {
         return { coreVersion: cv, sourceFile: "capability.json" };
+      }
+      const capMin = capBlock.minCoreVersion ?? capObj.minCoreVersion;
+      if (typeof capMin === "string" && capMin.length > 0) {
+        return { minCoreVersion: capMin, sourceFile: "capability.json" };
       }
     }
   }

--- a/packages/devtools/src/methodology/capability-lint.ts
+++ b/packages/devtools/src/methodology/capability-lint.ts
@@ -11,8 +11,14 @@
  *     `@linchkit/core` barrel, never deep internals (`@linchkit/core/src/...`
  *     or `/dist/...`), nor relative paths that escape into core internals.
  *     Enforces CLAUDE.md: "只依赖 @linchkit/core 的公开 API（不用内部路径）".
- *  3. Test existence — at least one test file must be present (proxy for the
- *     spec's "覆盖率 > 0 / 必须有测试").
+ *  3. Test existence — at least one test file must be present AND contain at
+ *     least one executable test (`test(`/`it(`/`describe(`/`Bun.test(`); an
+ *     empty or assertion-less stub fails (proxy for the spec's "覆盖率 > 0 /
+ *     必须有测试").
+ *  4. Core version declaration consistency — `@linchkit/core` must be a
+ *     peerDependency and a core-version range must be declared (`coreVersion`,
+ *     preferred over the deprecated `minCoreVersion`); when the peerDep pins a
+ *     concrete range it must equal the declared core version (Spec 21 §10.1).
  *
  * Filesystem access uses node:fs/node:path only; import scanning is a simple
  * line/regex scan (no TS AST) to match the existing methodology approach.
@@ -58,6 +64,7 @@ export function lintCapability(dir: string): CapabilityLintResult {
   issues.push(...checkMetadata(root));
   issues.push(...checkImportBoundary(root));
   issues.push(...checkTestExistence(root));
+  issues.push(...checkCoreVersion(root));
 
   const hasError = issues.some((i) => i.level === "error");
   return { dir: root, ok: !hasError, issues };
@@ -233,28 +240,64 @@ function checkImportBoundary(root: string): CapabilityLintIssue[] {
   return issues;
 }
 
-// -- Check 3: test existence ---------------------------------------------
+// -- Check 3: test existence + executable test ---------------------------
 
 const TEST_FILE_RE = /\.(test|spec)\.(ts|tsx)$/;
 
+/**
+ * Detects a call to a Bun/Jest-style test runner: `test(`, `it(`, `describe(`,
+ * their `.only`/`.skip`/`.each` member forms (`test.`/`it.`/`describe.`), or
+ * the explicit `Bun.test(`. Run AFTER `stripComments`, so a commented-out test
+ * never counts. The `\b` anchor avoids matching identifiers like `submit(` or
+ * `unit(`.
+ */
+const EXECUTABLE_TEST_RE = /\b(?:Bun\.test\s*\(|(?:test|it|describe)\s*(?:\(|\.))/;
+
 function checkTestExistence(root: string): CapabilityLintIssue[] {
-  if (hasTestFile(root)) return [];
-  return [
-    {
-      check: "test-existence",
-      level: "error",
-      message:
-        "No test file found. A capability must contain at least one *.test.ts(x), *.spec.ts, or a __tests__/ test (Spec 21 §9.1).",
-    },
-  ];
+  const testFiles = collectTestFiles(root);
+  if (testFiles.length === 0) {
+    return [
+      {
+        check: "test-existence",
+        level: "error",
+        message:
+          "No test file found. A capability must contain at least one *.test.ts(x), *.spec.ts, or a __tests__/ test (Spec 21 §9.1).",
+      },
+    ];
+  }
+
+  const hasExecutableTest = testFiles.some((file) => {
+    let content: string;
+    try {
+      content = readFileSync(file, "utf-8");
+    } catch {
+      return false;
+    }
+    return EXECUTABLE_TEST_RE.test(stripComments(content));
+  });
+
+  if (!hasExecutableTest) {
+    return [
+      {
+        check: "test-existence",
+        level: "error",
+        message:
+          "Test file(s) found but none contain an executable test (test(...)/it(...)/describe(...)). An empty or stub test does not satisfy coverage > 0 (Spec 21 §9.1).",
+      },
+    ];
+  }
+
+  return [];
 }
 
-function hasTestFile(dir: string): boolean {
+/** Collect all `*.test.ts(x)` / `*.spec.ts(x)` files under a directory. */
+function collectTestFiles(dir: string): string[] {
+  const out: string[] = [];
   let entries: string[];
   try {
     entries = readdirSync(dir);
   } catch {
-    return false;
+    return out;
   }
 
   for (const entry of entries) {
@@ -267,12 +310,170 @@ function hasTestFile(dir: string): boolean {
     }
     if (isDir) {
       if (isIgnoredDir(entry)) continue;
-      if (hasTestFile(full)) return true;
+      out.push(...collectTestFiles(full));
     } else if (TEST_FILE_RE.test(entry)) {
-      return true;
+      out.push(full);
     }
   }
-  return false;
+  return out;
+}
+
+// -- Check 4: core version declaration consistency -----------------------
+
+/**
+ * A `workspace:` protocol specifier used inside the monorepo (e.g.
+ * `workspace:*`). Such peerDeps resolve to the local core at build time, so we
+ * cannot compare them against a published semver range — the equality check is
+ * skipped and only presence of a declared `coreVersion` is required.
+ */
+const WORKSPACE_PROTOCOL_RE = /^workspace:/;
+
+/**
+ * Validate the @linchkit/core version contract (Spec 21 §10.1):
+ *  - `@linchkit/core` MUST be declared in `peerDependencies` → error if absent.
+ *  - A core-version range MUST be declared: `capability.json` `coreVersion`
+ *    (precedence) else `package.json` `linchkit.coreVersion`. If only the
+ *    deprecated `linchkit.minCoreVersion` is present it is accepted with a
+ *    WARNING recommending migration; if none present → error.
+ *  - When the peerDep is a concrete semver range AND a coreVersion is declared,
+ *    they MUST be equal → error on mismatch. A `workspace:*` peerDep skips the
+ *    equality check (only presence of a coreVersion is required).
+ */
+function checkCoreVersion(root: string): CapabilityLintIssue[] {
+  const issues: CapabilityLintIssue[] = [];
+
+  const packageJsonPath = join(root, "package.json");
+  if (!existsSync(packageJsonPath)) {
+    // No package.json at all — there is no peerDependencies block to inspect.
+    // The metadata check already reports the missing manifest; surface the core
+    // contract failure here too so this check is self-contained.
+    return [
+      {
+        check: "core-version",
+        level: "error",
+        message:
+          'No package.json found, so "@linchkit/core" cannot be declared in peerDependencies (Spec 21 §10.1).',
+        file: "package.json",
+      },
+    ];
+  }
+
+  const pkgParsed = readJson(packageJsonPath);
+  if (pkgParsed.error || typeof pkgParsed.value !== "object" || pkgParsed.value === null) {
+    return [
+      {
+        check: "core-version",
+        level: "error",
+        message: `Failed to parse package.json for core-version check: ${pkgParsed.error ?? "not an object"}`,
+        file: "package.json",
+      },
+    ];
+  }
+  const pkg = pkgParsed.value as Record<string, unknown>;
+
+  // 1. peerDependencies["@linchkit/core"] must be present.
+  const peerDeps =
+    typeof pkg.peerDependencies === "object" && pkg.peerDependencies !== null
+      ? (pkg.peerDependencies as Record<string, unknown>)
+      : {};
+  const peerCore = peerDeps["@linchkit/core"];
+  if (typeof peerCore !== "string" || peerCore.length === 0) {
+    issues.push({
+      check: "core-version",
+      level: "error",
+      message:
+        '"@linchkit/core" must be declared in package.json "peerDependencies" (Spec 21 §10.1).',
+      file: "package.json",
+    });
+  }
+
+  // 2. A core-version range must be declared. capability.json.coreVersion takes
+  //    precedence over package.json.linchkit.coreVersion; the deprecated
+  //    minCoreVersion is accepted as a fallback (with a warning).
+  const declared = resolveDeclaredCoreVersion(root, pkg);
+  if (declared.coreVersion === undefined && declared.minCoreVersion === undefined) {
+    issues.push({
+      check: "core-version",
+      level: "error",
+      message:
+        'No core-version range declared. Add "coreVersion" to capability.json or package.json "linchkit" (Spec 21 §10.1).',
+      file: declared.sourceFile,
+    });
+    return issues;
+  }
+
+  let effectiveRange: string;
+  if (declared.coreVersion !== undefined) {
+    effectiveRange = declared.coreVersion;
+  } else {
+    // Only the deprecated minCoreVersion is present — accept with a warning.
+    // (declared.minCoreVersion is defined here per the guard above.)
+    effectiveRange = declared.minCoreVersion as string;
+    issues.push({
+      check: "core-version",
+      level: "warning",
+      message:
+        'Deprecated "minCoreVersion" used. Migrate to "coreVersion" (a semver range) — minCoreVersion is @deprecated (Spec 21 §10.1).',
+      file: declared.sourceFile,
+    });
+  }
+
+  // 3. Equality check — only when the peerDep is a concrete range. workspace:*
+  //    resolves locally and cannot be compared, so it is skipped.
+  if (typeof peerCore === "string" && peerCore.length > 0 && !WORKSPACE_PROTOCOL_RE.test(peerCore)) {
+    if (peerCore !== effectiveRange) {
+      issues.push({
+        check: "core-version",
+        level: "error",
+        message: `Core-version mismatch: peerDependencies["@linchkit/core"] is "${peerCore}" but the declared coreVersion is "${effectiveRange}". They must be equal (Spec 21 §10.1).`,
+        file: "package.json",
+      });
+    }
+  }
+
+  return issues;
+}
+
+interface DeclaredCoreVersion {
+  /** Resolved `coreVersion` range (capability.json precedence), if any. */
+  coreVersion?: string;
+  /** Deprecated `linchkit.minCoreVersion` from package.json, if any. */
+  minCoreVersion?: string;
+  /** File the declaration came from, for issue attribution. */
+  sourceFile: string;
+}
+
+/**
+ * Resolve the declared core-version range. `capability.json` `coreVersion`
+ * wins; otherwise fall back to `package.json` `linchkit.coreVersion`, then the
+ * deprecated `package.json` `linchkit.minCoreVersion`.
+ */
+function resolveDeclaredCoreVersion(root: string, pkg: Record<string, unknown>): DeclaredCoreVersion {
+  const capabilityJsonPath = join(root, "capability.json");
+  if (existsSync(capabilityJsonPath)) {
+    const parsed = readJson(capabilityJsonPath);
+    if (!parsed.error && typeof parsed.value === "object" && parsed.value !== null) {
+      const cv = (parsed.value as Record<string, unknown>).coreVersion;
+      if (typeof cv === "string" && cv.length > 0) {
+        return { coreVersion: cv, sourceFile: "capability.json" };
+      }
+    }
+  }
+
+  const block =
+    typeof pkg.linchkit === "object" && pkg.linchkit !== null
+      ? (pkg.linchkit as Record<string, unknown>)
+      : {};
+  const cv = block.coreVersion;
+  if (typeof cv === "string" && cv.length > 0) {
+    return { coreVersion: cv, sourceFile: "package.json" };
+  }
+  const min = block.minCoreVersion;
+  if (typeof min === "string" && min.length > 0) {
+    return { minCoreVersion: min, sourceFile: "package.json" };
+  }
+
+  return { sourceFile: existsSync(capabilityJsonPath) ? "capability.json" : "package.json" };
 }
 
 // -- Filesystem helpers --------------------------------------------------


### PR DESCRIPTION
## What

Two new deterministic checks in `linch lint-capability` (Spec 21 §9.1/§10.1), plus a metadata fix across all addons. Advances #122.

### Check 1 — real test required (§9.1 "基本测试 / 覆盖率 > 0")
The existing test-existence check is upgraded: at least one discovered test file must contain an **executable test** (`test(` / `it(` / `describe(` / `Bun.test(`, detected after `stripComments` so commented-out tests don't count). An empty or comment-only stub file now fails.

### Check 2 — core-version declaration consistency (§10.1)
A capability must:
- declare `@linchkit/core` in `peerDependencies` (error if missing);
- declare a `coreVersion` range — `capability.json` precedence, else `package.json` `linchkit.coreVersion`; the deprecated `linchkit.minCoreVersion` is still accepted but emits a **warning** to migrate;
- when the peerDep is a concrete semver range and a coreVersion is declared, the two must be **equal** (error on mismatch). A `workspace:*` peerDep (monorepo) skips the equality check.

### Metadata fix
Migrated all **27** addons that declared the deprecated `linchkit.minCoreVersion` to `coreVersion`, set equal to their `peerDependencies["@linchkit/core"]` (`^0.2.0`, matching core `0.2.0`). Fixes a **latent inconsistency**: the runtime range was stale `^0.1.0` while npm's peerDep already required `^0.2.0`. Surgical edits (27 files, 27±). The 2 private demos already used `coreVersion: ^0.2.0`.

## Verification
- `bun test packages/devtools/__tests__/capability-lint.test.ts` → **51 pass / 0 fail** (12 new).
- Full `bun test` → **0 named failures** (phantom "1 fail" = known Bun teardown segfault, #400).
- `bun run typecheck` clean; `bunx biome check .` exit 0.
- **Dogfood: 29/29 addons pass `lint-capability` (0 errors).**

## Out of scope
`addons/adapter-ui/cap-adapter-ui/ui-kit` (`@linchkit/ui-kit`, nested sub-package, not a `cap-*`) still uses `minCoreVersion` — not a lint target; can migrate separately.

## Review note
Local `gemini` CLI is quota-exhausted, `codex` needs node (repo hook blocks it); per the established fallback the async PR bots (gemini-code-assist + CodeRabbit) are the cross-model pass — findings addressed before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core version compatibility metadata across multiple packages to declare support for version 0.2.0

* **Tests**
  * Enhanced test validation to ensure executable tests are present and properly formatted
  * Added comprehensive core version consistency checks between package dependencies and declarations
  * Improved detection of various test method formats and variants

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laofahai/linchkit/pull/418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->