### PR TITLE
feat(adapter-server): register watcher_state as a queryable system entity (Spec 45 §7.1)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/system-data-provider-watcher.integration.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/system-data-provider-watcher.integration.test.ts
@@ -1,0 +1,197 @@
+/**
+ * SystemDataProvider — watcher_state DB source integration tests (Spec 45 §7.1).
+ *
+ * Drives the REAL DB-backed `watcher_state` path of SystemDataProvider against a
+ * real `_linchkit.watcher_state` table (the production debounce-state backend
+ * shipped by Spec 45 PR-2), proving the admin management UI can list/count the
+ * persisted per-(watcher, group) condition state.
+ *
+ * Mirrors the harness used by the cap-ai-provider DrizzleWatcherStateStore
+ * integration suite: self-creates the `_linchkit.watcher_state` fixture table
+ * (this is NOT production DDL — production DDL is delegated to drizzle-kit; the
+ * shape mirrors src/watcher-state-table.ts).
+ *
+ * Requires a running PostgreSQL instance. Set DATABASE_TEST_URL to connect.
+ * Default: postgres://linchkit_test:linchkit_test@localhost:5434/linchkit_test
+ * Skips gracefully when no database is available; CI provides the `postgres`
+ * service so this suite RUNS there.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { watcherStateTable } from "@linchkit/cap-ai-provider";
+import { closeDatabase, createDatabase, InMemoryStore } from "@linchkit/core/server";
+import { sql } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import { SystemDataProvider } from "../src/system-data-provider";
+
+// ── Test configuration ───────────────────────────────────────
+
+const DATABASE_URL =
+  process.env.DATABASE_TEST_URL ??
+  "postgres://linchkit_test:linchkit_test@localhost:5434/linchkit_test";
+
+const TABLE = `"_linchkit"."watcher_state"`;
+
+// ── Connection check ─────────────────────────────────────────
+
+async function canConnect(): Promise<boolean> {
+  try {
+    const testDb = createDatabase({ url: DATABASE_URL });
+    await testDb.execute(sql`SELECT 1`);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    await closeDatabase();
+  }
+}
+
+const dbAvailable = await canConnect();
+
+if (!dbAvailable) {
+  console.warn(
+    "PostgreSQL not available, skipping SystemDataProvider watcher_state integration tests",
+  );
+}
+
+// ── Fixtures ─────────────────────────────────────────────────
+
+let db: PostgresJsDatabase | null = null;
+
+/**
+ * Narrow `db` to non-null. Assigned in beforeAll; the suite is skipped when no
+ * DB is available, so this never throws in practice. A clear error beats the
+ * repo-banned `db!` non-null assertion (biome `noNonNullAssertion`).
+ */
+function requireDb(): PostgresJsDatabase {
+  if (!db) throw new Error("db not initialized — beforeAll did not run");
+  return db;
+}
+
+// ── Test suite ───────────────────────────────────────────────
+
+describe.skipIf(!dbAvailable)("SystemDataProvider watcher_state (DB integration)", () => {
+  beforeAll(async () => {
+    db = createDatabase({ url: DATABASE_URL });
+
+    await db.execute(sql.raw(`CREATE SCHEMA IF NOT EXISTS "_linchkit"`));
+
+    // Self-create the fixture table mirroring src/watcher-state-table.ts. This
+    // is NOT production DDL (drizzle-kit owns that) — it gives the real
+    // SystemDataProvider an authentic schema to query against.
+    await db.execute(sql.raw(`DROP TABLE IF EXISTS ${TABLE} CASCADE`));
+    await db.execute(
+      sql.raw(`
+      CREATE TABLE ${TABLE} (
+        "watcher_name" text NOT NULL,
+        "group_key" text NOT NULL,
+        "last_fired_at" timestamp,
+        "condition_met" boolean DEFAULT false NOT NULL,
+        "tenant_id" text,
+        "updated_at" timestamp DEFAULT now() NOT NULL,
+        CONSTRAINT "watcher_state_watcher_name_group_key_pk" PRIMARY KEY ("watcher_name", "group_key")
+      )
+    `),
+    );
+  });
+
+  afterAll(async () => {
+    if (db) {
+      await db.execute(sql.raw(`DROP TABLE IF EXISTS ${TABLE} CASCADE`));
+      await closeDatabase();
+    }
+  });
+
+  beforeEach(async () => {
+    if (db) {
+      await db.execute(sql.raw(`TRUNCATE TABLE ${TABLE}`));
+    }
+  });
+
+  function makeProvider(): SystemDataProvider {
+    return new SystemDataProvider(new InMemoryStore(), { db: requireDb() });
+  }
+
+  async function seed(rows: Array<typeof watcherStateTable.$inferInsert>): Promise<void> {
+    await requireDb().insert(watcherStateTable).values(rows);
+  }
+
+  test("query returns rows with snake_case fields and ISO timestamps", async () => {
+    const firedAt = new Date("2026-02-02T03:04:05.000Z");
+    await seed([
+      {
+        watcherName: "low-stock",
+        groupKey: "item-1",
+        lastFiredAt: firedAt,
+        conditionMet: true,
+        tenantId: "t1",
+      },
+    ]);
+
+    const provider = makeProvider();
+    const rows = await provider.query("watcher_state", {});
+    expect(rows).toHaveLength(1);
+
+    const record = rows[0];
+    expect(record.watcher_name).toBe("low-stock");
+    expect(record.group_key).toBe("item-1");
+    expect(record.condition_met).toBe(true);
+    expect(record.tenant_id).toBe("t1");
+    // Timestamps serialized to ISO strings for GraphQL compatibility.
+    expect(record.last_fired_at).toBe("2026-02-02T03:04:05.000Z");
+    expect(typeof record.updated_at).toBe("string");
+  });
+
+  test("count returns total and supports filtering by a mapped column", async () => {
+    await seed([
+      { watcherName: "w1", groupKey: "a", conditionMet: true },
+      { watcherName: "w1", groupKey: "b", conditionMet: false },
+      { watcherName: "w2", groupKey: "a", conditionMet: true },
+    ]);
+
+    const provider = makeProvider();
+    expect(await provider.count("watcher_state")).toBe(3);
+
+    // Filter on a snake_case field that maps to a camelCase DB column.
+    const filtered = await provider.query("watcher_state", { watcher_name: "w1" });
+    expect(filtered).toHaveLength(2);
+    expect(await provider.count("watcher_state", { watcher_name: "w1" })).toBe(2);
+  });
+
+  test("query sorts by updated_at desc and paginates", async () => {
+    await seed([
+      { watcherName: "w", groupKey: "g1", updatedAt: new Date("2026-01-01T00:00:00.000Z") },
+      { watcherName: "w", groupKey: "g2", updatedAt: new Date("2026-03-01T00:00:00.000Z") },
+      { watcherName: "w", groupKey: "g3", updatedAt: new Date("2026-02-01T00:00:00.000Z") },
+    ]);
+
+    const provider = makeProvider();
+    const sorted = await provider.query("watcher_state", {
+      sortField: "updated_at",
+      sortOrder: "desc",
+    });
+    expect(sorted.map((r) => r.group_key)).toEqual(["g2", "g3", "g1"]);
+
+    const page = await provider.query("watcher_state", {
+      sortField: "updated_at",
+      sortOrder: "desc",
+      page: 1,
+      pageSize: 2,
+    });
+    expect(page.map((r) => r.group_key)).toEqual(["g2", "g3"]);
+  });
+
+  test("get-by-id is unsupported for the composite-PK table (degrades, does not crash)", async () => {
+    const provider = makeProvider();
+    await expect(provider.get("watcher_state", "anything")).rejects.toThrow(
+      /not supported for "watcher_state"/,
+    );
+  });
+
+  test("create/update/delete are rejected (read-only system entity)", async () => {
+    const provider = makeProvider();
+    await expect(provider.create("watcher_state", {})).rejects.toThrow("Cannot create");
+    await expect(provider.update("watcher_state", "x", {})).rejects.toThrow("Cannot update");
+    await expect(provider.delete("watcher_state", "x")).rejects.toThrow("Cannot delete");
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/__tests__/system-schemas-watcher.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/system-schemas-watcher.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Watcher-state system entity registration tests (Spec 45 §7.1).
+ *
+ * Asserts that `watcher_state` is registered as a system entity exactly like
+ * the other system entities (execution_log, approval, rule, flow,
+ * state_machine, proposal): present in the `INTERNAL_SCHEMA_NAMES` whitelist,
+ * the `systemSchemas` array, and the `systemViews` array — and that its
+ * EntityDefinition + ViewDefinition mirror the `_linchkit.watcher_state` table.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  INTERNAL_SCHEMA_NAMES,
+  systemSchemas,
+  systemViews,
+  watcherStateListView,
+  watcherStateSchema,
+} from "../src/system-schemas";
+
+describe("watcher_state system entity registration", () => {
+  test("watcher_state is in the INTERNAL_SCHEMA_NAMES whitelist", () => {
+    expect(INTERNAL_SCHEMA_NAMES.has("watcher_state")).toBe(true);
+  });
+
+  test("watcher_state schema is registered in systemSchemas", () => {
+    const found = systemSchemas.find((s) => s.name === "watcher_state");
+    expect(found).toBeDefined();
+    expect(found).toBe(watcherStateSchema);
+  });
+
+  test("watcher_state list view is registered in systemViews", () => {
+    const found = systemViews.find((v) => v.name === "watcher_state_list");
+    expect(found).toBeDefined();
+    expect(found).toBe(watcherStateListView);
+    expect(found?.entity).toBe("watcher_state");
+  });
+
+  test("watcher_state schema mirrors the _linchkit.watcher_state table columns", () => {
+    const fieldNames = Object.keys(watcherStateSchema.fields).sort();
+    expect(fieldNames).toEqual(
+      [
+        "condition_met",
+        "group_key",
+        "last_fired_at",
+        "tenant_id",
+        "updated_at",
+        "watcher_name",
+      ].sort(),
+    );
+
+    // Field types match the table shape.
+    expect(watcherStateSchema.fields.watcher_name?.type).toBe("string");
+    expect(watcherStateSchema.fields.group_key?.type).toBe("string");
+    expect(watcherStateSchema.fields.last_fired_at?.type).toBe("datetime");
+    expect(watcherStateSchema.fields.condition_met?.type).toBe("boolean");
+    expect(watcherStateSchema.fields.tenant_id?.type).toBe("string");
+    expect(watcherStateSchema.fields.updated_at?.type).toBe("datetime");
+
+    // Composite PK members are required + primary in the UI.
+    expect(watcherStateSchema.fields.watcher_name?.required).toBe(true);
+    expect(watcherStateSchema.fields.group_key?.required).toBe(true);
+    expect(watcherStateSchema.fields.watcher_name?.ui?.importance).toBe("primary");
+    expect(watcherStateSchema.fields.group_key?.ui?.importance).toBe("primary");
+
+    // i18n labels follow the `t:entities.watcher_state.*` convention.
+    expect(watcherStateSchema.label).toBe("t:entities.watcher_state._label");
+    expect(watcherStateSchema.presentation?.titleField).toBe("watcher_name");
+  });
+
+  test("watcher_state list view sorts by updated_at desc and has no rowActionRoute", () => {
+    expect(watcherStateListView.type).toBe("list");
+    expect(watcherStateListView.defaultSort).toEqual({ field: "updated_at", order: "desc" });
+    expect(watcherStateListView.pageSize).toBe(20);
+    // Composite PK / no admin detail route → no rowActionRoute.
+    expect(watcherStateListView.rowActionRoute).toBeUndefined();
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/src/system-data-provider.ts
+++ b/addons/adapter-server/cap-adapter-server/src/system-data-provider.ts
@@ -271,7 +271,10 @@ const TABLE_MAP = {
 type DbBackedSchema = keyof typeof TABLE_MAP;
 
 function isDbBackedSchema(schema: string): schema is DbBackedSchema {
-  return schema in TABLE_MAP;
+  // hasOwnProperty (not the `in` operator) so a schema name colliding with an
+  // Object.prototype member ("constructor", "toString", …) can't be mistaken
+  // for a DB-backed table — hardens the DB-read path against prototype keys.
+  return Object.hasOwn(TABLE_MAP, schema);
 }
 
 /** Column name mapping: schema field name → DB column name */

--- a/addons/adapter-server/cap-adapter-server/src/system-data-provider.ts
+++ b/addons/adapter-server/cap-adapter-server/src/system-data-provider.ts
@@ -2,7 +2,8 @@
  * System Data Provider
  *
  * Handles data queries for internal/system entities that are backed by either:
- * - System tables in the `_linchkit` PostgreSQL schema (execution_log, approval)
+ * - System tables in the `_linchkit` PostgreSQL schema (execution_log, approval,
+ *   watcher_state)
  * - In-memory registries (rule, flow, state_machine)
  * - REST/proposal store (proposal)
  *
@@ -10,6 +11,7 @@
  * queries for internal entities, delegating all others to the inner provider.
  */
 
+import { watcherStateTable } from "@linchkit/cap-ai-provider";
 import type {
   DataProvider,
   DataQueryOptions,
@@ -262,7 +264,15 @@ function executionEntryToRecord(e: ExecutionLogEntry): Record<string, unknown> {
 const TABLE_MAP = {
   execution_log: executionsTable,
   approval: approvalsTable,
+  watcher_state: watcherStateTable,
 } as const;
+
+/** System entities whose data is backed by a `_linchkit` DB table. */
+type DbBackedSchema = keyof typeof TABLE_MAP;
+
+function isDbBackedSchema(schema: string): schema is DbBackedSchema {
+  return schema in TABLE_MAP;
+}
 
 /** Column name mapping: schema field name → DB column name */
 const COLUMN_ALIAS: Record<string, Record<string, string>> = {
@@ -302,6 +312,14 @@ const COLUMN_ALIAS: Record<string, Record<string, string>> = {
     created_at: "createdAt",
     updated_at: "updatedAt",
     tenant_id: "tenantId",
+  },
+  watcher_state: {
+    watcher_name: "watcherName",
+    group_key: "groupKey",
+    last_fired_at: "lastFiredAt",
+    condition_met: "conditionMet",
+    tenant_id: "tenantId",
+    updated_at: "updatedAt",
   },
 };
 
@@ -354,7 +372,7 @@ export class SystemDataProvider implements DataProvider {
   ): Promise<Record<string, unknown>> {
     if (!this.isInternal(schema)) return this.inner.get(schema, id, options);
 
-    if (schema === "execution_log" || schema === "approval") {
+    if (isDbBackedSchema(schema)) {
       // Fallback to ExecutionLogger when DB is not available
       if (!this.sources.db && schema === "execution_log" && this.sources.executionLogger) {
         const entry = await this.sources.executionLogger.getById(id);
@@ -385,7 +403,7 @@ export class SystemDataProvider implements DataProvider {
   ): Promise<Array<Record<string, unknown>>> {
     if (!this.isInternal(schema)) return this.inner.query(schema, filter, options);
 
-    if (schema === "execution_log" || schema === "approval") {
+    if (isDbBackedSchema(schema)) {
       // Fallback to ExecutionLogger when DB is not available
       if (!this.sources.db && schema === "execution_log" && this.sources.executionLogger) {
         return this.executionLoggerQuery(filter);
@@ -407,7 +425,7 @@ export class SystemDataProvider implements DataProvider {
   ): Promise<number> {
     if (!this.isInternal(schema)) return this.inner.count(schema, filter, options);
 
-    if (schema === "execution_log" || schema === "approval") {
+    if (isDbBackedSchema(schema)) {
       // Fallback to ExecutionLogger when DB is not available
       if (!this.sources.db && schema === "execution_log" && this.sources.executionLogger) {
         return this.executionLoggerCount(filter ?? {});
@@ -503,17 +521,20 @@ export class SystemDataProvider implements DataProvider {
 
   // ── DB query implementations ─────────────────────────
 
-  private async dbGet(
-    schema: "execution_log" | "approval",
-    id: string,
-  ): Promise<Record<string, unknown>> {
+  private async dbGet(schema: DbBackedSchema, id: string): Promise<Record<string, unknown>> {
     const db = this.sources.db;
     if (!db) throw new Error("Database not available for system table query");
 
     const table = TABLE_MAP[schema];
     const columns = getTableColumns(table) as Record<string, PgColumn>;
-    // biome-ignore lint/style/noNonNullAssertion: id column always exists in system tables
-    const idCol = columns.id!;
+    const idCol = columns.id;
+    // Tables with a composite primary key (e.g. watcher_state's
+    // `(watcher_name, group_key)`) have no single `id` column, so get-by-id
+    // does not apply. List/count are the primary needs for those entities;
+    // degrade with a clear error instead of crashing.
+    if (!idCol) {
+      throw new Error(`Get-by-id is not supported for "${schema}" (no single id column)`);
+    }
     const rows = await db.select().from(table).where(eq(idCol, id)).limit(1);
     if (rows.length === 0) {
       throw new Error(`${schema} "${id}" not found`);
@@ -523,7 +544,7 @@ export class SystemDataProvider implements DataProvider {
   }
 
   private async dbQuery(
-    schema: "execution_log" | "approval",
+    schema: DbBackedSchema,
     filter: FilterObject,
     _options?: DataQueryOptions,
   ): Promise<Array<Record<string, unknown>>> {
@@ -580,7 +601,7 @@ export class SystemDataProvider implements DataProvider {
   }
 
   private async dbCount(
-    schema: "execution_log" | "approval",
+    schema: DbBackedSchema,
     filter: FilterObject,
     _options?: DataQueryOptions,
   ): Promise<number> {

--- a/addons/adapter-server/cap-adapter-server/src/system-schemas-watcher.ts
+++ b/addons/adapter-server/cap-adapter-server/src/system-schemas-watcher.ts
@@ -66,9 +66,9 @@ export const watcherStateListView: ViewDefinition = {
   type: "list",
   label: "t:entities.watcher_state._labelPlural",
   fields: [
-    { field: "watcher_name", sortable: true },
+    { field: "watcher_name", sortable: true, filterable: true },
     { field: "group_key", sortable: true, filterable: true },
-    { field: "condition_met", sortable: true, width: 100 },
+    { field: "condition_met", sortable: true, filterable: true, width: 100 },
     { field: "last_fired_at", sortable: true, width: 160 },
     { field: "updated_at", sortable: true, width: 160 },
   ],

--- a/addons/adapter-server/cap-adapter-server/src/system-schemas-watcher.ts
+++ b/addons/adapter-server/cap-adapter-server/src/system-schemas-watcher.ts
@@ -1,0 +1,79 @@
+/**
+ * Watcher-state system entity definition (Spec 45 §7.1).
+ *
+ * Registers the persisted watcher debounce state (`_linchkit.watcher_state`,
+ * shipped by Spec 45 PR-2) as a read-only, queryable system entity so the
+ * per-`(watcher_name, group_key)` condition state can be surfaced in the admin
+ * automation management UI alongside the other system entities.
+ *
+ * Kept in this sibling module (rather than inlined in `system-schemas.ts`) to
+ * avoid pushing the main file further past the ~500-line guideline; the
+ * registration arrays still live in `system-schemas.ts`, which re-exports these.
+ *
+ * The underlying table is `watcherStateTable` from `@linchkit/cap-ai-provider`
+ * (columns: watcher_name, group_key, last_fired_at, condition_met, tenant_id,
+ * updated_at; composite PK `(watcher_name, group_key)` — no single `id`).
+ */
+
+import type { EntityDefinition, ViewDefinition } from "@linchkit/core";
+
+// ── Watcher State ─────────────────────────────────────────
+
+export const watcherStateSchema: EntityDefinition = {
+  name: "watcher_state",
+  label: "t:entities.watcher_state._label",
+  description: "Persisted watcher debounce state per (watcher, group) for restart-safe firing",
+  presentation: {
+    titleField: "watcher_name",
+    summaryFields: ["group_key", "condition_met", "last_fired_at"],
+    icon: "radar",
+  },
+  fields: {
+    watcher_name: {
+      type: "string",
+      required: true,
+      label: "t:entities.watcher_state.fields.watcher_name",
+      ui: { importance: "primary" },
+    },
+    group_key: {
+      type: "string",
+      required: true,
+      label: "t:entities.watcher_state.fields.group_key",
+      ui: { importance: "primary" },
+    },
+    last_fired_at: {
+      type: "datetime",
+      label: "t:entities.watcher_state.fields.last_fired_at",
+    },
+    condition_met: {
+      type: "boolean",
+      label: "t:entities.watcher_state.fields.condition_met",
+    },
+    tenant_id: {
+      type: "string",
+      label: "t:entities.watcher_state.fields.tenant_id",
+    },
+    updated_at: {
+      type: "datetime",
+      label: "t:entities.watcher_state.fields.updated_at",
+    },
+  },
+};
+
+export const watcherStateListView: ViewDefinition = {
+  name: "watcher_state_list",
+  entity: "watcher_state",
+  type: "list",
+  label: "t:entities.watcher_state._labelPlural",
+  fields: [
+    { field: "watcher_name", sortable: true },
+    { field: "group_key", sortable: true, filterable: true },
+    { field: "condition_met", sortable: true, width: 100 },
+    { field: "last_fired_at", sortable: true, width: 160 },
+    { field: "updated_at", sortable: true, width: 160 },
+  ],
+  defaultSort: { field: "updated_at", order: "desc" },
+  pageSize: 20,
+  // No `rowActionRoute`: watcher_state has a composite PK (no single `id`) and
+  // no dedicated admin detail route exists, so the list is read-only.
+};

--- a/addons/adapter-server/cap-adapter-server/src/system-schemas.ts
+++ b/addons/adapter-server/cap-adapter-server/src/system-schemas.ts
@@ -11,6 +11,11 @@
  */
 
 import type { EntityDefinition, ViewDefinition } from "@linchkit/core";
+import { watcherStateListView, watcherStateSchema } from "./system-schemas-watcher";
+
+// Re-export the watcher-state definitions (kept in a sibling module to keep this
+// file under the ~500-line guideline) so consumers can import everything here.
+export { watcherStateListView, watcherStateSchema } from "./system-schemas-watcher";
 
 /** Shorthand to build enum options from plain string values */
 const opts = (...values: string[]) => values.map((value) => ({ value }));
@@ -577,6 +582,7 @@ export const INTERNAL_SCHEMA_NAMES = new Set([
   "flow",
   "state_machine",
   "proposal",
+  "watcher_state",
 ]);
 
 // ── Aggregated exports ────────────────────────────────────
@@ -588,6 +594,7 @@ export const systemSchemas: EntityDefinition[] = [
   flowSchema,
   stateMachineSchema,
   proposalSchema,
+  watcherStateSchema,
 ];
 
 export const systemViews: ViewDefinition[] = [
@@ -597,4 +604,5 @@ export const systemViews: ViewDefinition[] = [
   flowListView,
   stateMachineListView,
   proposalListView,
+  watcherStateListView,
 ];

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
@@ -618,6 +618,18 @@
         "deployed_at": "Deployed At",
         "rejection_reason": "Rejection Reason"
       }
+    },
+    "watcher_state": {
+      "_label": "Watcher State",
+      "_labelPlural": "Watcher States",
+      "fields": {
+        "watcher_name": "Watcher",
+        "group_key": "Group Key",
+        "last_fired_at": "Last Fired At",
+        "condition_met": "Condition Met",
+        "tenant_id": "Tenant",
+        "updated_at": "Updated At"
+      }
     }
   },
   "flows": {

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
@@ -618,6 +618,18 @@
         "deployed_at": "部署时间",
         "rejection_reason": "拒绝原因"
       }
+    },
+    "watcher_state": {
+      "_label": "监视器状态",
+      "_labelPlural": "监视器状态",
+      "fields": {
+        "watcher_name": "监视器",
+        "group_key": "分组键",
+        "last_fired_at": "上次触发时间",
+        "condition_met": "条件已满足",
+        "tenant_id": "租户",
+        "updated_at": "更新时间"
+      }
     }
   },
   "flows": {


### PR DESCRIPTION
## What

Closes Spec 45 §7.1's explicit gap: the watcher debounce state persisted by #443 (`_linchkit.watcher_state`) had no system `EntityDefinition` and no `SystemDataProvider` data source, so it wasn't visible/manageable in the admin UI. This registers it as a queryable system entity alongside `execution_log` / `approval` / `rule` / `flow` / `state_machine` / `proposal`.

## Changes

- **`system-schemas-watcher.ts` (new)** — `watcherStateSchema` (EntityDefinition: watcher_name, group_key, last_fired_at, condition_met, tenant_id, updated_at) + `watcherStateListView`. Re-exported from `system-schemas.ts`, which adds `watcher_state` to `INTERNAL_SCHEMA_NAMES`, `systemSchemas[]`, `systemViews[]`. (Sibling file keeps the already-600-line `system-schemas.ts` from bloating — it grew ~8 lines.)
- **`system-data-provider.ts`** — serves the rows via the **existing** DB-table read path: imports the already-public `watcherStateTable` from `@linchkit/cap-ai-provider` (an existing dependency — **no new dep**), generalizes the hardcoded `execution_log`/`approval` gate into an `isDbBackedSchema()` helper keyed off the table map, and makes `dbGet` composite-PK-safe. `watcher_state` has PK `(watcher_name, group_key)` and no single `id`, so get-by-id now throws a clear unsupported-operation error **instead of the previous banned non-null assertion (`columns.id!`)**; list / count / filter / sort / paginate work via the generic path.
- **i18n** — `entities.watcher_state` added to `en.json` + `zh-CN.json`.

## Boundaries

`adapter-server` already depends on `@linchkit/cap-ai-provider` (AI routes), and `watcherStateTable` is already in cap-ai-provider's public barrel — so this adds no new coupling. `SystemDataProvider` stays generic (the table handle flows through its existing source map). DDL is still owned by drizzle-kit / `db:push` (the addon provisions the table); the integration test self-creates a fixture table, it does NOT hand-write production DDL.

## Test plan

- `bun run typecheck` clean; `bun run check` (biome) clean.
- `system-schemas-watcher.test.ts` — registration + schema/view shape (no DB).
- `system-data-provider-watcher.integration.test.ts` — list / count+filter / sort+paginate / composite-PK get-by-id degradation / read-only CRUD guards; mirrors `watcher-state-store-drizzle`'s harness (skips without PG, runs on CI's postgres service; verified green against a live PG locally).
- Full `adapter-server` suite: **648 pass / 0 fail** (30 DB-gated skips locally) — confirms the `isDbBackedSchema()` generalization did not regress `execution_log`/`approval`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new read-only system entity for tracking watcher state with database persistence.
  * Enabled querying, filtering, and sorting of watcher state data.
  * Added multi-language support (English and Chinese) for watcher state labels and field descriptions.

* **Tests**
  * Added integration and unit test suites for watcher state functionality with PostgreSQL backend validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->