### PR TITLE
ci: run DB-gated integration/e2e suites against a Postgres service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,25 @@ jobs:
   quality:
     name: Code Quality
     runs-on: ubuntu-latest
+    services:
+      # Postgres for the DB-gated integration/e2e suites. Without it those
+      # `describe.skipIf(!dbAvailable)` suites SKIP in CI — i.e. ~124 tests that
+      # never actually ran. Mirrors the `postgres-test` service in
+      # docker-compose.yml (image/creds/port) so local and CI behave identically;
+      # the tests connect to localhost:5434 via DATABASE_TEST_URL below.
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: linchkit_test
+          POSTGRES_PASSWORD: linchkit_test
+          POSTGRES_DB: linchkit_test
+        ports:
+          - 5434:5432
+        options: >-
+          --health-cmd "pg_isready -U linchkit_test"
+          --health-interval 2s
+          --health-timeout 5s
+          --health-retries 15
     steps:
       - uses: actions/checkout@v5
 
@@ -28,6 +47,11 @@ jobs:
 
       - name: Run tests
         shell: bash
+        env:
+          # Flips the DB-gated `describe.skipIf(!dbAvailable)` suites from skip to
+          # run. Matches the `postgres` service above and the hardcoded default
+          # the test files fall back to.
+          DATABASE_TEST_URL: postgres://linchkit_test:linchkit_test@localhost:5434/linchkit_test
         run: |
           # Bun 1.2.18 occasionally segfaults during process teardown
           # (panic 0x4A at exit) even when every test passes. The crash can land


### PR DESCRIPTION
## What
Adds a `postgres:16-alpine` service to the **Code Quality** CI job and sets `DATABASE_TEST_URL` on the test step, so the DB-gated integration/e2e suites actually **run** in CI instead of silently skipping.

## Why
The integration/e2e suites guard themselves with `describe.skipIf(!dbAvailable)` and connect via `DATABASE_TEST_URL` (fallback `localhost:5434`). CI had **no Postgres**, so every one **SKIPPED** — **~124 tests across 7 files that never actually ran**. This is exactly the gap that let a non-booting dev server pass the suite.

## Changes
- New `services: postgres` block on the `quality` job, mirroring the `postgres-test` service in `docker-compose.yml` (image `postgres:16-alpine`, creds `linchkit_test`, host port `5434`, health-check).
- `env: DATABASE_TEST_URL=...localhost:5434...` on the **Run tests** step — flips the gated suites skip → run.
- **No test code changed.**

## Suites now running in CI (124 tests, all green vs real PG)
`drizzle-data-provider.integration` (26) · `persistent-event-bus.integration` (14) · `outbox-worker` (20) · `dlq-service` (19) · `event-replay-service` (20) · `graphql-drizzle.integration` (15) · `e2e-integration` (10)

Verified locally with the service running: full `bun test` → **0 fail, 0 skip**, 3872 pass lines (segfault-guard handles the known Bun teardown panic).

## Out of scope
- `ai-service-e2e.test.ts` stays gated on `VOLCENGINE_API_KEY` (real billed calls) — intentionally skipped in CI.
- The CI Biome step (`bunx biome`) being a no-op is a separate, tracked issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)