### PR TITLE
chore(ci): rescue Bun teardown segfault that crashes before the test summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,12 @@ jobs:
           if [ "$RC" -eq 0 ]; then
             exit 0
           fi
-          if printf '%s\n' "$OUTPUT" | grep -qE '^\(pass\)' \
-             && ! printf '%s\n' "$OUTPUT" | grep -qE '^\(fail\)'; then
+          # Use here-strings (not `printf | grep`): the shell runs with pipefail,
+          # and `grep -q` closes the pipe on its first match (an early `(pass)`
+          # line), which SIGPIPEs printf and makes the pipeline return non-zero —
+          # defeating the check. `<<<` feeds grep directly with no pipe.
+          if grep -qE '^\(pass\)' <<< "$OUTPUT" \
+             && ! grep -qE '^\(fail\)' <<< "$OUTPUT"; then
             echo "::warning::bun test exited $RC with passing tests and no (fail) lines — treating as success (known Bun teardown segfault, panic 0x4A; the crash may precede the summary)."
             exit 0
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,12 @@ jobs:
         shell: bash
         run: |
           # Bun 1.2.18 occasionally segfaults during process teardown
-          # (panic 0x4A at exit) even when every test passes. Detect this
-          # specific pattern (non-zero exit + "0 fail" in summary) and
-          # treat it as success instead of failing the build.
+          # (panic 0x4A at exit) even when every test passes. The crash can land
+          # AFTER the summary (a "0 fail" line is printed) or BEFORE it (no
+          # summary at all). In both cases bun prints a per-test "(fail)" line
+          # for any genuine failure as the tests run, so the reliable signal is:
+          # a non-zero exit with at least one "(pass)" line and ZERO "(fail)"
+          # lines is the teardown segfault — not a real test failure.
           set +e
           OUTPUT=$(bun test 2>&1)
           RC=$?
@@ -41,9 +44,9 @@ jobs:
           if [ "$RC" -eq 0 ]; then
             exit 0
           fi
-          if printf '%s\n' "$OUTPUT" | grep -qE '^[[:space:]]+0 fail$' \
-             && printf '%s\n' "$OUTPUT" | grep -qE '^[[:space:]]+[0-9]+ pass$'; then
-            echo "::warning::bun test exited $RC after reporting 0 failures — treating as success (known Bun teardown segfault)."
+          if printf '%s\n' "$OUTPUT" | grep -qE '^\(pass\)' \
+             && ! printf '%s\n' "$OUTPUT" | grep -qE '^\(fail\)'; then
+            echo "::warning::bun test exited $RC with passing tests and no (fail) lines — treating as success (known Bun teardown segfault, panic 0x4A; the crash may precede the summary)."
             exit 0
           fi
           exit "$RC"


### PR DESCRIPTION
## Problem

The Run-tests guard added in #400 only rescued the Bun 1.2.18 teardown segfault (panic 0x4A at exit) when the crash landed **after** the summary printed — it grepped for a `0 fail` summary line. On the Linux CI runner the segfault frequently crashes **before** the summary is printed (no `0 fail` line at all), so the guard missed it and `Code Quality` went **red despite every test passing**.

Observed repeatedly on #418: the `Run tests` step ends with the last test `(pass)` and then `exit code 1` — no `Ran N tests` summary, no `(fail)` line anywhere.

## Fix

bun prints a per-test `(fail)` line for any genuine failure **as the tests run** (before the summary). So the reliable signal is:

> non-zero exit **with** at least one `(pass)` line **and ZERO** `(fail)` lines → teardown segfault, not a real failure.

The guard now uses that condition, covering both crash-before- and crash-after-summary. Safety preserved:
- a real test failure still prints `(fail)` → build fails;
- a "no tests ran" error (compile/import failure) has no `(pass)` line → build fails;
- a clean run (RC 0) short-circuits to success as before.

## Why now
This is the root cause blocking #418 (lint-capability §9.1/§10.1). It's a repo-wide test-gate reliability fix, so it's split out as its own PR. Validated: YAML parses (jobs `quality` + `capability-lint`), bash guard syntax checks clean. Cross-model pass via PR bots (local gemini CLI quota-exhausted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test detection reliability in CI workflow to better handle edge cases during test execution, ensuring more accurate reporting of test results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laofahai/linchkit/pull/420?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->