### PR TITLE
feat(adapter-server): GraphQL field-lock introspection (Spec 63)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/graphql-field-meta.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/graphql-field-meta.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { EntityDefinition } from "@linchkit/core";
+import { GraphQLNonNull, type GraphQLObjectType, graphql, printType } from "graphql";
+import { buildGraphQLSchema } from "../src/graphql/build-schema";
+import {
+  buildFieldMetaList,
+  clearFieldMetaTypeCache,
+  getFieldMetaType,
+  toLockConditionMeta,
+} from "../src/graphql/field-meta";
+
+// ── Fixture: an entity exercising every Phase-1 lock declaration ──
+//  - code:     immutable (exempt from lockAllWhen via lockAllowFields, so it
+//              demonstrates immutable-only with no inherited lock condition)
+//  - legacy:   deprecated `readonly` alias (treated as immutable); also exempt
+//  - amount:   per-field lockWhen with a positive state list
+//  - supplier: per-field lockWhen with a { not } clause
+//  - title:    no per-field lock → covered by entity-level lockAllWhen
+//  - notes:    in lockAllowFields → exempt from lockAllWhen
+//  - plain:    no lock at all (exempt from lockAllWhen)
+const orderSchema: EntityDefinition = {
+  name: "purchase_order",
+  label: "Purchase Order",
+  lockAllWhen: { state: "posted" },
+  lockAllowFields: ["notes", "code", "legacy", "plain"],
+  fields: {
+    code: { type: "string", immutable: true, label: "Code" },
+    legacy: { type: "string", readonly: true, label: "Legacy" },
+    amount: { type: "number", lockWhen: { state: ["submitted", "approved"] } },
+    supplier: { type: "string", lockWhen: { state: { not: "draft" } } },
+    title: { type: "string", label: "Title" },
+    notes: { type: "text", label: "Notes" },
+    plain: { type: "string", label: "Plain" },
+  },
+};
+
+afterEach(() => {
+  clearFieldMetaTypeCache();
+});
+
+// ── Pure builder: toLockConditionMeta ─────────────────────────────
+
+describe("toLockConditionMeta", () => {
+  test("positive single state → stateIn", () => {
+    const meta = toLockConditionMeta({ state: "posted" });
+    expect(meta.stateIn).toEqual(["posted"]);
+    expect(meta.stateNotIn).toBeNull();
+    expect(meta.domain).toBeNull();
+    expect(JSON.parse(meta.raw)).toEqual({ state: "posted" });
+  });
+
+  test("positive state array → stateIn", () => {
+    const meta = toLockConditionMeta({ state: ["submitted", "approved"] });
+    expect(meta.stateIn).toEqual(["submitted", "approved"]);
+    expect(meta.stateNotIn).toBeNull();
+  });
+
+  test("{ not: string } → stateNotIn", () => {
+    const meta = toLockConditionMeta({ state: { not: "draft" } });
+    expect(meta.stateNotIn).toEqual(["draft"]);
+    expect(meta.stateIn).toBeNull();
+  });
+
+  test("{ not: string[] } → stateNotIn", () => {
+    const meta = toLockConditionMeta({ state: { not: ["draft", "rejected"] } });
+    expect(meta.stateNotIn).toEqual(["draft", "rejected"]);
+  });
+
+  test("domain clause is JSON-encoded and raw preserves authored shape", () => {
+    const condition = { domain: [["amount", ">", 100]] } as const;
+    const meta = toLockConditionMeta(condition);
+    expect(meta.stateIn).toBeNull();
+    expect(meta.stateNotIn).toBeNull();
+    expect(JSON.parse(meta.domain ?? "null")).toEqual([["amount", ">", 100]]);
+    expect(JSON.parse(meta.raw)).toEqual({ domain: [["amount", ">", 100]] });
+  });
+});
+
+// ── Pure builder: buildFieldMetaList ──────────────────────────────
+
+describe("buildFieldMetaList", () => {
+  const list = buildFieldMetaList(orderSchema);
+  const byName = new Map(list.map((m) => [m.name, m]));
+
+  test("emits one meta per user-defined field", () => {
+    expect(list.map((m) => m.name).sort()).toEqual(
+      ["amount", "code", "legacy", "notes", "plain", "supplier", "title"].sort(),
+    );
+  });
+
+  test("immutable field is flagged immutable with no lock condition", () => {
+    const code = byName.get("code");
+    expect(code?.immutable).toBe(true);
+    expect(code?.lockWhen).toBeNull();
+    expect(code?.lockSource).toBe("none");
+  });
+
+  test("deprecated readonly alias is reported as immutable", () => {
+    expect(byName.get("legacy")?.immutable).toBe(true);
+  });
+
+  test("per-field lockWhen wins with source=field (positive list)", () => {
+    const amount = byName.get("amount");
+    expect(amount?.immutable).toBe(false);
+    expect(amount?.lockSource).toBe("field");
+    expect(amount?.lockWhen?.stateIn).toEqual(["submitted", "approved"]);
+  });
+
+  test("per-field lockWhen { not } projects to stateNotIn", () => {
+    const supplier = byName.get("supplier");
+    expect(supplier?.lockSource).toBe("field");
+    expect(supplier?.lockWhen?.stateNotIn).toEqual(["draft"]);
+  });
+
+  test("uncovered field inherits entity lockAllWhen with source=entity", () => {
+    const title = byName.get("title");
+    expect(title?.lockSource).toBe("entity");
+    expect(title?.lockWhen?.stateIn).toEqual(["posted"]);
+  });
+
+  test("lockAllowFields member is exempt from lockAllWhen", () => {
+    const notes = byName.get("notes");
+    expect(notes?.lockSource).toBe("none");
+    expect(notes?.lockWhen).toBeNull();
+  });
+
+  test("field with no lock declaration has none", () => {
+    const plain = byName.get("plain");
+    expect(plain?.immutable).toBe(false);
+    expect(plain?.lockWhen).toBeNull();
+    expect(plain?.lockSource).toBe("none");
+  });
+});
+
+// ── Schema shape: the FieldMeta GraphQL type exists ───────────────
+
+describe("FieldMeta GraphQL type", () => {
+  test("FieldMeta type has the spec §6 fields with correct nullability", () => {
+    const type = getFieldMetaType();
+    const fields = type.getFields();
+    expect(fields.name.type).toBeInstanceOf(GraphQLNonNull);
+    expect(fields.immutable.type).toBeInstanceOf(GraphQLNonNull);
+    expect(fields.lockSource.type).toBeInstanceOf(GraphQLNonNull);
+    // lockWhen is nullable (no NonNull wrapper) — fields without a lock are null
+    expect(fields.lockWhen.type).not.toBeInstanceOf(GraphQLNonNull);
+    // sanity: printable without throwing
+    expect(printType(type)).toContain("type FieldMeta");
+  });
+});
+
+// ── End-to-end: query the real built schema ───────────────────────
+
+describe("buildGraphQLSchema exposes <entity>FieldMeta", () => {
+  // No dataProvider — field-meta is pure static metadata and must resolve
+  // even in mock mode. Exercises the real build-schema path.
+  const schema = buildGraphQLSchema([orderSchema]);
+
+  test("Query exposes a purchaseOrderFieldMeta field returning [FieldMeta!]!", () => {
+    const queryType = schema.getQueryType() as GraphQLObjectType;
+    const field = queryType.getFields().purchaseOrderFieldMeta;
+    expect(field).toBeDefined();
+    // [FieldMeta!]! — outer NonNull
+    expect(field.type).toBeInstanceOf(GraphQLNonNull);
+  });
+
+  test("introspected metadata matches the declared locks", async () => {
+    const result = await graphql({
+      schema,
+      source: `
+        query {
+          purchaseOrderFieldMeta {
+            name
+            immutable
+            lockSource
+            lockWhen {
+              stateIn
+              stateNotIn
+              domain
+              raw
+            }
+          }
+        }
+      `,
+    });
+
+    expect(result.errors).toBeUndefined();
+    const metas = (result.data?.purchaseOrderFieldMeta ?? []) as Array<{
+      name: string;
+      immutable: boolean;
+      lockSource: string;
+      lockWhen: {
+        stateIn: string[] | null;
+        stateNotIn: string[] | null;
+        domain: string | null;
+        raw: string;
+      } | null;
+    }>;
+    const byName = new Map(metas.map((m) => [m.name, m]));
+
+    // immutable
+    expect(byName.get("code")?.immutable).toBe(true);
+    expect(byName.get("code")?.lockWhen).toBeNull();
+
+    // per-field positive lockWhen
+    expect(byName.get("amount")?.lockSource).toBe("field");
+    expect(byName.get("amount")?.lockWhen?.stateIn).toEqual(["submitted", "approved"]);
+
+    // per-field { not } lockWhen
+    expect(byName.get("supplier")?.lockWhen?.stateNotIn).toEqual(["draft"]);
+
+    // entity-level lockAllWhen inherited
+    expect(byName.get("title")?.lockSource).toBe("entity");
+    expect(byName.get("title")?.lockWhen?.stateIn).toEqual(["posted"]);
+
+    // lockAllowFields exemption
+    expect(byName.get("notes")?.lockSource).toBe("none");
+    expect(byName.get("notes")?.lockWhen).toBeNull();
+
+    // raw preserves the authored condition verbatim
+    expect(JSON.parse(byName.get("amount")?.lockWhen?.raw ?? "null")).toEqual({
+      state: ["submitted", "approved"],
+    });
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/__tests__/graphql-field-meta.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/graphql-field-meta.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import type { EntityDefinition } from "@linchkit/core";
+import type { EntityDefinition, FieldOverlayRecord, LockCondition } from "@linchkit/core";
 import { GraphQLNonNull, type GraphQLObjectType, graphql, printType } from "graphql";
 import { buildGraphQLSchema } from "../src/graphql/build-schema";
 import {
@@ -74,6 +74,30 @@ describe("toLockConditionMeta", () => {
     expect(JSON.parse(meta.domain ?? "null")).toEqual([["amount", ">", 100]]);
     expect(JSON.parse(meta.raw)).toEqual({ domain: [["amount", ">", 100]] });
   });
+
+  test("malformed { not: undefined } does not throw → empty stateNotIn", () => {
+    // A LockCondition whose `not` clause is undefined (empty/malformed `state`
+    // object) must not crash introspection. The static type forbids this, so
+    // we cast to exercise the runtime-drift guard.
+    const condition = { state: { not: undefined } } as unknown as LockCondition;
+    let meta: ReturnType<typeof toLockConditionMeta> | undefined;
+    expect(() => {
+      meta = toLockConditionMeta(condition);
+    }).not.toThrow();
+    expect(meta?.stateNotIn).toEqual([]);
+    expect(meta?.stateIn).toBeNull();
+  });
+
+  test("empty state object {} does not throw → null lists", () => {
+    // An empty `state` object has no `not` key at all → neither list applies.
+    const condition = { state: {} } as unknown as LockCondition;
+    let meta: ReturnType<typeof toLockConditionMeta> | undefined;
+    expect(() => {
+      meta = toLockConditionMeta(condition);
+    }).not.toThrow();
+    expect(meta?.stateNotIn).toBeNull();
+    expect(meta?.stateIn).toBeNull();
+  });
 });
 
 // ── Pure builder: buildFieldMetaList ──────────────────────────────
@@ -129,6 +153,50 @@ describe("buildFieldMetaList", () => {
     expect(plain?.immutable).toBe(false);
     expect(plain?.lockWhen).toBeNull();
     expect(plain?.lockSource).toBe("none");
+  });
+
+  test("active overlay fields are surfaced as unlocked, collisions skipped", () => {
+    const overlays: FieldOverlayRecord[] = [
+      {
+        id: "ov1",
+        entityName: "purchase_order",
+        fieldName: "color",
+        fieldType: "string",
+        config: { label: { en: "Color" } },
+        status: "active",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        // Collides with a code-defined field → must be skipped (mirrors the
+        // type generator which also skips colliding overlays).
+        id: "ov2",
+        entityName: "purchase_order",
+        fieldName: "amount",
+        fieldType: "number",
+        config: {},
+        status: "active",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+    const withOverlays = buildFieldMetaList(orderSchema, overlays);
+    const overlayMap = new Map(withOverlays.map((m) => [m.name, m]));
+
+    // The new overlay field appears, reported as fully unlocked.
+    const color = overlayMap.get("color");
+    expect(color).toBeDefined();
+    expect(color?.immutable).toBe(false);
+    expect(color?.lockWhen).toBeNull();
+    expect(color?.lockSource).toBe("none");
+
+    // The colliding overlay does NOT add a duplicate; "amount" keeps its
+    // code-declared per-field lock.
+    expect(withOverlays.filter((m) => m.name === "amount")).toHaveLength(1);
+    expect(overlayMap.get("amount")?.lockSource).toBe("field");
+
+    // Code-defined fields are unaffected in count; only "color" is added.
+    expect(withOverlays.length).toBe(list.length + 1);
   });
 });
 

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
@@ -46,6 +46,7 @@ import { buildBatchMutationField } from "./build-batch-mutation";
 import { buildOnchangeMutationFields } from "./build-onchange-mutations";
 import { buildSubscriptionFields, createEventBusPubSub } from "./build-subscriptions";
 import { buildEventsGraphQLExtension } from "./events";
+import { buildFieldMetaList, getFieldMetaType } from "./field-meta";
 import { safeParseJSON } from "./json-arg";
 import {
   generateActionInputType,
@@ -603,6 +604,19 @@ export function buildGraphQLSchema(
             });
           }
         : () => ({ items: [], total: 0, pageInfo: { limit: 20, offset: 0, hasMore: false } }),
+    };
+
+    // ── Query: static field-lock metadata (Spec 63 §6) ────
+    // Pure schema metadata: per-field `immutable` + effective `lockWhen`
+    // (per-field `lockWhen`, else entity `lockAllWhen` when covered). No live
+    // record is read here — clients use this to pre-compute lock state.
+    // Computed once per entity (the definition is static) and shared across
+    // requests; no dataProvider dependency, so it works even in mock mode.
+    const fieldMetaList = buildFieldMetaList(entity);
+    queryFields[`${camelName}FieldMeta`] = {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(getFieldMetaType()))),
+      description: `Static field-lock metadata for ${entity.label ?? entityName} (Spec 63 §6)`,
+      resolve: () => fieldMetaList,
     };
 
     // Internal schemas are read-only — skip mutation generation

--- a/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/build-schema.ts
@@ -610,9 +610,16 @@ export function buildGraphQLSchema(
     // Pure schema metadata: per-field `immutable` + effective `lockWhen`
     // (per-field `lockWhen`, else entity `lockAllWhen` when covered). No live
     // record is read here — clients use this to pre-compute lock state.
-    // Computed once per entity (the definition is static) and shared across
-    // requests; no dataProvider dependency, so it works even in mock mode.
-    const fieldMetaList = buildFieldMetaList(entity);
+    // Active overlay fields are passed so the introspected field set matches
+    // the entity's GraphQL object/input types (which include overlay fields);
+    // overlays carry no lock vocabulary, so they surface as unlocked — see
+    // `buildFieldMetaList`. Computed once per entity at build time and shared
+    // across requests; no dataProvider dependency, so it works in mock mode.
+    const fieldMetaOverlays = overlayRegistry?.overlaysFor(entityName);
+    const fieldMetaList = buildFieldMetaList(
+      entity,
+      fieldMetaOverlays?.length ? fieldMetaOverlays : undefined,
+    );
     queryFields[`${camelName}FieldMeta`] = {
       type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(getFieldMetaType()))),
       description: `Static field-lock metadata for ${entity.label ?? entityName} (Spec 63 §6)`,

--- a/addons/adapter-server/cap-adapter-server/src/graphql/field-meta.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/field-meta.ts
@@ -20,7 +20,7 @@
  * metadata with the same model the engine uses.
  */
 
-import type { EntityDefinition, LockCondition } from "@linchkit/core";
+import type { EntityDefinition, FieldOverlayRecord, LockCondition } from "@linchkit/core";
 import {
   GraphQLBoolean,
   GraphQLList,
@@ -109,9 +109,20 @@ export function toLockConditionMeta(condition: LockCondition): LockConditionMeta
     stateIn = [spec];
   } else if (Array.isArray(spec)) {
     stateIn = [...spec];
-  } else if (spec && typeof spec === "object") {
+  } else if (spec && typeof spec === "object" && "not" in spec) {
+    // Defensive: a malformed `{ not }` clause (e.g. `{ not: undefined }` or an
+    // empty `state` object) must not crash introspection. The `LockCondition`
+    // type guarantees `not` is a string | string[], but runtime data can drift
+    // from the static type, so we narrow before spreading and fall back to an
+    // empty `stateNotIn` for any shape we cannot interpret.
     const excluded = spec.not;
-    stateNotIn = typeof excluded === "string" ? [excluded] : [...excluded];
+    if (typeof excluded === "string") {
+      stateNotIn = [excluded];
+    } else if (Array.isArray(excluded)) {
+      stateNotIn = [...excluded];
+    } else {
+      stateNotIn = [];
+    }
   }
 
   return {
@@ -151,9 +162,25 @@ function resolveLockCondition(
  * entity. System fields are not included — they are framework-managed and
  * never user-writable, so their lock state is not actionable for clients.
  *
- * Pure function of the {@link EntityDefinition}: no live record is consulted.
+ * Pure function of the {@link EntityDefinition} (plus any active overlay
+ * records): no live record is consulted.
+ *
+ * Runtime overlay fields (Spec — `_extensions` JSONB) are surfaced for
+ * completeness so the introspected field set matches the entity's GraphQL
+ * object/input types, which DO include overlay fields. Overlays in this
+ * runtime are purely additive: {@link import("@linchkit/core").OverlayFieldConfig}
+ * carries only validation/i18n config (label, required, min/max, enumValues),
+ * NOT the field-lock vocabulary (`immutable`, `readonly`, `lockWhen`). An
+ * overlay therefore cannot lock a field, so each overlay field is reported as
+ * `immutable: false`, `lockWhen: null`, `lockSource: "none"`. The entity-level
+ * `lockAllWhen` is NOT applied to overlay fields: they live in `_extensions`,
+ * are never code-declared, and the Phase-1 engine only evaluates `lockAllWhen`
+ * over the resolved code-defined field set.
  */
-export function buildFieldMetaList(entity: EntityDefinition): FieldMeta[] {
+export function buildFieldMetaList(
+  entity: EntityDefinition,
+  overlays?: FieldOverlayRecord[],
+): FieldMeta[] {
   const metas: FieldMeta[] = [];
 
   for (const [fieldName, field] of Object.entries(entity.fields)) {
@@ -166,6 +193,23 @@ export function buildFieldMetaList(entity: EntityDefinition): FieldMeta[] {
       lockWhen: condition ? toLockConditionMeta(condition) : null,
       lockSource: source,
     });
+  }
+
+  if (overlays?.length) {
+    const codeFields = entity.fields;
+    for (const overlay of overlays) {
+      // Skip overlays that collide with a code-defined or system field — the
+      // type generator skips these too, so they are not part of the surface.
+      if (overlay.fieldName in codeFields || SYSTEM_FIELD_NAMES.has(overlay.fieldName)) {
+        continue;
+      }
+      metas.push({
+        name: overlay.fieldName,
+        immutable: false,
+        lockWhen: null,
+        lockSource: "none",
+      });
+    }
   }
 
   return metas;

--- a/addons/adapter-server/cap-adapter-server/src/graphql/field-meta.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/field-meta.ts
@@ -1,0 +1,262 @@
+/**
+ * Field-lock introspection metadata (Spec 63 §6, Phase 2).
+ *
+ * Exposes the STATIC, declarative lock metadata of an entity's fields in the
+ * generated GraphQL schema so clients can pre-compute which fields are
+ * immutable / conditionally locked without trial-and-error mutations.
+ *
+ * This is schema metadata only — it does NOT evaluate a lock condition against
+ * a live record. Resolving "is this field locked for THIS record right now?"
+ * is the Phase-1 runtime engine's job (`matchesLockCondition`) and the UI's
+ * job (Spec 63 §5.1). Here we only surface the declared rules:
+ *
+ *  - per-field `immutable` (and the deprecated `readonly` alias, which the
+ *    engine treats as immutable — see Spec 63 §8)
+ *  - per-field `lockWhen` (a {@link LockCondition})
+ *  - entity-level `lockAllWhen` + `lockAllowFields` (the `__all__` shorthand)
+ *
+ * The vocabulary mirrors core's declarations exactly (`state`, `not`,
+ * `domain`, `lockAllWhen`, `lockAllowFields`) so clients can reason about the
+ * metadata with the same model the engine uses.
+ */
+
+import type { EntityDefinition, LockCondition } from "@linchkit/core";
+import {
+  GraphQLBoolean,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  type GraphQLOutputType,
+  GraphQLString,
+} from "graphql";
+
+/**
+ * The same system-field set the Phase-1 checker auto-exempts from
+ * `lockAllWhen` (`packages/core/src/engine/field-lock-checker.ts`). We mirror
+ * it here so the introspected "effective lock condition" of a field matches
+ * what the runtime engine will actually enforce: a system field is never
+ * covered by `lockAllWhen`, even though an explicit per-field `lockWhen` on it
+ * still applies. Kept in sync manually — core does not export this set.
+ */
+const SYSTEM_FIELD_NAMES = new Set([
+  "id",
+  "tenant_id",
+  "created_at",
+  "updated_at",
+  "created_by",
+  "updated_by",
+  "_version",
+  "deleted_at",
+  "status",
+]);
+
+/**
+ * Serializable projection of a {@link LockCondition} for GraphQL.
+ *
+ * `LockCondition.state` is a union (`string | string[] | { not }`) that has no
+ * single clean GraphQL scalar, so it is flattened into two list fields plus a
+ * JSON fallback that preserves the exact authored shape:
+ *
+ *  - `stateIn`    — states that LOCK the field (positive form: `"submitted"`
+ *                   or `["submitted","approved"]`). Null for the `not` form.
+ *  - `stateNotIn` — states that, when current, do NOT lock; i.e. the field is
+ *                   locked when status is anything EXCEPT these (`{ not }`
+ *                   form). Null for the positive form.
+ *  - `domain`     — JSON-encoded `domain` clause (Spec 63 reserves it for a
+ *                   future phase; surfaced verbatim so clients can detect it).
+ *  - `raw`        — JSON of the entire LockCondition, for forward-compat with
+ *                   clauses this projection does not yet model.
+ */
+export interface LockConditionMeta {
+  stateIn: string[] | null;
+  stateNotIn: string[] | null;
+  domain: string | null;
+  raw: string;
+}
+
+/**
+ * Static lock metadata for a single field (Spec 63 §6 `FieldMeta`).
+ *
+ * `lockWhen` is the field's EFFECTIVE static lock condition: the per-field
+ * `lockWhen` if declared, otherwise the entity-level `lockAllWhen` when the
+ * field is covered by it (i.e. not in `lockAllowFields` and not a system
+ * field). This matches the resolution order the Phase-1 engine uses, so a
+ * client reading `FieldMeta.lockWhen` sees the same rule the engine enforces.
+ *
+ * `lockSource` reports WHERE that effective condition came from so clients can
+ * distinguish a deliberate per-field rule from the entity-wide shorthand.
+ */
+export interface FieldMeta {
+  name: string;
+  immutable: boolean;
+  lockWhen: LockConditionMeta | null;
+  lockSource: FieldMetaLockSource;
+}
+
+export type FieldMetaLockSource = "none" | "field" | "entity";
+
+/**
+ * Project a {@link LockCondition} into its serializable GraphQL form. The
+ * authored vocabulary is preserved verbatim in `raw`; the convenience list
+ * fields are derived from `state` only.
+ */
+export function toLockConditionMeta(condition: LockCondition): LockConditionMeta {
+  let stateIn: string[] | null = null;
+  let stateNotIn: string[] | null = null;
+
+  const spec = condition.state;
+  if (typeof spec === "string") {
+    stateIn = [spec];
+  } else if (Array.isArray(spec)) {
+    stateIn = [...spec];
+  } else if (spec && typeof spec === "object") {
+    const excluded = spec.not;
+    stateNotIn = typeof excluded === "string" ? [excluded] : [...excluded];
+  }
+
+  return {
+    stateIn,
+    stateNotIn,
+    domain: condition.domain ? JSON.stringify(condition.domain) : null,
+    raw: JSON.stringify(condition),
+  };
+}
+
+/**
+ * Resolve the EFFECTIVE static lock condition for a field, applying the same
+ * precedence the Phase-1 engine uses:
+ *
+ *  1. an explicit per-field `lockWhen` always wins (source = "field");
+ *  2. otherwise the entity-level `lockAllWhen` applies, UNLESS the field is in
+ *     `lockAllowFields` or is a system field (source = "entity");
+ *  3. otherwise no lock condition (source = "none").
+ */
+function resolveLockCondition(
+  fieldName: string,
+  fieldLockWhen: LockCondition | undefined,
+  entity: EntityDefinition,
+): { condition: LockCondition | undefined; source: FieldMetaLockSource } {
+  if (fieldLockWhen) {
+    return { condition: fieldLockWhen, source: "field" };
+  }
+  const exempt = entity.lockAllowFields?.includes(fieldName) || SYSTEM_FIELD_NAMES.has(fieldName);
+  if (!exempt && entity.lockAllWhen) {
+    return { condition: entity.lockAllWhen, source: "entity" };
+  }
+  return { condition: undefined, source: "none" };
+}
+
+/**
+ * Build the static {@link FieldMeta} list for every user-defined field of an
+ * entity. System fields are not included — they are framework-managed and
+ * never user-writable, so their lock state is not actionable for clients.
+ *
+ * Pure function of the {@link EntityDefinition}: no live record is consulted.
+ */
+export function buildFieldMetaList(entity: EntityDefinition): FieldMeta[] {
+  const metas: FieldMeta[] = [];
+
+  for (const [fieldName, field] of Object.entries(entity.fields)) {
+    const immutable = field.immutable === true || field.readonly === true;
+    const { condition, source } = resolveLockCondition(fieldName, field.lockWhen, entity);
+
+    metas.push({
+      name: fieldName,
+      immutable,
+      lockWhen: condition ? toLockConditionMeta(condition) : null,
+      lockSource: source,
+    });
+  }
+
+  return metas;
+}
+
+// ── GraphQL types ────────────────────────────────────────────────
+
+let lockConditionMetaType: GraphQLObjectType | undefined;
+let fieldMetaType: GraphQLObjectType | undefined;
+
+/** Build (once) the shared `LockConditionMeta` GraphQL object type. */
+function getLockConditionMetaType(): GraphQLObjectType {
+  if (lockConditionMetaType) return lockConditionMetaType;
+
+  lockConditionMetaType = new GraphQLObjectType({
+    name: "LockConditionMeta",
+    description:
+      "Serializable projection of a Spec 63 LockCondition. Lists are derived " +
+      "from the `state` clause; `raw` preserves the authored condition verbatim.",
+    fields: {
+      stateIn: {
+        type: new GraphQLList(new GraphQLNonNull(GraphQLString)),
+        description: "States that LOCK the field (positive `state` form). Null for the `not` form.",
+      },
+      stateNotIn: {
+        type: new GraphQLList(new GraphQLNonNull(GraphQLString)),
+        description:
+          "States excluded by the `{ not }` form — the field is locked when " +
+          "status is anything except these. Null for the positive form.",
+      },
+      domain: {
+        type: GraphQLString,
+        description: "JSON-encoded `domain` clause (reserved by Spec 63 for a future phase).",
+      },
+      raw: {
+        type: new GraphQLNonNull(GraphQLString),
+        description: "JSON of the entire LockCondition, for forward-compatibility.",
+      },
+    },
+  });
+
+  return lockConditionMetaType;
+}
+
+/**
+ * Build (once) the shared `FieldMeta` GraphQL object type exposing a field's
+ * static lock metadata (Spec 63 §6).
+ */
+export function getFieldMetaType(): GraphQLObjectType {
+  if (fieldMetaType) return fieldMetaType;
+
+  const lockConditionType: GraphQLOutputType = getLockConditionMetaType();
+
+  fieldMetaType = new GraphQLObjectType({
+    name: "FieldMeta",
+    description:
+      "Static field-lock metadata (Spec 63 §6). Declarative rules only — does " +
+      "not evaluate locks against a live record.",
+    fields: {
+      name: {
+        type: new GraphQLNonNull(GraphQLString),
+        description: "Field name.",
+      },
+      immutable: {
+        type: new GraphQLNonNull(GraphQLBoolean),
+        description:
+          "Whether the field cannot change once set (`immutable: true`, or the " +
+          "deprecated `readonly: true` alias).",
+      },
+      lockWhen: {
+        type: lockConditionType,
+        description:
+          "Effective static lock condition: the per-field `lockWhen` if declared, " +
+          "otherwise the entity-level `lockAllWhen` when this field is covered by " +
+          "it. Null when the field has no lock condition.",
+      },
+      lockSource: {
+        type: new GraphQLNonNull(GraphQLString),
+        description: 'Where `lockWhen` originates: "field", "entity", or "none".',
+      },
+    },
+  });
+
+  return fieldMetaType;
+}
+
+/**
+ * Reset the cached GraphQL types. Test-only — mirrors `clearEnumTypeCache` so
+ * suites that build multiple schemas don't reuse a stale type instance.
+ */
+export function clearFieldMetaTypeCache(): void {
+  lockConditionMetaType = undefined;
+  fieldMetaType = undefined;
+}

--- a/addons/adapter-server/cap-adapter-server/src/graphql/index.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/index.ts
@@ -9,6 +9,13 @@ export type {
 } from "./build-schema";
 export { buildGraphQLSchema, generateCrudActions } from "./build-schema";
 export { buildSubscriptionFields, buildTopic, createEventBusPubSub } from "./build-subscriptions";
+export type { FieldMeta, FieldMetaLockSource, LockConditionMeta } from "./field-meta";
+export {
+  buildFieldMetaList,
+  clearFieldMetaTypeCache,
+  getFieldMetaType,
+  toLockConditionMeta,
+} from "./field-meta";
 export type { RelationResolverContext } from "./schema-to-graphql";
 export {
   buildOverlayInputFields,


### PR DESCRIPTION
## What

Exposes per-entity **field-lock metadata over GraphQL** (Spec 63) so UI / API
clients can render field lock state without re-deriving core's rule vocabulary
on the client.

- Adds `FieldMeta` + `LockConditionMeta` GraphQL types and a
  `{camelName}FieldMeta` query field per entity.
- Mirrors core's lock vocabulary: `state` / `not` / `domain` / `lockAllWhen` /
  `lockAllowFields`, plus `lockSource` (`field` | `entity` | `none`) and a `raw`
  JSON fallback for shapes the typed schema does not yet model.
- Read-only introspection — no new write path; honors the GraphQL = reads-only
  rule.

## Files

| File | Change |
|------|--------|
| `src/graphql/field-meta.ts` | **new** — types + `buildFieldMetaList` / `toLockConditionMeta` / `getFieldMetaType` |
| `src/graphql/build-schema.ts` | register the per-entity `FieldMeta` query field |
| `src/graphql/index.ts` | barrel export |
| `__tests__/graphql-field-meta.test.ts` | **new** — 16 tests |

## Testing

- `bun run check` (Biome 2.4.16) — clean
- `bun run typecheck` — exit 0
- Targeted `bun test addons/adapter-server/cap-adapter-server/` — **672 pass / 0 fail** (56 files)
- Full `bun run test` runs in CI as the authoritative backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
