### PR TITLE
fix(cli/tests): restructure lint-capability test to avoid Bun panic 0x4A (#434)

### DIFF
--- a/packages/cli/__tests__/lint-capability.test.ts
+++ b/packages/cli/__tests__/lint-capability.test.ts
@@ -38,7 +38,7 @@ describe("lint-capability command", () => {
     expect(args?.json?.type).toBe("boolean");
   });
 
-  test("runs the checker (JSON) and reports ok for a clean capability", () => {
+  test("CLI subprocess exits zero and reports ok for a clean capability", async () => {
     const root = makeCapDir();
     writeFile(
       root,
@@ -51,26 +51,34 @@ describe("lint-capability command", () => {
         label: "CLI Clean",
       }),
     );
+    // package.json with peerDependencies is required by the core-version check (Spec 21 §10.1).
+    writeFile(
+      root,
+      "package.json",
+      JSON.stringify({
+        name: "@linchkit/cap-cli-clean",
+        version: "1.0.0",
+        peerDependencies: { "@linchkit/core": "^0.2.0" },
+        linchkit: { coreVersion: "^0.2.0" },
+      }),
+    );
     writeFile(root, "src/index.ts", `import { defineEntity } from "@linchkit/core";\nexport {};\n`);
     writeFile(root, "src/x.test.ts", `import { test } from "bun:test";\ntest("x", () => {});\n`);
 
-    const logs: string[] = [];
-    const origLog = console.log;
-    console.log = (...a: unknown[]) => logs.push(a.map(String).join(" "));
-    try {
-      // run() prints JSON and does NOT call process.exit for a clean cap.
-      // citty's run signature accepts a context object; we only need args here.
-      // biome-ignore lint/suspicious/noExplicitAny: invoking citty handler directly in test
-      (lintCapabilityCommand.run as any)({ args: { dir: root, json: true } });
-    } finally {
-      console.log = origLog;
-    }
+    const cliEntry = join(import.meta.dir, "../src/index.ts");
+    const proc = Bun.spawn(["bun", "run", cliEntry, "lint-capability", root, "--json"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    await proc.exited;
+    const stdout = await new Response(proc.stdout).text();
 
-    const parsed = JSON.parse(logs.join("\n"));
+    expect(proc.exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(true);
     expect(parsed.issues).toHaveLength(0);
     expect(parsed.dir).toBe(root);
-  });
+  }, 15_000);
 
   test("CLI subprocess exits non-zero on a failing capability", async () => {
     const root = makeCapDir();

--- a/packages/cli/__tests__/lint-capability.test.ts
+++ b/packages/cli/__tests__/lint-capability.test.ts
@@ -68,10 +68,10 @@ describe("lint-capability command", () => {
     const cliEntry = join(import.meta.dir, "../src/index.ts");
     const proc = Bun.spawn(["bun", "run", cliEntry, "lint-capability", root, "--json"], {
       stdout: "pipe",
-      stderr: "pipe",
+      stderr: "ignore",
     });
-    await proc.exited;
     const stdout = await new Response(proc.stdout).text();
+    await proc.exited;
 
     expect(proc.exitCode).toBe(0);
     const parsed = JSON.parse(stdout);
@@ -88,10 +88,10 @@ describe("lint-capability command", () => {
     const cliEntry = join(import.meta.dir, "../src/index.ts");
     const proc = Bun.spawn(["bun", "run", cliEntry, "lint-capability", root, "--json"], {
       stdout: "pipe",
-      stderr: "pipe",
+      stderr: "ignore",
     });
-    await proc.exited;
     const stdout = await new Response(proc.stdout).text();
+    await proc.exited;
 
     expect(proc.exitCode).toBe(1);
     const parsed = JSON.parse(stdout);

--- a/packages/cli/__tests__/lint-capability.test.ts
+++ b/packages/cli/__tests__/lint-capability.test.ts
@@ -74,7 +74,12 @@ describe("lint-capability command", () => {
     await proc.exited;
 
     expect(proc.exitCode).toBe(0);
-    const parsed = JSON.parse(stdout);
+    let parsed: ReturnType<typeof JSON.parse>;
+    try {
+      parsed = JSON.parse(stdout);
+    } catch {
+      throw new Error(`JSON.parse failed (exitCode=${proc.exitCode}). stdout: ${stdout.slice(0, 200)}`);
+    }
     expect(parsed.ok).toBe(true);
     expect(parsed.issues).toHaveLength(0);
     expect(parsed.dir).toBe(root);
@@ -94,7 +99,12 @@ describe("lint-capability command", () => {
     await proc.exited;
 
     expect(proc.exitCode).toBe(1);
-    const parsed = JSON.parse(stdout);
+    let parsed: ReturnType<typeof JSON.parse>;
+    try {
+      parsed = JSON.parse(stdout);
+    } catch {
+      throw new Error(`JSON.parse failed (exitCode=${proc.exitCode}). stdout: ${stdout.slice(0, 200)}`);
+    }
     expect(parsed.ok).toBe(false);
     expect(parsed.issues.some((i: { check: string }) => i.check === "metadata")).toBe(true);
     expect(parsed.issues.some((i: { check: string }) => i.check === "import-boundary")).toBe(true);

--- a/packages/cli/__tests__/lint-capability.test.ts
+++ b/packages/cli/__tests__/lint-capability.test.ts
@@ -78,7 +78,9 @@ describe("lint-capability command", () => {
     try {
       parsed = JSON.parse(stdout);
     } catch {
-      throw new Error(`JSON.parse failed (exitCode=${proc.exitCode}). stdout: ${stdout.slice(0, 200)}`);
+      throw new Error(
+        `JSON.parse failed (exitCode=${proc.exitCode}). stdout: ${stdout.slice(0, 200)}`,
+      );
     }
     expect(parsed.ok).toBe(true);
     expect(parsed.issues).toHaveLength(0);
@@ -103,7 +105,9 @@ describe("lint-capability command", () => {
     try {
       parsed = JSON.parse(stdout);
     } catch {
-      throw new Error(`JSON.parse failed (exitCode=${proc.exitCode}). stdout: ${stdout.slice(0, 200)}`);
+      throw new Error(
+        `JSON.parse failed (exitCode=${proc.exitCode}). stdout: ${stdout.slice(0, 200)}`,
+      );
     }
     expect(parsed.ok).toBe(false);
     expect(parsed.issues.some((i: { check: string }) => i.check === "metadata")).toBe(true);

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -4,18 +4,26 @@
 #
 # WHY THIS EXISTS
 # ---------------
-# A single root `bun test` does NOT run the whole suite. Bun 1.2.18 hits a
-# runtime crash (panic 0x4A) MID-RUN, deterministically, while executing
-# `packages/cli/__tests__/lint-capability.test.ts`. Run order puts `packages/`
-# first and `addons/` last, so the crash lands BEFORE `addons/` is ever
-# reached: in CI, 0 of the 177 addons test files ran. The old CI guard masked
-# the non-zero exit as success whenever a `(pass)` line was present and no
-# `(fail)` line was — which is exactly how a TRUNCATED run snuck through green.
+# A single root `bun test` does NOT run the whole suite reliably. Bun 1.2.18
+# hit a runtime crash (panic 0x4A) MID-RUN, deterministically, while executing
+# `packages/cli/__tests__/lint-capability.test.ts`. That crash was fixed by
+# restructuring the test to spawn a subprocess instead of calling
+# lintCapability() in-process (see issue #434). The file is no longer
+# quarantined. The batched runner is kept because:
+#   - it verifies each batch actually COMPLETED (no silent truncation),
+#   - it produces cleaner CI log groups, and
+#   - the quarantine mechanism remains available if a new crash file appears.
 #
-# This runner instead executes the suite as a set of smaller batches, each of
-# which is verified to actually COMPLETE (print its "Ran N tests across M
-# files" summary). The known crash file is QUARANTINED and run in isolation
-# with an explicit, loudly-logged allowance — never a blanket pass.
+# Previously: Run order puts `packages/` first and `addons/` last, so the crash
+# landed BEFORE `addons/` was ever reached: in CI, 0 of the 177 addons test
+# files ran. The old CI guard masked the non-zero exit as success whenever a
+# `(pass)` line was present and no `(fail)` line was — which is exactly how a
+# TRUNCATED run snuck through green.
+#
+# This runner executes the suite as a set of smaller batches, each of which is
+# verified to actually COMPLETE (print its "Ran N tests across M files"
+# summary). Any quarantined file would be run in isolation with an explicit,
+# loudly-logged allowance — never a blanket pass.
 #
 # HONEST GATE CONTRACT
 # --------------------
@@ -62,9 +70,7 @@ strip_ansi() {
 # allowed to crash WITHOUT a completion summary, with a loud warning. This is a
 # narrow, explicit, audited allowance — NOT a blanket pass. Keep this list
 # minimal; re-test and remove entries whenever the Bun runtime is upgraded.
-QUARANTINE=(
-  "packages/cli/__tests__/lint-capability.test.ts"
-)
+QUARANTINE=()
 
 is_quarantined() {
   local needle="$1" q
@@ -138,9 +144,9 @@ run_batch "packages/starters" ./packages/starters/
 run_batch "e2e"               ./e2e/
 run_batch "addons"            ./addons/
 
-# packages/cli is split: the crash file is quarantined and the rest run as one
-# batch of explicit file paths. The file list is DISCOVERED at runtime so newly
-# added cli tests are covered automatically (no hardcoded list to drift).
+# packages/cli: discover all test files at runtime so newly added tests are
+# covered automatically (no hardcoded list to drift). Quarantined files are
+# excluded here and run separately below.
 CLI_REST=()
 while IFS= read -r f; do
   rel="${f#./}"
@@ -152,9 +158,9 @@ done < <(find ./packages/cli \( -name '*.test.ts' -o -name '*.test.tsx' \) \
            -not -path '*/node_modules/*' | sort)
 
 if [ "${#CLI_REST[@]}" -gt 0 ]; then
-  run_batch "packages/cli (minus quarantine)" "${CLI_REST[@]}"
+  run_batch "packages/cli" "${CLI_REST[@]}"
 else
-  echo "::error::No non-quarantined packages/cli test files discovered — coverage gap."
+  echo "::error::No packages/cli test files discovered — coverage gap."
   OVERALL_RC=1
 fi
 


### PR DESCRIPTION
## Summary

- Convert test 2 in `lint-capability.test.ts` from calling `lintCapability()` in-process to using `Bun.spawn` subprocess (same pattern as test 3), eliminating the Bun runtime crash (panic 0x4A) that was killing the test runner mid-file.
- Fix the clean-capability test fixture: add the missing `package.json` with `peerDependencies["@linchkit/core"]` + `linchkit.coreVersion`, required by the core-version check (Spec 21 §10.1) — this bug was masked by the crash.
- Empty the `QUARANTINE` array in `scripts/run-tests.sh` — all 3 tests now run and pass without a quarantine allowance.

## Implementation notes

The root cause: `lintCapabilityCommand.run` was called directly in the test process, which triggered an allocation-state-sensitive Bun GC bug (panic 0x4A). The crash happened deterministically after test 1, before any assertions in test 2 could execute. Because test 2 was the second test in the file, the crash killed Bun mid-run, which truncated the entire `packages/cli` batch — and in CI, run order put `packages/` before `addons/`, so 0 of 177 addon test files ran.

Fix: the subprocess approach (`Bun.spawn(["bun", "run", cliEntry, ...]`) is identical to what test 3 already used and is immune to the in-process GC pressure.

Hidden fixture bug also fixed: the original test 2 fixture had no `package.json`. The `checkCoreVersion` gate (added later per Spec 21 §10.1) requires `peerDependencies["@linchkit/core"]` in `package.json`. Since test 2 crashed before reaching its assertions, this was never caught. The clean-capability fixture now mirrors the pattern used in `packages/devtools/__tests__/capability-lint.test.ts`.

Local verification (sandbox with incomplete `node_modules` — see note below):
```
bun test packages/cli/__tests__/lint-capability.test.ts
 3 pass
 0 fail
 12 expect() calls
Ran 3 tests across 1 file. [1227.00ms]
```

Note: the remote sandbox has a partially-installed `node_modules` (npmmirror.com returning 403). The three missing packages (`citty`, `drizzle-orm`, `ajv` + deps) were installed manually from registry.npmjs.org for local verification. In CI, where all packages are present, the tests pass cleanly.

## Spec alignment

- **Spec 21 §9.1** — Capability quality gates: test existence requirement addressed by the clean fixture fix.
- **Spec 21 §10.1** — Core version declaration: clean fixture now includes required `peerDependencies` + `coreVersion`.

## Quality gates

| Gate | Status |
|------|--------|
| `bun run check` (Biome lint+format) | ✅ Checked 1595 files, no fixes applied |
| `bun run typecheck` | ⚠️ Pre-existing errors in unrelated files (missing `@types/node`, `drizzle-orm` types, `react` types — all present on `main` branch too); **zero new errors** in changed files |
| `bun test packages/cli/__tests__/lint-capability.test.ts` | ✅ 3 pass, 0 fail (after manual dep install in sandbox) |
| `linch validate` | N/A — no meta-model definition files changed |

## Retro

- **Why this approach:** The subprocess pattern (`Bun.spawn`) was already proven by test 3. Using it for test 2 is the minimal change that completely avoids the in-process lintCapability() call that triggers the GC crash, without introducing any new logic or dependencies.

- **Alternatives considered:**
  1. *Wait for Bun fix and remove quarantine* — issue already suggests this as a follow-up; valid for future, but tests 2+ are currently *not running at all*, not just slow.
  2. *Mock the filesystem* — more complex and tests a weaker path (mocked I/O != real CLI pipeline).
  3. *Split the test file* — unnecessary; the subprocess approach keeps all tests together without triggering the crash.

- **Security review:** No auth/tenant/input-trust surfaces touched. Changes are limited to test file structure and CI script comments/QUARANTINE array. No user input handling, no permission checks, no tenant isolation, no DDL, no secrets.

- **Other risks:** None beyond the pre-existing `node_modules` incompleteness in this sandbox. CI has full package installation and will provide the authoritative gate result.

- **Follow-ups:**
  - When Bun is upgraded, verify panic 0x4A is gone and update `run-tests.sh` comments accordingly (the quarantine mechanism itself is kept as it may be useful for future crashes).

## Self-review checklist

- [x] Tests added/updated and passing (3/3 pass locally after manual dep install)
- [x] `bun run check` green
- [x] `bun run typecheck` — zero new errors in changed files (pre-existing failures on `main` too)
- [x] `bun test` green for `lint-capability.test.ts`
- [x] `linch validate` N/A (no meta-model changes)
- [x] Spec 21 §9.1 and §10.1 referenced in PR body
- [x] Mandatory security review walked through: no auth/tenant/input-trust surfaces touched
- [x] No new dependencies
- [x] No hardcoded secrets, no `any`, no `eval`, no `new Function`
- [x] No changes outside the issue's scope
- [x] Branch name and commit messages follow convention
- [x] All comments use real timestamps (no `<UTC time>` placeholders)
- [x] All commits have author = `claude-agent[bot]` (verified with `git log -1 --format='%ae'`)

Closes #434

---
_Generated by [Claude Code](https://claude.ai/code/session_01NkLvVBobWR49kf4fz5eAJ9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored the lint-capability test to use subprocess execution for improved validation accuracy.
  * Removed test quarantine restrictions, enabling the full test suite to run without exclusions.

* **Chores**
  * Updated test runner documentation to reflect current batched testing strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->