### PR TITLE
chore(ci): make Biome lint gate real — pin @biomejs/biome@2.4.16 as devDep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: bun install
 
       - name: Biome check
-        run: bunx biome check .
+        run: bun run check
 
       - name: TypeScript type check
         run: bun run typecheck

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
         run: bun install
 
       - name: Biome check
-        run: bunx biome check .
+        run: bun run check
 
       - name: TypeScript type check
         run: bun run typecheck

--- a/addons/adapter-ui/cap-adapter-ui/src/pages/entity-form-actions.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/pages/entity-form-actions.ts
@@ -130,7 +130,7 @@ export function useFormActions(opts: UseFormActionsOptions) {
             // Allow both explicit FK fields and auto-generated FK columns from relations
             const fieldDef = schema?.fields[fieldName];
             const isRelationFk = relationFkColumns.has(fieldName);
-            if (!isRelationFk && (!fieldDef || fieldDef.type !== "string")) continue;
+            if (!isRelationFk && fieldDef?.type !== "string") continue;
             // Resolve target entity from relations
             const relation = bundle?.relations?.find(
               (l) => l.from === entityName && l.fromName === fieldName.replace(/_id$/, ""),

--- a/addons/auth/cap-auth/src/providers/drizzle-provider.ts
+++ b/addons/auth/cap-auth/src/providers/drizzle-provider.ts
@@ -190,7 +190,7 @@ class DrizzleAuthProvider implements AuthProvider {
     input: { refresh_token: string },
   ): Promise<RefreshResult> {
     const payload = await this.verifyToken(input.refresh_token);
-    if (!payload || payload.type !== "refresh") {
+    if (payload?.type !== "refresh") {
       throw new Error("Invalid or expired refresh token");
     }
 
@@ -317,7 +317,7 @@ class DrizzleAuthProvider implements AuthProvider {
 
   async resolveToken(token: string): Promise<Actor | null> {
     const payload = await this.verifyToken(token);
-    if (!payload || payload.type !== "access") return null;
+    if (payload?.type !== "access") return null;
 
     return {
       type: "human",

--- a/addons/demo/cap-purchase-demo/src/automations/purchase-status.ts
+++ b/addons/demo/cap-purchase-demo/src/automations/purchase-status.ts
@@ -21,7 +21,7 @@ export const autoSetSubmittedAt = defineEventHandler({
     if (event.entity !== "purchase_request") return;
 
     const newValues = event.payload._new as Record<string, unknown> | undefined;
-    if (!newValues || newValues._state !== "pending") return;
+    if (newValues?._state !== "pending") return;
 
     // In a real implementation, this would call an action to set the field.
     // For demo purposes, the logic is shown inline.
@@ -43,7 +43,7 @@ export const autoSetApprovedFields = defineEventHandler({
     if (event.entity !== "purchase_request") return;
 
     const newValues = event.payload._new as Record<string, unknown> | undefined;
-    if (!newValues || newValues._state !== "approved") return;
+    if (newValues?._state !== "approved") return;
 
     console.log(
       `[purchase-demo] Auto-setting approved_at and approved_by for purchase_request (state -> approved, actor=${event.actor.id})`,
@@ -63,7 +63,7 @@ export const notifyHighPrioritySubmission = defineEventHandler({
     if (event.entity !== "purchase_request") return;
 
     const newValues = event.payload._new as Record<string, unknown> | undefined;
-    if (!newValues || newValues._state !== "pending") return;
+    if (newValues?._state !== "pending") return;
 
     console.log(`[purchase-demo] Notification: Purchase request submitted (state -> pending)`);
   },

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "sonner": "^2.0.7",
       },
       "devDependencies": {
+        "@biomejs/biome": "2.4.16",
         "@changesets/cli": "^2.30.0",
         "bun-types": "latest",
         "drizzle-kit": "^0.31.10",
@@ -647,6 +648,24 @@
     "@better-auth/utils": ["@better-auth/utils@0.3.1", "", {}, "sha512-+CGp4UmZSUrHHnpHhLPYu6cV+wSUSvVbZbNykxhUDocpVNTo9uFFxw/NqJlh1iC4wQ9HKKWGCKuZ5wUgS0v6Kg=="],
 
     "@better-fetch/fetch": ["@better-fetch/fetch@1.1.21", "", {}, "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="],
+
+    "@biomejs/biome": ["@biomejs/biome@2.4.16", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.16", "@biomejs/cli-darwin-x64": "2.4.16", "@biomejs/cli-linux-arm64": "2.4.16", "@biomejs/cli-linux-arm64-musl": "2.4.16", "@biomejs/cli-linux-x64": "2.4.16", "@biomejs/cli-linux-x64-musl": "2.4.16", "@biomejs/cli-win32-arm64": "2.4.16", "@biomejs/cli-win32-x64": "2.4.16" }, "bin": { "biome": "bin/biome" } }, "sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.16", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.16", "", { "os": "darwin", "cpu": "x64" }, "sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.16", "", { "os": "win32", "cpu": "arm64" }, "sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "https://registry.npmmirror.com/@borewit/text-codec/-/text-codec-0.2.2.tgz", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   ],
   "scripts": {
     "ai:eval": "bun addons/ai-provider/cap-ai-provider/bin/ai-eval.ts",
-    "check": "bunx @biomejs/biome check .",
-    "format": "bunx @biomejs/biome format --write .",
-    "lint": "bunx @biomejs/biome lint .",
+    "check": "biome check .",
+    "format": "biome format --write .",
+    "lint": "biome lint .",
     "typecheck": "bunx tsc --noEmit",
     "test": "bun test",
     "build": "bun run --filter '@linchkit/core' build && bun run --filter '@linchkit/devtools' build && bun run --filter '@linchkit/cli' --filter '@linchkit/cap-adapter-ui' build",
@@ -26,6 +26,7 @@
     "release": "bun scripts/release.ts"
   },
   "devDependencies": {
+    "@biomejs/biome": "2.4.16",
     "@changesets/cli": "^2.30.0",
     "bun-types": "latest",
     "drizzle-kit": "^0.31.10",

--- a/packages/core/src/ai/byok-key-store.ts
+++ b/packages/core/src/ai/byok-key-store.ts
@@ -135,7 +135,7 @@ export function createInMemoryBYOKKeyStore(options?: InMemoryBYOKKeyStoreOptions
       assertNonEmpty(provider, "provider");
 
       const record = records.get(buildKey(tenantId, provider));
-      if (!record || record.status !== "active") {
+      if (record?.status !== "active") {
         return { provider, decryptedKey: null, source: "missing" };
       }
       const decryptedKey = await resolveEncryptedKey(record.encryptedKeyRef);

--- a/packages/core/src/ai/proposal-compatibility-checker.ts
+++ b/packages/core/src/ai/proposal-compatibility-checker.ts
@@ -274,7 +274,7 @@ function checkEnumOptionsChange(
   snapshot: CompatibilityRegistrySnapshot,
 ): CompatibilityIssue | undefined {
   const current = getField(snapshot, change.entity, change.field);
-  if (!current || current.type !== "enum") {
+  if (current?.type !== "enum") {
     return undefined;
   }
   const oldOptions = new Set((current as EnumField).options.map((o) => o.value));

--- a/packages/core/src/deployment/rollback-orchestrator.ts
+++ b/packages/core/src/deployment/rollback-orchestrator.ts
@@ -449,7 +449,7 @@ export function rollbackInputFromProposal(
   // Defensive against null/malformed input (this is a consumption point that may
   // receive deserialized/untrusted Proposals): a missing proposal or a
   // non-array `changes` declines rather than throwing a TypeError.
-  if (!proposal || proposal.status !== "approved" || !Array.isArray(proposal.changes)) {
+  if (proposal?.status !== "approved" || !Array.isArray(proposal.changes)) {
     return null;
   }
 

--- a/packages/core/src/entity/derived-registry.ts
+++ b/packages/core/src/entity/derived-registry.ts
@@ -386,7 +386,7 @@ export class DerivedPropertyEngine {
     // Resolve compute-strategy fields in topological order
     for (const key of order) {
       const info = this.fields.get(key);
-      if (!info || info.strategy !== "compute") continue;
+      if (info?.strategy !== "compute") continue;
 
       const value = resolveDerivedValue(info.derived, record);
       if (value !== undefined) {
@@ -461,7 +461,7 @@ export class DerivedPropertyEngine {
     // Resolve store-strategy fields in topological order
     for (const key of order) {
       const info = this.fields.get(key);
-      if (!info || info.strategy !== "store") continue;
+      if (info?.strategy !== "store") continue;
 
       // Skip aggregates in sync mode — they need async resolution
       if (info.derived.type === "aggregate") continue;
@@ -526,7 +526,7 @@ export class DerivedPropertyEngine {
     const order = this.topoOrder.get(entityName) ?? [];
     for (const key of order) {
       const info = this.fields.get(key);
-      if (!info || info.strategy !== "store") continue;
+      if (info?.strategy !== "store") continue;
       if (info.derived.type === "aggregate") continue;
 
       // Check if any dependency is an aggregate field


### PR DESCRIPTION
## Problem — the CI lint gate was a silent no-op

Both `ci.yml` and `publish.yml` ran `bunx biome check .`. But `biome` (unscoped) is a **wrong/stub npm package** that exits `0` without linting anything — so lint regressions have been merging undetected. Meanwhile the root `package.json` scripts used the correct `@biomejs/biome` but **unpinned**, floating to a stricter version than `biome.json`'s `$schema` targets → local-vs-CI drift (local `bun run check` reported errors CI never saw).

## Fix — treat the linter like the repo already treats `typescript`

`tsc` works because `typescript` is a real, pinned devDependency (`node_modules/.bin/tsc -> ../typescript/bin/tsc`). Do the same for Biome:

- **package.json**: add `@biomejs/biome@2.4.16` to `devDependencies` (exact pin — a lint gate must be deterministic); `check`/`format`/`lint` scripts call the local `biome` binary instead of `bunx`.
- **bun.lock**: single source of truth for the version.
- **biome.json**: bump `$schema` `2.4.10 → 2.4.16` to match the binary.
- **ci.yml + publish.yml**: run `bun run check` — reuse the script, one source of truth, no duplicated command, no stub-package risk.

Net: no stub risk (explicit scoped dependency), no drift (lockfile pins it), version in one place, upgrades are one `bun add -D @biomejs/biome@x`.

## Resulting cleanup

Upgrading to 2.4.16 surfaced **12 pre-existing `lint/complexity/useOptionalChain` warnings** (0 errors) that 2.4.10 didn't flag. Cleared all 12 via the optional-chain rewrite; every site guards an `object | null | undefined` reference (Map.get / find / nullable returns), so the rewrites are behavior-preserving (verified per-site).

## Verification

- `bun run check` (local `biome` 2.4.16) → **0 errors / 0 warnings** across 1588 files.
- `bun run typecheck` → clean.
- Full `bun test` → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)