### PR TITLE
docs(spec21): canonical coreVersion + declaration consistency rule (#122)

### DIFF
--- a/docs/specs/21_capability_ecosystem.md
+++ b/docs/specs/21_capability_ecosystem.md
@@ -268,10 +268,10 @@ $ linch install some-random-package
   "name": "@linchkit/cap-auth",
   "version": "1.0.0",
   "peerDependencies": {
-    "@linchkit/core": "^0.1.0"
+    "@linchkit/core": "^0.2.0"
   },
   "linchkit": {
-    "minCoreVersion": "^0.1.0",
+    "coreVersion": "^0.2.0",
     "type": "standard",
     "category": "system",
     "trustLevel": "official",
@@ -285,7 +285,7 @@ $ linch install some-random-package
 ```json
 {
   "name": "@linchkit/cap-auth",
-  "minCoreVersion": "^0.1.0",
+  "coreVersion": "^0.2.0",
   "type": "standard",
   "category": "system",
   "trustLevel": "official",
@@ -312,7 +312,7 @@ $ linch install some-random-package
 | 字段 | 类型 | 必填 | 说明 |
 |------|------|:----:|------|
 | `name` | string | ✓ | 包名（与 npm 包名一致） |
-| `minCoreVersion` | semver range | ✓ | 要求的 core 最低版本 |
+| `coreVersion` | semver range | ✓ | 兼容的 `@linchkit/core` 版本范围（如 `^0.2.0`）。`minCoreVersion` 为其 **@deprecated** 别名，仅在 `coreVersion` 缺失时作为兜底识别 |
 | `type` | enum | ✓ | `standard` / `bridge` / `adapter` |
 | `category` | string | ✓ | 分类，见 `01_capability_structure.md` |
 | `trustLevel` | enum | — | `official` / `verified` / `community` / `unverified` |
@@ -356,7 +356,7 @@ linch install linchkit-cap-crm
   ├── 1. 解析 npm 包 → 下载
   ├── 2. 读取 capability.json / package.json linchkit 字段
   ├── 3. 检查信任层级 → 提示用户确认
-  ├── 4. 检查 minCoreVersion 兼容性 → 不兼容则警告/中止
+  ├── 4. 检查 coreVersion 兼容性 → 不兼容则警告/中止
   ├── 5. 检查 systemPermissions → 提示用户确认
   ├── 6. 解析依赖树 → 自动安装缺失的强依赖
   ├── 7. 检测循环依赖 → 有则报错
@@ -439,21 +439,25 @@ my-capability/
 ```json
 {
   "peerDependencies": {
-    "@linchkit/core": "^0.1.0"
+    "@linchkit/core": "^0.2.0"
   }
 }
 ```
 
-2. **linchkit.minCoreVersion**（元数据）：
+2. **linchkit.coreVersion**（元数据）：
 ```json
 {
   "linchkit": {
-    "minCoreVersion": "^0.1.0"
+    "coreVersion": "^0.2.0"
   }
 }
 ```
 
-两者都要声明。peerDependencies 用于 npm 安装时的版本解析，minCoreVersion 用于运行时校验。
+`coreVersion` 是声明所需 core 版本的规范字段，取值为 semver 范围（如 `^0.2.0`、`>=0.2.0 <0.4.0`）。`minCoreVersion` 是其 **@deprecated** 别名，仅在 `coreVersion` 缺失时作为兜底被识别。
+
+**两者都要声明，且范围必须一致（相等）**：`peerDependencies["@linchkit/core"]` 用于 npm 安装时的版本解析，`coreVersion` 用于运行时校验。唯一例外是 monorepo 内部私有包——其 peerDep 为 `workspace:*` 时，只需声明 `coreVersion`。
+
+当存在独立的 `capability.json` 时，其中的 `coreVersion` 优先级高于 `package.json` 的 `linchkit` 块。
 
 ### 10.2 CLI 行为
 

--- a/docs/specs/21_capability_ecosystem.md
+++ b/docs/specs/21_capability_ecosystem.md
@@ -285,9 +285,13 @@ $ linch install some-random-package
 ```json
 {
   "name": "@linchkit/cap-auth",
-  "coreVersion": "^0.2.0",
+  "version": "1.0.0",
+  "label": "Authentication",
   "type": "standard",
   "category": "system",
+  "linchkit": {
+    "coreVersion": "^0.2.0"
+  },
   "trustLevel": "official",
   "systemPermissions": ["database.create_table"],
   "dependencies": [
@@ -312,7 +316,9 @@ $ linch install some-random-package
 | 字段 | 类型 | 必填 | 说明 |
 |------|------|:----:|------|
 | `name` | string | ✓ | 包名（与 npm 包名一致） |
-| `coreVersion` | semver range | ✓ | 兼容的 `@linchkit/core` 版本范围（如 `^0.2.0`）。`minCoreVersion` 为其 **@deprecated** 别名，仅在 `coreVersion` 缺失时作为兜底识别 |
+| `version` | string | ✓ | 包版本（与 npm 包版本一致） |
+| `label` | string | ✓ | 人类可读的展示名 |
+| `linchkit.coreVersion` | semver range | ✓ | 兼容的 `@linchkit/core` 版本范围（如 `^0.2.0`），嵌套在 `linchkit` 块下。`linchkit.minCoreVersion` 为其 **@deprecated** 别名，仅在 `coreVersion` 缺失时作为兜底识别 |
 | `type` | enum | ✓ | `standard` / `bridge` / `adapter` |
 | `category` | string | ✓ | 分类，见 `01_capability_structure.md` |
 | `trustLevel` | enum | — | `official` / `verified` / `community` / `unverified` |
@@ -455,9 +461,9 @@ my-capability/
 
 `coreVersion` 是声明所需 core 版本的规范字段，取值为 semver 范围（如 `^0.2.0`、`>=0.2.0 <0.4.0`）。`minCoreVersion` 是其 **@deprecated** 别名，仅在 `coreVersion` 缺失时作为兜底被识别。
 
-**两者都要声明，且范围必须一致（相等）**：`peerDependencies["@linchkit/core"]` 用于 npm 安装时的版本解析，`coreVersion` 用于运行时校验。唯一例外是 monorepo 内部私有包——其 peerDep 为 `workspace:*` 时，只需声明 `coreVersion`。
+**两者都要声明，且范围必须一致（相等）**：`peerDependencies["@linchkit/core"]` 用于 npm 安装时的版本解析，`linchkit.coreVersion` 用于运行时校验。唯一例外是 monorepo 内部私有包——其 peerDep 为 `workspace:*` 时，只需声明 `linchkit.coreVersion`。
 
-当存在独立的 `capability.json` 时，其中的 `coreVersion` 优先级高于 `package.json` 的 `linchkit` 块。
+`coreVersion` 在 `capability.json` 与 `package.json` 中都嵌套于 `linchkit` 块下。当存在独立的 `capability.json` 时，其 `linchkit.coreVersion` 优先级高于 `package.json` 的 `linchkit.coreVersion`。
 
 ### 10.2 CLI 行为
 

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -67,7 +67,7 @@ Capability definition, extension, composition, and distribution.
 | [01](./01_capability_structure.md) | Capability Structure | `defineCapability()` — standard/adapter/bridge types, lifecycle, dependencies | M0 | Done |
 | [14](./14_system_capabilities.md) | System Capabilities | Built-in capabilities (auth, permission, MCP, UI), cold-start packs | M0 | Partial |
 | [20](./20_extension_mechanism.md) | Extension Mechanism | `extensions` — schemas/actions/rules/views/middlewares/transports/fieldTypes/services/hooks | M0 | Done |
-| [21](./21_capability_ecosystem.md) | Capability Ecosystem | Capability lifecycle, publishing, version management, compatibility matrix | M1 | Partial |
+| [21](./21_capability_ecosystem.md) | Capability Ecosystem | Capability lifecycle, publishing, version management, compatibility matrix. Implemented: §7.2 runtime-honored standalone `capability.json`, §9.1 `linch lint-capability` quality checks, §10.1 `coreVersion` compatibility declaration + consistency. Pending: Hub (21b) + `@linchkit/starter-*` bundles | M1 | Partial |
 | [21b](./21_capability_hub.md) | Capability Hub | Discovery, registration, installation, dependency resolution | M2+ | Draft |
 | [57](./57_addon_architecture.md) | Addon Architecture | OCA pattern — addons/ grouping, autoInstall, graphqlExtensions, Panel registration | M2 | Done |
 


### PR DESCRIPTION
## What

Spec 21 documentation fix. Its §7.1/§7.2/§7.3/§8.2/§10.1 documented the **@deprecated** `linchkit.minCoreVersion` as the way to declare the required core version. The canonical field is `coreVersion` (per `packages/core/src/types/capability-metadata.ts`, where `minCoreVersion` is honored only as a deprecated fallback alias).

## Changes
- **§7.1 / §7.2 / §7.3 / §8.2**: examples + field table use `coreVersion`; example ranges bumped to `^0.2.0` (core is `0.2.0`); one-line deprecated-alias note kept in §7.3 and §10.1.
- **§10.1**: clarified the rule — `peerDependencies["@linchkit/core"]` and `coreVersion` must **both be declared and be consistent (equal)**, with the `workspace:*` exception for private monorepo packages; `capability.json`'s `coreVersion` takes precedence over the `package.json` `linchkit` block.
- **INDEX.md**: Spec 21 row notes implemented pieces (§7.2 runtime `capability.json`, §9.1 `lint-capability`, §10.1 version-compat) + pending (Hub 21b, `@linchkit/starter-*`); status stays **Partial**.

## Notes
Pairs with #418 (which enforces this consistency rule in `linch lint-capability` and migrates the addons). Docs-only — no code touched. Cross-model pass via PR bots per the established fallback (local gemini CLI quota-exhausted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)