### PR TITLE
feat(lock): cap-lock — shadow/bypass/tolerance field-lock policy (Spec 63 PR-2)

### DIFF
--- a/addons/lock/cap-lock/README.md
+++ b/addons/lock/cap-lock/README.md
@@ -1,0 +1,47 @@
+# @linchkit/cap-lock
+
+Advanced field-lock policy capability (Spec 63 Phase 3).
+
+Layers four optional escape hatches on top of core's Phase 1 field-lock
+enforcement, exposed through a single value-returning `field-lock-check`
+interceptor:
+
+| Knob | Default | Behavior |
+|------|---------|----------|
+| `shadowMode` | `false` | Audit-log every violation, then **allow** (rollout observation). |
+| `bypassGroups` | `[]` | If `actor.groups` intersects this list, audit-log and **allow**. |
+| `toleranceMs` | `0` | If a record is younger than `toleranceMs` (from `created_at`), audit-log and **allow**. `0` disables. |
+
+Evaluated in that order; the first match suppresses the violations (returns
+`[]` = allow). With no match the interceptor returns the violations
+**unchanged** so core re-throws (fail-closed). With default config the
+capability is a no-op over core.
+
+## Usage
+
+```ts
+import { createCapLock } from "@linchkit/cap-lock";
+
+const capLock = createCapLock({
+  logger,
+  config: {
+    shadowMode: false,
+    bypassGroups: ["admin", "finance_manager"],
+    toleranceMs: 5 * 60 * 1000, // 5 minutes
+  },
+});
+```
+
+For the default-config form use the exported `capLock` definition directly.
+
+## Audit trail
+
+When violations are suppressed, a structured `logger.info` is emitted with
+`{ capability: "lock", reason: "shadow" | "bypass" | "tolerance", entity,
+actorId, fields }` (Spec 63 §4.2).
+
+## Out of scope (separate follow-up PRs)
+
+- §5.2 cap-lock UI extensions (lock icon / tooltip / unlock button)
+- SOFT_LOCK two-step confirmation
+- Notification integration

--- a/addons/lock/cap-lock/__tests__/capability.test.ts
+++ b/addons/lock/cap-lock/__tests__/capability.test.ts
@@ -30,7 +30,7 @@ describe("cap-lock capability metadata", () => {
     expect(capLock.name).toBe("cap-lock");
     expect(capLock.type).toBe("standard");
     expect(capLock.category).toBe("system");
-    expect(capLock.version).toBe("0.0.1");
+    expect(capLock.version).toBe("1.0.0");
     expect(capLock.coreVersion).toBe("^0.2.0");
   });
 

--- a/addons/lock/cap-lock/__tests__/capability.test.ts
+++ b/addons/lock/cap-lock/__tests__/capability.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for cap-lock capability wiring (Spec 63 §4.2, §9).
+ *
+ * Asserts metadata + that the capability exposes `extensions.interceptors`
+ * with exactly one entry at point "field-lock-check" whose handler behaves
+ * per the policy (allow on shadow, block otherwise — fail-closed).
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { FieldLockCheckContext, FieldLockViolation, Logger } from "@linchkit/core";
+import { capLock } from "../src/capability";
+import { createCapLock } from "../src/factory";
+
+function makeContext(): FieldLockCheckContext {
+  return {
+    entity: "purchase_request",
+    actor: { type: "human", id: "user-1", groups: ["admin"] },
+    record: { status: "submitted", created_at: new Date("2026-01-01T00:00:00Z") },
+    input: { amount: 200 },
+    tenantId: "t1",
+  };
+}
+
+function makeViolations(): FieldLockViolation[] {
+  return [{ field: "amount", type: "locked", message: 'Field "amount" is locked' }];
+}
+
+describe("cap-lock capability metadata", () => {
+  it("has the expected metadata", () => {
+    expect(capLock.name).toBe("cap-lock");
+    expect(capLock.type).toBe("standard");
+    expect(capLock.category).toBe("system");
+    expect(capLock.version).toBe("0.0.1");
+    expect(capLock.coreVersion).toBe("^0.2.0");
+  });
+
+  it("declares only the database.read system permission", () => {
+    expect(capLock.systemPermissions).toEqual(["database.read"]);
+  });
+
+  it("exposes a config schema", () => {
+    expect(capLock.configSchema).toBeDefined();
+  });
+});
+
+describe("cap-lock interceptor registration", () => {
+  it("exposes exactly one field-lock-check interceptor", () => {
+    const interceptors = capLock.extensions?.interceptors;
+    expect(interceptors).toBeDefined();
+    expect(interceptors).toHaveLength(1);
+    const reg = interceptors?.[0];
+    expect(reg?.point).toBe("field-lock-check");
+    expect(reg?.capability).toBe("lock");
+    expect(typeof reg?.handler).toBe("function");
+  });
+
+  it("default-config handler blocks (returns violations unchanged)", async () => {
+    const reg = capLock.extensions?.interceptors?.[0];
+    if (!reg) throw new Error("expected an interceptor registration");
+    const violations = makeViolations();
+
+    const result = await reg.handler(violations, makeContext());
+
+    expect(result).toBe(violations);
+  });
+
+  it("registered handler honors shadow-mode config and logs via injected logger", async () => {
+    const calls: Array<{ message: string; context?: Record<string, unknown> }> = [];
+    const logger: Logger = {
+      debug: () => {},
+      info: (message, context) => calls.push({ message, context }),
+      warn: () => {},
+      error: () => {},
+    };
+    const cap = createCapLock({ config: { shadowMode: true }, logger });
+    const reg = cap.extensions?.interceptors?.[0];
+    if (!reg) throw new Error("expected an interceptor registration");
+
+    const result = await reg.handler(makeViolations(), makeContext());
+
+    expect(result).toEqual([]);
+    expect(calls.find((c) => c.context?.reason === "shadow")).toBeDefined();
+  });
+
+  it("registered handler honors bypass-group config", async () => {
+    const cap = createCapLock({ config: { bypassGroups: ["admin"] } });
+    const reg = cap.extensions?.interceptors?.[0];
+    if (!reg) throw new Error("expected an interceptor registration");
+
+    const result = await reg.handler(makeViolations(), makeContext());
+
+    expect(result).toEqual([]);
+  });
+
+  it("uses the injected clock for tolerance", async () => {
+    const cap = createCapLock({
+      config: { toleranceMs: 5 * 60 * 1000 },
+      now: () => Date.parse("2026-01-01T00:01:00Z"),
+    });
+    const reg = cap.extensions?.interceptors?.[0];
+    if (!reg) throw new Error("expected an interceptor registration");
+
+    const result = await reg.handler(makeViolations(), makeContext());
+
+    expect(result).toEqual([]);
+  });
+});

--- a/addons/lock/cap-lock/__tests__/config.test.ts
+++ b/addons/lock/cap-lock/__tests__/config.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Tests for cap-lock config defaults / normalization / validation (Spec 63 §4.2).
+ */
+
+import { describe, expect, it } from "bun:test";
+import { resolveCapLockPolicy } from "../src/config";
+
+describe("resolveCapLockPolicy", () => {
+  it("applies safe defaults for an empty config (no-op over core)", () => {
+    const policy = resolveCapLockPolicy();
+    expect(policy.shadowMode).toBe(false);
+    expect(policy.bypassGroups).toEqual([]);
+    expect(policy.toleranceMs).toBe(0);
+  });
+
+  it("preserves explicitly provided values", () => {
+    const policy = resolveCapLockPolicy({
+      shadowMode: true,
+      bypassGroups: ["admin", "finance_manager"],
+      toleranceMs: 60_000,
+    });
+    expect(policy.shadowMode).toBe(true);
+    expect(policy.bypassGroups).toEqual(["admin", "finance_manager"]);
+    expect(policy.toleranceMs).toBe(60_000);
+  });
+
+  it("rejects a negative toleranceMs", () => {
+    expect(() => resolveCapLockPolicy({ toleranceMs: -1 })).toThrow();
+  });
+
+  it("rejects a non-integer toleranceMs", () => {
+    expect(() => resolveCapLockPolicy({ toleranceMs: 1.5 })).toThrow();
+  });
+
+  it("rejects unknown config keys (strict schema)", () => {
+    // @ts-expect-error — unknown key is rejected at runtime by .strict().
+    expect(() => resolveCapLockPolicy({ bogus: true })).toThrow();
+  });
+});

--- a/addons/lock/cap-lock/__tests__/field-lock-interceptor.test.ts
+++ b/addons/lock/cap-lock/__tests__/field-lock-interceptor.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Tests for the cap-lock `field-lock-check` interceptor (Spec 63 §4.2, §9).
+ *
+ * Covers: shadow on/off, bypass group hit/miss, tolerance within/after window,
+ * toleranceMs=0, missing/unparseable created_at (fail-closed), the no-condition
+ * default (returns the SAME violations), and the audit-log shape. Time is
+ * injected via `now`; logging is captured by a fake logger spy.
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import type { Actor, FieldLockCheckContext, FieldLockViolation, Logger } from "@linchkit/core";
+import { resolveCapLockPolicy } from "../src/config";
+import {
+  createFieldLockInterceptor,
+  type FieldLockInterceptorOptions,
+} from "../src/field-lock-interceptor";
+
+// ── Test fixtures ─────────────────────────────────────────
+
+interface LoggedCall {
+  level: "debug" | "info" | "warn" | "error";
+  message: string;
+  context?: Record<string, unknown>;
+}
+
+/** A fake logger that records every call for assertions. */
+function createFakeLogger(): Logger & { calls: LoggedCall[] } {
+  const calls: LoggedCall[] = [];
+  return {
+    calls,
+    debug: (message, context) => calls.push({ level: "debug", message, context }),
+    info: (message, context) => calls.push({ level: "info", message, context }),
+    warn: (message, context) => calls.push({ level: "warn", message, context }),
+    error: (message, context) => calls.push({ level: "error", message, context }),
+  };
+}
+
+function makeActor(groups: string[] = []): Actor {
+  return { type: "human", id: "user-1", groups };
+}
+
+function makeViolations(): FieldLockViolation[] {
+  return [
+    { field: "amount", type: "locked", message: 'Field "amount" is locked in state "submitted"' },
+    {
+      field: "code",
+      type: "immutable",
+      message: 'Field "code" is immutable and cannot be modified',
+    },
+  ];
+}
+
+function makeContext(overrides?: Partial<FieldLockCheckContext>): FieldLockCheckContext {
+  return {
+    entity: "purchase_request",
+    actor: makeActor(),
+    record: { id: "r1", status: "submitted", created_at: new Date("2026-01-01T00:00:00Z") },
+    input: { amount: 200 },
+    tenantId: "t1",
+    ...overrides,
+  };
+}
+
+/** Build a handler with a fixed `now` and fake logger for determinism. */
+function buildHandler(
+  partial: Partial<FieldLockInterceptorOptions> & {
+    config?: Parameters<typeof resolveCapLockPolicy>[0];
+  },
+) {
+  const logger = createFakeLogger();
+  const handler = createFieldLockInterceptor({
+    policy: resolveCapLockPolicy(partial.config),
+    logger,
+    now: partial.now ?? (() => Date.parse("2026-01-01T00:01:00Z")),
+  });
+  return { handler, logger };
+}
+
+// ── Tests ─────────────────────────────────────────────────
+
+describe("cap-lock field-lock-check interceptor", () => {
+  let violations: FieldLockViolation[];
+
+  beforeEach(() => {
+    violations = makeViolations();
+  });
+
+  describe("shadow mode", () => {
+    it("shadow on → all violations suppressed and audit-logged", async () => {
+      const { handler, logger } = buildHandler({ config: { shadowMode: true } });
+
+      const result = await handler(violations, makeContext());
+
+      expect(result).toEqual([]);
+      const log = logger.calls.find((c) => c.context?.reason === "shadow");
+      expect(log).toBeDefined();
+      expect(log?.level).toBe("info");
+    });
+
+    it("shadow off (default) → pass-through (returns the same violations)", async () => {
+      const { handler, logger } = buildHandler({ config: {} });
+
+      const result = await handler(violations, makeContext());
+
+      expect(result).toBe(violations); // unchanged reference
+      expect(result).toEqual(makeViolations());
+      expect(logger.calls).toHaveLength(0);
+    });
+  });
+
+  describe("bypass groups", () => {
+    it("actor in a bypass group → suppressed and audit-logged", async () => {
+      const { handler, logger } = buildHandler({ config: { bypassGroups: ["admin"] } });
+      const ctx = makeContext({ actor: makeActor(["staff", "admin"]) });
+
+      const result = await handler(violations, ctx);
+
+      expect(result).toEqual([]);
+      const log = logger.calls.find((c) => c.context?.reason === "bypass");
+      expect(log).toBeDefined();
+    });
+
+    it("actor NOT in any bypass group → violations returned UNCHANGED", async () => {
+      const { handler, logger } = buildHandler({ config: { bypassGroups: ["admin"] } });
+      const ctx = makeContext({ actor: makeActor(["staff"]) });
+
+      const result = await handler(violations, ctx);
+
+      expect(result).toBe(violations);
+      expect(logger.calls).toHaveLength(0);
+    });
+
+    it("empty bypassGroups never suppresses even for empty actor groups", async () => {
+      const { handler } = buildHandler({ config: { bypassGroups: [] } });
+      const ctx = makeContext({ actor: makeActor([]) });
+
+      const result = await handler(violations, ctx);
+
+      expect(result).toBe(violations);
+    });
+  });
+
+  describe("tolerance period", () => {
+    const created = "2026-01-01T00:00:00Z";
+
+    it("within window → suppressed and audit-logged", async () => {
+      // age = 60s; window = 5min → within.
+      const { handler, logger } = buildHandler({
+        config: { toleranceMs: 5 * 60 * 1000 },
+        now: () => Date.parse("2026-01-01T00:01:00Z"),
+      });
+      const ctx = makeContext({ record: { status: "submitted", created_at: created } });
+
+      const result = await handler(violations, ctx);
+
+      expect(result).toEqual([]);
+      expect(logger.calls.find((c) => c.context?.reason === "tolerance")).toBeDefined();
+    });
+
+    it("after window → violations returned UNCHANGED", async () => {
+      // age = 10min; window = 5min → expired.
+      const { handler, logger } = buildHandler({
+        config: { toleranceMs: 5 * 60 * 1000 },
+        now: () => Date.parse("2026-01-01T00:10:00Z"),
+      });
+      const ctx = makeContext({ record: { status: "submitted", created_at: created } });
+
+      const result = await handler(violations, ctx);
+
+      expect(result).toBe(violations);
+      expect(logger.calls).toHaveLength(0);
+    });
+
+    it("toleranceMs=0 (default) → never suppresses on age", async () => {
+      const { handler } = buildHandler({
+        config: { toleranceMs: 0 },
+        now: () => Date.parse("2026-01-01T00:00:00Z"), // age 0
+      });
+      const ctx = makeContext({ record: { status: "submitted", created_at: created } });
+
+      const result = await handler(violations, ctx);
+
+      expect(result).toBe(violations);
+    });
+
+    it("accepts Date, ISO string, and epoch-number created_at", async () => {
+      const now = () => Date.parse("2026-01-01T00:01:00Z");
+      const epoch = Date.parse(created);
+      for (const createdAt of [new Date(created), created, epoch]) {
+        const { handler } = buildHandler({ config: { toleranceMs: 5 * 60 * 1000 }, now });
+        const ctx = makeContext({ record: { status: "submitted", created_at: createdAt } });
+        const result = await handler(makeViolations(), ctx);
+        expect(result).toEqual([]);
+      }
+    });
+
+    it("missing created_at → NOT suppressed (fail-closed)", async () => {
+      const { handler } = buildHandler({
+        config: { toleranceMs: 5 * 60 * 1000 },
+        now: () => Date.parse("2026-01-01T00:01:00Z"),
+      });
+      const ctx = makeContext({ record: { status: "submitted" } });
+
+      const result = await handler(violations, ctx);
+
+      expect(result).toBe(violations);
+    });
+
+    it("unparseable created_at → NOT suppressed (fail-closed)", async () => {
+      const { handler } = buildHandler({
+        config: { toleranceMs: 5 * 60 * 1000 },
+        now: () => Date.parse("2026-01-01T00:01:00Z"),
+      });
+      const ctx = makeContext({ record: { status: "submitted", created_at: "not-a-date" } });
+
+      const result = await handler(violations, ctx);
+
+      expect(result).toBe(violations);
+    });
+  });
+
+  describe("fail-closed default", () => {
+    it("no condition matches → returns the SAME violations", async () => {
+      const { handler, logger } = buildHandler({
+        config: { shadowMode: false, bypassGroups: ["admin"], toleranceMs: 1000 },
+        now: () => Date.parse("2026-01-01T01:00:00Z"), // long after creation
+      });
+      const ctx = makeContext({ actor: makeActor(["staff"]) });
+
+      const result = await handler(violations, ctx);
+
+      expect(result).toBe(violations);
+      expect(result).toEqual(makeViolations());
+      expect(logger.calls).toHaveLength(0);
+    });
+
+    it("empty violation set is returned unchanged and never logged", async () => {
+      const { handler, logger } = buildHandler({ config: { shadowMode: true } });
+
+      const result = await handler([], makeContext());
+
+      expect(result).toEqual([]);
+      expect(logger.calls).toHaveLength(0);
+    });
+
+    it("does not mutate its violations argument when suppressing", async () => {
+      const { handler } = buildHandler({ config: { shadowMode: true } });
+      const input = makeViolations();
+      const snapshot = JSON.stringify(input);
+
+      await handler(input, makeContext());
+
+      expect(JSON.stringify(input)).toBe(snapshot);
+    });
+  });
+
+  describe("audit logger shape (Spec 63 §4.2)", () => {
+    it("logs the documented structured context", async () => {
+      const { handler, logger } = buildHandler({ config: { shadowMode: true } });
+      const ctx = makeContext({ actor: makeActor(["staff"]) });
+
+      await handler(violations, ctx);
+
+      const log = logger.calls.find((c) => c.context?.reason === "shadow");
+      expect(log).toBeDefined();
+      expect(log?.context).toMatchObject({
+        capability: "lock",
+        reason: "shadow",
+        entity: "purchase_request",
+        actorId: "user-1",
+        tenantId: "t1",
+        fields: ["amount", "code"],
+      });
+    });
+
+    it("suppression is silent when no logger is injected", async () => {
+      const handler = createFieldLockInterceptor({
+        policy: resolveCapLockPolicy({ shadowMode: true }),
+        now: () => 0,
+      });
+
+      // Must not throw despite no logger.
+      const result = await handler(makeViolations(), makeContext());
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/addons/lock/cap-lock/capability.json
+++ b/addons/lock/cap-lock/capability.json
@@ -1,0 +1,14 @@
+{
+  "name": "@linchkit/cap-lock",
+  "version": "1.0.0",
+  "type": "standard",
+  "category": "system",
+  "label": "Field Lock Policy",
+  "description": "Advanced field-lock policy: shadow mode, bypass groups, tolerance period, and audit trail over core field-lock enforcement (Spec 63 Phase 3)",
+  "extensions": {
+    "interceptors": ["field-lock-check"]
+  },
+  "linchkit": {
+    "coreVersion": "^0.2.0"
+  }
+}

--- a/addons/lock/cap-lock/package.json
+++ b/addons/lock/cap-lock/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@linchkit/cap-lock",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "files": [
+    "src/",
+    "capability.json",
+    "package.json",
+    "README.md"
+  ],
+  "scripts": {
+    "test": "bun test"
+  },
+  "peerDependencies": {
+    "@linchkit/core": "^0.2.0"
+  },
+  "devDependencies": {
+    "@linchkit/core": "workspace:*",
+    "typescript": "^6.0.2"
+  },
+  "linchkit": {
+    "coreVersion": "^0.2.0",
+    "type": "standard",
+    "category": "system"
+  }
+}

--- a/addons/lock/cap-lock/src/capability.ts
+++ b/addons/lock/cap-lock/src/capability.ts
@@ -1,0 +1,15 @@
+/**
+ * cap-lock capability definition (static, default-config form).
+ *
+ * Advanced field-lock policy layered on core's Phase 1 enforcement (Spec 63
+ * §4.2): shadow mode, bypass groups, tolerance period, and an audit trail —
+ * exposed through a single `field-lock-check` interceptor.
+ *
+ * This static definition uses default config (shadow off, no bypass groups,
+ * no tolerance), which is a no-op over core. To customize policy or inject a
+ * logger, use {@link createCapLock} from `./factory` instead.
+ */
+
+import { createCapLock } from "./factory";
+
+export const capLock = createCapLock();

--- a/addons/lock/cap-lock/src/config.ts
+++ b/addons/lock/cap-lock/src/config.ts
@@ -1,0 +1,80 @@
+/**
+ * cap-lock configuration schema (Spec 63 §4.2, Phase 3).
+ *
+ * Declares the three policy knobs the `field-lock-check` interceptor consumes:
+ *  - `shadowMode`   — log violations but never block (rollout observation).
+ *  - `bypassGroups` — actor groups/roles allowed to override locks.
+ *  - `toleranceMs`  — grace window (ms) after a record's `created_at` during
+ *                     which locked-field edits are permitted; `0` = disabled.
+ *
+ * Every knob has a SAFE default that preserves core enforcement byte-for-byte
+ * (shadow off, no bypass groups, no tolerance) — installing cap-lock with an
+ * empty config must NOT weaken the boundary.
+ */
+
+import { defineConfigSchema } from "@linchkit/core/config";
+import { z } from "zod";
+
+/**
+ * Zod shape for the cap-lock config. Declared standalone so a precise policy
+ * type can be inferred (the `defineConfigSchema` ref widens `.schema` to
+ * `ZodObject<any>`, which erases the field types).
+ */
+const capLockConfigShape = {
+  /**
+   * When true, every lock violation is audit-logged and then SUPPRESSED
+   * (the interceptor returns `[]`). For observing a lock rollout without
+   * blocking writes. Default false — locks are enforced.
+   */
+  shadowMode: z
+    .boolean()
+    .default(false)
+    .describe("Log lock violations but do not block (rollout observation mode)"),
+
+  /**
+   * Actor groups/roles that may override locks. An actor whose `groups`
+   * intersect this list has its violations audit-logged then suppressed.
+   * Default [] — no group can bypass.
+   */
+  bypassGroups: z
+    .array(z.string())
+    .default([])
+    .describe("Actor groups/roles permitted to override field locks (e.g. admin, finance_manager)"),
+
+  /**
+   * Grace window in milliseconds after a record's `created_at` during which
+   * locked fields remain editable. `0` (default) disables the tolerance
+   * period entirely. Negative values are rejected by validation.
+   */
+  toleranceMs: z
+    .number()
+    .int()
+    .nonnegative()
+    .default(0)
+    .describe(
+      "Milliseconds after created_at during which locked fields stay editable (0 = disabled)",
+    ),
+} as const;
+
+export const capLockConfig = defineConfigSchema("cap-lock", capLockConfigShape);
+
+/**
+ * Strict schema used to validate/normalize input into a fully-defaulted policy.
+ * `.strict()` rejects unknown keys, matching `defineConfigSchema`'s behavior.
+ */
+const capLockPolicySchema = z.object(capLockConfigShape).strict();
+
+/** Resolved, normalized cap-lock policy consumed by the interceptor handler. */
+export type CapLockPolicy = z.infer<typeof capLockPolicySchema>;
+
+/**
+ * Normalize a partial config into a fully-defaulted {@link CapLockPolicy}.
+ *
+ * Parsing through the Zod schema applies defaults AND validates input
+ * (rejecting e.g. a negative `toleranceMs` or a non-string in
+ * `bypassGroups`), so a caller-supplied config can never silently produce an
+ * unsafe policy. The strict schema also rejects unknown keys.
+ */
+export function resolveCapLockPolicy(config?: Partial<CapLockPolicy>): CapLockPolicy {
+  return capLockPolicySchema.parse(config ?? {});
+}

--- a/addons/lock/cap-lock/src/factory.ts
+++ b/addons/lock/cap-lock/src/factory.ts
@@ -1,0 +1,71 @@
+/**
+ * createCapLock — Factory that wires the cap-lock policy + logger into a
+ * `field-lock-check` interceptor and produces a fully-wired
+ * CapabilityDefinition (mirrors cap-permission's factory pattern).
+ *
+ * The interceptor is registered via `extensions.interceptors` with
+ * `{ point: "field-lock-check", capability: "lock", handler }`; core's startup
+ * collects it into the InterceptorRegistry and the Action Engine threads
+ * computed violations through it before enforcing.
+ */
+
+import type { CapabilityDefinition, InterceptorRegistration, Logger } from "@linchkit/core";
+import { defineCapability } from "@linchkit/core";
+import { type CapLockPolicy, capLockConfig, resolveCapLockPolicy } from "./config";
+import { createFieldLockInterceptor } from "./field-lock-interceptor";
+
+export interface CapLockOptions {
+  /**
+   * Declarative configuration — validated/normalized via the capLockConfig
+   * schema. Partial; omitted knobs fall back to safe defaults (shadow off,
+   * no bypass groups, no tolerance).
+   */
+  config?: Partial<CapLockPolicy>;
+  /**
+   * Structured logger for the audit trail. Injected the same way cap-permission
+   * receives its programmatic dependencies. When omitted, suppressions are
+   * silent (policy decisions are unaffected).
+   */
+  logger?: Logger;
+  /**
+   * Injectable wall-clock source (epoch ms) for deterministic tolerance
+   * evaluation. Defaults to `Date.now` inside the interceptor.
+   */
+  now?: () => number;
+}
+
+export function createCapLock(options?: CapLockOptions): CapabilityDefinition {
+  const policy: CapLockPolicy = resolveCapLockPolicy(options?.config);
+
+  const handler = createFieldLockInterceptor({
+    policy,
+    logger: options?.logger,
+    now: options?.now,
+  });
+
+  const interceptors: InterceptorRegistration[] = [
+    {
+      point: "field-lock-check",
+      capability: "lock",
+      handler,
+    },
+  ];
+
+  return defineCapability({
+    name: "cap-lock",
+    label: "Field Lock Policy",
+    description:
+      "Advanced field-lock policy: shadow mode, bypass groups, tolerance period, and audit trail over core field-lock enforcement",
+    type: "standard",
+    category: "system",
+    version: "0.0.1",
+    coreVersion: "^0.2.0",
+
+    configSchema: capLockConfig.schema,
+    config: policy,
+
+    extensions: { interceptors },
+
+    systemPermissions: ["database.read"],
+  });
+}

--- a/addons/lock/cap-lock/src/factory.ts
+++ b/addons/lock/cap-lock/src/factory.ts
@@ -58,7 +58,7 @@ export function createCapLock(options?: CapLockOptions): CapabilityDefinition {
       "Advanced field-lock policy: shadow mode, bypass groups, tolerance period, and audit trail over core field-lock enforcement",
     type: "standard",
     category: "system",
-    version: "0.0.1",
+    version: "1.0.0",
     coreVersion: "^0.2.0",
 
     configSchema: capLockConfig.schema,

--- a/addons/lock/cap-lock/src/field-lock-interceptor.ts
+++ b/addons/lock/cap-lock/src/field-lock-interceptor.ts
@@ -143,7 +143,7 @@ export function createFieldLockInterceptor(
     //    the spec example references as `context.actor.groups`. Use it directly.
     if (
       policy.bypassGroups.length > 0 &&
-      context.actor.groups.some((group) => policy.bypassGroups.includes(group))
+      context.actor.groups?.some((group) => policy.bypassGroups.includes(group))
     ) {
       audit("bypass");
       return [];

--- a/addons/lock/cap-lock/src/field-lock-interceptor.ts
+++ b/addons/lock/cap-lock/src/field-lock-interceptor.ts
@@ -1,0 +1,174 @@
+/**
+ * cap-lock `field-lock-check` interceptor (Spec 63 §4.2, Phase 3 PR-2).
+ *
+ * This is the capability layer on top of core's Phase 1 field-lock enforcement.
+ * Core's Action Engine threads the computed `FieldLockViolation[]` through the
+ * `field-lock-check` interceptor point BEFORE throwing; this handler decides
+ * whether to suppress those violations under one of three policy escape hatches.
+ *
+ * ## Contract with the core interceptor registry
+ *
+ * The handler TRANSFORMS the violation set by RETURNING a value, never by
+ * mutating its argument (core hands us a defensive deep clone, but we still
+ * return a fresh/unmutated array). Per the catalog typing:
+ *  - return `[]`                     → ALLOW all (suppress every violation).
+ *  - return the violations UNCHANGED → BLOCK (fail-closed; core re-throws).
+ *
+ * It must NEVER weaken core enforcement beyond the explicit, audited policy
+ * below — every suppression path requires an active config knob AND is
+ * audit-logged. The default (no knob matches) returns the violations exactly
+ * as received, so cap-lock with empty config is a no-op over core.
+ *
+ * ## Evaluation order (first match wins, returns `[]`)
+ *  1. Shadow mode      — `shadowMode: true`.
+ *  2. Bypass groups    — actor belongs to ANY `bypassGroups` entry.
+ *  3. Tolerance period — `toleranceMs > 0` AND record age < toleranceMs.
+ *  4. Otherwise        — return violations UNCHANGED (block, fail-closed).
+ */
+
+import type { FieldLockCheckContext, FieldLockViolation, Logger } from "@linchkit/core";
+import type { CapLockPolicy } from "./config";
+
+/** Reason an audited suppression occurred — surfaced in the audit log. */
+export type LockSuppressionReason = "shadow" | "bypass" | "tolerance";
+
+/** Options for {@link createFieldLockInterceptor}. */
+export interface FieldLockInterceptorOptions {
+  /** Resolved, fully-defaulted policy (see {@link resolveCapLockPolicy}). */
+  policy: CapLockPolicy;
+  /**
+   * Structured logger for the audit trail (Spec 63 §4.2 "Audit trail — Log all
+   * lock violations and forced modifications"). When omitted, suppressions are
+   * silent — but the policy decision is unchanged.
+   */
+  logger?: Logger;
+  /**
+   * Injectable wall-clock source (epoch ms) for deterministic tolerance tests.
+   * Defaults to {@link Date.now}. Using `Date.now` in real capability code is
+   * fine; the seam exists purely so tests can pin "now".
+   */
+  now?: () => number;
+}
+
+/**
+ * Coerce a `created_at` value to an epoch-millisecond timestamp.
+ *
+ * Robustly accepts:
+ *  - a `Date`          → `getTime()` (rejected if the Date is Invalid → NaN).
+ *  - an ISO/parseable string → `Date.parse`, accepted only when finite.
+ *  - a finite epoch number   → returned as-is (already milliseconds).
+ *
+ * Returns `null` for anything missing, non-finite, or unparseable. The caller
+ * treats `null` as "cannot apply tolerance" and FAILS CLOSED (does not
+ * suppress), so a missing/garbage timestamp can never open the grace window.
+ */
+function parseCreatedAt(value: unknown): number | null {
+  if (value instanceof Date) {
+    const t = value.getTime();
+    return Number.isFinite(t) ? t : null;
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === "string") {
+    const t = Date.parse(value);
+    return Number.isFinite(t) ? t : null;
+  }
+  return null;
+}
+
+/**
+ * Build the structured audit context emitted when violations are suppressed.
+ * Includes the required fields from Spec 63 §4.2: capability, reason, entity,
+ * actor id, and the suppressed field names.
+ */
+function buildAuditContext(opts: {
+  reason: LockSuppressionReason;
+  context: FieldLockCheckContext;
+  violations: readonly FieldLockViolation[];
+}): Record<string, unknown> {
+  return {
+    capability: "lock",
+    reason: opts.reason,
+    entity: opts.context.entity,
+    actorId: opts.context.actor.id,
+    actorType: opts.context.actor.type,
+    tenantId: opts.context.tenantId,
+    fields: opts.violations.map((v) => v.field),
+    violationCount: opts.violations.length,
+  };
+}
+
+/**
+ * Create the cap-lock `field-lock-check` interceptor handler.
+ *
+ * @returns an async handler matching `InterceptorCatalog["field-lock-check"]`.
+ */
+export function createFieldLockInterceptor(
+  options: FieldLockInterceptorOptions,
+): (
+  violations: FieldLockViolation[],
+  context: FieldLockCheckContext,
+) => Promise<FieldLockViolation[]> {
+  const { policy, logger } = options;
+  const now = options.now ?? Date.now;
+
+  return async (
+    violations: FieldLockViolation[],
+    context: FieldLockCheckContext,
+  ): Promise<FieldLockViolation[]> => {
+    // Nothing to decide: no violations means core would have allowed the write.
+    // Return the (empty) set unchanged — never log a no-op as a suppression.
+    if (violations.length === 0) {
+      return violations;
+    }
+
+    const audit = (reason: LockSuppressionReason): void => {
+      logger?.info(
+        `cap-lock suppressed ${violations.length} field-lock violation(s) (${reason})`,
+        buildAuditContext({ reason, context, violations }),
+      );
+    };
+
+    // 1. Shadow mode — observe without blocking. Log every violation, allow.
+    if (policy.shadowMode) {
+      audit("shadow");
+      return [];
+    }
+
+    // 2. Bypass groups — the actor's groups/roles override locks.
+    //    The core `Actor.groups: string[]` field carries the actor's
+    //    group/role memberships (set by the auth/permission slots — see
+    //    cap-permission's `actor.groups` usage), which is exactly the concept
+    //    the spec example references as `context.actor.groups`. Use it directly.
+    if (
+      policy.bypassGroups.length > 0 &&
+      context.actor.groups.some((group) => policy.bypassGroups.includes(group))
+    ) {
+      audit("bypass");
+      return [];
+    }
+
+    // 3. Tolerance period — fresh records may be freely edited for a window.
+    //    Disabled when toleranceMs <= 0. Fails CLOSED on a missing/unparseable
+    //    created_at (parseCreatedAt → null) so an absent timestamp never opens
+    //    the window.
+    if (policy.toleranceMs > 0) {
+      const createdAt = parseCreatedAt(context.record.created_at);
+      if (createdAt !== null) {
+        const age = now() - createdAt;
+        // age < 0 (clock skew / future created_at) still falls inside the
+        // window — a record that claims to be from the future is trivially
+        // "younger" than the tolerance, so it is treated as within grace.
+        if (age < policy.toleranceMs) {
+          audit("tolerance");
+          return [];
+        }
+      }
+    }
+
+    // 4. No policy matched — BLOCK. Return the violations UNCHANGED so core
+    //    re-throws with the full per-field detail (fail-closed default).
+    return violations;
+  };
+}

--- a/addons/lock/cap-lock/src/index.ts
+++ b/addons/lock/cap-lock/src/index.ts
@@ -1,0 +1,22 @@
+/**
+ * @linchkit/cap-lock — Advanced field-lock policy capability (Spec 63 Phase 3).
+ *
+ * Layers shadow mode, bypass groups, a tolerance period, and an audit trail on
+ * top of core's Phase 1 field-lock enforcement via a `field-lock-check`
+ * interceptor. With default config it is a no-op over core (fail-closed).
+ */
+
+// Capability definition (static, default config)
+export { capLock } from "./capability";
+// Config schema + policy resolver
+export type { CapLockPolicy } from "./config";
+export { capLockConfig, resolveCapLockPolicy } from "./config";
+// Factory (custom config + logger + clock injection)
+export type { CapLockOptions } from "./factory";
+export { createCapLock } from "./factory";
+// Interceptor handler factory + types
+export type {
+  FieldLockInterceptorOptions,
+  LockSuppressionReason,
+} from "./field-lock-interceptor";
+export { createFieldLockInterceptor } from "./field-lock-interceptor";

--- a/addons/lock/cap-lock/tsconfig.json
+++ b/addons/lock/cap-lock/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun-types"]
+  },
+  "include": ["src", "__tests__"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -336,6 +336,17 @@
         "react-i18next": "^14",
       },
     },
+    "addons/lock/cap-lock": {
+      "name": "@linchkit/cap-lock",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@linchkit/core": "workspace:*",
+        "typescript": "^6.0.2",
+      },
+      "peerDependencies": {
+        "@linchkit/core": "^0.2.0",
+      },
+    },
     "addons/migration/cap-migration": {
       "name": "@linchkit/cap-migration",
       "version": "1.0.0",
@@ -898,6 +909,8 @@
     "@linchkit/cap-keyboard-shortcuts": ["@linchkit/cap-keyboard-shortcuts@workspace:addons/keyboard-shortcuts/cap-keyboard-shortcuts"],
 
     "@linchkit/cap-life-demo": ["@linchkit/cap-life-demo@workspace:addons/demo/cap-life-demo"],
+
+    "@linchkit/cap-lock": ["@linchkit/cap-lock@workspace:addons/lock/cap-lock"],
 
     "@linchkit/cap-mcp-ui": ["@linchkit/cap-mcp-ui@workspace:addons/adapter-mcp/cap-mcp-ui"],
 

--- a/packages/core/src/types/capability-metadata.ts
+++ b/packages/core/src/types/capability-metadata.ts
@@ -44,6 +44,13 @@ const extensionManifestSchema = z.object({
   ruleEffects: z.array(z.string()).optional(),
   /** Hook identifiers */
   hooks: z.array(z.string()).optional(),
+  /**
+   * Interceptor point names this capability attaches to via
+   * `extensions.interceptors` — the value-returning extension seam (Spec 63
+   * §4.2, e.g. "field-lock-check"). Distinct from `hooks`: an interceptor
+   * transforms and returns a value rather than reacting to an event.
+   */
+  interceptors: z.array(z.string()).optional(),
   /** Middleware slot names */
   middlewares: z.array(z.string()).optional(),
   /** CLI command names */


### PR DESCRIPTION
## What

New capability **`addons/lock/cap-lock`** — Spec 63 Phase 3 PR-2. The advanced, opt-in policy layer on top of core's Phase-1 field-lock enforcement, consuming the `field-lock-check` interceptor seam landed in #445.

It registers a `field-lock-check` interceptor (`extensions.interceptors`, `{ point: "field-lock-check", capability: "lock", handler }`) that may suppress computed `FieldLockViolation[]` only under an explicit, audited policy (Spec 63 §4.2):

| Knob | Behavior |
|------|----------|
| `shadowMode` | observe + audit-log violations, do not block (rollout observation) |
| `bypassGroups: string[]` | if `actor.groups` intersects the list → override locks (audited) |
| `toleranceMs: number` | records younger than the window are freely editable |

Evaluation is first-match-wins (shadow → bypass → tolerance); on a match it audit-logs and returns `[]` (allow).

## Security posture (this capability can weaken an enforcement boundary, so:)

- **Fail-closed default**: empty config is a pure no-op — the handler returns the violation set **unchanged** whenever no knob matches, so core re-throws with full per-field detail.
- **Never mutates** its argument (core already hands a deep clone; we still return a fresh/unmodified array — covered by a test).
- **Every suppression is audit-logged** via the injected `Logger` with `{ capability, reason, entity, actorId, actorType, tenantId, fields, violationCount }` (Spec 63 §4.2 audit trail). No logger → silent, but the policy decision is unchanged.
- **Tolerance fails closed** on a missing/unparseable `created_at` (parsed as Date / ISO / epoch). Note: a *future* `created_at` (clock skew) counts as within-window — `created_at` is a server-managed system field, so this is acceptable; flagging for reviewer awareness.
- Static `capLock` export uses default (no-op) config; real wiring uses `createCapLock({ config, logger })` (mirrors cap-permission's programmatic factory). The dev bootstrap must inject the logger for the audit trail.

## Core change

Adds an optional `interceptors` key to the capability manifest schema (`extensionManifestSchema`) so a capability can declaratively name the interceptor points it attaches to. cap-lock is the first interceptor-using capability; previously only `hooks` existed (a distinct event-reaction concept). Additive + backward-compatible; the manifest `extensions` block is declarative-only (no code exhaustively iterates its keys).

## Out of scope (separate follow-up PRs)

§5.2 cap-lock UI extensions (lock icon / tooltip / unlock button), SOFT_LOCK two-step confirmation, notification integration.

## Test plan

- `bun test addons/lock/cap-lock/__tests__/` → **29 pass / 0 fail** (interceptor behavior incl. fail-closed + no-mutation + tolerance edge cases; capability metadata/registration; config defaults/validation).
- Core `capability-metadata` schema test green with the new key.
- `bun run typecheck` + `bun run check` clean.
- `linch lint-capability addons/lock/cap-lock` → all checks pass (§9.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
