### PR TITLE
feat(ai-provider): watcher cron scheduling via croner (Spec 45)

### DIFF
--- a/addons/ai-provider/cap-ai-provider/__tests__/watcher-schedule.test.ts
+++ b/addons/ai-provider/cap-ai-provider/__tests__/watcher-schedule.test.ts
@@ -1,0 +1,434 @@
+/**
+ * WatcherEngine — schedule (cron) trigger tests (Spec 45 §2.4).
+ *
+ * The engine is driven by an INJECTED clock so the scheduler is deterministic
+ * and never time-flaky. Tests advance a mutable `now` and call
+ * `engine.runScheduleTick()` directly (no real timers, no mocked engine/cron),
+ * then assert on a FAKE WatcherActionExecutor's captured calls.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { defineWatcher } from "@linchkit/core";
+import { createWatcherRegistry, type WatcherRegistry } from "@linchkit/core/server";
+import {
+  createWatcherEngine,
+  type WatcherActionExecutor,
+  type WatcherDataQuerier,
+  type WatcherEngine,
+} from "../src/watcher-engine";
+
+// ── Fakes ────────────────────────────────────────────────
+
+function createFakeActionExecutor(): WatcherActionExecutor & {
+  calls: Array<{ actionName: string; input: Record<string, unknown> }>;
+} {
+  const calls: Array<{ actionName: string; input: Record<string, unknown> }> = [];
+  return {
+    calls,
+    async executeAction(actionName, input) {
+      calls.push({ actionName, input });
+      return { ok: true };
+    },
+  };
+}
+
+/** Mutable clock so tests can fast-forward deterministically. */
+function createClock(start: Date): { now: () => Date; set: (d: Date) => void } {
+  let current = start;
+  return {
+    now: () => current,
+    set: (d: Date) => {
+      current = d;
+    },
+  };
+}
+
+function at(iso: string): Date {
+  return new Date(iso);
+}
+
+// ── Tests ────────────────────────────────────────────────
+
+describe("WatcherEngine — schedule (cron) triggers", () => {
+  let registry: WatcherRegistry;
+  let actionExecutor: ReturnType<typeof createFakeActionExecutor>;
+  let engine: WatcherEngine;
+
+  beforeEach(() => {
+    registry = createWatcherRegistry();
+    actionExecutor = createFakeActionExecutor();
+  });
+
+  afterEach(() => {
+    engine?.stop();
+  });
+
+  it("seeds the next-due time to the first occurrence after start", () => {
+    registry.register(
+      defineWatcher({
+        name: "daily-report",
+        watch: { entity: "purchase_request" },
+        // Every day at 09:00 UTC.
+        trigger: { type: "schedule", cron: "0 9 * * *" },
+        effect: { action: "send_report", params: {} },
+      }),
+    );
+
+    const clock = createClock(at("2024-01-01T08:00:00.000Z")); // before 09:00
+    engine = createWatcherEngine({
+      registry,
+      actionExecutor,
+      clock: clock.now,
+      scheduleIntervalMs: 60_000,
+    });
+    engine.start();
+
+    expect(engine.getNextScheduledRun("daily-report")?.toISOString()).toBe(
+      "2024-01-01T09:00:00.000Z",
+    );
+  });
+
+  it("does not fire before the cron is due, fires exactly once when due", async () => {
+    registry.register(
+      defineWatcher({
+        name: "daily-report",
+        watch: { entity: "purchase_request" },
+        trigger: { type: "schedule", cron: "0 9 * * *" },
+        effect: { action: "send_report", params: { kind: "daily" } },
+      }),
+    );
+
+    const clock = createClock(at("2024-01-01T08:00:00.000Z"));
+    engine = createWatcherEngine({ registry, actionExecutor, clock: clock.now });
+    engine.start();
+
+    // 08:30 — not yet due.
+    clock.set(at("2024-01-01T08:30:00.000Z"));
+    const r1 = await engine.runScheduleTick();
+    expect(r1).toHaveLength(0);
+    expect(actionExecutor.calls).toHaveLength(0);
+
+    // 09:00 — due exactly.
+    clock.set(at("2024-01-01T09:00:00.000Z"));
+    const r2 = await engine.runScheduleTick();
+    expect(r2).toHaveLength(1);
+    expect(r2[0]?.fired).toBe(true);
+    expect(actionExecutor.calls).toHaveLength(1);
+    expect(actionExecutor.calls[0]?.actionName).toBe("send_report");
+    expect(actionExecutor.calls[0]?.input.kind).toBe("daily");
+
+    // 09:30 same day — already consumed, next due is tomorrow 09:00.
+    clock.set(at("2024-01-01T09:30:00.000Z"));
+    const r3 = await engine.runScheduleTick();
+    expect(r3).toHaveLength(0);
+    expect(actionExecutor.calls).toHaveLength(1);
+    expect(engine.getNextScheduledRun("daily-report")?.toISOString()).toBe(
+      "2024-01-02T09:00:00.000Z",
+    );
+  });
+
+  it("fires once per crossed occurrence when the clock jumps several days", async () => {
+    registry.register(
+      defineWatcher({
+        name: "daily-report",
+        watch: { entity: "purchase_request" },
+        trigger: { type: "schedule", cron: "0 9 * * *" },
+        effect: { action: "send_report", params: {} },
+      }),
+    );
+
+    const clock = createClock(at("2024-01-01T08:00:00.000Z")); // next due 01-01 09:00
+    engine = createWatcherEngine({ registry, actionExecutor, clock: clock.now });
+    engine.start();
+
+    // Jump to 01-04 10:00 — occurrences 01-01, 01-02, 01-03, 01-04 all due (4).
+    clock.set(at("2024-01-04T10:00:00.000Z"));
+    const results = await engine.runScheduleTick();
+
+    expect(results).toHaveLength(4);
+    expect(results.every((r) => r.fired)).toBe(true);
+    expect(actionExecutor.calls).toHaveLength(4);
+    // After consuming through 01-04, next due is 01-05 09:00.
+    expect(engine.getNextScheduledRun("daily-report")?.toISOString()).toBe(
+      "2024-01-05T09:00:00.000Z",
+    );
+  });
+
+  it("fires on the weekly Monday-09:00 cron only on the right tick", async () => {
+    registry.register(
+      defineWatcher({
+        name: "weekly-digest",
+        watch: { entity: "purchase_request" },
+        // 0 9 * * 1 = Mondays at 09:00 UTC.
+        trigger: { type: "schedule", cron: "0 9 * * 1" },
+        effect: { action: "send_digest", params: {} },
+      }),
+    );
+
+    // 2024-01-07 is a Sunday; 2024-01-08 is a Monday.
+    const clock = createClock(at("2024-01-07T00:00:00.000Z"));
+    engine = createWatcherEngine({ registry, actionExecutor, clock: clock.now });
+    engine.start();
+
+    expect(engine.getNextScheduledRun("weekly-digest")?.toISOString()).toBe(
+      "2024-01-08T09:00:00.000Z",
+    );
+
+    // Tuesday — not yet due (Monday this week already passed for seed? no: seed was Mon 01-08).
+    clock.set(at("2024-01-09T12:00:00.000Z"));
+    await engine.runScheduleTick();
+    expect(actionExecutor.calls).toHaveLength(1); // the 01-08 Monday occurrence
+    expect(engine.getNextScheduledRun("weekly-digest")?.toISOString()).toBe(
+      "2024-01-15T09:00:00.000Z",
+    );
+
+    // Advance to next Monday 09:00.
+    clock.set(at("2024-01-15T09:00:00.000Z"));
+    await engine.runScheduleTick();
+    expect(actionExecutor.calls).toHaveLength(2);
+  });
+
+  // ── condition.count semantics (Spec 45 §2.4) ───────────
+
+  it("fires only when the count condition is met", async () => {
+    registry.register(
+      defineWatcher({
+        name: "weekly-unapproved",
+        watch: {
+          entity: "purchase_request",
+          filter: { field: "target.status", operator: "eq", value: "submitted" },
+        },
+        trigger: {
+          type: "schedule",
+          cron: "0 9 * * 1",
+          condition: { count: { gt: 0 } },
+        },
+        effect: { action: "send_digest", params: {} },
+      }),
+    );
+
+    // Querier returns 2 submitted + 1 approved → submitted count = 2 (> 0).
+    const querier: WatcherDataQuerier = {
+      async queryRecords() {
+        return [
+          { id: "pr-1", status: "submitted" },
+          { id: "pr-2", status: "submitted" },
+          { id: "pr-3", status: "approved" },
+        ];
+      },
+    };
+
+    const clock = createClock(at("2024-01-07T00:00:00.000Z")); // Sunday, seed Mon 01-08
+    engine = createWatcherEngine({
+      registry,
+      actionExecutor,
+      dataQuerier: querier,
+      clock: clock.now,
+    });
+    engine.start();
+
+    clock.set(at("2024-01-08T09:00:00.000Z"));
+    const results = await engine.runScheduleTick();
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.fired).toBe(true);
+    expect(actionExecutor.calls).toHaveLength(1);
+    // Context count/value reflects the filtered count.
+    expect(actionExecutor.calls[0]?.input._watcher).toEqual({ name: "weekly-unapproved" });
+  });
+
+  it("does not fire when the count condition is not met", async () => {
+    registry.register(
+      defineWatcher({
+        name: "weekly-unapproved",
+        watch: {
+          entity: "purchase_request",
+          filter: { field: "target.status", operator: "eq", value: "submitted" },
+        },
+        trigger: {
+          type: "schedule",
+          cron: "0 9 * * 1",
+          condition: { count: { gt: 0 } },
+        },
+        effect: { action: "send_digest", params: {} },
+      }),
+    );
+
+    // No submitted records → count = 0, condition (gt: 0) fails.
+    const querier: WatcherDataQuerier = {
+      async queryRecords() {
+        return [
+          { id: "pr-3", status: "approved" },
+          { id: "pr-4", status: "draft" },
+        ];
+      },
+    };
+
+    const clock = createClock(at("2024-01-07T00:00:00.000Z"));
+    engine = createWatcherEngine({
+      registry,
+      actionExecutor,
+      dataQuerier: querier,
+      clock: clock.now,
+    });
+    engine.start();
+
+    clock.set(at("2024-01-08T09:00:00.000Z"));
+    const results = await engine.runScheduleTick();
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.fired).toBe(false);
+    expect(results[0]?.reason).toBe("count_condition_not_met");
+    expect(actionExecutor.calls).toHaveLength(0);
+  });
+
+  it("reports missing dataQuerier when a count condition is declared", async () => {
+    registry.register(
+      defineWatcher({
+        name: "weekly-unapproved",
+        watch: { entity: "purchase_request" },
+        trigger: {
+          type: "schedule",
+          cron: "0 9 * * 1",
+          condition: { count: { gt: 0 } },
+        },
+        effect: { action: "send_digest", params: {} },
+      }),
+    );
+
+    const clock = createClock(at("2024-01-07T00:00:00.000Z"));
+    // No dataQuerier provided.
+    engine = createWatcherEngine({ registry, actionExecutor, clock: clock.now });
+    engine.start();
+
+    clock.set(at("2024-01-08T09:00:00.000Z"));
+    const results = await engine.runScheduleTick();
+
+    expect(results[0]?.fired).toBe(false);
+    expect(results[0]?.reason).toBe("no_data_querier_for_count_condition");
+    expect(actionExecutor.calls).toHaveLength(0);
+  });
+
+  // ── Debounce + lifecycle ───────────────────────────────
+
+  it("honors cooldown debounce across due occurrences", async () => {
+    registry.register(
+      defineWatcher({
+        name: "hourly-cooldown",
+        watch: { entity: "purchase_request" },
+        // Every hour at minute 0.
+        trigger: {
+          type: "schedule",
+          cron: "0 * * * *",
+          debounce: "cooldown",
+          cooldownPeriod: "90m",
+        },
+        effect: { action: "ping", params: {} },
+      }),
+    );
+
+    const clock = createClock(at("2024-01-01T00:30:00.000Z")); // next due 01:00
+    engine = createWatcherEngine({ registry, actionExecutor, clock: clock.now });
+    engine.start();
+
+    // 01:00 — fires (no prior fire).
+    clock.set(at("2024-01-01T01:00:00.000Z"));
+    await engine.runScheduleTick();
+    expect(actionExecutor.calls).toHaveLength(1);
+
+    // 02:00 — only 60m since last fire (< 90m cooldown) → debounced.
+    clock.set(at("2024-01-01T02:00:00.000Z"));
+    const r2 = await engine.runScheduleTick();
+    expect(r2[0]?.fired).toBe(false);
+    expect(r2[0]?.reason).toBe("debounced");
+    expect(actionExecutor.calls).toHaveLength(1);
+
+    // 03:00 — 120m since last fire (≥ 90m) → fires again.
+    clock.set(at("2024-01-01T03:00:00.000Z"));
+    await engine.runScheduleTick();
+    expect(actionExecutor.calls).toHaveLength(2);
+  });
+
+  it("does not fire after the watcher is disabled", async () => {
+    registry.register(
+      defineWatcher({
+        name: "daily-report",
+        watch: { entity: "purchase_request" },
+        trigger: { type: "schedule", cron: "0 9 * * *" },
+        effect: { action: "send_report", params: {} },
+      }),
+    );
+
+    const clock = createClock(at("2024-01-01T08:00:00.000Z"));
+    engine = createWatcherEngine({ registry, actionExecutor, clock: clock.now });
+    engine.start();
+
+    registry.disable("daily-report");
+
+    clock.set(at("2024-01-01T09:00:00.000Z"));
+    const results = await engine.runScheduleTick();
+
+    expect(results[0]?.fired).toBe(false);
+    expect(results[0]?.reason).toBe("watcher_unavailable");
+    expect(actionExecutor.calls).toHaveLength(0);
+  });
+
+  it("ignores an invalid cron expression and keeps other schedules running", async () => {
+    registry.register(
+      defineWatcher({
+        name: "broken",
+        watch: { entity: "purchase_request" },
+        trigger: { type: "schedule", cron: "not-a-cron" },
+        effect: { action: "noop", params: {} },
+      }),
+    );
+    registry.register(
+      defineWatcher({
+        name: "daily-report",
+        watch: { entity: "purchase_request" },
+        trigger: { type: "schedule", cron: "0 9 * * *" },
+        effect: { action: "send_report", params: {} },
+      }),
+    );
+
+    const clock = createClock(at("2024-01-01T08:00:00.000Z"));
+    engine = createWatcherEngine({
+      registry,
+      actionExecutor,
+      clock: clock.now,
+      logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+    });
+    engine.start();
+
+    // Invalid cron was not tracked.
+    expect(engine.getNextScheduledRun("broken")).toBeUndefined();
+    // Valid one still scheduled.
+    expect(engine.getNextScheduledRun("daily-report")?.toISOString()).toBe(
+      "2024-01-01T09:00:00.000Z",
+    );
+
+    clock.set(at("2024-01-01T09:00:00.000Z"));
+    await engine.runScheduleTick();
+    expect(actionExecutor.calls).toHaveLength(1);
+    expect(actionExecutor.calls[0]?.actionName).toBe("send_report");
+  });
+
+  it("clears schedule state on stop", () => {
+    registry.register(
+      defineWatcher({
+        name: "daily-report",
+        watch: { entity: "purchase_request" },
+        trigger: { type: "schedule", cron: "0 9 * * *" },
+        effect: { action: "send_report", params: {} },
+      }),
+    );
+
+    const clock = createClock(at("2024-01-01T08:00:00.000Z"));
+    engine = createWatcherEngine({ registry, actionExecutor, clock: clock.now });
+    engine.start();
+    expect(engine.getNextScheduledRun("daily-report")).toBeDefined();
+
+    engine.stop();
+    expect(engine.getNextScheduledRun("daily-report")).toBeUndefined();
+  });
+});

--- a/addons/ai-provider/cap-ai-provider/__tests__/watcher-schedule.test.ts
+++ b/addons/ai-provider/cap-ai-provider/__tests__/watcher-schedule.test.ts
@@ -413,6 +413,193 @@ describe("WatcherEngine — schedule (cron) triggers", () => {
     expect(actionExecutor.calls[0]?.actionName).toBe("send_report");
   });
 
+  it("drops a disabled watcher from the tracker after a tick (Finding 2)", async () => {
+    registry.register(
+      defineWatcher({
+        name: "daily-report",
+        watch: { entity: "purchase_request" },
+        trigger: { type: "schedule", cron: "0 9 * * *" },
+        effect: { action: "send_report", params: {} },
+      }),
+    );
+
+    const clock = createClock(at("2024-01-01T08:00:00.000Z"));
+    engine = createWatcherEngine({ registry, actionExecutor, clock: clock.now });
+    engine.start();
+
+    // Tracked after start.
+    expect(engine.getNextScheduledRun("daily-report")).toBeDefined();
+
+    // Disable, then advance past the due time and tick.
+    registry.disable("daily-report");
+    clock.set(at("2024-01-01T09:00:00.000Z"));
+    const results = await engine.runScheduleTick();
+
+    expect(results[0]?.reason).toBe("watcher_unavailable");
+    // No longer tracked: the engine stops computing next-run times for it.
+    expect(engine.getNextScheduledRun("daily-report")).toBeUndefined();
+
+    // A subsequent tick the next day produces nothing (the schedule is gone).
+    clock.set(at("2024-01-02T09:00:00.000Z"));
+    const results2 = await engine.runScheduleTick();
+    expect(results2).toHaveLength(0);
+    expect(actionExecutor.calls).toHaveLength(0);
+  });
+
+  it("re-fires an once_until_reset watcher after its count drops then rises (Finding 1)", async () => {
+    registry.register(
+      defineWatcher({
+        name: "hourly-unapproved",
+        watch: {
+          entity: "purchase_request",
+          filter: { field: "target.status", operator: "eq", value: "submitted" },
+        },
+        trigger: {
+          type: "schedule",
+          // Every hour at minute 0 so we get multiple due occurrences.
+          cron: "0 * * * *",
+          condition: { count: { gt: 0 } },
+          debounce: "once_until_reset",
+        },
+        effect: { action: "send_digest", params: {} },
+      }),
+    );
+
+    // Mutable submitted-record count driving the querier across ticks.
+    let submittedCount = 1;
+    const querier: WatcherDataQuerier = {
+      async queryRecords() {
+        const records: Array<Record<string, unknown>> = [];
+        for (let i = 0; i < submittedCount; i += 1) {
+          records.push({ id: `pr-${i}`, status: "submitted" });
+        }
+        return records;
+      },
+    };
+
+    const clock = createClock(at("2024-01-01T00:30:00.000Z")); // next due 01:00
+    engine = createWatcherEngine({
+      registry,
+      actionExecutor,
+      dataQuerier: querier,
+      clock: clock.now,
+    });
+    engine.start();
+
+    // 01:00 — count = 1 (> 0), first transition false→true → fires.
+    clock.set(at("2024-01-01T01:00:00.000Z"));
+    const r1 = await engine.runScheduleTick();
+    expect(r1[0]?.fired).toBe(true);
+    expect(actionExecutor.calls).toHaveLength(1);
+
+    // 02:00 — still 1, condition still met, once_until_reset suppresses → debounced.
+    clock.set(at("2024-01-01T02:00:00.000Z"));
+    const r2 = await engine.runScheduleTick();
+    expect(r2[0]?.fired).toBe(false);
+    expect(r2[0]?.reason).toBe("debounced");
+    expect(actionExecutor.calls).toHaveLength(1);
+
+    // 03:00 — count drops to 0, condition NOT met → resets debounce state to false.
+    submittedCount = 0;
+    clock.set(at("2024-01-01T03:00:00.000Z"));
+    const r3 = await engine.runScheduleTick();
+    expect(r3[0]?.fired).toBe(false);
+    expect(r3[0]?.reason).toBe("count_condition_not_met");
+    expect(actionExecutor.calls).toHaveLength(1);
+
+    // 04:00 — count rises back to 2, condition met again. Because the state was
+    // reset at 03:00, once_until_reset allows a fresh false→true fire.
+    submittedCount = 2;
+    clock.set(at("2024-01-01T04:00:00.000Z"));
+    const r4 = await engine.runScheduleTick();
+    expect(r4[0]?.fired).toBe(true);
+    expect(actionExecutor.calls).toHaveLength(2);
+  });
+
+  it("fires each due occurrence only once when ticks overlap with a slow effect (Finding 4)", async () => {
+    registry.register(
+      defineWatcher({
+        name: "daily-report",
+        watch: { entity: "purchase_request" },
+        trigger: { type: "schedule", cron: "0 9 * * *" },
+        effect: { action: "send_report", params: {} },
+      }),
+    );
+
+    // A slow action executor that resolves only when we release it, letting two
+    // runScheduleTick() calls overlap deterministically (no real timers).
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const calls: string[] = [];
+    const slowExecutor: WatcherActionExecutor = {
+      async executeAction(actionName) {
+        calls.push(actionName);
+        await gate;
+        return { ok: true };
+      },
+    };
+
+    const clock = createClock(at("2024-01-01T08:00:00.000Z"));
+    engine = createWatcherEngine({ registry, actionExecutor: slowExecutor, clock: clock.now });
+    engine.start();
+
+    // 09:00 — due. Start the first tick (awaiting the slow effect) WITHOUT
+    // awaiting it, then start a second overlapping tick before the first resolves.
+    clock.set(at("2024-01-01T09:00:00.000Z"));
+    const tick1 = engine.runScheduleTick();
+    const tick2 = engine.runScheduleTick();
+
+    // The second call coalesces onto the in-flight pass — it must be the same
+    // promise, not a fresh pass that re-consumes the same due occurrence.
+    expect(tick2).toBe(tick1);
+
+    release();
+    const [r1, r2] = await Promise.all([tick1, tick2]);
+
+    // The effect ran exactly once for the single due occurrence.
+    expect(calls).toHaveLength(1);
+    expect(r1).toEqual(r2);
+    expect(r1.filter((r) => r.fired)).toHaveLength(1);
+  });
+
+  it("returns due occurrences sorted by due time across iteration order (Finding 5)", async () => {
+    // Register the LATER-due watcher first so Map iteration order (insertion)
+    // differs from chronological order; the engine must still emit chronologically.
+    registry.register(
+      defineWatcher({
+        name: "later-10am",
+        watch: { entity: "purchase_request" },
+        trigger: { type: "schedule", cron: "0 10 * * *" }, // due 10:00
+        effect: { action: "later_effect", params: {} },
+      }),
+    );
+    registry.register(
+      defineWatcher({
+        name: "earlier-9am",
+        watch: { entity: "purchase_request" },
+        trigger: { type: "schedule", cron: "0 9 * * *" }, // due 09:00
+        effect: { action: "earlier_effect", params: {} },
+      }),
+    );
+
+    const clock = createClock(at("2024-01-01T08:00:00.000Z"));
+    engine = createWatcherEngine({ registry, actionExecutor, clock: clock.now });
+    engine.start();
+
+    // Advance past BOTH due times in a single tick.
+    clock.set(at("2024-01-01T11:00:00.000Z"));
+    const results = await engine.runScheduleTick();
+
+    // Both fired, ordered by due time (09:00 before 10:00) — not registration order.
+    expect(results.map((r) => r.watcherName)).toEqual(["earlier-9am", "later-10am"]);
+    expect(actionExecutor.calls.map((c) => c.actionName)).toEqual([
+      "earlier_effect",
+      "later_effect",
+    ]);
+  });
+
   it("clears schedule state on stop", () => {
     registry.register(
       defineWatcher({

--- a/addons/ai-provider/cap-ai-provider/package.json
+++ b/addons/ai-provider/cap-ai-provider/package.json
@@ -16,6 +16,7 @@
     "@ai-sdk/anthropic": "^3.0.63",
     "@ai-sdk/openai": "^3.0.47",
     "ai": "^6.0.134",
+    "croner": "^10.0.1",
     "zod": "^4.3.6"
   },
   "peerDependencies": {

--- a/addons/ai-provider/cap-ai-provider/src/mutation-engine.ts
+++ b/addons/ai-provider/cap-ai-provider/src/mutation-engine.ts
@@ -1,0 +1,375 @@
+/**
+ * Watcher reactive + staleness evaluation subsystem (Spec 45).
+ *
+ * Extracted from `watcher-engine.ts` to keep that file under the repo's
+ * 500-line ceiling. Owns:
+ * - post-mutation reactive evaluation (`threshold`, `set_change`)
+ * - the staleness polling loop (timer + per-record age check)
+ * - aggregate computation and per-watcher group-key derivation
+ *
+ * Debounce/effect concerns are delegated back to the host engine through
+ * explicitly injected collaborators so this module never owns the shared
+ * debounce state map directly.
+ */
+
+import type {
+  Logger,
+  WatcherAggregateConfig,
+  WatcherContext,
+  WatcherDefinition,
+  WatcherEvaluationResult,
+} from "@linchkit/core";
+import { type ConditionContext, evaluateCondition } from "@linchkit/core";
+import type { WatcherRegistry } from "@linchkit/core/server";
+
+// ── Collaborators injected by the host WatcherEngine ──────
+
+export interface MutationEngineDeps {
+  registry: WatcherRegistry;
+  /** Data querier for aggregate + staleness checks (queries matching records). */
+  dataQuerier?: {
+    queryRecords(
+      schema: string,
+      filter?: Record<string, unknown>,
+    ): Promise<Array<Record<string, unknown>>>;
+  };
+  logger: Logger;
+  /** Staleness check interval in ms. */
+  stalenessIntervalMs: number;
+  /** Numeric comparison evaluator (shared with the engine). */
+  evaluateComparison: (
+    value: number,
+    condition: { gt?: number; gte?: number; lt?: number; lte?: number; eq?: number },
+  ) => boolean;
+  /** Parse a duration string (e.g. "48h") to milliseconds, or null. */
+  parseDuration: (duration: string) => number | null;
+  /** Debounce gate — returns true when the watcher should fire for this group. */
+  shouldFire: (watcher: WatcherDefinition, groupKey: string, conditionMet: boolean) => boolean;
+  /** Execute the watcher's effect through the action pipeline. */
+  fireEffect: (watcher: WatcherDefinition, ctx: WatcherContext) => Promise<void>;
+  /** Record debounce state after evaluating a watcher occurrence. */
+  updateState: (watcherName: string, groupKey: string, conditionMet: boolean) => void;
+  /**
+   * Clear the `conditionMet` flag for a group so a `once_until_reset` watcher
+   * can fire again once the condition re-occurs. No-op when no state exists.
+   */
+  resetConditionMet: (watcherName: string, groupKey: string) => void;
+}
+
+/** A watcher's declarative record filter (inferred from the core type). */
+type WatcherFilter = NonNullable<WatcherDefinition["watch"]["filter"]>;
+
+function systemActor(): { type: string; id: string; groups: string[] } {
+  return { type: "system", id: "watcher", groups: [] };
+}
+
+function matchesFilter(filter: WatcherFilter, target: Record<string, unknown>): boolean {
+  const ctx: ConditionContext = { target, context: {}, actor: systemActor() };
+  return evaluateCondition(filter, ctx);
+}
+
+// ── Subsystem ─────────────────────────────────────────────
+
+/**
+ * Evaluates the non-schedule watcher triggers: reactive (`threshold`,
+ * `set_change`) and the polled `staleness` trigger.
+ */
+export class MutationEngine {
+  private readonly deps: MutationEngineDeps;
+  private stalenessInterval?: ReturnType<typeof setInterval>;
+
+  constructor(deps: MutationEngineDeps) {
+    this.deps = deps;
+  }
+
+  /** Start the staleness polling loop. No-op without staleness watchers. */
+  start(): void {
+    const stalenessWatchers = this.deps.registry
+      .getEnabled()
+      .filter((w) => w.trigger.type === "staleness");
+
+    if (stalenessWatchers.length === 0) return;
+    if (!this.deps.dataQuerier) {
+      this.deps.logger.warn?.(
+        "[WatcherEngine] Staleness watchers registered but no dataQuerier provided",
+      );
+      return;
+    }
+
+    this.stalenessInterval = setInterval(async () => {
+      for (const watcher of stalenessWatchers) {
+        // Re-check enabled status
+        const current = this.deps.registry.get(watcher.name);
+        if (!current?.enabled) continue;
+
+        try {
+          await this.evaluateStaleness(current);
+        } catch (err) {
+          this.deps.logger.error?.(
+            `[WatcherEngine] Staleness check error for "${watcher.name}": ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        }
+      }
+    }, this.deps.stalenessIntervalMs);
+  }
+
+  /** Stop the staleness polling loop. */
+  stop(): void {
+    if (this.stalenessInterval !== undefined) {
+      clearInterval(this.stalenessInterval);
+      this.stalenessInterval = undefined;
+    }
+  }
+
+  // ── Post-mutation reactive evaluation ───────────────────
+
+  /**
+   * Evaluate one watcher against a mutated record. `threshold` and `set_change`
+   * are handled here; `staleness` and `schedule` are polled, not reactive.
+   */
+  async evaluate(
+    watcher: WatcherDefinition,
+    record: Record<string, unknown>,
+    oldRecord?: Record<string, unknown>,
+  ): Promise<WatcherEvaluationResult> {
+    const trigger = watcher.trigger;
+
+    // For set_change watchers, the filter is evaluated internally
+    // (old vs new against filter). For other types, apply filter as a pre-check.
+    if (trigger.type !== "set_change" && watcher.watch.filter) {
+      if (!matchesFilter(watcher.watch.filter, record)) {
+        return { watcherName: watcher.name, fired: false, reason: "filter_not_matched" };
+      }
+    }
+
+    switch (trigger.type) {
+      case "threshold":
+        return this.evaluateThreshold(watcher, record);
+
+      case "set_change":
+        return this.evaluateSetChange(watcher, record, oldRecord);
+
+      default:
+        // staleness and schedule are handled by polling, not post-mutation
+        return {
+          watcherName: watcher.name,
+          fired: false,
+          reason: "trigger_type_not_reactive",
+        };
+    }
+  }
+
+  // ── Threshold evaluation ────────────────────────────────
+
+  private async evaluateThreshold(
+    watcher: WatcherDefinition,
+    record: Record<string, unknown>,
+  ): Promise<WatcherEvaluationResult> {
+    const trigger = watcher.trigger;
+    if (trigger.type !== "threshold") {
+      return { watcherName: watcher.name, fired: false, reason: "wrong_trigger_type" };
+    }
+
+    // Determine the value to compare
+    let currentValue: number;
+
+    if (watcher.watch.aggregate) {
+      // Aggregate watchers need a data querier to compute aggregates
+      if (!this.deps.dataQuerier) {
+        return {
+          watcherName: watcher.name,
+          fired: false,
+          reason: "no_data_querier_for_aggregate",
+        };
+      }
+
+      const records = await this.deps.dataQuerier.queryRecords(watcher.watch.entity);
+      // Apply filter in-memory if present
+      const watchFilter = watcher.watch.filter;
+      const filtered = watchFilter ? records.filter((r) => matchesFilter(watchFilter, r)) : records;
+
+      currentValue = this.computeAggregate(filtered, watcher.watch.aggregate);
+    } else {
+      // Single-record: read the field value directly
+      const fieldName = trigger.field;
+      if (!fieldName) {
+        return { watcherName: watcher.name, fired: false, reason: "no_field_specified" };
+      }
+      const rawValue = record[fieldName];
+      if (typeof rawValue !== "number") {
+        return { watcherName: watcher.name, fired: false, reason: "field_not_numeric" };
+      }
+      currentValue = rawValue;
+    }
+
+    const conditionMet = this.deps.evaluateComparison(currentValue, trigger.condition);
+    const groupKey = this.getGroupKey(watcher, record);
+
+    // Debounce check
+    if (!this.deps.shouldFire(watcher, groupKey, conditionMet)) {
+      return { watcherName: watcher.name, fired: false, reason: "debounced" };
+    }
+
+    // Fire the effect
+    const ctx: WatcherContext = {
+      record,
+      value: currentValue,
+      watcherName: watcher.name,
+    };
+
+    await this.deps.fireEffect(watcher, ctx);
+
+    // Update state
+    this.deps.updateState(watcher.name, groupKey, conditionMet);
+
+    return { watcherName: watcher.name, fired: true };
+  }
+
+  // ── Set-change evaluation ───────────────────────────────
+
+  private async evaluateSetChange(
+    watcher: WatcherDefinition,
+    record: Record<string, unknown>,
+    oldRecord?: Record<string, unknown>,
+  ): Promise<WatcherEvaluationResult> {
+    const trigger = watcher.trigger;
+    if (trigger.type !== "set_change") {
+      return { watcherName: watcher.name, fired: false, reason: "wrong_trigger_type" };
+    }
+
+    const filter = watcher.watch.filter;
+    if (!filter) {
+      return { watcherName: watcher.name, fired: false, reason: "set_change_requires_filter" };
+    }
+
+    const newMatchesFilter = matchesFilter(filter, record);
+    const oldMatchesFilter = oldRecord ? matchesFilter(filter, oldRecord) : false;
+
+    let shouldTrigger = false;
+
+    switch (trigger.on) {
+      case "added":
+        // Record entered the set (was not in set, now is)
+        shouldTrigger = !oldMatchesFilter && newMatchesFilter;
+        break;
+      case "removed":
+        // Record left the set (was in set, now is not)
+        shouldTrigger = oldMatchesFilter && !newMatchesFilter;
+        break;
+      case "modified":
+        // Record was in set and still is, but data changed
+        shouldTrigger = oldMatchesFilter && newMatchesFilter && oldRecord !== undefined;
+        break;
+    }
+
+    if (!shouldTrigger) {
+      return { watcherName: watcher.name, fired: false, reason: "set_change_not_detected" };
+    }
+
+    const groupKey = this.getGroupKey(watcher, record);
+
+    if (!this.deps.shouldFire(watcher, groupKey, true)) {
+      return { watcherName: watcher.name, fired: false, reason: "debounced" };
+    }
+
+    const ctx: WatcherContext = { record, watcherName: watcher.name };
+
+    await this.deps.fireEffect(watcher, ctx);
+    this.deps.updateState(watcher.name, groupKey, true);
+
+    return { watcherName: watcher.name, fired: true };
+  }
+
+  // ── Staleness evaluation ────────────────────────────────
+
+  private async evaluateStaleness(watcher: WatcherDefinition): Promise<void> {
+    const trigger = watcher.trigger;
+    if (trigger.type !== "staleness" || !this.deps.dataQuerier) return;
+
+    const thresholdMs = this.deps.parseDuration(trigger.threshold);
+    if (thresholdMs === null) {
+      this.deps.logger.warn?.(
+        `[WatcherEngine] Cannot parse staleness threshold "${trigger.threshold}" for watcher "${watcher.name}"`,
+      );
+      return;
+    }
+
+    const records = await this.deps.dataQuerier.queryRecords(watcher.watch.entity);
+
+    // Apply filter
+    const watchFilter = watcher.watch.filter;
+    const filtered = watchFilter ? records.filter((r) => matchesFilter(watchFilter, r)) : records;
+
+    const now = Date.now();
+
+    for (const record of filtered) {
+      const fieldValue = record[trigger.field];
+      if (!fieldValue) continue;
+
+      const timestamp =
+        fieldValue instanceof Date
+          ? fieldValue.getTime()
+          : new Date(fieldValue as string).getTime();
+
+      if (Number.isNaN(timestamp)) continue;
+
+      const age = now - timestamp;
+      const isStale = age > thresholdMs;
+
+      const groupKey = String(record.id ?? JSON.stringify(record));
+
+      if (!isStale) {
+        // Condition no longer met — reset state so it can fire again later.
+        this.deps.resetConditionMet(watcher.name, groupKey);
+        continue;
+      }
+
+      if (!this.deps.shouldFire(watcher, groupKey, true)) {
+        continue;
+      }
+
+      const ctx: WatcherContext = { record, watcherName: watcher.name };
+
+      await this.deps.fireEffect(watcher, ctx);
+      this.deps.updateState(watcher.name, groupKey, true);
+    }
+  }
+
+  // ── Aggregate computation ───────────────────────────────
+
+  private computeAggregate(
+    records: Array<Record<string, unknown>>,
+    config: WatcherAggregateConfig,
+  ): number {
+    const values = records
+      .map((r) => r[config.field])
+      .filter((v): v is number => typeof v === "number");
+
+    switch (config.op) {
+      case "sum":
+        return values.reduce((acc, v) => acc + v, 0);
+      case "count":
+        return values.length;
+      case "avg":
+        return values.length > 0 ? values.reduce((acc, v) => acc + v, 0) / values.length : 0;
+      case "min":
+        return values.length > 0 ? Math.min(...values) : 0;
+      case "max":
+        return values.length > 0 ? Math.max(...values) : 0;
+      default:
+        return 0;
+    }
+  }
+
+  // ── Group key ───────────────────────────────────────────
+
+  private getGroupKey(watcher: WatcherDefinition, record: Record<string, unknown>): string {
+    if (watcher.watch.aggregate?.groupBy) {
+      return String(record[watcher.watch.aggregate.groupBy] ?? "default");
+    }
+    // Use record ID as group key for per-record watchers
+    return String(record.id ?? "default");
+  }
+}

--- a/addons/ai-provider/cap-ai-provider/src/schedule-engine.ts
+++ b/addons/ai-provider/cap-ai-provider/src/schedule-engine.ts
@@ -1,0 +1,253 @@
+/**
+ * Watcher schedule subsystem (Spec 45 §2.4).
+ *
+ * Extracted from `watcher-engine.ts` to keep both files under the repo's
+ * 500-line ceiling. Owns the cron scheduler bootstrap (interval management) and
+ * the schedule-watcher evaluation logic, delegating debounce/effect concerns
+ * back to the host engine through explicitly injected collaborators so the two
+ * modules stay loosely coupled (no circular state ownership).
+ *
+ * The scheduler is driven by an injectable clock; tests advance the clock and
+ * call `runTick()` directly without real timers.
+ */
+
+import type {
+  Logger,
+  WatcherContext,
+  WatcherDefinition,
+  WatcherEvaluationResult,
+} from "@linchkit/core";
+import { evaluateCondition } from "@linchkit/core";
+import type { WatcherRegistry } from "@linchkit/core/server";
+import { ScheduleTracker } from "./watcher-schedule";
+
+// ── Collaborators injected by the host WatcherEngine ──────
+
+export interface ScheduleEngineDeps {
+  registry: WatcherRegistry;
+  /** Data querier used to evaluate `condition.count` (queries matching records). */
+  dataQuerier?: {
+    queryRecords(
+      schema: string,
+      filter?: Record<string, unknown>,
+    ): Promise<Array<Record<string, unknown>>>;
+  };
+  logger: Logger;
+  /** Injectable clock — drives the scheduler deterministically. */
+  clock: () => Date;
+  /** Schedule (cron) tick interval in ms. */
+  scheduleIntervalMs: number;
+  /** Numeric comparison evaluator (shared with the engine). */
+  evaluateComparison: (
+    value: number,
+    condition: { gt?: number; gte?: number; lt?: number; lte?: number; eq?: number },
+  ) => boolean;
+  /** Debounce gate — returns true when the watcher should fire for this group. */
+  shouldFire: (watcher: WatcherDefinition, groupKey: string, conditionMet: boolean) => boolean;
+  /** Execute the watcher's effect through the action pipeline. */
+  fireEffect: (watcher: WatcherDefinition, ctx: WatcherContext) => Promise<void>;
+  /** Record debounce state after evaluating a watcher occurrence. */
+  updateState: (watcherName: string, groupKey: string, conditionMet: boolean) => void;
+}
+
+// ── Schedule subsystem ────────────────────────────────────
+
+/**
+ * Manages cron-scheduled watchers: seeds next-due times, runs ticks (with
+ * serialized, non-overlapping execution), and evaluates each due occurrence.
+ */
+export class ScheduleEngine {
+  private readonly deps: ScheduleEngineDeps;
+  private readonly tracker = new ScheduleTracker();
+  private interval?: ReturnType<typeof setInterval>;
+
+  /**
+   * In-flight tick promise. While set, a concurrent `runTick()` awaits the same
+   * pass instead of starting a fresh one — so a slow `fireEffect` can never let
+   * the next interval tick fire the same due occurrence twice before debounce
+   * state has been written.
+   */
+  private tickInFlight?: Promise<WatcherEvaluationResult[]>;
+
+  constructor(deps: ScheduleEngineDeps) {
+    this.deps = deps;
+  }
+
+  /** Group key under which schedule debounce state is stored. */
+  private static readonly GROUP_KEY = "schedule";
+
+  /**
+   * Seed next-due times for all enabled schedule watchers and start the tick
+   * interval. No-op when there are no (valid) schedule watchers.
+   */
+  start(): void {
+    const scheduleWatchers = this.deps.registry
+      .getEnabled()
+      .filter((w) => w.trigger.type === "schedule");
+
+    if (scheduleWatchers.length === 0) return;
+
+    // Seed the next-due time for each schedule watcher from the current clock.
+    const now = this.deps.clock();
+    let registered = 0;
+    for (const watcher of scheduleWatchers) {
+      const trigger = watcher.trigger;
+      if (trigger.type !== "schedule") continue;
+
+      const state = this.tracker.register({
+        watcherName: watcher.name,
+        cron: trigger.cron,
+        // Interpret cron expressions in UTC for deterministic, region-stable
+        // server-side scheduling (independent of the host's local timezone).
+        timezone: "UTC",
+        from: now,
+      });
+
+      if (state) {
+        registered += 1;
+      } else {
+        this.deps.logger.warn?.(
+          `[WatcherEngine] Invalid cron "${trigger.cron}" for schedule watcher "${watcher.name}"`,
+        );
+      }
+    }
+
+    // All cron expressions failed to register — nothing to poll.
+    if (registered === 0) return;
+
+    this.interval = setInterval(() => {
+      void this.runTick();
+    }, this.deps.scheduleIntervalMs);
+  }
+
+  /** Stop the tick interval and clear all tracked schedules. */
+  stop(): void {
+    if (this.interval !== undefined) {
+      clearInterval(this.interval);
+      this.interval = undefined;
+    }
+    this.tracker.clear();
+  }
+
+  /** A scheduled watcher's next-due time (for testing/debugging). */
+  getNextScheduledRun(watcherName: string): Date | null | undefined {
+    return this.tracker.get(watcherName)?.nextDue;
+  }
+
+  /**
+   * Evaluate all schedule watchers whose cron occurrence is due at the current
+   * clock time. Serialized: a concurrent call returns the in-flight pass.
+   */
+  runTick(): Promise<WatcherEvaluationResult[]> {
+    // Coalesce concurrent callers onto a single in-flight pass so a slow
+    // fireEffect can never let the next tick re-consume the same due occurrence
+    // before debounce state has been written. The stored promise IS the one
+    // returned to every caller, and it self-clears once it settles.
+    const inFlight = this.tickInFlight;
+    if (inFlight) return inFlight;
+
+    const pass = (async () => {
+      try {
+        return await this.runTickInternal();
+      } finally {
+        this.tickInFlight = undefined;
+      }
+    })();
+    this.tickInFlight = pass;
+    return pass;
+  }
+
+  private async runTickInternal(): Promise<WatcherEvaluationResult[]> {
+    const now = this.deps.clock();
+    const dueWatcherNames = this.tracker.collectDue(now);
+    const results: WatcherEvaluationResult[] = [];
+
+    for (const watcherName of dueWatcherNames) {
+      // Re-check enabled status on every occurrence — a watcher may have been
+      // disabled or removed since the schedule was registered.
+      const watcher = this.deps.registry.get(watcherName);
+      if (!watcher?.enabled || watcher.trigger.type !== "schedule") {
+        results.push({ watcherName, fired: false, reason: "watcher_unavailable" });
+        // Drop the orphaned schedule so we stop computing next-run times for a
+        // watcher that no longer exists / is disabled (CPU + memory leak).
+        this.tracker.remove(watcherName);
+        continue;
+      }
+
+      try {
+        results.push(await this.evaluate(watcher));
+      } catch (err) {
+        const error = err instanceof Error ? err.message : String(err);
+        this.deps.logger.error?.(
+          `[WatcherEngine] Schedule tick error for "${watcherName}": ${error}`,
+        );
+        results.push({ watcherName, fired: false, error });
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Evaluate one due occurrence of a schedule watcher. When the trigger carries
+   * a `condition.count`, the matching record count is compared against it and
+   * the effect only fires if the comparison holds. Without a condition, the
+   * effect fires on each due tick (Spec 45 §2.4).
+   */
+  private async evaluate(watcher: WatcherDefinition): Promise<WatcherEvaluationResult> {
+    const trigger = watcher.trigger;
+    if (trigger.type !== "schedule") {
+      return { watcherName: watcher.name, fired: false, reason: "wrong_trigger_type" };
+    }
+
+    const groupKey = ScheduleEngine.GROUP_KEY;
+    const ctx: WatcherContext = { watcherName: watcher.name };
+
+    // Optional count condition: evaluate the matching-record count.
+    const countCondition = trigger.condition?.count;
+    if (countCondition) {
+      if (!this.deps.dataQuerier) {
+        return {
+          watcherName: watcher.name,
+          fired: false,
+          reason: "no_data_querier_for_count_condition",
+        };
+      }
+
+      const records = await this.deps.dataQuerier.queryRecords(watcher.watch.entity);
+      const watchFilter = watcher.watch.filter;
+      const matching = watchFilter
+        ? records.filter((r) =>
+            evaluateCondition(watchFilter, {
+              target: r,
+              context: {},
+              actor: { type: "system", id: "watcher", groups: [] },
+            }),
+          )
+        : records;
+
+      const count = matching.length;
+      if (!this.deps.evaluateComparison(count, countCondition)) {
+        // Reset debounce state so a `once_until_reset` watcher can fire again
+        // once the count later rises back above the threshold. Without this the
+        // prior `conditionMet: true` would permanently suppress future fires.
+        this.deps.updateState(watcher.name, groupKey, false);
+        return { watcherName: watcher.name, fired: false, reason: "count_condition_not_met" };
+      }
+
+      ctx.records = matching;
+      ctx.count = count;
+      ctx.value = count;
+    }
+
+    // Schedule watchers fire per due occurrence; cron itself is the debounce.
+    if (!this.deps.shouldFire(watcher, groupKey, true)) {
+      return { watcherName: watcher.name, fired: false, reason: "debounced" };
+    }
+
+    await this.deps.fireEffect(watcher, ctx);
+    this.deps.updateState(watcher.name, groupKey, true);
+
+    return { watcherName: watcher.name, fired: true };
+  }
+}

--- a/addons/ai-provider/cap-ai-provider/src/watcher-engine.ts
+++ b/addons/ai-provider/cap-ai-provider/src/watcher-engine.ts
@@ -24,9 +24,9 @@ import type {
   WatcherEvaluationResult,
   WatcherStateEntry,
 } from "@linchkit/core";
-import { type ConditionContext, evaluateCondition } from "@linchkit/core";
 import type { WatcherRegistry } from "@linchkit/core/server";
-import { ScheduleTracker } from "./watcher-schedule";
+import { MutationEngine } from "./mutation-engine";
+import { ScheduleEngine } from "./schedule-engine";
 
 // ── Action executor interface (shared with watcher effects) ──
 
@@ -170,14 +170,16 @@ class WatcherEngineImpl implements WatcherEngine {
   private clock: () => Date;
 
   private unsubscribers: Array<() => void> = [];
-  private intervals: Array<ReturnType<typeof setInterval>> = [];
   private started = false;
 
   /** In-memory debounce state — maps `${watcherName}:${groupKey}` → state entry */
   private stateMap = new Map<string, WatcherStateEntry>();
 
-  /** Tracks next-due times for `schedule` watchers (in-memory) */
-  private scheduleTracker = new ScheduleTracker();
+  /** Cron scheduling subsystem (next-due tracking + tick evaluation). */
+  private scheduleEngine: ScheduleEngine;
+
+  /** Reactive (threshold/set_change) + staleness evaluation subsystem. */
+  private mutationEngine: MutationEngine;
 
   constructor(options: WatcherEngineOptions) {
     this.id = options.id ?? "automation.watcher_engine";
@@ -194,6 +196,39 @@ class WatcherEngineImpl implements WatcherEngine {
       error: console.error,
       debug: () => {},
     };
+
+    // Delegate cron scheduling to a dedicated subsystem. Debounce + effect
+    // concerns are passed back as bound callbacks so the engine retains sole
+    // ownership of the shared debounce state map.
+    this.scheduleEngine = new ScheduleEngine({
+      registry: this.registry,
+      dataQuerier: this.dataQuerier,
+      logger: this.logger,
+      clock: this.clock,
+      scheduleIntervalMs: this.scheduleIntervalMs,
+      evaluateComparison,
+      shouldFire: (watcher, groupKey, conditionMet) =>
+        this.shouldFire(watcher, groupKey, conditionMet),
+      fireEffect: (watcher, ctx) => this.fireEffect(watcher, ctx),
+      updateState: (watcherName, groupKey, conditionMet) =>
+        this.updateState(watcherName, groupKey, conditionMet),
+    });
+
+    // Reactive + staleness evaluation, sharing the same debounce collaborators.
+    this.mutationEngine = new MutationEngine({
+      registry: this.registry,
+      dataQuerier: this.dataQuerier,
+      logger: this.logger,
+      stalenessIntervalMs: this.stalenessIntervalMs,
+      evaluateComparison,
+      parseDuration,
+      shouldFire: (watcher, groupKey, conditionMet) =>
+        this.shouldFire(watcher, groupKey, conditionMet),
+      fireEffect: (watcher, ctx) => this.fireEffect(watcher, ctx),
+      updateState: (watcherName, groupKey, conditionMet) =>
+        this.updateState(watcherName, groupKey, conditionMet),
+      resetConditionMet: (watcherName, groupKey) => this.resetConditionMet(watcherName, groupKey),
+    });
   }
 
   start(): void {
@@ -206,10 +241,10 @@ class WatcherEngineImpl implements WatcherEngine {
     }
 
     // Start staleness polling
-    this.startStalenessPoller();
+    this.mutationEngine.start();
 
     // Start cron scheduler
-    this.startScheduler();
+    this.scheduleEngine.start();
 
     const watcherCount = this.registry.getEnabled().length;
     this.logger.info?.(`[WatcherEngine] Started with ${watcherCount} enabled watcher(s)`);
@@ -221,12 +256,8 @@ class WatcherEngineImpl implements WatcherEngine {
     }
     this.unsubscribers = [];
 
-    for (const interval of this.intervals) {
-      clearInterval(interval);
-    }
-    this.intervals = [];
-
-    this.scheduleTracker.clear();
+    this.mutationEngine.stop();
+    this.scheduleEngine.stop();
 
     this.started = false;
     this.logger.info?.("[WatcherEngine] Stopped");
@@ -242,7 +273,7 @@ class WatcherEngineImpl implements WatcherEngine {
 
     for (const watcher of watchers) {
       try {
-        const result = await this.evaluateWatcher(watcher, record, oldRecord);
+        const result = await this.mutationEngine.evaluate(watcher, record, oldRecord);
         results.push(result);
       } catch (err) {
         const error = err instanceof Error ? err.message : String(err);
@@ -276,33 +307,11 @@ class WatcherEngineImpl implements WatcherEngine {
   }
 
   getNextScheduledRun(watcherName: string): Date | null | undefined {
-    return this.scheduleTracker.get(watcherName)?.nextDue;
+    return this.scheduleEngine.getNextScheduledRun(watcherName);
   }
 
-  async runScheduleTick(): Promise<WatcherEvaluationResult[]> {
-    const now = this.clock();
-    const dueWatcherNames = this.scheduleTracker.collectDue(now);
-    const results: WatcherEvaluationResult[] = [];
-
-    for (const watcherName of dueWatcherNames) {
-      // Re-check enabled status on every occurrence — a watcher may have been
-      // disabled or removed since the schedule was registered.
-      const watcher = this.registry.get(watcherName);
-      if (!watcher?.enabled || watcher.trigger.type !== "schedule") {
-        results.push({ watcherName, fired: false, reason: "watcher_unavailable" });
-        continue;
-      }
-
-      try {
-        results.push(await this.evaluateScheduleWatcher(watcher));
-      } catch (err) {
-        const error = err instanceof Error ? err.message : String(err);
-        this.logger.error?.(`[WatcherEngine] Schedule tick error for "${watcherName}": ${error}`);
-        results.push({ watcherName, fired: false, error });
-      }
-    }
-
-    return results;
+  runScheduleTick(): Promise<WatcherEvaluationResult[]> {
+    return this.scheduleEngine.runTick();
   }
 
   // ── Private: event binding ──────────────────────────────
@@ -328,438 +337,6 @@ class WatcherEngineImpl implements WatcherEngine {
         await this.evaluateAfterMutation(entityName, record, oldRecord);
       });
       this.unsubscribers.push(unsub);
-    }
-  }
-
-  // ── Private: staleness polling ──────────────────────────
-
-  private startStalenessPoller(): void {
-    const stalenessWatchers = this.registry
-      .getEnabled()
-      .filter((w) => w.trigger.type === "staleness");
-
-    if (stalenessWatchers.length === 0) return;
-    if (!this.dataQuerier) {
-      this.logger.warn?.(
-        "[WatcherEngine] Staleness watchers registered but no dataQuerier provided",
-      );
-      return;
-    }
-
-    const interval = setInterval(async () => {
-      for (const watcher of stalenessWatchers) {
-        // Re-check enabled status
-        const current = this.registry.get(watcher.name);
-        if (!current?.enabled) continue;
-
-        try {
-          await this.evaluateStalenessWatcher(current);
-        } catch (err) {
-          this.logger.error?.(
-            `[WatcherEngine] Staleness check error for "${watcher.name}": ${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
-      }
-    }, this.stalenessIntervalMs);
-
-    this.intervals.push(interval);
-  }
-
-  // ── Private: cron scheduler ─────────────────────────────
-
-  private startScheduler(): void {
-    const scheduleWatchers = this.registry
-      .getEnabled()
-      .filter((w) => w.trigger.type === "schedule");
-
-    if (scheduleWatchers.length === 0) return;
-
-    // Seed the next-due time for each schedule watcher from the current clock.
-    const now = this.clock();
-    let registered = 0;
-    for (const watcher of scheduleWatchers) {
-      const trigger = watcher.trigger;
-      if (trigger.type !== "schedule") continue;
-
-      const state = this.scheduleTracker.register({
-        watcherName: watcher.name,
-        cron: trigger.cron,
-        // Interpret cron expressions in UTC for deterministic, region-stable
-        // server-side scheduling (independent of the host's local timezone).
-        timezone: "UTC",
-        from: now,
-      });
-
-      if (state) {
-        registered += 1;
-      } else {
-        this.logger.warn?.(
-          `[WatcherEngine] Invalid cron "${trigger.cron}" for schedule watcher "${watcher.name}"`,
-        );
-      }
-    }
-
-    // All cron expressions failed to register — nothing to poll.
-    if (registered === 0) return;
-
-    const interval = setInterval(() => {
-      void this.runScheduleTick();
-    }, this.scheduleIntervalMs);
-
-    this.intervals.push(interval);
-  }
-
-  /**
-   * Evaluate one due occurrence of a schedule watcher. When the trigger carries
-   * a `condition.count`, the matching record count is compared against it and
-   * the effect only fires if the comparison holds. Without a condition, the
-   * effect fires on each due tick (Spec 45 §2.4).
-   */
-  private async evaluateScheduleWatcher(
-    watcher: WatcherDefinition,
-  ): Promise<WatcherEvaluationResult> {
-    const trigger = watcher.trigger;
-    if (trigger.type !== "schedule") {
-      return { watcherName: watcher.name, fired: false, reason: "wrong_trigger_type" };
-    }
-
-    const ctx: WatcherContext = { watcherName: watcher.name };
-
-    // Optional count condition: evaluate the matching-record count.
-    const countCondition = trigger.condition?.count;
-    if (countCondition) {
-      if (!this.dataQuerier) {
-        return {
-          watcherName: watcher.name,
-          fired: false,
-          reason: "no_data_querier_for_count_condition",
-        };
-      }
-
-      const records = await this.dataQuerier.queryRecords(watcher.watch.entity);
-      const watchFilter = watcher.watch.filter;
-      const matching = watchFilter
-        ? records.filter((r) =>
-            evaluateCondition(watchFilter, {
-              target: r,
-              context: {},
-              actor: { type: "system", id: "watcher", groups: [] },
-            }),
-          )
-        : records;
-
-      const count = matching.length;
-      if (!evaluateComparison(count, countCondition)) {
-        return { watcherName: watcher.name, fired: false, reason: "count_condition_not_met" };
-      }
-
-      ctx.records = matching;
-      ctx.count = count;
-      ctx.value = count;
-    }
-
-    // Schedule watchers fire per due occurrence; cron itself is the debounce.
-    const groupKey = "schedule";
-    if (!this.shouldFire(watcher, groupKey, true)) {
-      return { watcherName: watcher.name, fired: false, reason: "debounced" };
-    }
-
-    await this.fireEffect(watcher, ctx);
-    this.updateState(watcher.name, groupKey, true);
-
-    return { watcherName: watcher.name, fired: true };
-  }
-
-  // ── Private: evaluate a single watcher ──────────────────
-
-  private async evaluateWatcher(
-    watcher: WatcherDefinition,
-    record: Record<string, unknown>,
-    oldRecord?: Record<string, unknown>,
-  ): Promise<WatcherEvaluationResult> {
-    const trigger = watcher.trigger;
-
-    // For set_change watchers, the filter is evaluated internally
-    // (old vs new against filter). For other types, apply filter as a pre-check.
-    if (trigger.type !== "set_change" && watcher.watch.filter) {
-      const ctx: ConditionContext = {
-        target: record,
-        context: {},
-        actor: { type: "system", id: "watcher", groups: [] },
-      };
-      if (!evaluateCondition(watcher.watch.filter, ctx)) {
-        return { watcherName: watcher.name, fired: false, reason: "filter_not_matched" };
-      }
-    }
-
-    switch (trigger.type) {
-      case "threshold":
-        return this.evaluateThresholdWatcher(watcher, record, oldRecord);
-
-      case "set_change":
-        return this.evaluateSetChangeWatcher(watcher, record, oldRecord);
-
-      default:
-        // staleness and schedule are handled by polling, not post-mutation
-        return {
-          watcherName: watcher.name,
-          fired: false,
-          reason: "trigger_type_not_reactive",
-        };
-    }
-  }
-
-  // ── Threshold evaluation ────────────────────────────────
-
-  private async evaluateThresholdWatcher(
-    watcher: WatcherDefinition,
-    record: Record<string, unknown>,
-    _oldRecord?: Record<string, unknown>,
-  ): Promise<WatcherEvaluationResult> {
-    const trigger = watcher.trigger;
-    if (trigger.type !== "threshold") {
-      return { watcherName: watcher.name, fired: false, reason: "wrong_trigger_type" };
-    }
-
-    // Determine the value to compare
-    let currentValue: number;
-
-    if (watcher.watch.aggregate) {
-      // Aggregate watchers need a data querier to compute aggregates
-      if (!this.dataQuerier) {
-        return {
-          watcherName: watcher.name,
-          fired: false,
-          reason: "no_data_querier_for_aggregate",
-        };
-      }
-
-      const records = await this.dataQuerier.queryRecords(watcher.watch.entity);
-      // Apply filter in-memory if present
-      const watchFilter = watcher.watch.filter;
-      const filtered = watchFilter
-        ? records.filter((r) => {
-            const ctx: ConditionContext = {
-              target: r,
-              context: {},
-              actor: { type: "system", id: "watcher", groups: [] },
-            };
-            return evaluateCondition(watchFilter, ctx);
-          })
-        : records;
-
-      currentValue = this.computeAggregate(filtered, watcher.watch.aggregate);
-    } else {
-      // Single-record: read the field value directly
-      const fieldName = trigger.field;
-      if (!fieldName) {
-        return {
-          watcherName: watcher.name,
-          fired: false,
-          reason: "no_field_specified",
-        };
-      }
-      const rawValue = record[fieldName];
-      if (typeof rawValue !== "number") {
-        return {
-          watcherName: watcher.name,
-          fired: false,
-          reason: "field_not_numeric",
-        };
-      }
-      currentValue = rawValue;
-    }
-
-    const conditionMet = evaluateComparison(currentValue, trigger.condition);
-    const groupKey = this.getGroupKey(watcher, record);
-
-    // Debounce check
-    if (!this.shouldFire(watcher, groupKey, conditionMet)) {
-      return { watcherName: watcher.name, fired: false, reason: "debounced" };
-    }
-
-    // Fire the effect
-    const ctx: WatcherContext = {
-      record,
-      value: currentValue,
-      watcherName: watcher.name,
-    };
-
-    await this.fireEffect(watcher, ctx);
-
-    // Update state
-    this.updateState(watcher.name, groupKey, conditionMet);
-
-    return { watcherName: watcher.name, fired: true };
-  }
-
-  // ── Set-change evaluation ───────────────────────────────
-
-  private async evaluateSetChangeWatcher(
-    watcher: WatcherDefinition,
-    record: Record<string, unknown>,
-    oldRecord?: Record<string, unknown>,
-  ): Promise<WatcherEvaluationResult> {
-    const trigger = watcher.trigger;
-    if (trigger.type !== "set_change") {
-      return { watcherName: watcher.name, fired: false, reason: "wrong_trigger_type" };
-    }
-
-    const filter = watcher.watch.filter;
-    if (!filter) {
-      return {
-        watcherName: watcher.name,
-        fired: false,
-        reason: "set_change_requires_filter",
-      };
-    }
-
-    const newMatchesFilter = evaluateCondition(filter, {
-      target: record,
-      context: {},
-      actor: { type: "system", id: "watcher", groups: [] },
-    });
-
-    const oldMatchesFilter = oldRecord
-      ? evaluateCondition(filter, {
-          target: oldRecord,
-          context: {},
-          actor: { type: "system", id: "watcher", groups: [] },
-        })
-      : false;
-
-    let shouldTrigger = false;
-
-    switch (trigger.on) {
-      case "added":
-        // Record entered the set (was not in set, now is)
-        shouldTrigger = !oldMatchesFilter && newMatchesFilter;
-        break;
-      case "removed":
-        // Record left the set (was in set, now is not)
-        shouldTrigger = oldMatchesFilter && !newMatchesFilter;
-        break;
-      case "modified":
-        // Record was in set and still is, but data changed
-        shouldTrigger = oldMatchesFilter && newMatchesFilter && oldRecord !== undefined;
-        break;
-    }
-
-    if (!shouldTrigger) {
-      return { watcherName: watcher.name, fired: false, reason: "set_change_not_detected" };
-    }
-
-    const groupKey = this.getGroupKey(watcher, record);
-
-    if (!this.shouldFire(watcher, groupKey, true)) {
-      return { watcherName: watcher.name, fired: false, reason: "debounced" };
-    }
-
-    const ctx: WatcherContext = {
-      record,
-      watcherName: watcher.name,
-    };
-
-    await this.fireEffect(watcher, ctx);
-    this.updateState(watcher.name, groupKey, true);
-
-    return { watcherName: watcher.name, fired: true };
-  }
-
-  // ── Staleness evaluation ────────────────────────────────
-
-  private async evaluateStalenessWatcher(watcher: WatcherDefinition): Promise<void> {
-    const trigger = watcher.trigger;
-    if (trigger.type !== "staleness" || !this.dataQuerier) return;
-
-    const thresholdMs = parseDuration(trigger.threshold);
-    if (thresholdMs === null) {
-      this.logger.warn?.(
-        `[WatcherEngine] Cannot parse staleness threshold "${trigger.threshold}" for watcher "${watcher.name}"`,
-      );
-      return;
-    }
-
-    const records = await this.dataQuerier.queryRecords(watcher.watch.entity);
-
-    // Apply filter
-    const watchFilter2 = watcher.watch.filter;
-    const filtered = watchFilter2
-      ? records.filter((r) => {
-          const ctx: ConditionContext = {
-            target: r,
-            context: {},
-            actor: { type: "system", id: "watcher", groups: [] },
-          };
-          return evaluateCondition(watchFilter2, ctx);
-        })
-      : records;
-
-    const now = Date.now();
-
-    for (const record of filtered) {
-      const fieldValue = record[trigger.field];
-      if (!fieldValue) continue;
-
-      const timestamp =
-        fieldValue instanceof Date
-          ? fieldValue.getTime()
-          : new Date(fieldValue as string).getTime();
-
-      if (Number.isNaN(timestamp)) continue;
-
-      const age = now - timestamp;
-      const isStale = age > thresholdMs;
-
-      const groupKey = String(record.id ?? JSON.stringify(record));
-
-      if (!isStale) {
-        // Condition no longer met — update state so it can fire again
-        const stateKey = `${watcher.name}:${groupKey}`;
-        const existing = this.stateMap.get(stateKey);
-        if (existing?.conditionMet) {
-          existing.conditionMet = false;
-        }
-        continue;
-      }
-
-      if (!this.shouldFire(watcher, groupKey, true)) {
-        continue;
-      }
-
-      const ctx: WatcherContext = {
-        record,
-        watcherName: watcher.name,
-      };
-
-      await this.fireEffect(watcher, ctx);
-      this.updateState(watcher.name, groupKey, true);
-    }
-  }
-
-  // ── Aggregate computation ───────────────────────────────
-
-  private computeAggregate(
-    records: Array<Record<string, unknown>>,
-    config: { field: string; op: string; groupBy?: string },
-  ): number {
-    const values = records
-      .map((r) => r[config.field])
-      .filter((v): v is number => typeof v === "number");
-
-    switch (config.op) {
-      case "sum":
-        return values.reduce((acc, v) => acc + v, 0);
-      case "count":
-        return values.length;
-      case "avg":
-        return values.length > 0 ? values.reduce((acc, v) => acc + v, 0) / values.length : 0;
-      case "min":
-        return values.length > 0 ? Math.min(...values) : 0;
-      case "max":
-        return values.length > 0 ? Math.max(...values) : 0;
-      default:
-        return 0;
     }
   }
 
@@ -789,14 +366,6 @@ class WatcherEngineImpl implements WatcherEngine {
   }
 
   // ── Debounce logic ──────────────────────────────────────
-
-  private getGroupKey(watcher: WatcherDefinition, record: Record<string, unknown>): string {
-    if (watcher.watch.aggregate?.groupBy) {
-      return String(record[watcher.watch.aggregate.groupBy] ?? "default");
-    }
-    // Use record ID as group key for per-record watchers
-    return String(record.id ?? "default");
-  }
 
   /**
    * Check whether the watcher should fire based on debounce strategy.
@@ -854,6 +423,18 @@ class WatcherEngineImpl implements WatcherEngine {
       lastFiredAt: this.clock(),
       conditionMet,
     });
+  }
+
+  /**
+   * Clear the `conditionMet` flag for a group (used by staleness evaluation when
+   * a record is no longer stale) so a `once_until_reset` watcher can fire again
+   * once the condition re-occurs. No-op when no state exists for the group.
+   */
+  private resetConditionMet(watcherName: string, groupKey: string): void {
+    const existing = this.stateMap.get(`${watcherName}:${groupKey}`);
+    if (existing?.conditionMet) {
+      existing.conditionMet = false;
+    }
   }
 }
 

--- a/addons/ai-provider/cap-ai-provider/src/watcher-engine.ts
+++ b/addons/ai-provider/cap-ai-provider/src/watcher-engine.ts
@@ -26,6 +26,7 @@ import type {
 } from "@linchkit/core";
 import { type ConditionContext, evaluateCondition } from "@linchkit/core";
 import type { WatcherRegistry } from "@linchkit/core/server";
+import { ScheduleTracker } from "./watcher-schedule";
 
 // ── Action executor interface (shared with watcher effects) ──
 
@@ -70,6 +71,20 @@ export interface WatcherEngine extends Watcher {
 
   /** Reset debounce state for a watcher (for testing) */
   resetState(watcherName: string, groupKey?: string): void;
+
+  /**
+   * Evaluate all `schedule` watchers whose cron occurrence is due at the
+   * current clock time, firing each that passes its optional count condition.
+   *
+   * In production this is invoked on an internal interval started by
+   * {@link Watcher.start}. Tests can call it directly after advancing the
+   * injected clock to drive the scheduler deterministically without timers.
+   * Returns one result per evaluated (due) occurrence.
+   */
+  runScheduleTick(): Promise<WatcherEvaluationResult[]>;
+
+  /** Get a scheduled watcher's next-due time (for testing/debugging). */
+  getNextScheduledRun(watcherName: string): Date | null | undefined;
 }
 
 // ── Options ───────────────────────────────────────────────
@@ -84,6 +99,18 @@ export interface WatcherEngineOptions {
   dataQuerier?: WatcherDataQuerier;
   /** Staleness check interval in ms (default: 60_000 = 1 minute) */
   stalenessIntervalMs?: number;
+  /**
+   * Schedule (cron) tick interval in ms (default: 60_000 = 1 minute).
+   * The scheduler re-checks due crons on each tick; cron resolution finer than
+   * this interval is not meaningful. Tests bypass the timer via
+   * {@link WatcherEngine.runScheduleTick}.
+   */
+  scheduleIntervalMs?: number;
+  /**
+   * Injectable clock — returns the current time. Defaults to `() => new Date()`.
+   * Drives the schedule trigger so tests can advance time deterministically.
+   */
+  clock?: () => Date;
   /** Optional override for the watcher's stable id (default: "automation.watcher_engine"). */
   id?: string;
   logger?: Logger;
@@ -139,6 +166,8 @@ class WatcherEngineImpl implements WatcherEngine {
   private dataQuerier?: WatcherDataQuerier;
   private logger: Logger;
   private stalenessIntervalMs: number;
+  private scheduleIntervalMs: number;
+  private clock: () => Date;
 
   private unsubscribers: Array<() => void> = [];
   private intervals: Array<ReturnType<typeof setInterval>> = [];
@@ -147,6 +176,9 @@ class WatcherEngineImpl implements WatcherEngine {
   /** In-memory debounce state — maps `${watcherName}:${groupKey}` → state entry */
   private stateMap = new Map<string, WatcherStateEntry>();
 
+  /** Tracks next-due times for `schedule` watchers (in-memory) */
+  private scheduleTracker = new ScheduleTracker();
+
   constructor(options: WatcherEngineOptions) {
     this.id = options.id ?? "automation.watcher_engine";
     this.registry = options.registry;
@@ -154,6 +186,8 @@ class WatcherEngineImpl implements WatcherEngine {
     this.actionExecutor = options.actionExecutor;
     this.dataQuerier = options.dataQuerier;
     this.stalenessIntervalMs = options.stalenessIntervalMs ?? 60_000;
+    this.scheduleIntervalMs = options.scheduleIntervalMs ?? 60_000;
+    this.clock = options.clock ?? (() => new Date());
     this.logger = options.logger ?? {
       info: () => {},
       warn: console.warn,
@@ -174,6 +208,9 @@ class WatcherEngineImpl implements WatcherEngine {
     // Start staleness polling
     this.startStalenessPoller();
 
+    // Start cron scheduler
+    this.startScheduler();
+
     const watcherCount = this.registry.getEnabled().length;
     this.logger.info?.(`[WatcherEngine] Started with ${watcherCount} enabled watcher(s)`);
   }
@@ -188,6 +225,8 @@ class WatcherEngineImpl implements WatcherEngine {
       clearInterval(interval);
     }
     this.intervals = [];
+
+    this.scheduleTracker.clear();
 
     this.started = false;
     this.logger.info?.("[WatcherEngine] Stopped");
@@ -234,6 +273,36 @@ class WatcherEngineImpl implements WatcherEngine {
         }
       }
     }
+  }
+
+  getNextScheduledRun(watcherName: string): Date | null | undefined {
+    return this.scheduleTracker.get(watcherName)?.nextDue;
+  }
+
+  async runScheduleTick(): Promise<WatcherEvaluationResult[]> {
+    const now = this.clock();
+    const dueWatcherNames = this.scheduleTracker.collectDue(now);
+    const results: WatcherEvaluationResult[] = [];
+
+    for (const watcherName of dueWatcherNames) {
+      // Re-check enabled status on every occurrence — a watcher may have been
+      // disabled or removed since the schedule was registered.
+      const watcher = this.registry.get(watcherName);
+      if (!watcher?.enabled || watcher.trigger.type !== "schedule") {
+        results.push({ watcherName, fired: false, reason: "watcher_unavailable" });
+        continue;
+      }
+
+      try {
+        results.push(await this.evaluateScheduleWatcher(watcher));
+      } catch (err) {
+        const error = err instanceof Error ? err.message : String(err);
+        this.logger.error?.(`[WatcherEngine] Schedule tick error for "${watcherName}": ${error}`);
+        results.push({ watcherName, fired: false, error });
+      }
+    }
+
+    return results;
   }
 
   // ── Private: event binding ──────────────────────────────
@@ -294,6 +363,111 @@ class WatcherEngineImpl implements WatcherEngine {
     }, this.stalenessIntervalMs);
 
     this.intervals.push(interval);
+  }
+
+  // ── Private: cron scheduler ─────────────────────────────
+
+  private startScheduler(): void {
+    const scheduleWatchers = this.registry
+      .getEnabled()
+      .filter((w) => w.trigger.type === "schedule");
+
+    if (scheduleWatchers.length === 0) return;
+
+    // Seed the next-due time for each schedule watcher from the current clock.
+    const now = this.clock();
+    let registered = 0;
+    for (const watcher of scheduleWatchers) {
+      const trigger = watcher.trigger;
+      if (trigger.type !== "schedule") continue;
+
+      const state = this.scheduleTracker.register({
+        watcherName: watcher.name,
+        cron: trigger.cron,
+        // Interpret cron expressions in UTC for deterministic, region-stable
+        // server-side scheduling (independent of the host's local timezone).
+        timezone: "UTC",
+        from: now,
+      });
+
+      if (state) {
+        registered += 1;
+      } else {
+        this.logger.warn?.(
+          `[WatcherEngine] Invalid cron "${trigger.cron}" for schedule watcher "${watcher.name}"`,
+        );
+      }
+    }
+
+    // All cron expressions failed to register — nothing to poll.
+    if (registered === 0) return;
+
+    const interval = setInterval(() => {
+      void this.runScheduleTick();
+    }, this.scheduleIntervalMs);
+
+    this.intervals.push(interval);
+  }
+
+  /**
+   * Evaluate one due occurrence of a schedule watcher. When the trigger carries
+   * a `condition.count`, the matching record count is compared against it and
+   * the effect only fires if the comparison holds. Without a condition, the
+   * effect fires on each due tick (Spec 45 §2.4).
+   */
+  private async evaluateScheduleWatcher(
+    watcher: WatcherDefinition,
+  ): Promise<WatcherEvaluationResult> {
+    const trigger = watcher.trigger;
+    if (trigger.type !== "schedule") {
+      return { watcherName: watcher.name, fired: false, reason: "wrong_trigger_type" };
+    }
+
+    const ctx: WatcherContext = { watcherName: watcher.name };
+
+    // Optional count condition: evaluate the matching-record count.
+    const countCondition = trigger.condition?.count;
+    if (countCondition) {
+      if (!this.dataQuerier) {
+        return {
+          watcherName: watcher.name,
+          fired: false,
+          reason: "no_data_querier_for_count_condition",
+        };
+      }
+
+      const records = await this.dataQuerier.queryRecords(watcher.watch.entity);
+      const watchFilter = watcher.watch.filter;
+      const matching = watchFilter
+        ? records.filter((r) =>
+            evaluateCondition(watchFilter, {
+              target: r,
+              context: {},
+              actor: { type: "system", id: "watcher", groups: [] },
+            }),
+          )
+        : records;
+
+      const count = matching.length;
+      if (!evaluateComparison(count, countCondition)) {
+        return { watcherName: watcher.name, fired: false, reason: "count_condition_not_met" };
+      }
+
+      ctx.records = matching;
+      ctx.count = count;
+      ctx.value = count;
+    }
+
+    // Schedule watchers fire per due occurrence; cron itself is the debounce.
+    const groupKey = "schedule";
+    if (!this.shouldFire(watcher, groupKey, true)) {
+      return { watcherName: watcher.name, fired: false, reason: "debounced" };
+    }
+
+    await this.fireEffect(watcher, ctx);
+    this.updateState(watcher.name, groupKey, true);
+
+    return { watcherName: watcher.name, fired: true };
   }
 
   // ── Private: evaluate a single watcher ──────────────────
@@ -661,7 +835,9 @@ class WatcherEngineImpl implements WatcherEngine {
         const cooldownMs = parseDuration(cooldownStr);
         if (cooldownMs === null) return true;
 
-        const elapsed = Date.now() - state.lastFiredAt.getTime();
+        // Use the injectable clock so cooldown is deterministic in tests and
+        // consistent with schedule evaluation.
+        const elapsed = this.clock().getTime() - state.lastFiredAt.getTime();
         return elapsed >= cooldownMs;
       }
 
@@ -675,7 +851,7 @@ class WatcherEngineImpl implements WatcherEngine {
     this.stateMap.set(stateKey, {
       watcherName,
       groupKey,
-      lastFiredAt: new Date(),
+      lastFiredAt: this.clock(),
       conditionMet,
     });
   }

--- a/addons/ai-provider/cap-ai-provider/src/watcher-schedule.ts
+++ b/addons/ai-provider/cap-ai-provider/src/watcher-schedule.ts
@@ -1,0 +1,119 @@
+/**
+ * Watcher schedule (cron) tracking — Spec 45 §2.4
+ *
+ * Implements the `schedule` trigger for the WatcherEngine. Each scheduled
+ * watcher owns a `croner` Cron instance used purely to *compute* the next run
+ * time relative to a supplied reference date — the Cron is constructed without
+ * a callback, so it never starts a real timer. The engine drives evaluation
+ * from an injectable clock (`now()`), which keeps tests deterministic and
+ * frees the scheduler from wall-clock flakiness.
+ *
+ * Verified croner@10.0.1 API (TS-native, zero runtime deps):
+ * - `new Cron(pattern, { timezone })` — no callback ⇒ no scheduled job/timer.
+ * - `cron.nextRun(prev?: Date | string | null): Date | null` — next run strictly
+ *   after `prev` (strips milliseconds). Returns null when the pattern can never
+ *   fire again.
+ */
+
+import { Cron } from "croner";
+
+// ── Per-watcher schedule state ─────────────────────────────
+
+export interface ScheduleState {
+  /** Watcher name (1:1 with a registered schedule watcher) */
+  watcherName: string;
+  /** Cron instance used only to compute next-run times (no live timer) */
+  cron: Cron;
+  /**
+   * The next scheduled fire time, or null if the cron can never fire again.
+   * Computed strictly after the most recent reference point so each cron
+   * occurrence is consumed exactly once.
+   */
+  nextDue: Date | null;
+}
+
+// ── Tracker ────────────────────────────────────────────────
+
+/**
+ * Tracks the next-due time for each scheduled watcher and reports which
+ * watchers are due as the clock advances. Pure bookkeeping — it does not fire
+ * effects itself; the engine consumes `collectDue()` results.
+ */
+export class ScheduleTracker {
+  private states = new Map<string, ScheduleState>();
+
+  /**
+   * Register (or re-register) a scheduled watcher. Seeds `nextDue` to the first
+   * cron occurrence strictly after `from`. Returns the created state, or null
+   * if the cron expression is invalid.
+   */
+  register(args: {
+    watcherName: string;
+    cron: string;
+    timezone?: string;
+    from: Date;
+  }): ScheduleState | null {
+    const { watcherName, cron, timezone, from } = args;
+    let cronInstance: Cron;
+    try {
+      // No callback ⇒ croner does not schedule a real timer (verified v10.0.1).
+      cronInstance = timezone ? new Cron(cron, { timezone }) : new Cron(cron);
+    } catch {
+      return null;
+    }
+
+    const state: ScheduleState = {
+      watcherName,
+      cron: cronInstance,
+      nextDue: cronInstance.nextRun(from),
+    };
+    this.states.set(watcherName, state);
+    return state;
+  }
+
+  /** Remove a watcher's schedule state. */
+  remove(watcherName: string): void {
+    this.states.delete(watcherName);
+  }
+
+  /** Clear all tracked schedules. */
+  clear(): void {
+    this.states.clear();
+  }
+
+  /** Inspect a watcher's current schedule state (for testing/debugging). */
+  get(watcherName: string): ScheduleState | undefined {
+    return this.states.get(watcherName);
+  }
+
+  /**
+   * Advance every tracked schedule up to `now` and return the watcher names
+   * that became due, in chronological order, one entry per crossed occurrence.
+   *
+   * If the clock jumps past several occurrences between ticks (e.g. the process
+   * was asleep, or a test fast-forwards the injected clock), each missed
+   * occurrence is emitted once — never coalesced and never skipped — so the
+   * effect fires the right number of times. A bounded guard prevents runaway
+   * loops on pathologically large jumps.
+   */
+  collectDue(now: Date, maxOccurrencesPerWatcher = 1000): string[] {
+    const due: string[] = [];
+
+    for (const state of this.states.values()) {
+      let guard = 0;
+      while (
+        state.nextDue !== null &&
+        state.nextDue.getTime() <= now.getTime() &&
+        guard < maxOccurrencesPerWatcher
+      ) {
+        due.push(state.watcherName);
+        // Advance strictly past the consumed occurrence so the same tick is
+        // never reported twice. croner's nextRun is exclusive of `prev`.
+        state.nextDue = state.cron.nextRun(state.nextDue);
+        guard += 1;
+      }
+    }
+
+    return due;
+  }
+}

--- a/addons/ai-provider/cap-ai-provider/src/watcher-schedule.ts
+++ b/addons/ai-provider/cap-ai-provider/src/watcher-schedule.ts
@@ -90,6 +90,10 @@ export class ScheduleTracker {
    * Advance every tracked schedule up to `now` and return the watcher names
    * that became due, in chronological order, one entry per crossed occurrence.
    *
+   * Due occurrences are collected with their fire time across ALL watchers, then
+   * sorted ascending by that time, so effect ordering reflects when each
+   * occurrence was due rather than the (arbitrary) watcher registration order.
+   *
    * If the clock jumps past several occurrences between ticks (e.g. the process
    * was asleep, or a test fast-forwards the injected clock), each missed
    * occurrence is emitted once — never coalesced and never skipped — so the
@@ -97,7 +101,7 @@ export class ScheduleTracker {
    * loops on pathologically large jumps.
    */
   collectDue(now: Date, maxOccurrencesPerWatcher = 1000): string[] {
-    const due: string[] = [];
+    const due: Array<{ watcherName: string; dueAt: Date }> = [];
 
     for (const state of this.states.values()) {
       let guard = 0;
@@ -106,7 +110,7 @@ export class ScheduleTracker {
         state.nextDue.getTime() <= now.getTime() &&
         guard < maxOccurrencesPerWatcher
       ) {
-        due.push(state.watcherName);
+        due.push({ watcherName: state.watcherName, dueAt: state.nextDue });
         // Advance strictly past the consumed occurrence so the same tick is
         // never reported twice. croner's nextRun is exclusive of `prev`.
         state.nextDue = state.cron.nextRun(state.nextDue);
@@ -114,6 +118,7 @@ export class ScheduleTracker {
       }
     }
 
-    return due;
+    due.sort((a, b) => a.dueAt.getTime() - b.dueAt.getTime());
+    return due.map(({ watcherName }) => watcherName);
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -180,6 +180,7 @@
         "@ai-sdk/anthropic": "^3.0.63",
         "@ai-sdk/openai": "^3.0.47",
         "ai": "^6.0.134",
+        "croner": "^10.0.1",
         "zod": "^4.3.6",
       },
       "devDependencies": {


### PR DESCRIPTION
## What

Gives watchers a real **time-based (cron) trigger** (Spec 45). Previously the
watcher engine evaluated on every poll; this adds deterministic cron-driven
scheduling.

- `ScheduleTracker` (croner) parses each watcher's cron expression and computes
  the next fire time in **UTC**.
- The engine learns when a scheduled tick is due via `runScheduleTick()` /
  `getNextScheduledRun()`, with an injectable `clock?: () => Date` so schedule
  logic is fully deterministic under test (no wall-clock dependency).
- Count-condition watchers resolve their threshold via `queryRecords`.

## Files

| File | Change |
|------|--------|
| `src/watcher-schedule.ts` | **new** — `ScheduleTracker`: cron parse + next-run computation |
| `src/watcher-engine.ts` | inject `clock` + `scheduleIntervalMs`; add `runScheduleTick()` / `getNextScheduledRun()` |
| `__tests__/watcher-schedule.test.ts` | **new** — tracker + engine tick tests |
| `package.json` / `bun.lock` | `croner ^10.0.1` (already an approved repo dep — core depends on it) |

## Testing

- `bun run check` (Biome 2.4.16) — clean
- `bun run typecheck` — exit 0
- Targeted `bun test addons/ai-provider/cap-ai-provider/` — **290 pass / 3 skip** (E2E, no API key) **/ 0 fail**
- Full `bun run test` runs in CI as the authoritative backstop.

## Note

`watcher-engine.ts` is now ~864 lines (over the 500-line guideline). The new
schedule logic itself lives in the separate `watcher-schedule.ts`; the engine
growth is integration glue. A follow-up to split `watcher-engine.ts` by
responsibility can be tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for schedule-based watchers using cron expressions to trigger actions at specified times.
  * New methods to query and execute scheduled watcher runs.

* **Tests**
  * Added comprehensive test suite for cron schedule trigger behavior, including edge cases and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->