### PR TITLE
feat(lock,ui): actor field-lock bypass signal for the unlock UI (Spec 63 §5.2)

### DIFF
--- a/addons/adapter-ui/cap-adapter-ui/__tests__/field-lock-bypass.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/field-lock-bypass.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for the field-lock bypass UI logic (Spec 63 §5.2).
+ *
+ * This package's test setup is logic-only (no jsdom / happy-dom — see
+ * action-proposal-card.test.ts), so the FieldLockBadge is exercised through its
+ * pure `resolveLockTooltip` helper (the reason→text mapping the static, non-
+ * bypass path renders), and the `useFieldLockBypass` hook through its exported
+ * `fetchCanBypass` helper with fetch mocks (the data extraction + error-swallow
+ * behavior the hook depends on).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+// Minimal localStorage shim — api.ts reads `linchkit:token` for auth headers.
+const _store = new Map<string, string>();
+if (typeof globalThis.localStorage === "undefined") {
+  Object.defineProperty(globalThis, "localStorage", {
+    value: {
+      getItem: (key: string) => _store.get(key) ?? null,
+      setItem: (key: string, value: string) => _store.set(key, value),
+      removeItem: (key: string) => _store.delete(key),
+      clear: () => _store.clear(),
+      get length() {
+        return _store.size;
+      },
+      key: (index: number) => [..._store.keys()][index] ?? null,
+    },
+    configurable: true,
+  });
+}
+
+import type { TFunction } from "i18next";
+import { resolveLockTooltip } from "../src/components/field-lock-badge";
+import { fetchCanBypass, resetFieldLockBypassCache } from "../src/hooks/use-field-lock-bypass";
+
+// ── resolveLockTooltip (static badge text mapping) ───────────
+
+/**
+ * Translation stub that echoes the default value, interpolating {{status}}.
+ * Cast to `TFunction` — i18next's `t` is heavily overloaded, and only the
+ * `(key, default)` / `(key, { defaultValue, status })` call shapes used by
+ * `resolveLockTooltip` are exercised here.
+ */
+const t = ((key: string, options?: string | Record<string, unknown>): string => {
+  if (typeof options === "string") return options;
+  if (options && typeof options === "object") {
+    const def = typeof options.defaultValue === "string" ? options.defaultValue : key;
+    const status = options.status;
+    return typeof status === "string" ? def.replace("{{status}}", status) : def;
+  }
+  return key;
+}) as unknown as TFunction;
+
+describe("resolveLockTooltip", () => {
+  test("immutable reason → immutable message", () => {
+    expect(resolveLockTooltip(t, "immutable")).toBe("This field cannot be changed after creation");
+  });
+
+  test("locked reason without status → generic locked message", () => {
+    expect(resolveLockTooltip(t, "locked")).toBe("This field is locked in the current state");
+  });
+
+  test("locked reason with status → state-specific message", () => {
+    expect(resolveLockTooltip(t, "locked", "submitted")).toBe(
+      'Locked because the record is in state "submitted"',
+    );
+  });
+});
+
+// ── fetchCanBypass (hook data layer) ─────────────────────────
+
+let originalFetch: typeof fetch;
+
+function installFetch(body: unknown) {
+  originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })) as typeof fetch;
+}
+
+beforeEach(() => {
+  resetFieldLockBypassCache();
+});
+
+afterEach(() => {
+  if (originalFetch) globalThis.fetch = originalFetch;
+});
+
+describe("fetchCanBypass", () => {
+  test("returns true when fieldLockBypass.canBypass is true", async () => {
+    installFetch({ data: { fieldLockBypass: { canBypass: true, reason: "bypass" } } });
+    expect(await fetchCanBypass()).toBe(true);
+  });
+
+  test("returns false when fieldLockBypass.canBypass is false", async () => {
+    installFetch({ data: { fieldLockBypass: { canBypass: false, reason: null } } });
+    expect(await fetchCanBypass()).toBe(false);
+  });
+
+  test("returns false (swallows error) when the field is missing (cap-lock not installed)", async () => {
+    // GraphQL validation error shape returned when `fieldLockBypass` is unknown.
+    installFetch({
+      errors: [{ message: 'Cannot query field "fieldLockBypass" on type "Query".' }],
+    });
+    expect(await fetchCanBypass()).toBe(false);
+  });
+
+  test("returns false when data is absent entirely", async () => {
+    installFetch({});
+    expect(await fetchCanBypass()).toBe(false);
+  });
+
+  test("returns false on a network/transport failure (no throw)", async () => {
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      throw new Error("network down");
+    }) as typeof fetch;
+    expect(await fetchCanBypass()).toBe(false);
+  });
+
+  test("caches the result — a second call does not refetch", async () => {
+    let calls = 0;
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      return new Response(JSON.stringify({ data: { fieldLockBypass: { canBypass: true } } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    expect(await fetchCanBypass()).toBe(true);
+    expect(await fetchCanBypass()).toBe(true);
+    expect(calls).toBe(1);
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/field-lock-bypass.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/field-lock-bypass.test.ts
@@ -4,34 +4,16 @@
  * This package's test setup is logic-only (no jsdom / happy-dom — see
  * action-proposal-card.test.ts), so the FieldLockBadge is exercised through its
  * pure `resolveLockTooltip` helper (the reason→text mapping the static, non-
- * bypass path renders), and the `useFieldLockBypass` hook through its exported
- * `fetchCanBypass` helper with fetch mocks (the data extraction + error-swallow
- * behavior the hook depends on).
+ * bypass path renders), and `fetchCanBypass` (the hook's data layer) through an
+ * injected `graphql` stub. Injection keeps the data-layer tests deterministic
+ * and independent of any global `fetch` state or batched-runner test ordering
+ * (reassigning `globalThis.fetch` proved flaky under the CI runner).
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-
-// Minimal localStorage shim — api.ts reads `linchkit:token` for auth headers.
-const _store = new Map<string, string>();
-if (typeof globalThis.localStorage === "undefined") {
-  Object.defineProperty(globalThis, "localStorage", {
-    value: {
-      getItem: (key: string) => _store.get(key) ?? null,
-      setItem: (key: string, value: string) => _store.set(key, value),
-      removeItem: (key: string) => _store.delete(key),
-      clear: () => _store.clear(),
-      get length() {
-        return _store.size;
-      },
-      key: (index: number) => [..._store.keys()][index] ?? null,
-    },
-    configurable: true,
-  });
-}
-
+import { describe, expect, test } from "bun:test";
 import type { TFunction } from "i18next";
 import { resolveLockTooltip } from "../src/components/field-lock-badge";
-import { fetchCanBypass, resetFieldLockBypassCache } from "../src/hooks/use-field-lock-bypass";
+import { fetchCanBypass } from "../src/hooks/use-field-lock-bypass";
 
 // ── resolveLockTooltip (static badge text mapping) ───────────
 
@@ -69,70 +51,47 @@ describe("resolveLockTooltip", () => {
 
 // ── fetchCanBypass (hook data layer) ─────────────────────────
 
-let originalFetch: typeof fetch;
-
-function installFetch(body: unknown) {
-  originalFetch = globalThis.fetch;
-  globalThis.fetch = (async () =>
-    new Response(JSON.stringify(body), {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    })) as typeof fetch;
+/** Deterministic `graphql` stub that resolves to `body` — no real network/fetch. */
+function stubGraphql(body: unknown): Parameters<typeof fetchCanBypass>[0] {
+  return (async () => body) as unknown as Parameters<typeof fetchCanBypass>[0];
 }
-
-beforeEach(() => {
-  resetFieldLockBypassCache();
-});
-
-afterEach(() => {
-  if (originalFetch) globalThis.fetch = originalFetch;
-});
 
 describe("fetchCanBypass", () => {
   test("returns true when fieldLockBypass.canBypass is true", async () => {
-    installFetch({ data: { fieldLockBypass: { canBypass: true, reason: "bypass" } } });
-    expect(await fetchCanBypass()).toBe(true);
+    expect(
+      await fetchCanBypass(
+        stubGraphql({ data: { fieldLockBypass: { canBypass: true, reason: "bypass" } } }),
+      ),
+    ).toBe(true);
   });
 
   test("returns false when fieldLockBypass.canBypass is false", async () => {
-    installFetch({ data: { fieldLockBypass: { canBypass: false, reason: null } } });
-    expect(await fetchCanBypass()).toBe(false);
+    expect(
+      await fetchCanBypass(
+        stubGraphql({ data: { fieldLockBypass: { canBypass: false, reason: null } } }),
+      ),
+    ).toBe(false);
   });
 
   test("returns false (swallows error) when the field is missing (cap-lock not installed)", async () => {
     // GraphQL validation error shape returned when `fieldLockBypass` is unknown.
-    installFetch({
-      errors: [{ message: 'Cannot query field "fieldLockBypass" on type "Query".' }],
-    });
-    expect(await fetchCanBypass()).toBe(false);
+    expect(
+      await fetchCanBypass(
+        stubGraphql({
+          errors: [{ message: 'Cannot query field "fieldLockBypass" on type "Query".' }],
+        }),
+      ),
+    ).toBe(false);
   });
 
   test("returns false when data is absent entirely", async () => {
-    installFetch({});
-    expect(await fetchCanBypass()).toBe(false);
+    expect(await fetchCanBypass(stubGraphql({}))).toBe(false);
   });
 
-  test("returns false on a network/transport failure (no throw)", async () => {
-    originalFetch = globalThis.fetch;
-    globalThis.fetch = (async () => {
+  test("returns false on a thrown error (no throw escapes)", async () => {
+    const throwing = (async () => {
       throw new Error("network down");
-    }) as typeof fetch;
-    expect(await fetchCanBypass()).toBe(false);
-  });
-
-  test("caches the result — a second call does not refetch", async () => {
-    let calls = 0;
-    originalFetch = globalThis.fetch;
-    globalThis.fetch = (async () => {
-      calls += 1;
-      return new Response(JSON.stringify({ data: { fieldLockBypass: { canBypass: true } } }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
-    }) as typeof fetch;
-
-    expect(await fetchCanBypass()).toBe(true);
-    expect(await fetchCanBypass()).toBe(true);
-    expect(calls).toBe(1);
+    }) as unknown as Parameters<typeof fetchCanBypass>[0];
+    expect(await fetchCanBypass(throwing)).toBe(false);
   });
 });

--- a/addons/adapter-ui/cap-adapter-ui/src/components/auto-form/auto-form.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/auto-form/auto-form.tsx
@@ -32,7 +32,7 @@ import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "rea
 import { useTranslation } from "react-i18next";
 import { z } from "zod";
 import { useEntityOnchange } from "../../hooks/use-entity-onchange";
-import { useFieldLockBypass } from "../../hooks/use-field-lock-bypass";
+import { useFieldUnlock } from "../../hooks/use-field-lock-bypass";
 import { useFieldLockState } from "../../hooks/use-field-lock-state";
 import { buildRelationFieldMap } from "../../lib/entity-form-utils";
 import { evaluateVisibility } from "../../lib/field-visibility";
@@ -166,24 +166,13 @@ export function AutoForm({
     mode,
   });
 
-  // ── Field-lock bypass (Spec 63 §5.2) ──
+  // ── Field-lock bypass / unlock (Spec 63 §5.2) ──
   // Whether the CURRENT actor may override field locks (decided by cap-lock's
-  // policy via the `fieldLockBypass` query; false when cap-lock is absent). A
-  // bypass-eligible actor can click a locked field's badge to unlock it for
-  // editing; `unlockedFields` tracks which fields they have opted to unlock.
-  const { canBypass } = useFieldLockBypass();
-  const [unlockedFields, setUnlockedFields] = useState<Set<string>>(() => new Set());
-  const toggleFieldUnlock = useCallback((fieldName: string) => {
-    setUnlockedFields((prev) => {
-      const next = new Set(prev);
-      if (next.has(fieldName)) {
-        next.delete(fieldName);
-      } else {
-        next.add(fieldName);
-      }
-      return next;
-    });
-  }, []);
+  // policy via the `fieldLockBypass` query; false when cap-lock is absent) and
+  // which fields they have opted to unlock for editing. A bypass-eligible actor
+  // can click a locked field's badge to unlock it. The state + derivation live
+  // in `useFieldUnlock` so this large component stays lean.
+  const { canBypass, isUnlocked, toggleUnlock } = useFieldUnlock();
 
   // ── Entity onchange (Spec 64) ──
   // Server-driven interactive form computation. Fires after a debounced field
@@ -826,7 +815,7 @@ export function AutoForm({
     if (fieldLockState[fieldName]?.locked) {
       // Spec 63 §5.2 — a bypass-eligible actor who has explicitly unlocked the
       // field may edit it; otherwise the lock stands.
-      if (canBypass && unlockedFields.has(fieldName)) return false;
+      if (canBypass && isUnlocked(fieldName)) return false;
       return true;
     }
     return false;
@@ -886,8 +875,8 @@ export function AutoForm({
             reason: lockInfo.reason ?? "locked",
             status: resolvedStatus,
             canBypass,
-            unlocked: unlockedFields.has(node.field),
-            onToggle: () => toggleFieldUnlock(node.field),
+            unlocked: isUnlocked(node.field),
+            onToggle: () => toggleUnlock(node.field),
           }
         : undefined;
 

--- a/addons/adapter-ui/cap-adapter-ui/src/components/auto-form/auto-form.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/auto-form/auto-form.tsx
@@ -32,6 +32,7 @@ import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "rea
 import { useTranslation } from "react-i18next";
 import { z } from "zod";
 import { useEntityOnchange } from "../../hooks/use-entity-onchange";
+import { useFieldLockBypass } from "../../hooks/use-field-lock-bypass";
 import { useFieldLockState } from "../../hooks/use-field-lock-state";
 import { buildRelationFieldMap } from "../../lib/entity-form-utils";
 import { evaluateVisibility } from "../../lib/field-visibility";
@@ -164,6 +165,25 @@ export function AutoForm({
     record: lockRecord,
     mode,
   });
+
+  // ── Field-lock bypass (Spec 63 §5.2) ──
+  // Whether the CURRENT actor may override field locks (decided by cap-lock's
+  // policy via the `fieldLockBypass` query; false when cap-lock is absent). A
+  // bypass-eligible actor can click a locked field's badge to unlock it for
+  // editing; `unlockedFields` tracks which fields they have opted to unlock.
+  const { canBypass } = useFieldLockBypass();
+  const [unlockedFields, setUnlockedFields] = useState<Set<string>>(() => new Set());
+  const toggleFieldUnlock = useCallback((fieldName: string) => {
+    setUnlockedFields((prev) => {
+      const next = new Set(prev);
+      if (next.has(fieldName)) {
+        next.delete(fieldName);
+      } else {
+        next.add(fieldName);
+      }
+      return next;
+    });
+  }, []);
 
   // ── Entity onchange (Spec 64) ──
   // Server-driven interactive form computation. Fires after a debounced field
@@ -803,7 +823,12 @@ export function AutoForm({
     // Spec 63 §5.1 — computed readonly from entity lock rules (immutable on
     // edit, lockWhen/lockAllWhen by current state). Supersedes the previous
     // inline `immutable` check, which this hook also covers.
-    if (fieldLockState[fieldName]?.locked) return true;
+    if (fieldLockState[fieldName]?.locked) {
+      // Spec 63 §5.2 — a bypass-eligible actor who has explicitly unlocked the
+      // field may edit it; otherwise the lock stands.
+      if (canBypass && unlockedFields.has(fieldName)) return false;
+      return true;
+    }
     return false;
   }
 
@@ -852,9 +877,18 @@ export function AutoForm({
     // Derive the displayed status from the SAME `resolvedStatus` used for lock
     // evaluation, so a field can never be evaluated locked under one status
     // while the tooltip shows a different one.
+    // Spec 63 §5.2 — when the actor may bypass, the badge becomes an unlock
+    // toggle. `lock` is still passed even after a field is unlocked (readonly
+    // cleared) so the open-lock toggle stays visible to re-lock the field.
     const lock =
       lockInfo?.locked && !isViewMode
-        ? { reason: lockInfo.reason ?? "locked", status: resolvedStatus }
+        ? {
+            reason: lockInfo.reason ?? "locked",
+            status: resolvedStatus,
+            canBypass,
+            unlocked: unlockedFields.has(node.field),
+            onToggle: () => toggleFieldUnlock(node.field),
+          }
         : undefined;
 
     const hasCondition = !!(

--- a/addons/adapter-ui/cap-adapter-ui/src/components/auto-form/form-field.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/auto-form/form-field.tsx
@@ -36,8 +36,19 @@ export interface FormFieldRowProps {
    * When set, the field is locked by an entity lock rule (Spec 63 §5.1). Drives
    * a lock indicator next to the label. The field's `readonly` prop is set by
    * the caller; this only controls the visual badge.
+   *
+   * `canBypass` / `unlocked` / `onToggle` (Spec 63 §5.2) make the badge an
+   * interactive unlock toggle for bypass-eligible actors. When `canBypass` is
+   * true and the actor has unlocked the field, the caller clears `readonly` —
+   * but still passes `lock` so the open-lock toggle stays visible (to re-lock).
    */
-  lock?: { reason: FieldLockReason; status?: string };
+  lock?: {
+    reason: FieldLockReason;
+    status?: string;
+    canBypass?: boolean;
+    unlocked?: boolean;
+    onToggle?: () => void;
+  };
 }
 
 /** Renders a single form field row with label alignment and overlay badge support. */
@@ -118,7 +129,15 @@ export function FormFieldRow({
         <span className="inline-flex items-center gap-1">
           {label}
           {overlayIndicator && <OverlayFieldBadge />}
-          {lock && <FieldLockBadge reason={lock.reason} status={lock.status} />}
+          {lock && (
+            <FieldLockBadge
+              reason={lock.reason}
+              status={lock.status}
+              canBypass={lock.canBypass}
+              unlocked={lock.unlocked}
+              onToggle={lock.onToggle}
+            />
+          )}
         </span>
       </Label>
 

--- a/addons/adapter-ui/cap-adapter-ui/src/components/field-lock-badge.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/field-lock-badge.tsx
@@ -4,6 +4,12 @@
  * Shown next to a field's label when the field is locked by an `immutable`
  * rule (edit mode) or a matching `lockWhen` / `lockAllWhen` condition
  * (Spec 63 §5.1). The tooltip explains why the field is locked.
+ *
+ * When the current actor may bypass locks (Spec 63 §5.2 — `canBypass`), the
+ * icon becomes an interactive unlock toggle: a real `<button>` that calls
+ * `onToggle`, rendering a `Lock` icon (click to unlock) or `LockOpen` icon
+ * (unlocked — click to re-lock). For non-bypass actors the badge renders
+ * exactly as before (a static reason-aware icon).
  */
 
 import {
@@ -12,7 +18,8 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@linchkit/ui-kit/components";
-import { Lock } from "lucide-react";
+import type { TFunction } from "i18next";
+import { Lock, LockOpen } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { FieldLockReason } from "../lib/field-lock-state";
 
@@ -23,28 +30,85 @@ interface FieldLockBadgeProps {
   status?: string;
   /** Additional CSS class names. */
   className?: string;
+  /** When true, the current actor may override locks → render an unlock toggle. */
+  canBypass?: boolean;
+  /** When `canBypass`, whether the actor has unlocked this field for editing. */
+  unlocked?: boolean;
+  /** Toggle handler for the unlock button (only used when `canBypass`). */
+  onToggle?: () => void;
 }
 
+/**
+ * Resolve the tooltip text for the static (non-bypass) lock badge.
+ *
+ * Exported as a pure helper so the reason→text mapping is unit-testable without
+ * a React render harness (this package's test setup is logic-only — no
+ * jsdom/happy-dom).
+ */
+export function resolveLockTooltip(t: TFunction, reason: FieldLockReason, status?: string): string {
+  if (reason === "immutable") {
+    return t("form.lock.immutable", "This field cannot be changed after creation");
+  }
+  if (status) {
+    return t("form.lock.lockedInState", {
+      defaultValue: 'Locked because the record is in state "{{status}}"',
+      status,
+    });
+  }
+  return t("form.lock.locked", "This field is locked in the current state");
+}
+
+/** Shared icon CSS — keeps the bypass toggle visually identical to the static badge. */
+const ICON_CLASS = "size-3 text-muted-foreground/60 shrink-0";
+
 /** Renders a small lock icon badge with a reason-aware tooltip on locked fields. */
-export function FieldLockBadge({ reason, status, className }: FieldLockBadgeProps) {
+export function FieldLockBadge({
+  reason,
+  status,
+  className,
+  canBypass,
+  unlocked,
+  onToggle,
+}: FieldLockBadgeProps) {
   const { t } = useTranslation();
 
-  const tooltip =
-    reason === "immutable"
-      ? t("form.lock.immutable", "This field cannot be changed after creation")
-      : status
-        ? t("form.lock.lockedInState", {
-            defaultValue: 'Locked because the record is in state "{{status}}"',
-            status,
-          })
-        : t("form.lock.locked", "This field is locked in the current state");
+  // Bypass-eligible actor → interactive unlock toggle.
+  if (canBypass) {
+    const tooltip = unlocked
+      ? t("form.lock.unlocked", "Unlocked — you may edit this field")
+      : t("form.lock.canOverride", "Locked — you may override. Click to unlock.");
+    const Icon = unlocked ? LockOpen : Lock;
+    return (
+      <TooltipProvider delayDuration={300}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={onToggle}
+              className={`inline-flex items-center ${className ?? ""}`}
+              aria-label={t("form.lock.toggleAriaLabel", "Toggle field lock")}
+              aria-pressed={unlocked === true}
+            >
+              <Icon className={ICON_CLASS} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="text-xs">
+            {tooltip}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
+  // Static (non-bypass) badge — preserved byte-for-byte from the original.
+  const tooltip = resolveLockTooltip(t, reason, status);
 
   return (
     <TooltipProvider delayDuration={300}>
       <Tooltip>
         <TooltipTrigger asChild>
           <Lock
-            className={`size-3 text-muted-foreground/60 shrink-0 ${className ?? ""}`}
+            className={`${ICON_CLASS} ${className ?? ""}`}
             aria-label={t("form.lock.ariaLabel", "Locked field")}
           />
         </TooltipTrigger>

--- a/addons/adapter-ui/cap-adapter-ui/src/components/field-lock-badge.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/field-lock-badge.tsx
@@ -84,7 +84,15 @@ export function FieldLockBadge({
           <TooltipTrigger asChild>
             <button
               type="button"
-              onClick={onToggle}
+              // The badge renders inside the field's <Label> (an HTML <label>),
+              // so a bare click would bubble up and trigger the label's default
+              // behavior (focusing / activating the associated input). Prevent
+              // and stop it so the toggle only flips the unlock state.
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                onToggle?.();
+              }}
               className={`inline-flex items-center ${className ?? ""}`}
               aria-label={t("form.lock.toggleAriaLabel", "Toggle field lock")}
               aria-pressed={unlocked === true}

--- a/addons/adapter-ui/cap-adapter-ui/src/hooks/use-field-lock-bypass.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/hooks/use-field-lock-bypass.ts
@@ -1,24 +1,31 @@
 /**
- * useFieldLockBypass — whether the CURRENT actor may override field locks
- * (Spec 63 §5.2).
+ * useFieldLockBypass / useFieldUnlock — whether the CURRENT actor may override
+ * field locks, plus the per-field unlock state the auto-form needs (Spec 63 §5.2).
  *
- * Runs ONE GraphQL query (`{ fieldLockBypass { canBypass reason } }`) against
- * the cap-lock read-side extension. The auto-form uses the result to render an
- * "unlock" affordance on locked fields for bypass-eligible actors.
+ * `useFieldLockBypass` runs ONE GraphQL query (`{ fieldLockBypass { canBypass
+ * reason } }`) per mount against the cap-lock read-side extension. The auto-form
+ * uses the result to render an "unlock" affordance on locked fields.
  *
  * ## Resilience: cap-lock may not be installed
  *
  * When cap-lock is absent, `fieldLockBypass` is NOT a schema field and the
- * server returns a GraphQL VALIDATION error. The hook swallows ALL errors (and
- * the missing-field case) and returns `{ canBypass: false }` — it never calls
+ * server returns a GraphQL VALIDATION error. `fetchCanBypass` swallows ALL
+ * errors (and the missing-field case) and resolves to `false` — it never calls
  * `throwOnErrors`, never throws, and stays SILENT on the expected
  * "field not found" path (no console noise).
  *
- * The result is cached at module level (session-scoped) so multiple forms on a
- * page share a single in-flight/resolved fetch; a full page reload resets it.
+ * ## No cross-session cache (deliberate)
+ *
+ * Each hook instance fetches once on mount and holds the result in component
+ * state — there is NO module-level cache. So a logout / login or tenant switch
+ * (which remounts the form) always re-evaluates for the current actor, and a
+ * transient fetch failure never sticks as a permanent fail-closed decision (the
+ * next mount retries). The query is cheap; correctness beats memoizing a
+ * per-session boolean that goes stale on user switch and gets stuck on a
+ * transient error.
  */
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { graphql } from "../lib/api";
 
 interface FieldLockBypassQueryResult {
@@ -26,49 +33,34 @@ interface FieldLockBypassQueryResult {
 }
 
 /**
- * Module-level cache of the resolved (or in-flight) bypass eligibility. Shared
- * across every form on the page; reset only by a page reload. Resolves to
- * `false` on ANY unexpected condition (missing field, network error, malformed
- * response) so the UI fails closed (no unlock affordance).
+ * Fetch the current actor's bypass eligibility via the `fieldLockBypass` query.
+ *
+ * `graphqlFn` is injectable PURELY so tests can supply a deterministic stub (the
+ * package's test setup is logic-only — no DOM, no reliable global-fetch harness
+ * under the batched runner); production always uses the real `graphql` helper.
+ * Resolves to `false` on ANY unexpected condition (missing field, network
+ * error, malformed response) so the UI fails closed (no unlock affordance).
+ * Never throws.
  */
-let cachedPromise: Promise<boolean> | null = null;
-
-/**
- * Fetch (and module-cache) the actor's bypass eligibility. Exported for
- * testing: the package's test setup is logic-only (no React render harness), so
- * the fetch / error-swallow behavior is verified directly against this helper —
- * mirroring how sibling component modules export their pure logic.
- */
-export function fetchCanBypass(): Promise<boolean> {
-  if (cachedPromise) return cachedPromise;
-  cachedPromise = (async () => {
-    try {
-      const res = await graphql<FieldLockBypassQueryResult>(
-        "query { fieldLockBypass { canBypass reason } }",
-      );
-      // Intentionally do NOT call throwOnErrors: a missing `fieldLockBypass`
-      // field (cap-lock not installed) surfaces as a GraphQL error we must
-      // swallow quietly. Read the value defensively and default to false.
-      return res.data?.fieldLockBypass?.canBypass === true;
-    } catch {
-      // Network / transport failure — fail closed.
-      return false;
-    }
-  })();
-  return cachedPromise;
+export async function fetchCanBypass(graphqlFn: typeof graphql = graphql): Promise<boolean> {
+  try {
+    const res = await graphqlFn<FieldLockBypassQueryResult>(
+      "query { fieldLockBypass { canBypass reason } }",
+    );
+    // Intentionally do NOT call throwOnErrors: a missing `fieldLockBypass` field
+    // (cap-lock not installed) surfaces as a GraphQL error we must swallow
+    // quietly. Read the value defensively and default to false.
+    return res.data?.fieldLockBypass?.canBypass === true;
+  } catch {
+    // Network / transport failure — fail closed.
+    return false;
+  }
 }
 
 /**
- * Reset the module-level cache. Test-only seam so each case starts fresh; not
- * used by production code (the cache is intentionally session-scoped there).
- */
-export function resetFieldLockBypassCache(): void {
-  cachedPromise = null;
-}
-
-/**
- * Returns `{ canBypass }` for the current actor. Starts `false` and flips to
- * the server's answer once the one-shot query resolves. Never throws.
+ * Returns `{ canBypass }` for the current actor. Starts `false` and flips to the
+ * server's answer once the one-shot query resolves. Fetches once per mount (no
+ * cross-session cache). Never throws.
  */
 export function useFieldLockBypass(): { canBypass: boolean } {
   const [canBypass, setCanBypass] = useState(false);
@@ -84,4 +76,41 @@ export function useFieldLockBypass(): { canBypass: boolean } {
   }, []);
 
   return { canBypass };
+}
+
+/** Per-field unlock state consumed by the auto-form (Spec 63 §5.2). */
+export interface FieldUnlockState {
+  /** Whether the current actor may override field locks. */
+  canBypass: boolean;
+  /** Whether the actor has unlocked `field` for editing this session. */
+  isUnlocked: (field: string) => boolean;
+  /** Toggle a field's unlocked state (only meaningful when `canBypass`). */
+  toggleUnlock: (field: string) => void;
+}
+
+/**
+ * Bundle the actor's bypass eligibility with the set of fields they have
+ * manually unlocked. Extracted from AutoForm so the bypass + lock/readonly
+ * derivation lives in one tested hook rather than inline in that already-large
+ * component.
+ */
+export function useFieldUnlock(): FieldUnlockState {
+  const { canBypass } = useFieldLockBypass();
+  const [unlockedFields, setUnlockedFields] = useState<Set<string>>(() => new Set());
+
+  const toggleUnlock = useCallback((field: string) => {
+    setUnlockedFields((prev) => {
+      const next = new Set(prev);
+      if (next.has(field)) {
+        next.delete(field);
+      } else {
+        next.add(field);
+      }
+      return next;
+    });
+  }, []);
+
+  const isUnlocked = useCallback((field: string) => unlockedFields.has(field), [unlockedFields]);
+
+  return { canBypass, isUnlocked, toggleUnlock };
 }

--- a/addons/adapter-ui/cap-adapter-ui/src/hooks/use-field-lock-bypass.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/hooks/use-field-lock-bypass.ts
@@ -1,0 +1,87 @@
+/**
+ * useFieldLockBypass — whether the CURRENT actor may override field locks
+ * (Spec 63 §5.2).
+ *
+ * Runs ONE GraphQL query (`{ fieldLockBypass { canBypass reason } }`) against
+ * the cap-lock read-side extension. The auto-form uses the result to render an
+ * "unlock" affordance on locked fields for bypass-eligible actors.
+ *
+ * ## Resilience: cap-lock may not be installed
+ *
+ * When cap-lock is absent, `fieldLockBypass` is NOT a schema field and the
+ * server returns a GraphQL VALIDATION error. The hook swallows ALL errors (and
+ * the missing-field case) and returns `{ canBypass: false }` — it never calls
+ * `throwOnErrors`, never throws, and stays SILENT on the expected
+ * "field not found" path (no console noise).
+ *
+ * The result is cached at module level (session-scoped) so multiple forms on a
+ * page share a single in-flight/resolved fetch; a full page reload resets it.
+ */
+
+import { useEffect, useState } from "react";
+import { graphql } from "../lib/api";
+
+interface FieldLockBypassQueryResult {
+  fieldLockBypass?: { canBypass?: boolean; reason?: string | null } | null;
+}
+
+/**
+ * Module-level cache of the resolved (or in-flight) bypass eligibility. Shared
+ * across every form on the page; reset only by a page reload. Resolves to
+ * `false` on ANY unexpected condition (missing field, network error, malformed
+ * response) so the UI fails closed (no unlock affordance).
+ */
+let cachedPromise: Promise<boolean> | null = null;
+
+/**
+ * Fetch (and module-cache) the actor's bypass eligibility. Exported for
+ * testing: the package's test setup is logic-only (no React render harness), so
+ * the fetch / error-swallow behavior is verified directly against this helper —
+ * mirroring how sibling component modules export their pure logic.
+ */
+export function fetchCanBypass(): Promise<boolean> {
+  if (cachedPromise) return cachedPromise;
+  cachedPromise = (async () => {
+    try {
+      const res = await graphql<FieldLockBypassQueryResult>(
+        "query { fieldLockBypass { canBypass reason } }",
+      );
+      // Intentionally do NOT call throwOnErrors: a missing `fieldLockBypass`
+      // field (cap-lock not installed) surfaces as a GraphQL error we must
+      // swallow quietly. Read the value defensively and default to false.
+      return res.data?.fieldLockBypass?.canBypass === true;
+    } catch {
+      // Network / transport failure — fail closed.
+      return false;
+    }
+  })();
+  return cachedPromise;
+}
+
+/**
+ * Reset the module-level cache. Test-only seam so each case starts fresh; not
+ * used by production code (the cache is intentionally session-scoped there).
+ */
+export function resetFieldLockBypassCache(): void {
+  cachedPromise = null;
+}
+
+/**
+ * Returns `{ canBypass }` for the current actor. Starts `false` and flips to
+ * the server's answer once the one-shot query resolves. Never throws.
+ */
+export function useFieldLockBypass(): { canBypass: boolean } {
+  const [canBypass, setCanBypass] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    fetchCanBypass().then((result) => {
+      if (active) setCanBypass(result);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return { canBypass };
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
@@ -97,6 +97,15 @@
       "hasErrors": "Please fix the errors below before submitting",
       "uniqueHint": "Must be unique — validated on save"
     },
+    "lock": {
+      "immutable": "This field cannot be changed after creation",
+      "locked": "This field is locked in the current state",
+      "lockedInState": "Locked because the record is in state \"{{status}}\"",
+      "ariaLabel": "Locked field",
+      "canOverride": "Locked — you may override. Click to unlock.",
+      "unlocked": "Unlocked — you may edit this field",
+      "toggleAriaLabel": "Toggle field lock"
+    },
     "overlayFields": "Custom Fields"
   },
   "list": {

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
@@ -97,6 +97,15 @@
       "hasErrors": "请先修正以下错误再提交",
       "uniqueHint": "必须唯一 — 保存时验证"
     },
+    "lock": {
+      "immutable": "此字段创建后不可更改",
+      "locked": "此字段在当前状态下已锁定",
+      "lockedInState": "因记录处于状态“{{status}}”而锁定",
+      "ariaLabel": "已锁定字段",
+      "canOverride": "已锁定 — 你有权限覆盖，点击解锁",
+      "unlocked": "已解锁 — 可编辑此字段",
+      "toggleAriaLabel": "切换字段锁定"
+    },
     "overlayFields": "自定义字段"
   },
   "list": {

--- a/addons/adapter-ui/cap-adapter-ui/src/index.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/index.ts
@@ -38,6 +38,8 @@ export {
   DEFAULT_ONCHANGE_DEBOUNCE_MS,
   useEntityOnchange,
 } from "./hooks/use-entity-onchange";
+// Field-lock bypass (Spec 63 §5.2)
+export { useFieldLockBypass } from "./hooks/use-field-lock-bypass";
 export type { FieldLockStateMap, UseFieldLockStateArgs } from "./hooks/use-field-lock-state";
 // Field-lock state (Spec 63 §5.1)
 export { useFieldLockState } from "./hooks/use-field-lock-state";

--- a/addons/adapter-ui/cap-adapter-ui/src/index.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/index.ts
@@ -38,8 +38,9 @@ export {
   DEFAULT_ONCHANGE_DEBOUNCE_MS,
   useEntityOnchange,
 } from "./hooks/use-entity-onchange";
-// Field-lock bypass (Spec 63 §5.2)
-export { useFieldLockBypass } from "./hooks/use-field-lock-bypass";
+// Field-lock bypass + unlock (Spec 63 §5.2)
+export type { FieldUnlockState } from "./hooks/use-field-lock-bypass";
+export { useFieldLockBypass, useFieldUnlock } from "./hooks/use-field-lock-bypass";
 export type { FieldLockStateMap, UseFieldLockStateArgs } from "./hooks/use-field-lock-state";
 // Field-lock state (Spec 63 §5.1)
 export { useFieldLockState } from "./hooks/use-field-lock-state";

--- a/addons/lock/cap-lock/__tests__/bypass.test.ts
+++ b/addons/lock/cap-lock/__tests__/bypass.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for the shared actor-level bypass predicate (Spec 63 §5.2).
+ *
+ * `evaluateActorBypass` is the single source of truth shared by the
+ * `field-lock-check` interceptor and the `fieldLockBypass` GraphQL query.
+ * Covers: shadow mode, bypass-group hit/miss, empty bypassGroups, an actor with
+ * undefined groups (no throw), and an actor in a non-bypass group. Policies are
+ * built via `resolveCapLockPolicy` so defaults match production.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { Actor } from "@linchkit/core";
+import { evaluateActorBypass } from "../src/bypass";
+import { resolveCapLockPolicy } from "../src/config";
+
+/** Build an actor; `groups` defaults to []. Pass `null` to omit `groups`. */
+function makeActor(groups: string[] | null = []): Actor {
+  if (groups === null) {
+    // Simulate a malformed actor whose `groups` is undefined at runtime.
+    return { type: "human", id: "user-1" } as unknown as Actor;
+  }
+  return { type: "human", id: "user-1", groups };
+}
+
+describe("evaluateActorBypass", () => {
+  it("shadow mode → canBypass true, reason 'shadow'", () => {
+    const policy = resolveCapLockPolicy({ shadowMode: true });
+    expect(evaluateActorBypass(makeActor([]), policy)).toEqual({
+      canBypass: true,
+      reason: "shadow",
+    });
+  });
+
+  it("shadow mode wins even when the actor is also in a bypass group", () => {
+    const policy = resolveCapLockPolicy({ shadowMode: true, bypassGroups: ["admin"] });
+    expect(evaluateActorBypass(makeActor(["admin"]), policy)).toEqual({
+      canBypass: true,
+      reason: "shadow",
+    });
+  });
+
+  it("bypass-group match → canBypass true, reason 'bypass'", () => {
+    const policy = resolveCapLockPolicy({ bypassGroups: ["admin", "finance_manager"] });
+    expect(evaluateActorBypass(makeActor(["finance_manager"]), policy)).toEqual({
+      canBypass: true,
+      reason: "bypass",
+    });
+  });
+
+  it("no match (actor in a non-bypass group) → canBypass false, reason null", () => {
+    const policy = resolveCapLockPolicy({ bypassGroups: ["admin"] });
+    expect(evaluateActorBypass(makeActor(["viewer"]), policy)).toEqual({
+      canBypass: false,
+      reason: null,
+    });
+  });
+
+  it("empty bypassGroups → canBypass false even when the actor has groups", () => {
+    const policy = resolveCapLockPolicy({ bypassGroups: [] });
+    expect(evaluateActorBypass(makeActor(["admin"]), policy)).toEqual({
+      canBypass: false,
+      reason: null,
+    });
+  });
+
+  it("actor with undefined groups → canBypass false, no throw", () => {
+    const policy = resolveCapLockPolicy({ bypassGroups: ["admin"] });
+    expect(() => evaluateActorBypass(makeActor(null), policy)).not.toThrow();
+    expect(evaluateActorBypass(makeActor(null), policy)).toEqual({
+      canBypass: false,
+      reason: null,
+    });
+  });
+
+  it("default policy (no knobs) → canBypass false", () => {
+    const policy = resolveCapLockPolicy();
+    expect(evaluateActorBypass(makeActor(["admin"]), policy)).toEqual({
+      canBypass: false,
+      reason: null,
+    });
+  });
+
+  it("ignores toleranceMs (actor-level subset only)", () => {
+    // A generous tolerance window must NOT make the actor bypass-eligible —
+    // tolerance is record-age based and stays interceptor-only.
+    const policy = resolveCapLockPolicy({ toleranceMs: 60_000 });
+    expect(evaluateActorBypass(makeActor(["admin"]), policy)).toEqual({
+      canBypass: false,
+      reason: null,
+    });
+  });
+});

--- a/addons/lock/cap-lock/__tests__/graphql.test.ts
+++ b/addons/lock/cap-lock/__tests__/graphql.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for the cap-lock `fieldLockBypass` GraphQL extension (Spec 63 §5.2).
+ *
+ * Builds the extension, asserts the `FieldLockBypass` type shape, then invokes
+ * the resolver with mock contexts covering: actor in a bypass group → bypass;
+ * actor not in a group → no bypass; shadow-mode policy → shadow; and a
+ * missing/undefined actor → no bypass with no throw. The resolver reuses the
+ * SHARED `evaluateActorBypass`, so this asserts the read-side hint matches
+ * enforcement.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { Actor } from "@linchkit/core";
+import {
+  GraphQLBoolean,
+  type GraphQLFieldConfig,
+  type GraphQLFieldResolver,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql";
+import { resolveCapLockPolicy } from "../src/config";
+import { buildLockGraphQLExtension } from "../src/graphql";
+
+function makeActor(groups: string[] = []): Actor {
+  return { type: "human", id: "user-1", groups };
+}
+
+/** Pull the resolver out of the `fieldLockBypass` field config. */
+function getResolver(
+  field: GraphQLFieldConfig<unknown, unknown>,
+): GraphQLFieldResolver<unknown, unknown> {
+  const resolve = field.resolve;
+  if (!resolve) throw new Error("fieldLockBypass field has no resolver");
+  return resolve;
+}
+
+describe("buildLockGraphQLExtension", () => {
+  it("exposes a single `fieldLockBypass` query field returning FieldLockBypass!", () => {
+    const ext = buildLockGraphQLExtension({ policy: resolveCapLockPolicy() });
+    expect(Object.keys(ext.queryFields)).toEqual(["fieldLockBypass"]);
+
+    const field = ext.queryFields.fieldLockBypass;
+    expect(field).toBeDefined();
+    if (!field) return;
+
+    // NonNull wrapper over the FieldLockBypass object type.
+    expect(field.type).toBeInstanceOf(GraphQLNonNull);
+    const inner = (field.type as GraphQLNonNull<GraphQLObjectType>).ofType;
+    expect(inner).toBeInstanceOf(GraphQLObjectType);
+    expect((inner as GraphQLObjectType).name).toBe("FieldLockBypass");
+  });
+
+  it("FieldLockBypass type has canBypass: Boolean! and reason: String", () => {
+    const ext = buildLockGraphQLExtension({ policy: resolveCapLockPolicy() });
+    const objectType = ext.types.find((t) => t.name === "FieldLockBypass");
+    expect(objectType).toBeDefined();
+    if (!objectType) return;
+
+    const fields = objectType.getFields();
+    // canBypass — NonNull Boolean.
+    expect(fields.canBypass).toBeDefined();
+    expect(fields.canBypass.type).toBeInstanceOf(GraphQLNonNull);
+    expect((fields.canBypass.type as GraphQLNonNull<typeof GraphQLBoolean>).ofType).toBe(
+      GraphQLBoolean,
+    );
+    // reason — nullable String.
+    expect(fields.reason).toBeDefined();
+    expect(fields.reason.type).toBe(GraphQLString);
+  });
+
+  it("resolves bypass for an actor in a bypass group", async () => {
+    const ext = buildLockGraphQLExtension({
+      policy: resolveCapLockPolicy({ bypassGroups: ["admin"] }),
+    });
+    const resolve = getResolver(ext.queryFields.fieldLockBypass);
+    const result = await resolve({}, {}, { actor: makeActor(["admin"]) }, {} as never);
+    expect(result).toEqual({ canBypass: true, reason: "bypass" });
+  });
+
+  it("resolves no-bypass for an actor not in a bypass group", async () => {
+    const ext = buildLockGraphQLExtension({
+      policy: resolveCapLockPolicy({ bypassGroups: ["admin"] }),
+    });
+    const resolve = getResolver(ext.queryFields.fieldLockBypass);
+    const result = await resolve({}, {}, { actor: makeActor(["viewer"]) }, {} as never);
+    expect(result).toEqual({ canBypass: false, reason: null });
+  });
+
+  it("resolves shadow for any actor under a shadowMode policy", async () => {
+    const ext = buildLockGraphQLExtension({
+      policy: resolveCapLockPolicy({ shadowMode: true }),
+    });
+    const resolve = getResolver(ext.queryFields.fieldLockBypass);
+    const result = await resolve({}, {}, { actor: makeActor([]) }, {} as never);
+    expect(result).toEqual({ canBypass: true, reason: "shadow" });
+  });
+
+  it("returns no-bypass (no throw) when the context has no actor", async () => {
+    const ext = buildLockGraphQLExtension({
+      policy: resolveCapLockPolicy({ bypassGroups: ["admin"] }),
+    });
+    const resolve = getResolver(ext.queryFields.fieldLockBypass);
+    // Missing actor + empty context + undefined context — all must be safe.
+    expect(await resolve({}, {}, {}, {} as never)).toEqual({ canBypass: false, reason: null });
+    expect(await resolve({}, {}, undefined, {} as never)).toEqual({
+      canBypass: false,
+      reason: null,
+    });
+  });
+});

--- a/addons/lock/cap-lock/capability.json
+++ b/addons/lock/cap-lock/capability.json
@@ -6,7 +6,8 @@
   "label": "Field Lock Policy",
   "description": "Advanced field-lock policy: shadow mode, bypass groups, tolerance period, and audit trail over core field-lock enforcement (Spec 63 Phase 3)",
   "extensions": {
-    "interceptors": ["field-lock-check"]
+    "interceptors": ["field-lock-check"],
+    "graphqlExtensions": ["fieldLockBypass"]
   },
   "linchkit": {
     "coreVersion": "^0.2.0"

--- a/addons/lock/cap-lock/package.json
+++ b/addons/lock/cap-lock/package.json
@@ -13,6 +13,9 @@
   "scripts": {
     "test": "bun test"
   },
+  "dependencies": {
+    "graphql": "^16.13.1"
+  },
   "peerDependencies": {
     "@linchkit/core": "^0.2.0"
   },

--- a/addons/lock/cap-lock/src/bypass.ts
+++ b/addons/lock/cap-lock/src/bypass.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared actor-level field-lock bypass predicate (Spec 63 §4.2 / §5.2).
+ *
+ * This is the SINGLE source of truth for "can THIS actor bypass field locks?",
+ * consumed by BOTH:
+ *  - the runtime `field-lock-check` interceptor (`./field-lock-interceptor`),
+ *    which suppresses violations when the actor is bypass-eligible; and
+ *  - the read-side `fieldLockBypass` GraphQL query (`./graphql`), which lets the
+ *    UI render an "unlock" affordance for the same actor.
+ *
+ * Keeping both sides on one predicate guarantees the UI hint can NEVER drift
+ * from the actual enforcement decision.
+ *
+ * ## Actor-level subset of the interceptor decision
+ *
+ * The interceptor's full decision has THREE escape hatches (see
+ * {@link createFieldLockInterceptor}): shadow mode, bypass groups, and a
+ * tolerance period. This function intentionally covers ONLY the first two —
+ * the ACTOR-level subset:
+ *
+ *  - `shadowMode`   — global observe-without-blocking switch.
+ *  - `bypassGroups` — actor group/role membership grants override.
+ *
+ * `toleranceMs` is DELIBERATELY EXCLUDED. Tolerance is a record-age / time-window
+ * check (transient, evaluated per-record against that record's `created_at`),
+ * NOT a stable capability of the actor. Surfacing it as an actor-level "can
+ * bypass" signal would be misleading (it flips as records age), so it remains
+ * interceptor-only and is evaluated there per write.
+ *
+ * The shadow → bypass evaluation order mirrors the interceptor exactly so the
+ * two can never disagree on the actor-level subset.
+ */
+
+import type { Actor } from "@linchkit/core";
+import type { CapLockPolicy } from "./config";
+
+/** Why an actor is bypass-eligible — surfaced to the UI and the audit log. */
+export type ActorBypassReason = "shadow" | "bypass";
+
+/** Result of {@link evaluateActorBypass}. */
+export interface ActorBypassResult {
+  /** Whether the actor may bypass field locks under the current policy. */
+  canBypass: boolean;
+  /** Why the actor may bypass — `null` when `canBypass` is false. */
+  reason: ActorBypassReason | null;
+}
+
+/**
+ * Decide whether `actor` may bypass field locks under `policy` (actor-level
+ * subset of the interceptor decision; see the module JSDoc).
+ *
+ * Evaluation order (first match wins), mirroring the interceptor:
+ *  1. `policy.shadowMode` → `{ canBypass: true, reason: "shadow" }`.
+ *  2. else if the actor belongs to ANY `policy.bypassGroups` entry →
+ *     `{ canBypass: true, reason: "bypass" }`.
+ *  3. otherwise → `{ canBypass: false, reason: null }`.
+ *
+ * Pure and side-effect-free. `toleranceMs` is NOT considered here (it is a
+ * per-record time-window check, evaluated only in the interceptor).
+ */
+export function evaluateActorBypass(actor: Actor, policy: CapLockPolicy): ActorBypassResult {
+  // 1. Shadow mode — global observe-without-blocking switch.
+  if (policy.shadowMode) {
+    return { canBypass: true, reason: "shadow" };
+  }
+
+  // 2. Bypass groups — the actor's group/role memberships override locks.
+  if (
+    policy.bypassGroups.length > 0 &&
+    actor.groups?.some((group) => policy.bypassGroups.includes(group))
+  ) {
+    return { canBypass: true, reason: "bypass" };
+  }
+
+  // 3. No actor-level escape hatch matched.
+  return { canBypass: false, reason: null };
+}

--- a/addons/lock/cap-lock/src/factory.ts
+++ b/addons/lock/cap-lock/src/factory.ts
@@ -13,6 +13,7 @@ import type { CapabilityDefinition, InterceptorRegistration, Logger } from "@lin
 import { defineCapability } from "@linchkit/core";
 import { type CapLockPolicy, capLockConfig, resolveCapLockPolicy } from "./config";
 import { createFieldLockInterceptor } from "./field-lock-interceptor";
+import { buildLockGraphQLExtension } from "./graphql";
 
 export interface CapLockOptions {
   /**
@@ -64,7 +65,16 @@ export function createCapLock(options?: CapLockOptions): CapabilityDefinition {
     configSchema: capLockConfig.schema,
     config: policy,
 
-    extensions: { interceptors },
+    extensions: {
+      interceptors,
+      // Read-side IoC counterpart to the interceptor: a single `fieldLockBypass`
+      // query the auto-form uses to render an unlock affordance for
+      // bypass-eligible actors. Core's `GraphQLExtensionRegistration` only
+      // carries `queryFields`/`mutationFields` (no `types`); the
+      // `FieldLockBypass` object type is reachable from the field's return type,
+      // so graphql-js registers it automatically.
+      graphqlExtensions: { queryFields: buildLockGraphQLExtension({ policy }).queryFields },
+    },
 
     systemPermissions: ["database.read"],
   });

--- a/addons/lock/cap-lock/src/field-lock-interceptor.ts
+++ b/addons/lock/cap-lock/src/field-lock-interceptor.ts
@@ -27,6 +27,7 @@
  */
 
 import type { FieldLockCheckContext, FieldLockViolation, Logger } from "@linchkit/core";
+import { evaluateActorBypass } from "./bypass";
 import type { CapLockPolicy } from "./config";
 
 /** Reason an audited suppression occurred — surfaced in the audit log. */
@@ -130,22 +131,17 @@ export function createFieldLockInterceptor(
       );
     };
 
-    // 1. Shadow mode — observe without blocking. Log every violation, allow.
-    if (policy.shadowMode) {
-      audit("shadow");
-      return [];
-    }
-
-    // 2. Bypass groups — the actor's groups/roles override locks.
-    //    The core `Actor.groups: string[]` field carries the actor's
+    // 1 & 2. Actor-level escape hatches — shadow mode, then bypass groups.
+    //    Delegated to the SHARED `evaluateActorBypass` predicate so the runtime
+    //    enforcement decision can never drift from the read-side
+    //    `fieldLockBypass` GraphQL hint (which calls the same function). The
+    //    returned `reason` ("shadow" | "bypass") flows straight into the audit
+    //    log. The core `Actor.groups: string[]` field carries the actor's
     //    group/role memberships (set by the auth/permission slots — see
-    //    cap-permission's `actor.groups` usage), which is exactly the concept
-    //    the spec example references as `context.actor.groups`. Use it directly.
-    if (
-      policy.bypassGroups.length > 0 &&
-      context.actor.groups?.some((group) => policy.bypassGroups.includes(group))
-    ) {
-      audit("bypass");
+    //    cap-permission's `actor.groups` usage), which the predicate inspects.
+    const actorBypass = evaluateActorBypass(context.actor, policy);
+    if (actorBypass.canBypass && actorBypass.reason !== null) {
+      audit(actorBypass.reason);
       return [];
     }
 

--- a/addons/lock/cap-lock/src/graphql.ts
+++ b/addons/lock/cap-lock/src/graphql.ts
@@ -1,0 +1,115 @@
+/**
+ * cap-lock GraphQL extension — the read-side IoC counterpart to the
+ * `field-lock-check` interceptor (Spec 63 §5.2).
+ *
+ * Registers a single GLOBAL query:
+ *   fieldLockBypass: FieldLockBypass!
+ *
+ * The field-lock UI (#441) renders a lock icon on locked fields but has no way
+ * to know whether the CURRENT actor is allowed to override those locks — that
+ * decision lives only in this capability's runtime interceptor. This extension
+ * surfaces it as a query so the UI can show an "unlock" affordance, WITHOUT
+ * `adapter-server` / `adapter-ui` ever depending on cap-lock: adapter-server
+ * auto-collects `graphqlExtensions` from installed capabilities via its
+ * `assemble-schema.ts`, mirroring how cap-search / cap-chatter contribute
+ * theirs.
+ *
+ * The query represents the actor's GLOBAL (policy-wide) bypass eligibility —
+ * cap-lock policy is NOT per-entity, so the field takes no arguments. It reuses
+ * the SHARED {@link evaluateActorBypass} predicate, so the hint can never drift
+ * from the interceptor's actual enforcement (actor-level subset; tolerance is
+ * intentionally excluded — see `./bypass`).
+ */
+
+import type { Actor } from "@linchkit/core";
+import type { GraphQLFieldConfig, GraphQLResolveInfo } from "graphql";
+import { GraphQLBoolean, GraphQLNonNull, GraphQLObjectType, GraphQLString } from "graphql";
+import { type ActorBypassResult, evaluateActorBypass } from "./bypass";
+import type { CapLockPolicy } from "./config";
+
+// ── GraphQL types ───────────────────────────────────────────
+
+const FieldLockBypassType = new GraphQLObjectType({
+  name: "FieldLockBypass",
+  description:
+    "Whether the current actor may bypass field locks (cap-lock policy-wide). " +
+    "Mirrors the actor-level subset of the `field-lock-check` interceptor decision.",
+  fields: {
+    canBypass: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      description: "True if the current actor may override field locks.",
+    },
+    reason: {
+      type: GraphQLString,
+      description:
+        'Why the actor may bypass: "shadow" (shadow mode) or "bypass" ' +
+        "(group membership). Null when `canBypass` is false.",
+    },
+  },
+});
+
+// ── Resolver context shape ──────────────────────────────────
+
+interface LockResolverContext {
+  actor?: Actor;
+}
+
+/** Anonymous fallback actor used when the resolver context carries none. */
+const ANONYMOUS_ACTOR: Actor = { type: "system", id: "anonymous", groups: [] };
+
+// ── Extension builder ───────────────────────────────────────
+
+export interface LockGraphQLExtensionOptions {
+  /** Resolved, fully-defaulted cap-lock policy (see `resolveCapLockPolicy`). */
+  policy: CapLockPolicy;
+}
+
+export interface LockGraphQLExtension {
+  /** GraphQL types contributed by cap-lock. */
+  types: GraphQLObjectType[];
+  /** Query fields to merge into the root Query type. */
+  queryFields: Record<string, GraphQLFieldConfig<unknown, unknown>>;
+}
+
+/**
+ * Build the GraphQL extension for cap-lock.
+ *
+ * Returns a single `fieldLockBypass` query field (no args). Its resolver reads
+ * `ctx.actor` from the request context (set by the adapter's yoga context
+ * factory) and returns the shared {@link evaluateActorBypass} result. The
+ * resolver NEVER throws: when no actor is present it falls back to an anonymous,
+ * empty-groups actor, which yields `{ canBypass: false, reason: null }` unless
+ * shadow mode is on policy-wide.
+ *
+ * The `FieldLockBypass` object type is reachable from this field's return type,
+ * so graphql-js registers it automatically — only `queryFields` need to be
+ * threaded into the capability manifest. `types` is returned for symmetry with
+ * the sibling extensions and for direct testability.
+ */
+export function buildLockGraphQLExtension(
+  options: LockGraphQLExtensionOptions,
+): LockGraphQLExtension {
+  const { policy } = options;
+
+  const fieldLockBypass: GraphQLFieldConfig<unknown, unknown> = {
+    type: new GraphQLNonNull(FieldLockBypassType),
+    description:
+      "Whether the current actor may bypass field locks (cap-lock policy-wide). " +
+      "Used by the auto-form to show an unlock affordance on locked fields.",
+    resolve: (
+      _source: unknown,
+      _args: Record<string, never>,
+      context: unknown,
+      _info: GraphQLResolveInfo,
+    ): ActorBypassResult => {
+      const ctx = (context ?? {}) as LockResolverContext;
+      const actor = ctx.actor ?? ANONYMOUS_ACTOR;
+      return evaluateActorBypass(actor, policy);
+    },
+  };
+
+  return {
+    types: [FieldLockBypassType],
+    queryFields: { fieldLockBypass },
+  };
+}

--- a/addons/lock/cap-lock/src/index.ts
+++ b/addons/lock/cap-lock/src/index.ts
@@ -6,6 +6,9 @@
  * interceptor. With default config it is a no-op over core (fail-closed).
  */
 
+// Shared actor-level bypass predicate (used by interceptor + GraphQL extension)
+export type { ActorBypassReason, ActorBypassResult } from "./bypass";
+export { evaluateActorBypass } from "./bypass";
 // Capability definition (static, default config)
 export { capLock } from "./capability";
 // Config schema + policy resolver
@@ -20,3 +23,6 @@ export type {
   LockSuppressionReason,
 } from "./field-lock-interceptor";
 export { createFieldLockInterceptor } from "./field-lock-interceptor";
+// GraphQL extension (read-side IoC counterpart to the interceptor)
+export type { LockGraphQLExtension, LockGraphQLExtensionOptions } from "./graphql";
+export { buildLockGraphQLExtension } from "./graphql";

--- a/bun.lock
+++ b/bun.lock
@@ -339,6 +339,9 @@
     "addons/lock/cap-lock": {
       "name": "@linchkit/cap-lock",
       "version": "1.0.0",
+      "dependencies": {
+        "graphql": "^16.13.1",
+      },
       "devDependencies": {
         "@linchkit/core": "workspace:*",
         "typescript": "^6.0.2",

--- a/packages/core/src/types/capability-metadata.ts
+++ b/packages/core/src/types/capability-metadata.ts
@@ -51,6 +51,14 @@ const extensionManifestSchema = z.object({
    * transforms and returns a value rather than reacting to an event.
    */
   interceptors: z.array(z.string()).optional(),
+  /**
+   * GraphQL query/mutation field names this capability contributes via
+   * `extensions.graphqlExtensions` — the read-side IoC seam merged into the
+   * root schema by adapter-server (Spec 63 §5.2, e.g. "fieldLockBypass").
+   * Declarative-only manifest mirror of the runtime extension, exactly like
+   * `interceptors` above.
+   */
+  graphqlExtensions: z.array(z.string()).optional(),
   /** Middleware slot names */
   middlewares: z.array(z.string()).optional(),
   /** CLI command names */


### PR DESCRIPTION
## What

Closes Spec 63 §5.2's last gap: the field-lock UI (#441) renders a lock icon on locked fields, but a **bypass-eligible actor had no way to unlock and edit them** — the bypass decision (shadow mode / bypass groups) lived only inside cap-lock's runtime `field-lock-check` interceptor, invisible to the UI until a mutation was attempted.

This adds a **read-side inversion-of-control seam** so the auto-form can show an "unlock" affordance to actors who may override locks — **without `adapter-server` or `adapter-ui` depending on the optional `cap-lock` capability** (cap-lock plugs into the existing `graphqlExtensions` seam, exactly like cap-search / cap-chatter).

## Design

The bypass decision must be computed by the **same logic that enforces it**, so the UI hint can never claim "you can edit" while the runtime fail-closes. The PR extracts that logic into one shared predicate used by both sides:

- **`cap-lock/bypass.ts` (new)** — `evaluateActorBypass(actor, policy)`, the single source of truth for the **actor-level** bypass decision: `shadowMode` → bypass; actor ∈ `bypassGroups` → bypass; else no. `toleranceMs` is **deliberately excluded** (it's a per-record, time-window grace — transient, not a stable actor capability — so it stays interceptor-only).
- **`cap-lock/field-lock-interceptor.ts`** — DRY refactor: the shadow + bypass-group branches now call `evaluateActorBypass`; the tolerance check and the fail-closed block are unchanged. **Zero behavior change** (existing interceptor tests pass untouched).
- **`cap-lock/graphql.ts` (new)** — `buildLockGraphQLExtension` contributes a single global `fieldLockBypass { canBypass reason }` query (no args; cap-lock policy is policy-wide, not per-entity). The resolver reads `ctx.actor` and **never throws** (anonymous fallback → `canBypass: false`). `adapter-server` auto-collects it via `assemble-schema.ts` — no new coupling, no `adapter-server` change.
- **`core/capability-metadata.ts`** — declares the optional `graphqlExtensions` key in `extensionManifestSchema` (declarative manifest mirror, exactly like the existing `interceptors` key).

## UI (adapter-ui)

- **`useFieldLockBypass` (new hook)** — one-shot `fieldLockBypass` query, module-cached (session-scoped). **Fails closed and silent** when cap-lock is absent (the query field doesn't exist → the GraphQL validation error is swallowed → `canBypass: false`, no console noise).
- **`FieldLockBadge`** — when `canBypass`, the lock icon becomes an accessible `<button>` toggle (`Lock` ⇄ `LockOpen`, `aria-pressed`). The static, non-bypass path is preserved byte-for-byte.
- **`auto-form`** — tracks `unlockedFields`; `isFieldReadonly` clears readonly for a field the bypass-eligible actor has unlocked. The badge stays visible (as the open-lock toggle) so the field can be re-locked.
- i18n: `form.lock.canOverride` / `form.lock.unlocked` / `form.lock.toggleAriaLabel` in en + zh-CN.

## Boundaries

`adapter-server` and `adapter-ui` gain **no dependency** on `cap-lock`. cap-lock declares `graphql` (the same `^16.13.1` already used repo-wide by cap-search / cap-chatter); `bun.lock` records only that one entry.

## Test plan

- `cap-lock` + `adapter-ui`: **414 pass / 0 fail** (incl. new `bypass.test.ts`, `graphql.test.ts`, `field-lock-bypass.test.ts`).
- `capability-metadata`: **28 pass / 0 fail**.
- `bun run check` (biome): clean (1640 files).
- Typecheck: all changed files are error-clean. (The only `tsc` errors are 3 pre-existing ones in `packages/cli/mcp-dev/generation-tools.ts` — an MCP-SDK / zod-4.3.6 type-skew that reproduces only under a local Bun 1.2.18 node_modules layout, **not** in CI, which is green on the same base. Unrelated to this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added field-lock bypass capability allowing authorized users to unlock locked form fields via interactive toggles
  * New query to check if the current user can bypass field locks
  
* **Localization**
  * Added English and Chinese translations for field-lock messaging and unlock controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->