### PR TITLE
feat(core): value-returning Interceptor extension seam + field-lock-check (Spec 63 Phase 3 PR-1)

### DIFF
--- a/packages/cli/__tests__/dev-wiring-overlay.test.ts
+++ b/packages/cli/__tests__/dev-wiring-overlay.test.ts
@@ -72,6 +72,7 @@ function buildInput(opts: { dataProvider?: InMemoryStore } = {}) {
     links: [],
     rules: [],
     middlewares: [],
+    interceptors: [],
     capabilities: [],
     sensors: [],
     dbInstance: undefined,

--- a/packages/cli/src/commands/dev-wiring.ts
+++ b/packages/cli/src/commands/dev-wiring.ts
@@ -18,6 +18,7 @@ import type {
   CapabilityDefinition,
   DataProvider,
   EntityDefinition,
+  InterceptorRegistration,
   LinchKitConfig,
   MiddlewareRegistration,
   RelationDefinition,
@@ -76,6 +77,7 @@ import {
   type OverlayRegistry,
   type PermissionRegistry,
 } from "@linchkit/core/server";
+import { buildInterceptorRegistry } from "./startup/build-interceptor-registry";
 
 // ── Input types ─────────────────────────────────────────────
 
@@ -99,6 +101,8 @@ export interface WireDevEnginesInput {
   links: RelationDefinition[];
   rules: RuleDefinition[];
   middlewares: MiddlewareRegistration[];
+  /** Interceptors collected from cap.extensions.interceptors (Spec 63 Phase 3) */
+  interceptors: InterceptorRegistration[];
   capabilities: CapabilityDefinition[];
 
   /** Sensors collected from cap.extensions.sensors (Spec 55 §3.3) */
@@ -137,6 +141,7 @@ export async function wireDevEngines(input: WireDevEnginesInput): Promise<WireDe
     links,
     rules,
     middlewares,
+    interceptors,
     capabilities,
     sensors,
     dbInstance,
@@ -223,6 +228,12 @@ export async function wireDevEngines(input: WireDevEnginesInput): Promise<WireDe
   // Build capability name set for ctx.hasCapability() weak dependency checks
   const capabilityNames = new Set(capabilities.map((c) => c.name));
 
+  // Interceptor registry — value-returning extension points (Spec 63 Phase 3).
+  // Built in a focused helper so the Action Engine can thread the field-lock
+  // violation set through policy capabilities. When no interceptors are
+  // registered, the engine's lock check behaves identically to Phase 1.
+  const interceptorRegistry = buildInterceptorRegistry(interceptors);
+
   const executor = createActionExecutor({
     dataProvider: overlayAwareDataProvider,
     transactionManager,
@@ -231,6 +242,7 @@ export async function wireDevEngines(input: WireDevEnginesInput): Promise<WireDe
     eventBus,
     capabilityNames,
     entityRegistry,
+    interceptorRegistry,
   });
   for (const action of actionRegistry.getAll()) {
     executor.registry.register(action);

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -143,7 +143,17 @@ export const devCommand = defineCommand({
 
     // ── Collect all definitions from capabilities ──
     const collected = collectCapabilityDefinitions(capabilities);
-    const { entities, actions, views, states, links, rules, middlewares, transports } = collected;
+    const {
+      entities,
+      actions,
+      views,
+      states,
+      links,
+      rules,
+      middlewares,
+      interceptors,
+      transports,
+    } = collected;
 
     consoleLogger.info(
       `Loaded ${capabilities.length} capabilities, ${entities.length} schemas, ${actions.length} actions`,
@@ -210,6 +220,7 @@ export const devCommand = defineCommand({
       links,
       rules,
       middlewares,
+      interceptors,
       capabilities,
       sensors: collected.sensors,
       dbInstance,

--- a/packages/cli/src/commands/startup/build-interceptor-registry.ts
+++ b/packages/cli/src/commands/startup/build-interceptor-registry.ts
@@ -1,0 +1,32 @@
+/**
+ * Build the runtime interceptor registry from collected capability
+ * registrations (Spec 63 Phase 3).
+ */
+
+import {
+  consoleLogger,
+  createInterceptorRegistry,
+  type InterceptorRegistration,
+  type InterceptorRegistry,
+} from "@linchkit/core/server";
+
+/**
+ * Create an {@link InterceptorRegistry} and register every collected
+ * interceptor. Logs a one-line summary when at least one is registered.
+ */
+export function buildInterceptorRegistry(
+  interceptors: InterceptorRegistration[] = [],
+): InterceptorRegistry {
+  const registry = createInterceptorRegistry({ logger: consoleLogger });
+  for (const reg of interceptors) {
+    registry.register(reg);
+  }
+  if (interceptors.length > 0) {
+    consoleLogger.info(
+      `Registered ${interceptors.length} interceptor(s): ${interceptors
+        .map((i) => `${i.capability}[${i.point}]`)
+        .join(", ")}`,
+    );
+  }
+  return registry;
+}

--- a/packages/cli/src/commands/startup/build-interceptor-registry.ts
+++ b/packages/cli/src/commands/startup/build-interceptor-registry.ts
@@ -24,7 +24,7 @@ export function buildInterceptorRegistry(
   if (interceptors.length > 0) {
     consoleLogger.info(
       `Registered ${interceptors.length} interceptor(s): ${interceptors
-        .map((i) => `${i.capability}[${i.point}]`)
+        .map((i) => `${i.capability || "unknown"}[${i.point}]`)
         .join(", ")}`,
     );
   }

--- a/packages/cli/src/commands/startup/collect-capabilities.ts
+++ b/packages/cli/src/commands/startup/collect-capabilities.ts
@@ -10,6 +10,7 @@ import type {
   EntityDefinition,
   EventHandlerDefinition,
   GraphQLExtensionRegistration,
+  InterceptorRegistration,
   InterfaceDefinition,
   MiddlewareRegistration,
   RelationDefinition,
@@ -31,6 +32,8 @@ export interface CollectedDefinitions {
   rules: RuleDefinition[];
   eventHandlers: EventHandlerDefinition[];
   middlewares: MiddlewareRegistration[];
+  /** Interceptors collected from `cap.extensions.interceptors` (Spec 63 Phase 3). */
+  interceptors: InterceptorRegistration[];
   transports: TransportAdapterDefinition[];
   graphqlExtensions: GraphQLExtensionRegistration[];
   commands: CliCommand[];
@@ -55,6 +58,7 @@ export function collectCapabilityDefinitions(
   const rules: RuleDefinition[] = [];
   const eventHandlers: EventHandlerDefinition[] = [];
   const middlewares: MiddlewareRegistration[] = [];
+  const interceptors: InterceptorRegistration[] = [];
   const transports: TransportAdapterDefinition[] = [];
   const graphqlExtensions: GraphQLExtensionRegistration[] = [];
   const commands: CliCommand[] = [];
@@ -77,6 +81,13 @@ export function collectCapabilityDefinitions(
           handler: mw.handler,
           order: mw.priority ?? (mw as MiddlewareRegistration).order,
         });
+      }
+    }
+    if (cap.extensions?.interceptors) {
+      for (const reg of cap.extensions.interceptors) {
+        // Default the owning capability name when a registration omits it,
+        // so fail-closed diagnostics always identify the source capability.
+        interceptors.push({ ...reg, capability: reg.capability || cap.name });
       }
     }
     if (cap.extensions?.transports) transports.push(...cap.extensions.transports);
@@ -104,6 +115,7 @@ export function collectCapabilityDefinitions(
     rules,
     eventHandlers,
     middlewares,
+    interceptors,
     transports,
     graphqlExtensions,
     commands,

--- a/packages/core/__tests__/barrel-public-surface.test.ts
+++ b/packages/core/__tests__/barrel-public-surface.test.ts
@@ -300,6 +300,7 @@ const EXPECTED_SERVER_EXPORTS = [
   "createFlowRegistry",
   "createFlowStepContext",
   "createGeneratorPriorityAggregator",
+  "createInterceptorRegistry",
   "createInterfaceRegistry",
   "createMigrationCoordinator",
   "createNoopAIService",

--- a/packages/core/__tests__/interceptors.test.ts
+++ b/packages/core/__tests__/interceptors.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Spec 63 Phase 3 — Interceptor registry + Action Engine integration tests.
+ *
+ * Covers:
+ *  - identity (empty registry → value unchanged)
+ *  - single-handler transforms
+ *  - ascending-order chaining (each handler's output feeds the next)
+ *  - fail-closed: a throwing handler keeps its INPUT and continues
+ *  - fail-closed: a handler returning null/undefined keeps its INPUT
+ *  - end-to-end via createActionExecutor: a `field-lock-check` interceptor that
+ *    returns `[]` lets a normally-locked update succeed; a passthrough one
+ *    still raises a LockViolationError.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { createActionExecutor } from "../src/engine/action-engine";
+import type { FieldLockViolation } from "../src/engine/field-lock-checker";
+import { createInterceptorRegistry, type FieldLockCheckContext } from "../src/engine/interceptors";
+import { createEntityRegistry } from "../src/entity/entity-registry";
+import type { ActionDefinition, Actor } from "../src/types/action";
+import type { EntityDefinition } from "../src/types/entity";
+import type { Logger } from "../src/types/logger";
+import { createMemoryDataProvider, lockActor } from "./field-lock-helpers";
+
+// ── Fixtures ───────────────────────────────────────────────
+
+const ctx: FieldLockCheckContext = {
+  entity: "doc",
+  actor: { type: "human", id: "u-1", groups: [] } as Actor,
+  record: {},
+  input: {},
+};
+
+function violation(field: string): FieldLockViolation {
+  return { field, type: "immutable", message: `Field "${field}" is immutable` };
+}
+
+/** Logger spy that records every error call. */
+function createSpyLogger(): { logger: Logger; errors: string[] } {
+  const errors: string[] = [];
+  const noop = () => {};
+  return {
+    errors,
+    logger: {
+      debug: noop,
+      info: noop,
+      warn: noop,
+      error: (message: string) => {
+        errors.push(message);
+      },
+    },
+  };
+}
+
+// ── Unit: identity ─────────────────────────────────────────
+
+describe("InterceptorRegistry — identity", () => {
+  it("returns the value unchanged when no interceptor is registered", async () => {
+    const registry = createInterceptorRegistry();
+    const input = [violation("code"), violation("sku")];
+    const out = await registry.run("field-lock-check", input, ctx);
+    expect(out).toBe(input);
+    expect(registry.has("field-lock-check")).toBe(false);
+  });
+});
+
+// ── Unit: single handler ───────────────────────────────────
+
+describe("InterceptorRegistry — single handler", () => {
+  it("a handler returning [] empties the violation set", async () => {
+    const registry = createInterceptorRegistry();
+    registry.register({
+      point: "field-lock-check",
+      capability: "cap-lock",
+      handler: () => [],
+    });
+    expect(registry.has("field-lock-check")).toBe(true);
+    const out = await registry.run("field-lock-check", [violation("code")], ctx);
+    expect(out).toEqual([]);
+  });
+
+  it("a handler returning a subset keeps that subset", async () => {
+    const registry = createInterceptorRegistry();
+    registry.register({
+      point: "field-lock-check",
+      capability: "cap-lock",
+      handler: (v) => v.filter((x) => x.field !== "code"),
+    });
+    const out = await registry.run("field-lock-check", [violation("code"), violation("sku")], ctx);
+    expect(out).toEqual([violation("sku")]);
+  });
+});
+
+// ── Unit: ascending-order chaining ─────────────────────────
+
+describe("InterceptorRegistry — chaining", () => {
+  it("runs in ascending order, threading each output into the next", async () => {
+    const registry = createInterceptorRegistry();
+    const calls: string[] = [];
+
+    // Registered out of order; B has higher `order` so must run after A.
+    registry.register({
+      point: "field-lock-check",
+      capability: "cap-b",
+      order: 200,
+      handler: (v) => {
+        calls.push("B");
+        // B should see A's output (X already dropped).
+        expect(v.some((x) => x.field === "X")).toBe(false);
+        return v.filter((x) => x.field !== "Y");
+      },
+    });
+    registry.register({
+      point: "field-lock-check",
+      capability: "cap-a",
+      order: 100,
+      handler: (v) => {
+        calls.push("A");
+        return v.filter((x) => x.field !== "X");
+      },
+    });
+
+    const out = await registry.run(
+      "field-lock-check",
+      [violation("X"), violation("Y"), violation("Z")],
+      ctx,
+    );
+
+    expect(calls).toEqual(["A", "B"]);
+    expect(out).toEqual([violation("Z")]);
+  });
+});
+
+// ── Unit: fail-closed (throw) ──────────────────────────────
+
+describe("InterceptorRegistry — fail-closed on throw", () => {
+  it("keeps the throwing handler's input, logs, and continues the chain", async () => {
+    const { logger, errors } = createSpyLogger();
+    const registry = createInterceptorRegistry({ logger });
+    const calls: string[] = [];
+
+    registry.register({
+      point: "field-lock-check",
+      capability: "cap-broken",
+      order: 100,
+      handler: () => {
+        calls.push("broken");
+        throw new Error("boom");
+      },
+    });
+    registry.register({
+      point: "field-lock-check",
+      capability: "cap-after",
+      order: 200,
+      handler: (v) => {
+        calls.push("after");
+        // The broken handler's input must have survived untouched.
+        expect(v).toEqual([violation("code")]);
+        return [];
+      },
+    });
+
+    const out = await registry.run("field-lock-check", [violation("code")], ctx);
+
+    expect(calls).toEqual(["broken", "after"]);
+    expect(out).toEqual([]);
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain("cap-broken");
+    expect(errors[0]).toContain("field-lock-check");
+  });
+});
+
+// ── Unit: fail-closed (null/undefined) ─────────────────────
+
+describe("InterceptorRegistry — fail-closed on null/undefined", () => {
+  it("keeps the input when a handler returns null", async () => {
+    const { logger, errors } = createSpyLogger();
+    const registry = createInterceptorRegistry({ logger });
+    registry.register({
+      point: "field-lock-check",
+      capability: "cap-null",
+      // Deliberately violate the contract to exercise the fail-closed path.
+      handler: (() => null) as unknown as () => FieldLockViolation[],
+    });
+    const input = [violation("code")];
+    const out = await registry.run("field-lock-check", input, ctx);
+    expect(out).toEqual(input);
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain("cap-null");
+  });
+
+  it("keeps the input when a handler returns undefined", async () => {
+    const { logger, errors } = createSpyLogger();
+    const registry = createInterceptorRegistry({ logger });
+    registry.register({
+      point: "field-lock-check",
+      capability: "cap-undef",
+      handler: (() => undefined) as unknown as () => FieldLockViolation[],
+    });
+    const input = [violation("sku")];
+    const out = await registry.run("field-lock-check", input, ctx);
+    expect(out).toEqual(input);
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain("cap-undef");
+  });
+});
+
+// ── Integration via createActionExecutor ───────────────────
+
+const lockedEntity: EntityDefinition = {
+  name: "invoice",
+  fields: {
+    code: { type: "string", immutable: true },
+    title: { type: "string" },
+  },
+};
+
+const updateAction: ActionDefinition = {
+  name: "update_record",
+  entity: "invoice",
+  label: "Update",
+  input: { id: { type: "string", required: true } },
+  policy: { mode: "sync", transaction: false },
+  handler: async (handlerCtx) => {
+    const id = handlerCtx.input.id as string;
+    const { id: _id, ...rest } = handlerCtx.input as Record<string, unknown>;
+    return handlerCtx.update("invoice", id, rest);
+  },
+};
+
+describe("Spec 63 Phase 3 — Action Engine integration", () => {
+  it("a field-lock-check interceptor returning [] lets a locked update succeed", async () => {
+    const entityRegistry = createEntityRegistry();
+    entityRegistry.register(lockedEntity);
+    const dataProvider = createMemoryDataProvider();
+
+    let sawContext: FieldLockCheckContext | undefined;
+    const interceptorRegistry = createInterceptorRegistry();
+    interceptorRegistry.register({
+      point: "field-lock-check",
+      capability: "cap-lock-bypass",
+      handler: (_violations, c) => {
+        sawContext = c;
+        return [];
+      },
+    });
+
+    const executor = createActionExecutor({ dataProvider, entityRegistry, interceptorRegistry });
+    executor.registry.register(updateAction);
+
+    await dataProvider.create("invoice", { id: "inv-1", code: "OLD", title: "T" });
+
+    const result = await executor.execute("update_record", { id: "inv-1", code: "NEW" }, lockActor);
+
+    expect(result.success).toBe(true);
+    const record = await dataProvider.get("invoice", "inv-1");
+    expect(record.code).toBe("NEW");
+
+    // The interceptor received the full enforcement context.
+    expect(sawContext?.entity).toBe("invoice");
+    expect(sawContext?.actor.id).toBe(lockActor.id);
+    expect(sawContext?.record.code).toBe("OLD");
+    expect(sawContext?.input.code).toBe("NEW");
+  });
+
+  it("a passthrough interceptor still raises a LockViolationError", async () => {
+    const entityRegistry = createEntityRegistry();
+    entityRegistry.register(lockedEntity);
+    const dataProvider = createMemoryDataProvider();
+
+    const interceptorRegistry = createInterceptorRegistry();
+    interceptorRegistry.register({
+      point: "field-lock-check",
+      capability: "cap-passthrough",
+      handler: (v) => v,
+    });
+
+    const executor = createActionExecutor({ dataProvider, entityRegistry, interceptorRegistry });
+    executor.registry.register(updateAction);
+
+    await dataProvider.create("invoice", { id: "inv-2", code: "OLD", title: "T" });
+
+    const result = await executor.execute("update_record", { id: "inv-2", code: "NEW" }, lockActor);
+
+    expect(result.success).toBe(false);
+    const data = result.data as Record<string, unknown>;
+    expect(data.code).toBe("validation.field.immutable");
+    // Record must NOT have mutated.
+    const record = await dataProvider.get("invoice", "inv-2");
+    expect(record.code).toBe("OLD");
+  });
+
+  it("with no interceptor registry, the lock check is identical to Phase 1", async () => {
+    const entityRegistry = createEntityRegistry();
+    entityRegistry.register(lockedEntity);
+    const dataProvider = createMemoryDataProvider();
+
+    const executor = createActionExecutor({ dataProvider, entityRegistry });
+    executor.registry.register(updateAction);
+
+    await dataProvider.create("invoice", { id: "inv-3", code: "OLD", title: "T" });
+
+    const result = await executor.execute("update_record", { id: "inv-3", code: "NEW" }, lockActor);
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/core/__tests__/interceptors.test.ts
+++ b/packages/core/__tests__/interceptors.test.ts
@@ -233,6 +233,35 @@ describe("InterceptorRegistry — fail-closed integrity", () => {
     expect(errors[0]).toContain("cap-evil");
   });
 
+  it("a handler that mutates a violation property in place then throws cannot weaken the set", async () => {
+    const { logger, errors } = createSpyLogger();
+    const registry = createInterceptorRegistry({ logger });
+    registry.register({
+      point: "field-lock-check",
+      capability: "cap-evil-element",
+      handler: (v) => {
+        // Hostile: rewrite the ENTRY in place (not the array container) so the
+        // violation appears to target an allowed field, THEN crash. The deep
+        // clone (array + elements) means the handler only ever touches its own
+        // copy — the authoritative element must remain `amount`/`immutable`.
+        const first = v[0];
+        if (first) {
+          first.field = "allowed";
+          first.type = "lockWhen";
+          first.message = "tampered";
+        }
+        throw new Error("boom");
+      },
+    });
+    const input = [violation("amount")];
+    const out = await registry.run("field-lock-check", input, ctx);
+    expect(out).toEqual([violation("amount")]);
+    // The caller's array AND its element must be untouched (handler got a deep clone).
+    expect(input).toEqual([violation("amount")]);
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain("cap-evil-element");
+  });
+
   it("a handler that empties the array in place then returns null cannot weaken the set", async () => {
     const { logger, errors } = createSpyLogger();
     const registry = createInterceptorRegistry({ logger });

--- a/packages/core/__tests__/interceptors.test.ts
+++ b/packages/core/__tests__/interceptors.test.ts
@@ -7,6 +7,8 @@
  *  - ascending-order chaining (each handler's output feeds the next)
  *  - fail-closed: a throwing handler keeps its INPUT and continues
  *  - fail-closed: a handler returning null/undefined keeps its INPUT
+ *  - fail-closed integrity: in-place mutation then throw/null, and non-array
+ *    returns, cannot weaken the violation set (handlers get a defensive clone)
  *  - end-to-end via createActionExecutor: a `field-lock-check` interceptor that
  *    returns `[]` lets a normally-locked update succeed; a passthrough one
  *    still raises a LockViolationError.
@@ -202,6 +204,66 @@ describe("InterceptorRegistry — fail-closed on null/undefined", () => {
     expect(out).toEqual(input);
     expect(errors.length).toBe(1);
     expect(errors[0]).toContain("cap-undef");
+  });
+});
+
+// ── Unit: fail-closed integrity (in-place mutation / invalid return) ──
+
+describe("InterceptorRegistry — fail-closed integrity", () => {
+  it("a handler that empties the array in place then throws cannot weaken the set", async () => {
+    const { logger, errors } = createSpyLogger();
+    const registry = createInterceptorRegistry({ logger });
+    registry.register({
+      point: "field-lock-check",
+      capability: "cap-evil",
+      handler: (v) => {
+        // Hostile: strip every violation in place, THEN crash. Fail-closed
+        // must restore the original (non-empty) set — the handler only ever
+        // sees a defensive clone, so the authoritative value is untouched.
+        v.length = 0;
+        throw new Error("boom");
+      },
+    });
+    const input = [violation("amount")];
+    const out = await registry.run("field-lock-check", input, ctx);
+    expect(out).toEqual([violation("amount")]);
+    // The caller's array must also be untouched (handler got a clone).
+    expect(input).toEqual([violation("amount")]);
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain("cap-evil");
+  });
+
+  it("a handler that empties the array in place then returns null cannot weaken the set", async () => {
+    const { logger, errors } = createSpyLogger();
+    const registry = createInterceptorRegistry({ logger });
+    registry.register({
+      point: "field-lock-check",
+      capability: "cap-evil-null",
+      handler: ((v: FieldLockViolation[]) => {
+        v.length = 0;
+        return null;
+      }) as unknown as () => FieldLockViolation[],
+    });
+    const input = [violation("amount")];
+    const out = await registry.run("field-lock-check", input, ctx);
+    expect(out).toEqual([violation("amount")]);
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain("cap-evil-null");
+  });
+
+  it("a handler returning a non-array value is rejected (fail-closed)", async () => {
+    const { logger, errors } = createSpyLogger();
+    const registry = createInterceptorRegistry({ logger });
+    registry.register({
+      point: "field-lock-check",
+      capability: "cap-bad-type",
+      handler: (() => "not-an-array") as unknown as () => FieldLockViolation[],
+    });
+    const input = [violation("amount")];
+    const out = await registry.run("field-lock-check", input, ctx);
+    expect(out).toEqual(input);
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain("cap-bad-type");
   });
 });
 

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -16,7 +16,7 @@ import { getCurrentTrace } from "../observability/trace-context";
 import { createTenantAwareDataProvider } from "../security/tenant-isolation";
 import type { ActionContext, ActionResult, Actor } from "../types/action";
 import type { AIService } from "../types/ai";
-import type { FieldDefinition } from "../types/entity";
+import type { FieldDefinition, LockCondition } from "../types/entity";
 import type { ExecutionLogEntry, ExecutionLogger } from "../types/execution-log";
 import type { ExecutionMeta } from "../types/execution-meta";
 import {
@@ -286,6 +286,60 @@ function fillMissingSystemKeys(
   }
   if (Object.keys(missing).length === 0) return meta;
   return extendExecutionMeta(meta, {}, missing);
+}
+
+/**
+ * Run the field-lock check and thread the resulting violations through the
+ * `field-lock-check` interceptor point (Spec 63 Phase 3), returning the
+ * (possibly transformed) violation set.
+ *
+ * Both update paths — the `ctx.update()` handler wrapper and the declarative
+ * `setFields` / `stateTransition` path — share this exact sequence; extracting
+ * it keeps them byte-for-byte identical. The interceptor step is an identity
+ * when no `field-lock-check` interceptor is registered, so behavior is
+ * unchanged from Phase 1 in that case.
+ */
+async function checkAndRunFieldLockInterceptor(opts: {
+  entity: string;
+  fields: Record<string, FieldDefinition>;
+  lockAllWhen: LockCondition | undefined;
+  lockAllowFields: string[] | undefined;
+  existingRecord: Record<string, unknown>;
+  writesToCheck: Record<string, unknown>;
+  actor: Actor;
+  tenantId?: string;
+  interceptorRegistry?: InterceptorRegistry;
+}): Promise<FieldLockViolation[]> {
+  const {
+    entity,
+    fields,
+    lockAllWhen,
+    lockAllowFields,
+    existingRecord,
+    writesToCheck,
+    actor,
+    tenantId,
+    interceptorRegistry,
+  } = opts;
+  let violations = checkFieldLocks({
+    fields,
+    lockAllWhen,
+    lockAllowFields,
+    existingRecord,
+    input: writesToCheck,
+  });
+  // Spec 63 Phase 3: let a policy capability transform the violation set
+  // (shadow / bypass / tolerance). Identity when no interceptor is registered.
+  if (interceptorRegistry?.has("field-lock-check")) {
+    violations = await interceptorRegistry.run("field-lock-check", violations, {
+      entity,
+      actor,
+      record: existingRecord,
+      input: writesToCheck,
+      tenantId,
+    });
+  }
+  return violations;
 }
 
 /**
@@ -1092,25 +1146,17 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
               }
               const writesToCheck: Record<string, unknown> = { ...data };
               delete writesToCheck.id;
-              let violations = checkFieldLocks({
+              const violations = await checkAndRunFieldLockInterceptor({
+                entity,
                 fields: targetFields,
                 lockAllWhen: targetLockAllWhen,
                 lockAllowFields: targetLockAllowFields,
                 existingRecord: current,
-                input: writesToCheck,
+                writesToCheck,
+                actor,
+                tenantId: execOptions?.tenantId,
+                interceptorRegistry,
               });
-              // Spec 63 Phase 3: let a policy capability transform the
-              // violation set (shadow / bypass / tolerance). Identity when
-              // no interceptor is registered.
-              if (interceptorRegistry?.has("field-lock-check")) {
-                violations = await interceptorRegistry.run("field-lock-check", violations, {
-                  entity,
-                  actor,
-                  record: current,
-                  input: writesToCheck,
-                  tenantId: execOptions?.tenantId,
-                });
-              }
               if (violations.length > 0) {
                 throw new LockViolationError(violations, entity);
               }
@@ -1425,25 +1471,17 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
                 }
                 const writesToCheck: Record<string, unknown> = { ...updates };
                 delete writesToCheck.id;
-                let violations = checkFieldLocks({
+                const violations = await checkAndRunFieldLockInterceptor({
+                  entity: action.entity,
                   fields: resolvedFields,
                   lockAllWhen,
                   lockAllowFields,
                   existingRecord: txCurrent,
-                  input: writesToCheck,
+                  writesToCheck,
+                  actor,
+                  tenantId: execOptions?.tenantId,
+                  interceptorRegistry,
                 });
-                // Spec 63 Phase 3: let a policy capability transform the
-                // violation set (shadow / bypass / tolerance). Identity when
-                // no interceptor is registered.
-                if (interceptorRegistry?.has("field-lock-check")) {
-                  violations = await interceptorRegistry.run("field-lock-check", violations, {
-                    entity: action.entity,
-                    actor,
-                    record: txCurrent,
-                    input: writesToCheck,
-                    tenantId: execOptions?.tenantId,
-                  });
-                }
                 if (violations.length > 0) {
                   throw new LockViolationError(violations, action.entity);
                 }

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -33,6 +33,7 @@ import {
   LockPreflightError,
   LockViolationError,
 } from "./field-lock-checker";
+import type { InterceptorRegistry } from "./interceptors";
 import type { StateMachine } from "./state-machine";
 import { canTransition, getAvailableActions } from "./state-machine";
 
@@ -239,6 +240,15 @@ export interface ActionExecutorOptions {
    * can omit this; production wiring (Runtime) always supplies it.
    */
   entityRegistry?: EntityRegistry;
+  /**
+   * Interceptor registry for value-returning core extension points (Spec 63
+   * Phase 3). Currently wires the `field-lock-check` point: a policy
+   * capability can transform the field-lock violation set (shadow / bypass /
+   * tolerance) before the engine throws. When omitted — or when no
+   * `field-lock-check` interceptor is registered — the lock check behaves
+   * byte-for-byte as Phase 1 (the registry's `run` is an identity).
+   */
+  interceptorRegistry?: InterceptorRegistry;
 }
 
 /**
@@ -306,6 +316,7 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
     eventBus,
     capabilityNames = new Set<string>(),
     entityRegistry,
+    interceptorRegistry,
   } = options;
 
   /** Silent noop logger — used when no logger is injected */
@@ -1081,13 +1092,25 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
               }
               const writesToCheck: Record<string, unknown> = { ...data };
               delete writesToCheck.id;
-              const violations = checkFieldLocks({
+              let violations = checkFieldLocks({
                 fields: targetFields,
                 lockAllWhen: targetLockAllWhen,
                 lockAllowFields: targetLockAllowFields,
                 existingRecord: current,
                 input: writesToCheck,
               });
+              // Spec 63 Phase 3: let a policy capability transform the
+              // violation set (shadow / bypass / tolerance). Identity when
+              // no interceptor is registered.
+              if (interceptorRegistry?.has("field-lock-check")) {
+                violations = await interceptorRegistry.run("field-lock-check", violations, {
+                  entity,
+                  actor,
+                  record: current,
+                  input: writesToCheck,
+                  tenantId: execOptions?.tenantId,
+                });
+              }
               if (violations.length > 0) {
                 throw new LockViolationError(violations, entity);
               }
@@ -1402,13 +1425,25 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
                 }
                 const writesToCheck: Record<string, unknown> = { ...updates };
                 delete writesToCheck.id;
-                const violations = checkFieldLocks({
+                let violations = checkFieldLocks({
                   fields: resolvedFields,
                   lockAllWhen,
                   lockAllowFields,
                   existingRecord: txCurrent,
                   input: writesToCheck,
                 });
+                // Spec 63 Phase 3: let a policy capability transform the
+                // violation set (shadow / bypass / tolerance). Identity when
+                // no interceptor is registered.
+                if (interceptorRegistry?.has("field-lock-check")) {
+                  violations = await interceptorRegistry.run("field-lock-check", violations, {
+                    entity: action.entity,
+                    actor,
+                    record: txCurrent,
+                    input: writesToCheck,
+                    tenantId: execOptions?.tenantId,
+                  });
+                }
                 if (violations.length > 0) {
                   throw new LockViolationError(violations, action.entity);
                 }

--- a/packages/core/src/engine/interceptors.ts
+++ b/packages/core/src/engine/interceptors.ts
@@ -143,16 +143,26 @@ class DefaultInterceptorRegistry implements InterceptorRegistry {
     let current: unknown = value;
     for (const reg of list) {
       // FAIL-CLOSED (security). field-lock-check is an ENFORCEMENT boundary:
-      // a buggy policy capability must NEVER silently WEAKEN it. If a handler
-      // throws OR returns null/undefined, we do NOT propagate the throw and
-      // do NOT drop the value — we keep this handler's INPUT (the stricter,
-      // pre-handler set) and continue the chain. Logged for visibility.
+      // a buggy or hostile policy capability must NEVER silently WEAKEN it.
+      // Handlers transform by RETURNING a value and must treat the argument as
+      // immutable. We hand each handler a defensive shallow clone of array
+      // values, so a handler that mutates its argument in place and THEN
+      // throws / returns null/undefined cannot strip violations out from under
+      // us — on any failure the authoritative `current` is left exactly as it
+      // was. A non-array return where an array was expected is likewise treated
+      // as a failure, so an invalid handler cannot corrupt the engine's
+      // downstream view of the value. Failures are logged for visibility.
+      const handlerInput = Array.isArray(current) ? [...current] : current;
       try {
         const handler = reg.handler as Interceptor<unknown, unknown>;
-        const next = await handler(current, context);
-        if (next === null || next === undefined) {
+        const next = await handler(handlerInput, context);
+        if (
+          next === null ||
+          next === undefined ||
+          (Array.isArray(current) && !Array.isArray(next))
+        ) {
           this.logger?.error(
-            `Interceptor "${reg.capability}" at point "${point}" returned ${String(next)}; keeping pre-handler value (fail-closed)`,
+            `Interceptor "${reg.capability}" at point "${point}" returned an invalid value (${next === null ? "null" : typeof next}); keeping pre-handler value (fail-closed)`,
             { capability: reg.capability, point },
           );
           continue;

--- a/packages/core/src/engine/interceptors.ts
+++ b/packages/core/src/engine/interceptors.ts
@@ -1,0 +1,185 @@
+/**
+ * Interceptors (Spec 63 Phase 3).
+ *
+ * A strongly-typed, chainable, **value-returning** capability → core
+ * extension mechanism. Unlike the `hooks` extension point (void, fire-and-
+ * forget event reactions) and unlike CommandLayer middlewares (request/response
+ * pipeline around an action), an Interceptor TRANSFORMS a specific in-flight
+ * value at a named extension point inside a core engine and returns the
+ * (possibly modified) value, which is threaded into the next interceptor.
+ *
+ * The set of extension points and their value/context types is the single
+ * source of truth {@link InterceptorCatalog}. Adding a new point = adding one
+ * entry there; the generic registry and `run<P>` typing follow automatically.
+ *
+ * Phase 3 PR-1 ships exactly one point: `field-lock-check`. The Action Engine
+ * runs the field-lock violation set through it before throwing, so a policy
+ * capability (e.g. cap-lock) can shadow / bypass / apply tolerance to
+ * violations. When NO interceptor is registered, behavior is byte-for-byte
+ * identical to Phase 1 (the registry's `run` is an identity).
+ */
+
+import type { Actor } from "../types/action";
+import type { Logger } from "../types/logger";
+import type { FieldLockViolation } from "./field-lock-checker";
+
+/**
+ * Context passed to a `field-lock-check` interceptor. Read-only inputs that
+ * describe the in-flight update; the interceptor transforms the violation
+ * VALUE (first argument of {@link Interceptor}), not this context.
+ */
+export interface FieldLockCheckContext {
+  /** Entity name whose field locks are being evaluated. */
+  entity: string;
+  /** Actor performing the write. */
+  actor: Actor;
+  /** Existing persisted record (carries `created_at`, `status`, etc.). */
+  record: Record<string, unknown>;
+  /** The attempted write set (after system-field/status stripping). */
+  input: Record<string, unknown>;
+  /** Tenant scope of the write, when known. */
+  tenantId?: string;
+}
+
+/**
+ * A value-returning extension function. Receives the current `value` plus a
+ * point-specific `context`, returns the (possibly transformed) value. May be
+ * sync or async.
+ */
+export type Interceptor<In, Ctx, Out = In> = (value: In, context: Ctx) => Out | Promise<Out>;
+
+/**
+ * Single source of truth mapping each interceptor point name to its
+ * `Interceptor<value, context>` signature. Adding a point here makes it
+ * available end-to-end with full typing (registration, `run`, capability
+ * declaration).
+ */
+export interface InterceptorCatalog {
+  "field-lock-check": Interceptor<FieldLockViolation[], FieldLockCheckContext>;
+}
+
+/** Valid interceptor point names (keys of {@link InterceptorCatalog}). */
+export type InterceptorPoint = keyof InterceptorCatalog;
+
+/**
+ * Registration record for one interceptor at one point. Declared by a
+ * capability via `extensions.interceptors`, collected at startup, and
+ * registered into the {@link InterceptorRegistry}.
+ */
+export interface InterceptorRegistration<P extends InterceptorPoint = InterceptorPoint> {
+  /** Which extension point this interceptor attaches to. */
+  point: P;
+  /** Owning capability name (for diagnostics / fail-closed logging). */
+  capability: string;
+  /** Ascending execution order within the point. Defaults to 100. */
+  order?: number;
+  /** The transform function — typed by {@link InterceptorCatalog}[P]. */
+  handler: InterceptorCatalog[P];
+}
+
+/** Registry of interceptors grouped by point, executed in `order` ascending. */
+export interface InterceptorRegistry {
+  /** Register an interceptor; keeps each point sorted by `order` (stable). */
+  register<P extends InterceptorPoint>(reg: InterceptorRegistration<P>): void;
+  /** True iff at least one interceptor is registered for `point`. */
+  has(point: InterceptorPoint): boolean;
+  /**
+   * Thread `value` through every interceptor at `point` in ascending `order`,
+   * each handler's output feeding the next, and return the final value. With
+   * no registrations, returns `value` unchanged (identity).
+   */
+  run<P extends InterceptorPoint>(
+    point: P,
+    value: Parameters<InterceptorCatalog[P]>[0],
+    context: Parameters<InterceptorCatalog[P]>[1],
+  ): Promise<Awaited<ReturnType<InterceptorCatalog[P]>>>;
+}
+
+/** Default execution order when a registration omits `order`. */
+const DEFAULT_ORDER = 100;
+
+/**
+ * Default {@link InterceptorRegistry} implementation. A class keeps the
+ * generic `run<P>` method on the prototype and the per-point registration
+ * groups as private state.
+ */
+class DefaultInterceptorRegistry implements InterceptorRegistry {
+  private readonly logger?: Logger;
+
+  // Registrations grouped by point. Each group is kept sorted by `order`
+  // ascending; ties preserve insertion order (stable sort).
+  private readonly groups = new Map<InterceptorPoint, InterceptorRegistration[]>();
+
+  constructor(logger?: Logger) {
+    this.logger = logger;
+  }
+
+  register<P extends InterceptorPoint>(reg: InterceptorRegistration<P>): void {
+    const list = this.groups.get(reg.point) ?? [];
+    list.push(reg as InterceptorRegistration);
+    // Stable sort by order — Array.prototype.sort is stable in modern engines,
+    // so equal `order` values retain insertion order.
+    list.sort((a, b) => (a.order ?? DEFAULT_ORDER) - (b.order ?? DEFAULT_ORDER));
+    this.groups.set(reg.point, list);
+  }
+
+  has(point: InterceptorPoint): boolean {
+    const list = this.groups.get(point);
+    return list !== undefined && list.length > 0;
+  }
+
+  async run<P extends InterceptorPoint>(
+    point: P,
+    value: Parameters<InterceptorCatalog[P]>[0],
+    context: Parameters<InterceptorCatalog[P]>[1],
+  ): Promise<Awaited<ReturnType<InterceptorCatalog[P]>>> {
+    type Out = Awaited<ReturnType<InterceptorCatalog[P]>>;
+    const list = this.groups.get(point);
+    // Identity fast-path: no registrations → return the value unchanged.
+    if (!list || list.length === 0) {
+      return value as unknown as Out;
+    }
+
+    let current: unknown = value;
+    for (const reg of list) {
+      // FAIL-CLOSED (security). field-lock-check is an ENFORCEMENT boundary:
+      // a buggy policy capability must NEVER silently WEAKEN it. If a handler
+      // throws OR returns null/undefined, we do NOT propagate the throw and
+      // do NOT drop the value — we keep this handler's INPUT (the stricter,
+      // pre-handler set) and continue the chain. Logged for visibility.
+      try {
+        const handler = reg.handler as Interceptor<unknown, unknown>;
+        const next = await handler(current, context);
+        if (next === null || next === undefined) {
+          this.logger?.error(
+            `Interceptor "${reg.capability}" at point "${point}" returned ${String(next)}; keeping pre-handler value (fail-closed)`,
+            { capability: reg.capability, point },
+          );
+          continue;
+        }
+        current = next;
+      } catch (err) {
+        this.logger?.error(
+          `Interceptor "${reg.capability}" at point "${point}" threw; keeping pre-handler value (fail-closed)`,
+          {
+            capability: reg.capability,
+            point,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        );
+      }
+    }
+
+    return current as Out;
+  }
+}
+
+/**
+ * Create an {@link InterceptorRegistry}.
+ *
+ * @param opts.logger - Optional structured logger; receives fail-closed
+ *   diagnostics. When omitted, fail-closed events are silent.
+ */
+export function createInterceptorRegistry(opts?: { logger?: Logger }): InterceptorRegistry {
+  return new DefaultInterceptorRegistry(opts?.logger);
+}

--- a/packages/core/src/engine/interceptors.ts
+++ b/packages/core/src/engine/interceptors.ts
@@ -70,7 +70,7 @@ export interface InterceptorRegistration<P extends InterceptorPoint = Intercepto
   /** Which extension point this interceptor attaches to. */
   point: P;
   /** Owning capability name (for diagnostics / fail-closed logging). */
-  capability: string;
+  capability?: string;
   /** Ascending execution order within the point. Defaults to 100. */
   order?: number;
   /** The transform function — typed by {@link InterceptorCatalog}[P]. */
@@ -97,6 +97,30 @@ export interface InterceptorRegistry {
 
 /** Default execution order when a registration omits `order`. */
 const DEFAULT_ORDER = 100;
+
+/**
+ * Produce a defensive clone of an interceptor's input value before handing it
+ * to a handler. Handlers transform by RETURNING a value and must treat the
+ * argument as immutable; cloning enforces that contract so a handler cannot
+ * reach back into the authoritative value and mutate it in place.
+ *
+ * For `field-lock-check` the value is a `FieldLockViolation[]` — an ENFORCEMENT
+ * set — so we deep-clone BOTH the array container AND each element. A shallow
+ * `[...value]` would still share the individual violation OBJECTS, letting a
+ * buggy or hostile handler do `violations[0].field = "allowed"` and then throw
+ * (so the fail-closed path keeps the pre-handler value) while having silently
+ * corrupted that pre-handler value — weakening the boundary. Cloning the
+ * elements closes that hole.
+ */
+function cloneInterceptorInput<P extends InterceptorPoint>(
+  point: P,
+  value: Parameters<InterceptorCatalog[P]>[0],
+): Parameters<InterceptorCatalog[P]>[0] {
+  if (point === "field-lock-check" && Array.isArray(value)) {
+    return value.map((violation) => ({ ...violation })) as Parameters<InterceptorCatalog[P]>[0];
+  }
+  return value;
+}
 
 /**
  * Default {@link InterceptorRegistry} implementation. A class keeps the
@@ -145,14 +169,19 @@ class DefaultInterceptorRegistry implements InterceptorRegistry {
       // FAIL-CLOSED (security). field-lock-check is an ENFORCEMENT boundary:
       // a buggy or hostile policy capability must NEVER silently WEAKEN it.
       // Handlers transform by RETURNING a value and must treat the argument as
-      // immutable. We hand each handler a defensive shallow clone of array
-      // values, so a handler that mutates its argument in place and THEN
-      // throws / returns null/undefined cannot strip violations out from under
-      // us — on any failure the authoritative `current` is left exactly as it
-      // was. A non-array return where an array was expected is likewise treated
-      // as a failure, so an invalid handler cannot corrupt the engine's
-      // downstream view of the value. Failures are logged for visibility.
-      const handlerInput = Array.isArray(current) ? [...current] : current;
+      // immutable. We hand each handler a defensive DEEP clone (array container
+      // AND its elements — see `cloneInterceptorInput`), so a handler that
+      // mutates its argument in place and THEN throws / returns null/undefined
+      // cannot strip violations out from under us — on any failure the
+      // authoritative `current` is left exactly as it was. A non-array return
+      // where an array was expected is likewise treated as a failure, so an
+      // invalid handler cannot corrupt the engine's downstream view of the
+      // value. Failures are logged for visibility.
+      const capabilityName = reg.capability || "unknown";
+      const handlerInput = cloneInterceptorInput(
+        point,
+        current as Parameters<InterceptorCatalog[P]>[0],
+      );
       try {
         const handler = reg.handler as Interceptor<unknown, unknown>;
         const next = await handler(handlerInput, context);
@@ -162,17 +191,17 @@ class DefaultInterceptorRegistry implements InterceptorRegistry {
           (Array.isArray(current) && !Array.isArray(next))
         ) {
           this.logger?.error(
-            `Interceptor "${reg.capability}" at point "${point}" returned an invalid value (${next === null ? "null" : typeof next}); keeping pre-handler value (fail-closed)`,
-            { capability: reg.capability, point },
+            `Interceptor "${capabilityName}" at point "${point}" returned an invalid value (${next === null ? "null" : typeof next}); keeping pre-handler value (fail-closed)`,
+            { capability: capabilityName, point },
           );
           continue;
         }
         current = next;
       } catch (err) {
         this.logger?.error(
-          `Interceptor "${reg.capability}" at point "${point}" threw; keeping pre-handler value (fail-closed)`,
+          `Interceptor "${capabilityName}" at point "${point}" threw; keeping pre-handler value (fail-closed)`,
           {
-            capability: reg.capability,
+            capability: capabilityName,
             point,
             error: err instanceof Error ? err.message : String(err),
           },

--- a/packages/core/src/exports/client/engines.ts
+++ b/packages/core/src/exports/client/engines.ts
@@ -57,6 +57,16 @@ export type {
   GeneratorWeightRecord,
   OutcomeObservation,
 } from "../../engine/generator-priority-aggregator";
+// Interceptor type surface (Spec 63 Phase 3) — pure types, browser-safe.
+// The runtime `createInterceptorRegistry` lives in ../server/engines.ts.
+export type {
+  FieldLockCheckContext,
+  Interceptor,
+  InterceptorCatalog,
+  InterceptorPoint,
+  InterceptorRegistration,
+  InterceptorRegistry,
+} from "../../engine/interceptors";
 export {
   canAutoApproveOverlayChange,
   canAutoApproveOverlayProposal,

--- a/packages/core/src/exports/server/engines.ts
+++ b/packages/core/src/exports/server/engines.ts
@@ -53,6 +53,16 @@ export {
   type GeneratorWeightRecord,
   type OutcomeObservation,
 } from "../../engine/generator-priority-aggregator";
+// Interceptors — value-returning capability → core extension points (Spec 63 Phase 3).
+export {
+  createInterceptorRegistry,
+  type FieldLockCheckContext,
+  type Interceptor,
+  type InterceptorCatalog,
+  type InterceptorPoint,
+  type InterceptorRegistration,
+  type InterceptorRegistry,
+} from "../../engine/interceptors";
 export {
   createOnchangeEvaluator,
   DEFAULT_COMPUTE_TIMEOUT_MS,
@@ -125,7 +135,6 @@ export {
   type RollbackInsightEmitterOptions,
   rollbackInsightId,
 } from "../../engine/rollback-insight-emitter";
-
 export {
   collectRules,
   evaluateConditions,

--- a/packages/core/src/types/capability.ts
+++ b/packages/core/src/types/capability.ts
@@ -6,6 +6,7 @@
  */
 
 import type { CommandContext } from "../engine/command-layer";
+import type { InterceptorRegistration } from "../engine/interceptors";
 import type { ActionDefinition, ActionOverride } from "./action";
 import type { CliCommand } from "./cli";
 import type {
@@ -200,6 +201,8 @@ export interface CapabilityExtensions {
   states?: Array<{ target: string; extension: StateExtension }>;
   views?: Array<{ target: string; extension: ViewExtension }>;
   middlewares?: CapabilityMiddlewareRegistration[];
+  /** Value-returning extension points (strongly typed; see InterceptorCatalog). */
+  interceptors?: InterceptorRegistration[];
   /** CLI commands registered by this capability */
   commands?: CliCommand[];
   /** Transport adapters (protocol entry points for CommandLayer) */


### PR DESCRIPTION
## What & why

Spec 63 Phase 3 needs a `cap-lock` capability that can **soften** core's field-lock result (shadow mode / bypass groups / tolerance period). Spec §4.2 specifies cap-lock does this via a `field-lock-check` hook that **returns** the (possibly filtered) `FieldLockViolation[]`. But the existing `extensions.hooks` are void, fire-and-forget, untyped (`(...args: unknown[]) => void`) and **uninvoked anywhere** — bolting a return onto them would be an `unknown`-soup precedent.

This PR (PR-1 of 2) introduces the **precedent** mechanism: a strongly-typed, chainable, value-returning capability→core extension category — **Interceptor** — distinct from void event hooks and from CommandLayer middlewares. It wires the first point, `field-lock-check`, into the Action Engine. **cap-lock itself is the follow-up PR-2.**

## Design

- **`InterceptorCatalog`** is the single typed source of truth for returning extension points (one entry today: `field-lock-check: (FieldLockViolation[], ctx) => FieldLockViolation[]`). Adding a future point = one catalog entry; the generic registry + `run<P>` typing follow.
- **`InterceptorRegistry`** runs a point's handlers in ascending `order`, threading each output into the next.
- **Identity when absent**: with no interceptor registered, `run` returns the value unchanged → Phase 1 lock behavior is **byte-for-byte unchanged**. The Action Engine even skips building the context object (`has()` guard) on the hot path.
- **FAIL-CLOSED (security)**: field-lock is an enforcement boundary. A handler that throws, returns `null`/`undefined`, or (for an array point) returns a non-array is treated as a failure — the engine keeps the **pre-handler (stricter)** value and logs it. A buggy or hostile policy capability can never silently *weaken* enforcement. Handlers receive a **defensive shallow clone** of array values, so a handler that mutates its argument in place and then throws cannot strip violations out from under the engine.

## Changes

- `packages/core/src/engine/interceptors.ts` — new mechanism (catalog, registry, fail-closed `run`).
- `action-engine.ts` — thread violations through the registry at both `checkFieldLocks` sites (declarative Step 4b + `ctx.update` wrapper), gated by `has("field-lock-check")`.
- `types/capability.ts` — new typed `extensions.interceptors` field.
- cli startup (`collect-capabilities.ts`, `dev-wiring.ts`, `dev.ts`) — collect `cap.extensions.interceptors`, build the registry, inject into `createActionExecutor` (mirrors the existing middlewares wiring).
- exports — `createInterceptorRegistry` on the server barrel; the six types on the client barrel (browser-safe; runtime factory stays server-side).

## Tests

13 tests in `packages/core/__tests__/interceptors.test.ts`: identity, single-handler transform, ascending-order chaining, fail-closed on throw / null / undefined, **fail-closed integrity** (in-place mutation then throw/null, and non-array returns, cannot weaken the set), plus end-to-end via `createActionExecutor` (interceptor returning `[]` lets a locked update succeed; passthrough still raises `LockViolationError`; no-registry == Phase 1).

## Review

Cross-model reviewed (gemini) before opening: it caught a real **HIGH** (mutate-in-place-then-throw bypass) and a **MED** (unchecked non-array return), both fixed in the second commit; two LOW findings were rejected with rationale (the `has()` guard is an intentional hot-path optimization; a flagged JSDoc spec link was a hallucination).

Refs #126 (Spec 63 Phase 3). Follow-up: PR-2 `cap-lock` capability; a separate issue will track the UI / two-step-confirmation / Proposal-flagging slices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interceptor registry added to support customizable field-lock checks during action execution
  * Capabilities can now declare interceptors; dev/runtime wiring includes those interceptors
  * Interceptor types and registry factory are exported for client/server use

* **Tests**
  * Added comprehensive tests for interceptor behavior, ordering, fail-closed semantics, and end-to-end integration with action execution
<!-- end of auto-generated comment: release notes by coderabbit.ai -->