### PR TITLE
fix(core): resolveEnvVars destroyed graphql type prototypes → dev:server boot crash + add boot smoke test

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/dev-schema-boot.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/dev-schema-boot.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Dev-server boot smoke test.
+ *
+ * Regression guard for the "dev server won't boot" bug:
+ *
+ *   error: One of the provided types for building the Schema is missing a name.
+ *     at new GraphQLSchema(...)
+ *     at buildGraphQLSchema(build-schema.ts)
+ *     at dev.ts
+ *
+ * Root cause was `resolveEnvVars` (called by `loadConfig`) deep-rebuilding
+ * every object via `{}` + `Object.entries`, which discarded the prototype of
+ * the graphql type INSTANCES that cap-chatter carries in
+ * `extensions.graphqlExtensions.queryFields` (a `GraphQLNonNull(...)` wrapper).
+ * The flattened plain object was no longer a `GraphQLNonNull`, so graphql-js
+ * could not unwrap it and `new GraphQLSchema(...)` rejected it as unnamed.
+ *
+ * Why no existing test caught it: every other build-schema test calls
+ * `buildGraphQLSchema` with the SIMPLIFIED shape (1-2 toy entities, no
+ * commandLayer / onchangeEvaluator, raw capability objects). The crash only
+ * surfaced with dev.ts's FULL assembly run through `loadConfig`'s
+ * `resolveEnvVars` pass.
+ *
+ * This test reproduces dev.ts's boot path EXACTLY and DB-free (InMemoryStore):
+ *   1. a representative configured-capability set — `cap-adapter-server` itself,
+ *      `cap-chatter` (a PUBLISHED system capability that carries the
+ *      `graphqlExtensions` graphql type INSTANCE that is the actual regression
+ *      trigger), and an inline SYNTHETIC business capability that contributes
+ *      entities + custom actions + a relation + a state machine — so
+ *      commandLayer, onchangeEvaluator AND a `graphqlExtensions` graphql type
+ *      instance are all exercised;
+ *   2. the capabilities flow through `resolveEnvVars` first, mirroring how
+ *      `loadConfig` hands them to the assembly (this is the step that broke
+ *      the type instances);
+ *   3. `assembleDevSchema` — the shared helper that both dev.ts and this test
+ *      call — builds the full schema.
+ *
+ * The synthetic business capability is defined INLINE (rather than pulling in
+ * a private demo package) so this PUBLISHED package keeps a clean dependency
+ * surface — it never depends on an unpublished `private: true` package.
+ *
+ * If `resolveEnvVars` ever clobbers graphql type instances again (or any other
+ * regression makes a reachable type lose its name), `assembleDevSchema` throws
+ * here and CI fails — instead of only `bun run dev:server` failing.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { capChatter } from "@linchkit/cap-chatter";
+import type {
+  ActionDefinition,
+  CapabilityDefinition,
+  EntityDefinition,
+  RelationDefinition,
+  StateDefinition,
+} from "@linchkit/core";
+import { defineCapability, defineRelation, resolveEnvVars } from "@linchkit/core";
+import { assembleDevSchema } from "../src/assemble-schema";
+import { capAdapterServer } from "../src/capability";
+
+// A silent logger so the missing-env warnings emitted by `resolveEnvVars`
+// don't spam the test output.
+const silentLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+// ── Synthetic business capability ─────────────────────────────────────────
+//
+// Stands in for the (private, unpublished) purchase demo. It contributes the
+// same breadth so the full entity/action/relation/state path through
+// `assembleDevSchema` (commandLayer + onchangeEvaluator) is still exercised:
+// two entities (one a relation target), a custom action, a relation, and a
+// state machine. Plain `*Definition` shapes from `@linchkit/core` — no `any`.
+
+const projectEntity: EntityDefinition = {
+  name: "smoke_project",
+  label: "Smoke Project",
+  description: "Synthetic project entity for the dev-boot smoke test",
+  presentation: {
+    titleField: "name",
+    badgeField: "status",
+    summaryFields: ["owner"],
+    icon: "folder",
+  },
+  fields: {
+    name: { type: "string", required: true, label: "Name", ui: { importance: "primary" } },
+    owner: { type: "string", label: "Owner", ui: { importance: "primary" } },
+    status: {
+      type: "state",
+      machine: "smoke_project_lifecycle",
+      default: "open",
+      ui: { importance: "primary", display: "badge" },
+    },
+  },
+};
+
+const milestoneEntity: EntityDefinition = {
+  name: "smoke_milestone",
+  label: "Smoke Milestone",
+  description: "Synthetic milestone entity — the relation target of a project",
+  presentation: {
+    titleField: "title",
+    summaryFields: ["due_at"],
+    icon: "flag",
+  },
+  fields: {
+    title: { type: "string", required: true, label: "Title", ui: { importance: "primary" } },
+    due_at: { type: "datetime", label: "Due At", ui: { importance: "detail" } },
+  },
+};
+
+const archiveProjectAction: ActionDefinition = {
+  name: "archive_smoke_project",
+  entity: "smoke_project",
+  label: "Archive Project",
+  description: "Custom action that drives the project state machine to archived",
+  policy: { mode: "sync", transaction: true },
+  exposure: "all",
+  stateTransition: { from: "open", to: "archived" },
+};
+
+const projectToMilestones: RelationDefinition = defineRelation({
+  name: "smoke_project_to_milestones",
+  from: "smoke_project",
+  to: "smoke_milestone",
+  cardinality: "one_to_many",
+  fromName: "milestones",
+  toName: "project",
+  cascade: "delete",
+  label: { from: "Milestones", to: "Project" },
+});
+
+const projectState: StateDefinition = {
+  name: "smoke_project_lifecycle",
+  entity: "smoke_project",
+  field: "status",
+  initial: "open",
+  states: ["open", "archived"],
+  transitions: [{ from: "open", to: "archived", action: "archive_smoke_project" }],
+  meta: {
+    open: { label: "Open", color: "green" },
+    archived: { label: "Archived", color: "gray" },
+  },
+};
+
+const capSmokeBusiness: CapabilityDefinition = defineCapability({
+  name: "cap-smoke-business",
+  label: "Smoke Business",
+  description:
+    "Synthetic business capability (inline) standing in for the unpublished demo — " +
+    "contributes entities + a custom action + a relation + a state machine",
+  type: "standard",
+  category: "business",
+  version: "0.1.0",
+  entities: [projectEntity, milestoneEntity],
+  actions: [archiveProjectAction],
+  states: [projectState],
+  relations: [projectToMilestones],
+});
+
+/**
+ * Representative configured-capability set. Mirrors `config/capabilities.ts`:
+ * the adapter itself, a published system capability that contributes a
+ * `graphqlExtensions` graphql type instance (cap-chatter), and a synthetic
+ * business module that contributes entities + actions + states + relations.
+ */
+function configuredCapabilities(): CapabilityDefinition[] {
+  return [capAdapterServer, capChatter, capSmokeBusiness];
+}
+
+describe("dev-server schema boot", () => {
+  it("assembles the full GraphQL schema after resolveEnvVars (no DB, no HTTP)", () => {
+    // Mirror loadConfig: env-resolve the whole config — INCLUDING capabilities —
+    // before assembly. This is the exact step that flattened graphql types.
+    const resolved = resolveEnvVars({ capabilities: configuredCapabilities() }, silentLogger) as {
+      capabilities: CapabilityDefinition[];
+    };
+
+    // Build the schema the SAME WAY dev.ts does: full runtime context with a
+    // real commandLayer + onchangeEvaluator + all contributed fields.
+    let assembled: ReturnType<typeof assembleDevSchema> | undefined;
+    expect(() => {
+      assembled = assembleDevSchema(resolved.capabilities);
+    }).not.toThrow();
+
+    const schema = assembled?.schema;
+    expect(schema).toBeDefined();
+    if (!schema) return;
+
+    // Query/Mutation roots exist.
+    expect(schema.getQueryType()?.name).toBe("Query");
+    expect(schema.getMutationType()?.name).toBe("Mutation");
+
+    // The capability-contributed graphqlExtensions field is wired (this is the
+    // field whose graphql type instance the regression destroyed).
+    expect(schema.getQueryType()?.getFields().chatterMessages).toBeDefined();
+    // ...and the type it references survived with its name intact.
+    expect(schema.getTypeMap().ChatterMessageConnection).toBeDefined();
+    expect(schema.getTypeMap().ChatterMessage).toBeDefined();
+
+    // Business entities from the synthetic capability are present, proving the
+    // full entity/action/relation/state path ran (commandLayer +
+    // onchangeEvaluator). The entity must surface in the GraphQL type map too.
+    expect(assembled?.allEntities.some((e) => e.name === "smoke_project")).toBe(true);
+    expect(schema.getTypeMap().SmokeProject).toBeDefined();
+
+    // No reachable named type in the type map has an empty name (the exact
+    // invariant `new GraphQLSchema` enforces).
+    for (const [name, type] of Object.entries(schema.getTypeMap())) {
+      expect(name.length).toBeGreaterThan(0);
+      expect((type as { name: string }).name.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("exercises commandLayer + onchangeEvaluator in the assembly", () => {
+    const assembled = assembleDevSchema(configuredCapabilities());
+    // The full production wiring is present — not the simplified test shape.
+    expect(assembled.runtime.commandLayer).toBeDefined();
+    expect(assembled.onchangeEvaluator).toBeDefined();
+    // A dev allow-all permission stub is injected (CommandLayer hard-fails on an
+    // empty permission slot), confirming the permission slot is wired.
+    expect(assembled.contributions.middlewares.some((m) => m.slot === "permission")).toBe(true);
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/__tests__/dev-schema-boot.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/dev-schema-boot.test.ts
@@ -54,7 +54,13 @@ import type {
   StateDefinition,
 } from "@linchkit/core";
 import { defineCapability, defineRelation, resolveEnvVars } from "@linchkit/core";
-import { assembleDevSchema } from "../src/assemble-schema";
+import {
+  GraphQLString,
+  getIntrospectionQuery,
+  graphqlSync,
+  type IntrospectionQuery,
+} from "graphql";
+import { assembleDevSchema, extractCapabilities } from "../src/assemble-schema";
 import { capAdapterServer } from "../src/capability";
 
 // A silent logger so the missing-env warnings emitted by `resolveEnvVars`
@@ -222,5 +228,61 @@ describe("dev-server schema boot", () => {
     // A dev allow-all permission stub is injected (CommandLayer hard-fails on an
     // empty permission slot), confirming the permission slot is wired.
     expect(assembled.contributions.middlewares.some((m) => m.slot === "permission")).toBe(true);
+  });
+
+  it("produces a schema the graphql runtime can EXECUTE, not merely construct", () => {
+    // A schema can construct but still be unservable (e.g. a field whose type
+    // fails to resolve at execution). Run the standard introspection query — the
+    // same one a GraphQL client issues on connect — straight through
+    // `graphqlSync`. It exercises every reachable type/field resolver without a
+    // DB or HTTP layer; any unresolvable/unnamed type surfaces as a GraphQL
+    // error here rather than only at first real request in `dev:server`.
+    const { schema } = assembleDevSchema(configuredCapabilities());
+    const result = graphqlSync({ schema, source: getIntrospectionQuery() });
+
+    expect(result.errors).toBeUndefined();
+    const data = result.data as unknown as IntrospectionQuery;
+    expect(data.__schema.queryType.name).toBe("Query");
+    // The capability-contributed type the regression destroyed is introspectable.
+    expect(data.__schema.types.some((t) => t.name === "ChatterMessageConnection")).toBe(true);
+    expect(data.__schema.types.some((t) => t.name === "SmokeProject")).toBe(true);
+  });
+});
+
+describe("capability contribution merging", () => {
+  // Build a minimal capability that contributes a single root query field, so
+  // two of them collide on the same field name.
+  function capWithQueryField(name: string, field: string): CapabilityDefinition {
+    return defineCapability({
+      name,
+      label: name,
+      description: `Synthetic capability contributing query field "${field}"`,
+      type: "standard",
+      category: "business",
+      version: "0.1.0",
+      extensions: {
+        graphqlExtensions: {
+          queryFields: {
+            [field]: { type: GraphQLString, resolve: () => "ok" },
+          },
+        },
+      },
+    });
+  }
+
+  it("throws (does not silently overwrite) on a duplicate root query field", () => {
+    const a = capWithQueryField("cap-collide-a", "duplicatedField");
+    const b = capWithQueryField("cap-collide-b", "duplicatedField");
+    expect(() => extractCapabilities([a, b])).toThrow(
+      /Duplicate GraphQL query field "duplicatedField"/,
+    );
+  });
+
+  it("allows distinct query fields from different capabilities", () => {
+    const a = capWithQueryField("cap-distinct-a", "fieldA");
+    const b = capWithQueryField("cap-distinct-b", "fieldB");
+    const contributions = extractCapabilities([a, b]);
+    expect(contributions.extraQueryFields.fieldA).toBeDefined();
+    expect(contributions.extraQueryFields.fieldB).toBeDefined();
   });
 });

--- a/addons/adapter-server/cap-adapter-server/package.json
+++ b/addons/adapter-server/cap-adapter-server/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@linchkit/cap-ai-provider": "workspace:*",
+    "@linchkit/cap-chatter": "workspace:*",
     "@linchkit/core": "workspace:*",
     "typescript": "^6.0.2"
   },

--- a/addons/adapter-server/cap-adapter-server/src/assemble-schema.ts
+++ b/addons/adapter-server/cap-adapter-server/src/assemble-schema.ts
@@ -1,0 +1,205 @@
+/**
+ * Schema assembly — the server-free core of the dev/boot path.
+ *
+ * `dev.ts` was previously a single top-level script that inlined the entire
+ * "capabilities → runtime context → GraphQLSchema" assembly. Because nothing
+ * exercised that exact assembly outside of actually starting the HTTP server,
+ * a regression (a deep-clone in `resolveEnvVars` flattening graphql type
+ * instances carried in `graphqlExtensions`) shipped undetected and crashed
+ * `bun run dev:server` at boot with "One of the provided types for building
+ * the Schema is missing a name."
+ *
+ * This module extracts that assembly into a reusable, exported, DB-free and
+ * server-free helper so it can be unit-tested with the real configured
+ * capabilities. `dev.ts` now calls `assembleDevSchema(...)`.
+ */
+
+import type {
+  ActionDefinition,
+  AIService,
+  CapabilityDefinition,
+  EntityDefinition,
+  MiddlewareRegistration,
+  RelationDefinition,
+  RuleDefinition,
+  StateDefinition,
+  ViewDefinition,
+} from "@linchkit/core";
+import { createOnchangeEvaluator } from "@linchkit/core/server";
+import type { GraphQLFieldConfig, GraphQLSchema } from "graphql";
+import { buildGraphQLSchema, generateCrudActions } from "./graphql/build-schema";
+import { createRuntimeContext, type RuntimeContext } from "./runtime-context";
+
+/** Flattened contributions collected across all loaded capabilities. */
+export interface CapabilityContributions {
+  entities: EntityDefinition[];
+  actions: ActionDefinition[];
+  states: StateDefinition[];
+  views: ViewDefinition[];
+  relations: RelationDefinition[];
+  rules: RuleDefinition[];
+  middlewares: MiddlewareRegistration[];
+  seed: Record<string, Array<Record<string, unknown>>>;
+  extraQueryFields: Record<string, unknown>;
+  extraMutationFields: Record<string, unknown>;
+}
+
+/**
+ * Flatten every capability's contributions into a single bucket.
+ *
+ * This is the same extraction `dev.ts` performed inline.
+ */
+export function extractCapabilities(
+  capabilities: CapabilityDefinition[] = [],
+): CapabilityContributions {
+  const entities: EntityDefinition[] = [];
+  const actions: ActionDefinition[] = [];
+  const states: StateDefinition[] = [];
+  const views: ViewDefinition[] = [];
+  const relations: RelationDefinition[] = [];
+  const rules: RuleDefinition[] = [];
+  const middlewares: MiddlewareRegistration[] = [];
+  const seed: Record<string, Array<Record<string, unknown>>> = {};
+  const extraQueryFields: Record<string, unknown> = {};
+  const extraMutationFields: Record<string, unknown> = {};
+
+  for (const cap of capabilities) {
+    if (cap.entities) entities.push(...cap.entities);
+    if (cap.actions) actions.push(...cap.actions);
+    if (cap.states) states.push(...cap.states);
+    if (cap.views) views.push(...cap.views);
+    if (cap.relations) relations.push(...cap.relations);
+    if (cap.rules) rules.push(...cap.rules);
+
+    if (cap.seed) {
+      for (const [entityName, records] of Object.entries(cap.seed)) {
+        if (!seed[entityName]) seed[entityName] = [];
+        seed[entityName].push(...records);
+      }
+    }
+
+    if (cap.extensions?.middlewares) {
+      for (const mw of cap.extensions.middlewares) {
+        middlewares.push({
+          name: `${cap.name}:${mw.slot}`,
+          slot: mw.slot,
+          order: mw.priority ?? 100,
+          handler: mw.handler,
+        });
+      }
+    }
+    if (cap.extensions?.graphqlExtensions?.queryFields) {
+      Object.assign(extraQueryFields, cap.extensions.graphqlExtensions.queryFields);
+    }
+    if (cap.extensions?.graphqlExtensions?.mutationFields) {
+      Object.assign(extraMutationFields, cap.extensions.graphqlExtensions.mutationFields);
+    }
+  }
+
+  return {
+    entities,
+    actions,
+    states,
+    views,
+    relations,
+    rules,
+    middlewares,
+    seed,
+    extraQueryFields,
+    extraMutationFields,
+  };
+}
+
+export interface AssembleDevSchemaOptions {
+  /** Optional AI service (built from config). Defaults to the noop service. */
+  aiService?: AIService;
+}
+
+export interface AssembledDevSchema {
+  schema: GraphQLSchema;
+  runtime: RuntimeContext;
+  contributions: CapabilityContributions;
+  allEntities: EntityDefinition[];
+  allActions: ActionDefinition[];
+  onchangeEvaluator: ReturnType<typeof createOnchangeEvaluator>;
+}
+
+/**
+ * Assemble the full dev GraphQL schema from a set of capabilities — the exact
+ * path `bun run dev:server` exercises, minus starting the HTTP server.
+ *
+ * DB-free: `createRuntimeContext` falls back to `InMemoryStore` when no
+ * `dataProvider` is supplied, so this runs in CI without Postgres.
+ *
+ * The returned `schema` is built with the FULL production shape — a real
+ * `commandLayer` and `onchangeEvaluator`, all entities/actions/relations/
+ * states, and capability-contributed `extraQueryFields`/`extraMutationFields`
+ * — not the simplified shape unit tests typically use.
+ */
+export function assembleDevSchema(
+  capabilities: CapabilityDefinition[],
+  options?: AssembleDevSchemaOptions,
+): AssembledDevSchema {
+  const contributions = extractCapabilities(capabilities);
+
+  // Dev-only allow-all permission stub. The CommandLayer hard-fails when the
+  // `permission` slot is empty, so inject a low-priority pass-through unless a
+  // capability already registered a permission middleware.
+  const hasPermissionMiddleware = contributions.middlewares.some((mw) => mw.slot === "permission");
+  if (!hasPermissionMiddleware) {
+    contributions.middlewares.push({
+      name: "dev:allow_all_permission",
+      slot: "permission",
+      order: 999,
+      handler: async (_ctx, next) => {
+        await next();
+      },
+    });
+  }
+
+  const allEntities = contributions.entities;
+
+  // Generate CRUD actions, skipping any name a capability already defined.
+  const capActionNames = new Set(contributions.actions.map((a) => a.name));
+  const crudActions = allEntities
+    .flatMap((entity) => generateCrudActions(entity))
+    .filter((crud) => !capActionNames.has(crud.name));
+  const allActions: ActionDefinition[] = [...crudActions, ...contributions.actions];
+
+  const capabilityNames = new Set(capabilities.map((c) => c.name));
+
+  const runtime = createRuntimeContext({
+    entities: allEntities,
+    actions: allActions,
+    states: contributions.states,
+    views: contributions.views,
+    middlewares: contributions.middlewares,
+    ai: options?.aiService,
+    capabilityNames,
+  });
+
+  const onchangeEvaluator = createOnchangeEvaluator({
+    entityRegistry: runtime.entityRegistry,
+    dataProvider: runtime.dataProvider,
+  });
+
+  const schema = buildGraphQLSchema(allEntities, {
+    executor: runtime.executor,
+    commandLayer: runtime.commandLayer,
+    dataProvider: runtime.dataProvider,
+    actions: contributions.actions,
+    relations: contributions.relations,
+    stateDefinitions: contributions.states,
+    onchangeEvaluator,
+    extraQueryFields: contributions.extraQueryFields as Record<
+      string,
+      GraphQLFieldConfig<unknown, unknown>
+    >,
+    extraMutationFields: contributions.extraMutationFields as Record<
+      string,
+      GraphQLFieldConfig<unknown, unknown>
+    >,
+  });
+
+  return { schema, runtime, contributions, allEntities, allActions, onchangeEvaluator };
+}

--- a/addons/adapter-server/cap-adapter-server/src/assemble-schema.ts
+++ b/addons/adapter-server/cap-adapter-server/src/assemble-schema.ts
@@ -30,6 +30,31 @@ import type { GraphQLFieldConfig, GraphQLSchema } from "graphql";
 import { buildGraphQLSchema, generateCrudActions } from "./graphql/build-schema";
 import { createRuntimeContext, type RuntimeContext } from "./runtime-context";
 
+/**
+ * Merge a capability's contributed GraphQL fields into the shared bucket,
+ * throwing on a name collision instead of silently overwriting.
+ *
+ * Two capabilities contributing the same root query/mutation field name would
+ * otherwise have the later one silently win — a hard-to-debug runtime surprise.
+ * Fail loud at assembly time with the offending capability and field named.
+ */
+function mergeGraphQLFields(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+  kind: "query" | "mutation",
+  capName: string,
+): void {
+  for (const [key, value] of Object.entries(source)) {
+    if (Object.hasOwn(target, key)) {
+      throw new Error(
+        `Duplicate GraphQL ${kind} field "${key}" contributed by capability "${capName}" — ` +
+          "another capability already registered a field with this name.",
+      );
+    }
+    target[key] = value;
+  }
+}
+
 /** Flattened contributions collected across all loaded capabilities. */
 export interface CapabilityContributions {
   entities: EntityDefinition[];
@@ -89,10 +114,20 @@ export function extractCapabilities(
       }
     }
     if (cap.extensions?.graphqlExtensions?.queryFields) {
-      Object.assign(extraQueryFields, cap.extensions.graphqlExtensions.queryFields);
+      mergeGraphQLFields(
+        extraQueryFields,
+        cap.extensions.graphqlExtensions.queryFields,
+        "query",
+        cap.name,
+      );
     }
     if (cap.extensions?.graphqlExtensions?.mutationFields) {
-      Object.assign(extraMutationFields, cap.extensions.graphqlExtensions.mutationFields);
+      mergeGraphQLFields(
+        extraMutationFields,
+        cap.extensions.graphqlExtensions.mutationFields,
+        "mutation",
+        cap.name,
+      );
     }
   }
 

--- a/addons/adapter-server/cap-adapter-server/src/dev.ts
+++ b/addons/adapter-server/cap-adapter-server/src/dev.ts
@@ -7,20 +7,9 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import type {
-  ActionDefinition,
-  CapabilityDefinition,
-  EntityDefinition,
-  MiddlewareRegistration,
-  RelationDefinition,
-  RuleDefinition,
-  StateDefinition,
-  ViewDefinition,
-} from "@linchkit/core";
-import { consoleLogger, createOnchangeEvaluator } from "@linchkit/core/server";
+import { consoleLogger } from "@linchkit/core/server";
+import { assembleDevSchema } from "./assemble-schema";
 import { loadConfig } from "./config-loader";
-import { buildGraphQLSchema, generateCrudActions } from "./graphql/build-schema";
-import { createRuntimeContext } from "./runtime-context";
 import { createServer } from "./server";
 
 // ── Resolve project root ────────────────────────────────
@@ -72,138 +61,40 @@ if (existsSync(envPath)) {
 
 const config = await loadConfig({ root: projectRoot });
 
-// ── Extract capability contributions ────────────────────
-
-function extractCapabilities(capabilities: CapabilityDefinition[] = []): {
-  entities: EntityDefinition[];
-  actions: ActionDefinition[];
-  states: StateDefinition[];
-  views: ViewDefinition[];
-  relations: RelationDefinition[];
-  rules: RuleDefinition[];
-  middlewares: MiddlewareRegistration[];
-  seed: Record<string, Array<Record<string, unknown>>>;
-  extraQueryFields: Record<string, unknown>;
-  extraMutationFields: Record<string, unknown>;
-} {
-  const entities: EntityDefinition[] = [];
-  const actions: ActionDefinition[] = [];
-  const states: StateDefinition[] = [];
-  const views: ViewDefinition[] = [];
-  const relations: RelationDefinition[] = [];
-  const rules: RuleDefinition[] = [];
-  const middlewares: MiddlewareRegistration[] = [];
-  const seed: Record<string, Array<Record<string, unknown>>> = {};
-  const extraQueryFields: Record<string, unknown> = {};
-  const extraMutationFields: Record<string, unknown> = {};
-
-  for (const cap of capabilities) {
-    if (cap.entities) entities.push(...cap.entities);
-    if (cap.actions) actions.push(...cap.actions);
-    if (cap.states) states.push(...cap.states);
-    if (cap.views) views.push(...cap.views);
-    if (cap.relations) relations.push(...cap.relations);
-    if (cap.rules) rules.push(...cap.rules);
-
-    // Collect seed data from capabilities
-    if (cap.seed) {
-      for (const [entityName, records] of Object.entries(cap.seed)) {
-        if (!seed[entityName]) seed[entityName] = [];
-        seed[entityName].push(...records);
-      }
-    }
-
-    // Convert CapabilityMiddlewareRegistration → MiddlewareRegistration
-    if (cap.extensions?.middlewares) {
-      for (const mw of cap.extensions.middlewares) {
-        middlewares.push({
-          name: `${cap.name}:${mw.slot}`,
-          slot: mw.slot,
-          order: mw.priority ?? 100,
-          handler: mw.handler,
-        });
-      }
-    }
-    if (cap.extensions?.graphqlExtensions?.queryFields) {
-      Object.assign(extraQueryFields, cap.extensions.graphqlExtensions.queryFields);
-    }
-    if (cap.extensions?.graphqlExtensions?.mutationFields) {
-      Object.assign(extraMutationFields, cap.extensions.graphqlExtensions.mutationFields);
-    }
-  }
-
-  return {
-    entities,
-    actions,
-    states,
-    views,
-    relations,
-    rules,
-    middlewares,
-    seed,
-    extraQueryFields,
-    extraMutationFields,
-  };
-}
-
-const capContributions = extractCapabilities(config.capabilities);
-
-// Dev-only allow-all permission middleware. The CommandLayer now hard-fails
-// when the `permission` slot is empty (even with `skipActionSlots: true`) to
-// prevent accidental production deploys without RBAC. `dev.ts` does not wire
-// cap-permission, so inject a stub at `order: 999` that simply calls `next()`.
-// Any real permission middleware registered by a capability will run first
-// (lower order) and take precedence.
-const hasPermissionMiddleware = capContributions.middlewares.some(
-  (mw: MiddlewareRegistration) => mw.slot === "permission",
-);
-if (!hasPermissionMiddleware) {
-  capContributions.middlewares.push({
-    name: "dev:allow_all_permission",
-    slot: "permission",
-    order: 999,
-    handler: async (_ctx, next) => {
-      await next();
-    },
-  });
-  consoleLogger.warn(
-    "[permission] no permission middleware registered — dev server is running with an allow-all stub. Register cap-permission (or an equivalent) before deploying to production.",
-  );
-}
-
-// ── Merge capability entities and actions ────────────────
-
-const allEntities = capContributions.entities;
-
-// Generate CRUD actions, skip if capability already defined one with same name
-const capActionNames = new Set(capContributions.actions.map((a) => a.name));
-const crudActions = allEntities
-  .flatMap((s) => generateCrudActions(s))
-  .filter((crud) => !capActionNames.has(crud.name));
-
-const allActions: ActionDefinition[] = [...crudActions, ...capContributions.actions];
-
-// ── Initialize runtime context ──────────────────────────
-
-// Build AI service from config (requires @linchkit/cap-ai-provider when AI is configured)
+// ── Build AI service from config ─────────────────────────
+// Requires @linchkit/cap-ai-provider only when AI is configured.
 let aiService: import("@linchkit/core").AIService | undefined;
 if (config.ai) {
   const { createAIService } = await import("@linchkit/cap-ai-provider");
   aiService = createAIService(config.ai);
 }
 
-// Build capability name set for ctx.hasCapability() weak dependency checks
-const capabilityNames = new Set((config.capabilities ?? []).map((c) => c.name));
+// ── Assemble the schema (server-free, DB-free core) ──────
+// `assembleDevSchema` is the shared, exported helper that both this dev entry
+// point AND the boot smoke test exercise — so a regression that breaks schema
+// assembly (e.g. graphql types in graphqlExtensions getting clobbered) is
+// caught by CI instead of only at `bun run dev:server`.
+const assembled = assembleDevSchema(config.capabilities ?? [], { aiService });
+const {
+  schema: graphqlSchema,
+  runtime,
+  contributions: capContributions,
+  onchangeEvaluator,
+} = assembled;
 
-const runtime = createRuntimeContext({
-  entities: allEntities,
-  actions: allActions,
-  states: capContributions.states,
-  views: capContributions.views,
-  middlewares: capContributions.middlewares,
-  ai: aiService,
-  capabilityNames,
-});
+// `assembleDevSchema` injects a named allow-all stub when no capability
+// supplied a permission middleware — surface that to the operator.
+const usingPermissionStub = capContributions.middlewares.some(
+  (mw) => mw.name === "dev:allow_all_permission",
+);
+if (usingPermissionStub) {
+  consoleLogger.warn(
+    "[permission] no permission middleware registered — dev server is running with an allow-all stub. Register cap-permission (or an equivalent) before deploying to production.",
+  );
+}
+consoleLogger.warn(
+  "[onchange] no checkReadPermission configured — lookup/query helpers return data without permission enforcement. Wire cap-permission (or an equivalent) to gate entity reads inside onchange hooks.",
+);
 
 // Seed dev data from capabilities (only works with InMemoryStore)
 const { InMemoryStore } = await import("@linchkit/core/server");
@@ -213,40 +104,8 @@ if (runtime.dataProvider instanceof InMemoryStore) {
   }
 }
 
-// ── Build schema and start server ────────────────────────
-
-const customActions = capContributions.actions;
-
-// Construct the onchange evaluator (Spec 64). No permission capability is wired
-// into `dev.ts`, so reads from within onchange hooks are ALL ALLOWED by default.
-// Log a structured warning once at startup so operators know the evaluator has
-// no permission gate; a production install should inject a `checkReadPermission`
-// callback (e.g. from cap-permission) that consults the real RBAC graph.
-const onchangeEvaluator = createOnchangeEvaluator({
-  entityRegistry: runtime.entityRegistry,
-  dataProvider: runtime.dataProvider,
-});
-consoleLogger.warn(
-  "[onchange] no checkReadPermission configured — lookup/query helpers return data without permission enforcement. Wire cap-permission (or an equivalent) to gate entity reads inside onchange hooks.",
-);
-
-const graphqlSchema = buildGraphQLSchema(allEntities, {
-  executor: runtime.executor,
-  commandLayer: runtime.commandLayer,
-  dataProvider: runtime.dataProvider,
-  actions: customActions,
-  relations: capContributions.relations,
-  stateDefinitions: capContributions.states,
-  onchangeEvaluator,
-  extraQueryFields: capContributions.extraQueryFields as Record<
-    string,
-    import("graphql").GraphQLFieldConfig<unknown, unknown>
-  >,
-  extraMutationFields: capContributions.extraMutationFields as Record<
-    string,
-    import("graphql").GraphQLFieldConfig<unknown, unknown>
-  >,
-});
+const allEntities = assembled.allEntities;
+const allActions = assembled.allActions;
 
 const port = config.server?.port ?? 3001;
 const host = config.server?.host ?? "0.0.0.0";

--- a/addons/adapter-server/cap-adapter-server/src/index.ts
+++ b/addons/adapter-server/cap-adapter-server/src/index.ts
@@ -8,6 +8,12 @@ export const VERSION = "0.0.1";
 
 export type { FindManyOptions } from "@linchkit/core/server";
 export { InMemoryStore } from "@linchkit/core/server";
+export type {
+  AssembleDevSchemaOptions,
+  AssembledDevSchema,
+  CapabilityContributions,
+} from "./assemble-schema";
+export { assembleDevSchema, extractCapabilities } from "./assemble-schema";
 export { capAdapterServer } from "./capability";
 export { generateGraphQLInputType, generateGraphQLObjectType } from "./graphql";
 export type {

--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,30 @@
         "tsup": "^8.5.1",
       },
     },
+    "addons/adapter-a2a/cap-adapter-a2a": {
+      "name": "@linchkit/cap-adapter-a2a",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@linchkit/core": "workspace:*",
+        "@linchkit/devtools": "workspace:*",
+        "typescript": "^6.0.2",
+      },
+      "peerDependencies": {
+        "@linchkit/core": "^0.2.0",
+      },
+    },
+    "addons/adapter-ag-ui/cap-adapter-ag-ui": {
+      "name": "@linchkit/cap-adapter-ag-ui",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@linchkit/core": "workspace:*",
+        "@linchkit/devtools": "workspace:*",
+        "typescript": "^6.0.2",
+      },
+      "peerDependencies": {
+        "@linchkit/core": "^0.2.0",
+      },
+    },
     "addons/adapter-mcp/cap-adapter-mcp": {
       "name": "@linchkit/cap-adapter-mcp",
       "version": "1.0.0",
@@ -68,6 +92,7 @@
       },
       "devDependencies": {
         "@linchkit/cap-ai-provider": "workspace:*",
+        "@linchkit/cap-chatter": "workspace:*",
         "@linchkit/core": "workspace:*",
         "typescript": "^6.0.2",
       },
@@ -237,7 +262,7 @@
         "typescript": "^6.0.2",
       },
       "peerDependencies": {
-        "@linchkit/core": "^0.1.0",
+        "@linchkit/core": "^0.2.0",
         "drizzle-orm": "^0.45.1",
         "graphql": "^16.13.1",
       },
@@ -820,6 +845,10 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "https://registry.npmmirror.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
+
+    "@linchkit/cap-adapter-a2a": ["@linchkit/cap-adapter-a2a@workspace:addons/adapter-a2a/cap-adapter-a2a"],
+
+    "@linchkit/cap-adapter-ag-ui": ["@linchkit/cap-adapter-ag-ui@workspace:addons/adapter-ag-ui/cap-adapter-ag-ui"],
 
     "@linchkit/cap-adapter-mcp": ["@linchkit/cap-adapter-mcp@workspace:addons/adapter-mcp/cap-adapter-mcp"],
 

--- a/packages/core/src/utils/env.ts
+++ b/packages/core/src/utils/env.ts
@@ -11,11 +11,26 @@ import type { Logger } from "../types/logger";
 const ENV_PATTERN = /^\$env\.(.+)$/;
 
 /**
+ * True only for plain objects (literal `{}` / `Object.create(null)`).
+ *
+ * Class instances (e.g. graphql-js `GraphQLNonNull` / `GraphQLObjectType`
+ * carried in `extensions.graphqlExtensions`) must NOT be rebuilt, or their
+ * prototype is lost and graphql treats them as unnamed types at schema build
+ * time. `$env.*` placeholders only ever live in plain config data, so it is
+ * safe to recurse into plain objects exclusively and pass instances through.
+ */
+function isPlainObject(value: object): boolean {
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
  * Resolve `$env.VAR_NAME` placeholders in a config object.
  *
  * - Only exact-match string values are substituted (no partial interpolation).
  * - Missing env vars produce a warning and resolve to `undefined`.
  * - Non-object values pass through unchanged.
+ * - Class instances pass through by reference (prototype preserved).
  */
 export function resolveEnvVars<T>(config: T, logger: Logger = consoleLogger): T {
   if (config === null || config === undefined) {
@@ -41,7 +56,9 @@ export function resolveEnvVars<T>(config: T, logger: Logger = consoleLogger): T 
     return config.map((item) => resolveEnvVars(item, logger)) as unknown as T;
   }
 
-  if (typeof config === "object") {
+  // Only recurse into plain objects. Class instances (graphql types, Date,
+  // Map, etc.) pass through by reference so their prototype is preserved.
+  if (typeof config === "object" && isPlainObject(config as object)) {
     const result: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(config as Record<string, unknown>)) {
       result[key] = resolveEnvVars(value, logger);


### PR DESCRIPTION
## The bug (found by running `bun run dev:server`)

`bun run dev:server` crashed at boot:
```
error: One of the provided types for building the Schema is missing a name.
  at new GraphQLSchema(...)
  at buildGraphQLSchema(build-schema.ts:1151)
  at dev.ts:233
```

**Root cause:** `resolveEnvVars` (in `@linchkit/core`, run by `loadConfig` over the **whole** config — including `config.capabilities`) deep-rebuilt every object via `{}` + `Object.entries`, discarding prototypes. Recursing into cap-chatter's `extensions.graphqlExtensions.queryFields` flattened a live `GraphQLNonNull(...)` instance into a plain object → no longer `instanceof GraphQLNonNull` → graphql-js could not unwrap it → `new GraphQLSchema(...)` rejected it as unnamed.

## Fix (`packages/core/src/utils/env.ts`)
`resolveEnvVars` now recurses only into **plain** objects (`{}` / `Object.create(null)`) and arrays; class instances (graphql types, `Date`, `Map`, …) pass through by reference with prototypes intact. `$env.*` placeholders only ever live in plain config data, so this is behavior-preserving (core env tests still green).

## The test gap this exposed (the `跑起来看看` finding)
A server that **could not boot** sailed through **6346 green unit tests**, because:
- every `build-schema` unit test calls `buildGraphQLSchema` with the **simplified** shape (1–2 toy entities, no `commandLayer`/`onchangeEvaluator`, raw capability objects);
- the E2E tests that exercise the real schema are `describe.skipIf(!dbAvailable)` → **skipped** without Postgres;
- **nothing** exercised dev.ts's full assembly run through `loadConfig`'s `resolveEnvVars`.

## Regression guard added
- Extracted dev.ts's schema assembly into a reusable, **server-free + DB-free** helper `assembleDevSchema()` (`src/assemble-schema.ts`); `dev.ts` now calls it (single shared path).
- New `__tests__/dev-schema-boot.test.ts`: runs the real configured capabilities (`cap-adapter-server` + published `cap-chatter` (carries the `graphqlExtensions` type instance = the trigger) + a synthetic in-test business cap with entities/action/relation/state) through `resolveEnvVars` **then** `assembleDevSchema`, asserting the schema builds with `commandLayer` + `onchangeEvaluator` and **no** unnamed types. **Verified fail-before / pass-after** the core fix.

## Notes
- devDep added: `@linchkit/cap-chatter` (`workspace:*`, published, test-only — needed because its graphql type instance is the regression trigger). I deliberately did NOT add a devDep on the **private** `cap-purchase-demo`; used a synthetic in-test capability instead (a published package must not devDep a private one).
- Touches published `@linchkit/core` — a changeset can be added at release time (kept out per the standing "暂不发布").

## Verification
- new smoke test → 2 pass; `bun test addons/adapter-server/cap-adapter-server` → 617 pass / 25 skip (DB) / 0 fail; core env tests green; full `bun test` → 0 named failures; `bun run typecheck` clean; `bunx biome check .` exit 0; `bun run dev:server` now boots.

Cross-model pass via PR bots (local gemini CLI quota-exhausted; codex needs node, blocked by repo hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced schema assembly utilities for development environments, enabling flexible capability composition with duplicate field detection.
  * Improved environment variable resolution to properly preserve non-plain object references.

* **Tests**
  * Added comprehensive test suite for development schema boot path and capability extraction.

* **Chores**
  * Updated development dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laofahai/linchkit/pull/421?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->