### PR TITLE
feat(core,lock,ui): SOFT_LOCK — advisory field lock + two-step UI confirmation (Spec 63 §4.2/§5.2)

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/graphql-field-meta.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/graphql-field-meta.test.ts
@@ -171,6 +171,30 @@ describe("buildFieldMetaList", () => {
     expect(discount?.lockMode).toBe("soft");
   });
 
+  // Spec 63 §4.2 — `lockMode` governs the CONDITIONAL lock only. A stray
+  // `lockMode: "soft"` on an immutable field, or on a field with no active lock,
+  // must NOT introspect as soft (immutable is always hard; an unlocked field has
+  // no soft semantics) — keeps GraphQL metadata aligned with runtime behavior and
+  // with adapter-ui's field-lock-state.ts.
+  test("lockMode: soft is ignored on immutable or unlocked fields", () => {
+    const guarded: EntityDefinition = {
+      name: "guarded",
+      label: "Guarded",
+      fields: {
+        // immutable + soft declared → still hard (immutable wins, no conditional lock)
+        frozen: { type: "string", immutable: true, lockMode: "soft" },
+        // soft declared but NO lockWhen and no entity lockAllWhen → unlocked → hard
+        loose: { type: "string", lockMode: "soft" },
+        // soft + an actual conditional lock → genuinely soft
+        editable: { type: "number", lockWhen: { state: "posted" }, lockMode: "soft" },
+      },
+    };
+    const byField = new Map(buildFieldMetaList(guarded).map((m) => [m.name, m]));
+    expect(byField.get("frozen")?.lockMode).toBe("hard");
+    expect(byField.get("loose")?.lockMode).toBe("hard");
+    expect(byField.get("editable")?.lockMode).toBe("soft");
+  });
+
   test("active overlay fields are surfaced as unlocked, collisions skipped", () => {
     const overlays: FieldOverlayRecord[] = [
       {

--- a/addons/adapter-server/cap-adapter-server/__tests__/graphql-field-meta.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/graphql-field-meta.test.ts
@@ -18,6 +18,7 @@ import {
 //  - title:    no per-field lock → covered by entity-level lockAllWhen
 //  - notes:    in lockAllowFields → exempt from lockAllWhen
 //  - plain:    no lock at all (exempt from lockAllWhen)
+//  - discount: per-field lockWhen with lockMode: "soft" (Spec 63 §4.2)
 const orderSchema: EntityDefinition = {
   name: "purchase_order",
   label: "Purchase Order",
@@ -31,6 +32,7 @@ const orderSchema: EntityDefinition = {
     title: { type: "string", label: "Title" },
     notes: { type: "text", label: "Notes" },
     plain: { type: "string", label: "Plain" },
+    discount: { type: "number", lockWhen: { state: "posted" }, lockMode: "soft" },
   },
 };
 
@@ -108,7 +110,7 @@ describe("buildFieldMetaList", () => {
 
   test("emits one meta per user-defined field", () => {
     expect(list.map((m) => m.name).sort()).toEqual(
-      ["amount", "code", "legacy", "notes", "plain", "supplier", "title"].sort(),
+      ["amount", "code", "discount", "legacy", "notes", "plain", "supplier", "title"].sort(),
     );
   });
 
@@ -155,6 +157,20 @@ describe("buildFieldMetaList", () => {
     expect(plain?.lockSource).toBe("none");
   });
 
+  test("lockMode defaults to hard for immutable, conditional, and unlocked fields", () => {
+    // immutable, per-field hard lock, and a plain unlocked field all → "hard".
+    expect(byName.get("code")?.lockMode).toBe("hard");
+    expect(byName.get("amount")?.lockMode).toBe("hard");
+    expect(byName.get("plain")?.lockMode).toBe("hard");
+  });
+
+  test("lockMode: soft is surfaced for a soft conditional lock (Spec 63 §4.2)", () => {
+    const discount = byName.get("discount");
+    expect(discount?.lockSource).toBe("field");
+    expect(discount?.lockWhen?.stateIn).toEqual(["posted"]);
+    expect(discount?.lockMode).toBe("soft");
+  });
+
   test("active overlay fields are surfaced as unlocked, collisions skipped", () => {
     const overlays: FieldOverlayRecord[] = [
       {
@@ -189,6 +205,8 @@ describe("buildFieldMetaList", () => {
     expect(color?.immutable).toBe(false);
     expect(color?.lockWhen).toBeNull();
     expect(color?.lockSource).toBe("none");
+    // Overlays cannot lock a field → conditional lock mode is the default "hard".
+    expect(color?.lockMode).toBe("hard");
 
     // The colliding overlay does NOT add a duplicate; "amount" keeps its
     // code-declared per-field lock.
@@ -209,6 +227,8 @@ describe("FieldMeta GraphQL type", () => {
     expect(fields.name.type).toBeInstanceOf(GraphQLNonNull);
     expect(fields.immutable.type).toBeInstanceOf(GraphQLNonNull);
     expect(fields.lockSource.type).toBeInstanceOf(GraphQLNonNull);
+    // lockMode is a non-null string ("hard" | "soft")
+    expect(fields.lockMode.type).toBeInstanceOf(GraphQLNonNull);
     // lockWhen is nullable (no NonNull wrapper) — fields without a lock are null
     expect(fields.lockWhen.type).not.toBeInstanceOf(GraphQLNonNull);
     // sanity: printable without throwing
@@ -240,6 +260,7 @@ describe("buildGraphQLSchema exposes <entity>FieldMeta", () => {
             name
             immutable
             lockSource
+            lockMode
             lockWhen {
               stateIn
               stateNotIn
@@ -256,6 +277,7 @@ describe("buildGraphQLSchema exposes <entity>FieldMeta", () => {
       name: string;
       immutable: boolean;
       lockSource: string;
+      lockMode: string;
       lockWhen: {
         stateIn: string[] | null;
         stateNotIn: string[] | null;
@@ -268,6 +290,11 @@ describe("buildGraphQLSchema exposes <entity>FieldMeta", () => {
     // immutable
     expect(byName.get("code")?.immutable).toBe(true);
     expect(byName.get("code")?.lockWhen).toBeNull();
+    expect(byName.get("code")?.lockMode).toBe("hard");
+
+    // soft conditional lock surfaces lockMode: "soft"
+    expect(byName.get("discount")?.lockSource).toBe("field");
+    expect(byName.get("discount")?.lockMode).toBe("soft");
 
     // per-field positive lockWhen
     expect(byName.get("amount")?.lockSource).toBe("field");

--- a/addons/adapter-server/cap-adapter-server/src/graphql/field-meta.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/field-meta.ts
@@ -20,7 +20,12 @@
  * metadata with the same model the engine uses.
  */
 
-import type { EntityDefinition, FieldOverlayRecord, LockCondition } from "@linchkit/core";
+import type {
+  EntityDefinition,
+  FieldLockMode,
+  FieldOverlayRecord,
+  LockCondition,
+} from "@linchkit/core";
 import {
   GraphQLBoolean,
   GraphQLList,
@@ -91,6 +96,14 @@ export interface FieldMeta {
   immutable: boolean;
   lockWhen: LockConditionMeta | null;
   lockSource: FieldMetaLockSource;
+  /**
+   * Enforcement mode of this field's CONDITIONAL lock (Spec 63 §4.2 SOFT_LOCK):
+   * `"hard"` (default — a matching lock blocks the write) or `"soft"` (advisory:
+   * cap-lock allows+audits and the UI requires a two-step confirmation). Always
+   * `"hard"` for `immutable` and for fields with no lock; only actionable
+   * alongside a `lockWhen`/`lockAllWhen`.
+   */
+  lockMode: FieldLockMode;
 }
 
 export type FieldMetaLockSource = "none" | "field" | "entity";
@@ -192,6 +205,10 @@ export function buildFieldMetaList(
       immutable,
       lockWhen: condition ? toLockConditionMeta(condition) : null,
       lockSource: source,
+      // `lockMode` governs the CONDITIONAL lock only; `immutable` is always hard
+      // and a field with no lock reports "hard" (a non-null string keeps the
+      // GraphQL field simple; it is only actionable alongside a lock condition).
+      lockMode: field.lockMode === "soft" ? "soft" : "hard",
     });
   }
 
@@ -208,6 +225,9 @@ export function buildFieldMetaList(
         immutable: false,
         lockWhen: null,
         lockSource: "none",
+        // Overlays cannot lock a field (no lock vocabulary), so the conditional
+        // lock mode is always the default "hard".
+        lockMode: "hard",
       });
     }
   }
@@ -289,6 +309,13 @@ export function getFieldMetaType(): GraphQLObjectType {
       lockSource: {
         type: new GraphQLNonNull(GraphQLString),
         description: 'Where `lockWhen` originates: "field", "entity", or "none".',
+      },
+      lockMode: {
+        type: new GraphQLNonNull(GraphQLString),
+        description:
+          'Conditional-lock enforcement mode (Spec 63 §4.2): "hard" (a matching ' +
+          'lock blocks the write) or "soft" (advisory — cap-lock allows+audits, the ' +
+          'UI requires a two-step confirmation). Always "hard" for immutable / unlocked fields.',
       },
     },
   });

--- a/addons/adapter-server/cap-adapter-server/src/graphql/field-meta.ts
+++ b/addons/adapter-server/cap-adapter-server/src/graphql/field-meta.ts
@@ -208,7 +208,10 @@ export function buildFieldMetaList(
       // `lockMode` governs the CONDITIONAL lock only; `immutable` is always hard
       // and a field with no lock reports "hard" (a non-null string keeps the
       // GraphQL field simple; it is only actionable alongside a lock condition).
-      lockMode: field.lockMode === "soft" ? "soft" : "hard",
+      // Gate "soft" on an actual, non-immutable conditional lock so the metadata
+      // matches runtime behavior (an immutable or unlocked field is never soft) —
+      // mirrors adapter-ui's field-lock-state.ts.
+      lockMode: !immutable && condition && field.lockMode === "soft" ? "soft" : "hard",
     });
   }
 

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/field-lock-bypass.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/field-lock-bypass.test.ts
@@ -47,6 +47,21 @@ describe("resolveLockTooltip", () => {
       'Locked because the record is in state "submitted"',
     );
   });
+
+  // Spec 63 §4.2 SOFT_LOCK — a soft-locked, not-yet-confirmed field gets the
+  // "editing requires confirmation" message regardless of reason/status.
+  test("soft lock not yet unlocked → softLocked confirmation prompt", () => {
+    expect(resolveLockTooltip(t, "locked", "submitted", { soft: true, unlocked: false })).toBe(
+      "Locked — editing requires confirmation. Click to confirm.",
+    );
+  });
+
+  test("soft lock already unlocked → falls through to the normal reason message", () => {
+    // Once unlocked, the soft prompt no longer applies; the standard mapping wins.
+    expect(resolveLockTooltip(t, "locked", "submitted", { soft: true, unlocked: true })).toBe(
+      'Locked because the record is in state "submitted"',
+    );
+  });
 });
 
 // ── fetchCanBypass (hook data layer) ─────────────────────────

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/field-lock-bypass.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/field-lock-bypass.test.ts
@@ -35,15 +35,19 @@ const t = ((key: string, options?: string | Record<string, unknown>): string => 
 
 describe("resolveLockTooltip", () => {
   test("immutable reason → immutable message", () => {
-    expect(resolveLockTooltip(t, "immutable")).toBe("This field cannot be changed after creation");
+    expect(resolveLockTooltip(t, { reason: "immutable" })).toBe(
+      "This field cannot be changed after creation",
+    );
   });
 
   test("locked reason without status → generic locked message", () => {
-    expect(resolveLockTooltip(t, "locked")).toBe("This field is locked in the current state");
+    expect(resolveLockTooltip(t, { reason: "locked" })).toBe(
+      "This field is locked in the current state",
+    );
   });
 
   test("locked reason with status → state-specific message", () => {
-    expect(resolveLockTooltip(t, "locked", "submitted")).toBe(
+    expect(resolveLockTooltip(t, { reason: "locked", status: "submitted" })).toBe(
       'Locked because the record is in state "submitted"',
     );
   });
@@ -51,16 +55,16 @@ describe("resolveLockTooltip", () => {
   // Spec 63 §4.2 SOFT_LOCK — a soft-locked, not-yet-confirmed field gets the
   // "editing requires confirmation" message regardless of reason/status.
   test("soft lock not yet unlocked → softLocked confirmation prompt", () => {
-    expect(resolveLockTooltip(t, "locked", "submitted", { soft: true, unlocked: false })).toBe(
-      "Locked — editing requires confirmation. Click to confirm.",
-    );
+    expect(
+      resolveLockTooltip(t, { reason: "locked", status: "submitted", soft: true, unlocked: false }),
+    ).toBe("Locked — editing requires confirmation. Click to confirm.");
   });
 
   test("soft lock already unlocked → falls through to the normal reason message", () => {
     // Once unlocked, the soft prompt no longer applies; the standard mapping wins.
-    expect(resolveLockTooltip(t, "locked", "submitted", { soft: true, unlocked: true })).toBe(
-      'Locked because the record is in state "submitted"',
-    );
+    expect(
+      resolveLockTooltip(t, { reason: "locked", status: "submitted", soft: true, unlocked: true }),
+    ).toBe('Locked because the record is in state "submitted"');
   });
 });
 

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/field-lock-state.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/field-lock-state.test.ts
@@ -89,7 +89,7 @@ describe("computeFieldLockState — immutable", () => {
       record: { status: "draft" },
       isEditMode: true,
     });
-    expect(state).toEqual({ locked: true, reason: "immutable" });
+    expect(state).toEqual({ locked: true, reason: "immutable", mode: "hard" });
   });
 
   test("immutable field is NOT locked on create (initial assignment allowed)", () => {
@@ -109,7 +109,7 @@ describe("computeFieldLockState — immutable", () => {
       record: {},
       isEditMode: true,
     });
-    expect(state).toEqual({ locked: true, reason: "immutable" });
+    expect(state).toEqual({ locked: true, reason: "immutable", mode: "hard" });
   });
 });
 
@@ -239,6 +239,67 @@ describe("computeFieldLockState — precedence", () => {
       isEditMode: true,
     });
     expect(state.reason).toBe("immutable");
+  });
+});
+
+// ── Lock mode (Spec 63 §4.2 SOFT_LOCK) ──
+
+describe("computeFieldLockState — mode (Spec 63 §4.2)", () => {
+  test("conditional lock defaults to mode=hard when lockMode is unset", () => {
+    const state = computeFieldLockState({
+      fieldName: "amount",
+      fieldDef: { type: "number", lockWhen: { state: "submitted" } },
+      record: { status: "submitted" },
+      isEditMode: true,
+    });
+    expect(state.locked).toBe(true);
+    expect(state.mode).toBe("hard");
+  });
+
+  test("conditional lock with lockMode=soft yields mode=soft", () => {
+    const state = computeFieldLockState({
+      fieldName: "amount",
+      fieldDef: { type: "number", lockWhen: { state: "submitted" }, lockMode: "soft" },
+      record: { status: "submitted" },
+      isEditMode: true,
+    });
+    expect(state.locked).toBe(true);
+    expect(state.reason).toBe("locked");
+    expect(state.mode).toBe("soft");
+  });
+
+  test("entity-level lockAllWhen on a soft field still yields mode=soft", () => {
+    const state = computeFieldLockState({
+      fieldName: "title",
+      fieldDef: { type: "string", lockMode: "soft" },
+      record: { status: "posted" },
+      isEditMode: true,
+      lockAllWhen: { state: "posted" },
+    });
+    expect(state.locked).toBe(true);
+    expect(state.mode).toBe("soft");
+  });
+
+  test("immutable stays mode=hard even with lockMode=soft (immutable is never soft)", () => {
+    const state = computeFieldLockState({
+      fieldName: "code",
+      fieldDef: { type: "string", immutable: true, lockMode: "soft" },
+      record: { status: "draft" },
+      isEditMode: true,
+    });
+    expect(state.reason).toBe("immutable");
+    expect(state.mode).toBe("hard");
+  });
+
+  test("unlocked field has no mode", () => {
+    const state = computeFieldLockState({
+      fieldName: "amount",
+      fieldDef: { type: "number", lockWhen: { state: "submitted" }, lockMode: "soft" },
+      record: { status: "draft" },
+      isEditMode: true,
+    });
+    expect(state.locked).toBe(false);
+    expect(state.mode).toBeUndefined();
   });
 });
 

--- a/addons/adapter-ui/cap-adapter-ui/src/components/auto-form/auto-form.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/auto-form/auto-form.tsx
@@ -883,15 +883,21 @@ export function AutoForm({
     // badge's two-step confirmation, so the badge renders its toggle when
     // `canBypass || soft`.
     const soft = lockInfo?.mode === "soft";
+    // The badge may only offer an unlock toggle when the lock is the ONLY reason
+    // the field is readonly. If another source still wins (view/node `readonly`
+    // or a `state`-typed field — the non-lock branches of isFieldReadonly), a
+    // confirmed unlock would flip the badge to "unlocked" while the input stays
+    // readonly — a broken soft-lock UX. In that case fall back to a static badge.
+    const unlockableByBadge = !node.readonly && !viewField?.readonly && fieldDef.type !== "state";
     const lock =
       lockInfo?.locked && !isViewMode
         ? {
             reason: lockInfo.reason ?? "locked",
             status: resolvedStatus,
-            canBypass,
-            soft,
-            unlocked: isUnlocked(node.field),
-            onToggle: () => toggleUnlock(node.field),
+            canBypass: unlockableByBadge && canBypass,
+            soft: unlockableByBadge && soft,
+            unlocked: unlockableByBadge && isUnlocked(node.field),
+            onToggle: unlockableByBadge ? () => toggleUnlock(node.field) : undefined,
           }
         : undefined;
 

--- a/addons/adapter-ui/cap-adapter-ui/src/components/auto-form/auto-form.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/auto-form/auto-form.tsx
@@ -799,6 +799,15 @@ export function AutoForm({
     }
   }
 
+  /**
+   * Whether a locked field can be unlocked from the form. True when the actor
+   * may bypass locks (Spec 63 §5.2) OR the lock is SOFT (advisory — anyone may
+   * unlock it via the two-step confirmation, Spec 63 §4.2).
+   */
+  function canUnlock(fieldName: string): boolean {
+    return fieldLockState[fieldName]?.mode === "soft" || canBypass;
+  }
+
   function isFieldReadonly(
     fieldName: string,
     fieldDef: FieldDefinition,
@@ -813,9 +822,10 @@ export function AutoForm({
     // edit, lockWhen/lockAllWhen by current state). Supersedes the previous
     // inline `immutable` check, which this hook also covers.
     if (fieldLockState[fieldName]?.locked) {
-      // Spec 63 §5.2 — a bypass-eligible actor who has explicitly unlocked the
-      // field may edit it; otherwise the lock stands.
-      if (canBypass && isUnlocked(fieldName)) return false;
+      // Spec 63 §5.2 / §4.2 — an actor who may unlock the field (bypass-eligible,
+      // or a SOFT lock anyone may confirm) and has explicitly unlocked it may
+      // edit it; otherwise the lock stands.
+      if (canUnlock(fieldName) && isUnlocked(fieldName)) return false;
       return true;
     }
     return false;
@@ -869,12 +879,17 @@ export function AutoForm({
     // Spec 63 §5.2 — when the actor may bypass, the badge becomes an unlock
     // toggle. `lock` is still passed even after a field is unlocked (readonly
     // cleared) so the open-lock toggle stays visible to re-lock the field.
+    // Spec 63 §4.2 — a soft (advisory) lock is unlockable by ANY actor via the
+    // badge's two-step confirmation, so the badge renders its toggle when
+    // `canBypass || soft`.
+    const soft = lockInfo?.mode === "soft";
     const lock =
       lockInfo?.locked && !isViewMode
         ? {
             reason: lockInfo.reason ?? "locked",
             status: resolvedStatus,
             canBypass,
+            soft,
             unlocked: isUnlocked(node.field),
             onToggle: () => toggleUnlock(node.field),
           }

--- a/addons/adapter-ui/cap-adapter-ui/src/components/auto-form/form-field.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/auto-form/form-field.tsx
@@ -46,6 +46,8 @@ export interface FormFieldRowProps {
     reason: FieldLockReason;
     status?: string;
     canBypass?: boolean;
+    /** Spec 63 §4.2 — the conditional lock is advisory; unlocking needs confirmation. */
+    soft?: boolean;
     unlocked?: boolean;
     onToggle?: () => void;
   };
@@ -134,6 +136,7 @@ export function FormFieldRow({
               reason={lock.reason}
               status={lock.status}
               canBypass={lock.canBypass}
+              soft={lock.soft}
               unlocked={lock.unlocked}
               onToggle={lock.onToggle}
             />

--- a/addons/adapter-ui/cap-adapter-ui/src/components/field-lock-badge.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/field-lock-badge.tsx
@@ -25,7 +25,7 @@ import {
 } from "@linchkit/ui-kit/components";
 import type { TFunction } from "i18next";
 import { Lock, LockOpen } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { FieldLockReason } from "../lib/field-lock-state";
 import { ConfirmDialog } from "./confirm-dialog";
@@ -96,6 +96,13 @@ export function FieldLockBadge({
 }: FieldLockBadgeProps) {
   const { t } = useTranslation();
   const [confirmOpen, setConfirmOpen] = useState(false);
+
+  // If the field is unlocked externally (e.g. an AI suggestion or a future
+  // "unlock all" action) while a stale confirm dialog state lingers, clear it —
+  // otherwise a later re-lock would auto-reopen the dialog without a click.
+  useEffect(() => {
+    if (unlocked) setConfirmOpen(false);
+  }, [unlocked]);
 
   // Interactive unlock toggle — bypass-eligible actor OR a soft (advisory) lock.
   if (canBypass || soft) {

--- a/addons/adapter-ui/cap-adapter-ui/src/components/field-lock-badge.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/field-lock-badge.tsx
@@ -5,11 +5,16 @@
  * rule (edit mode) or a matching `lockWhen` / `lockAllWhen` condition
  * (Spec 63 §5.1). The tooltip explains why the field is locked.
  *
- * When the current actor may bypass locks (Spec 63 §5.2 — `canBypass`), the
- * icon becomes an interactive unlock toggle: a real `<button>` that calls
- * `onToggle`, rendering a `Lock` icon (click to unlock) or `LockOpen` icon
- * (unlocked — click to re-lock). For non-bypass actors the badge renders
- * exactly as before (a static reason-aware icon).
+ * The icon becomes an interactive unlock toggle in two cases:
+ *  - `canBypass` (Spec 63 §5.2) — the current actor may override locks. Clicking
+ *    toggles the field's unlock state immediately.
+ *  - `soft` (Spec 63 §4.2 SOFT_LOCK) — the field's conditional lock is advisory.
+ *    Unlocking it requires an explicit TWO-STEP CONFIRMATION: clicking the toggle
+ *    while the field is still locked opens a confirm dialog; confirming calls
+ *    `onToggle`. (Re-locking an already-unlocked field is immediate, no dialog.)
+ *
+ * For a non-bypass, non-soft actor the badge renders exactly as before — a
+ * static reason-aware lock icon.
  */
 
 import {
@@ -20,8 +25,10 @@ import {
 } from "@linchkit/ui-kit/components";
 import type { TFunction } from "i18next";
 import { Lock, LockOpen } from "lucide-react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { FieldLockReason } from "../lib/field-lock-state";
+import { ConfirmDialog } from "./confirm-dialog";
 
 interface FieldLockBadgeProps {
   /** Why the field is locked — drives the tooltip text. */
@@ -32,20 +39,36 @@ interface FieldLockBadgeProps {
   className?: string;
   /** When true, the current actor may override locks → render an unlock toggle. */
   canBypass?: boolean;
-  /** When `canBypass`, whether the actor has unlocked this field for editing. */
+  /**
+   * When true, this field's conditional lock is a SOFT (advisory) lock. The badge
+   * becomes an unlock toggle for ANY actor, but unlocking requires a two-step
+   * confirmation dialog (Spec 63 §4.2).
+   */
+  soft?: boolean;
+  /** Whether the actor has unlocked this field for editing (used when the badge is a toggle). */
   unlocked?: boolean;
-  /** Toggle handler for the unlock button (only used when `canBypass`). */
+  /** Toggle handler for the unlock button (used when `canBypass` or `soft`). */
   onToggle?: () => void;
 }
 
 /**
- * Resolve the tooltip text for the static (non-bypass) lock badge.
+ * Resolve the tooltip text for the lock badge.
  *
  * Exported as a pure helper so the reason→text mapping is unit-testable without
  * a React render harness (this package's test setup is logic-only — no
- * jsdom/happy-dom).
+ * jsdom/happy-dom). `soft` (and `unlocked`) select the SOFT_LOCK message when a
+ * soft-locked field has not yet been confirmed for editing.
  */
-export function resolveLockTooltip(t: TFunction, reason: FieldLockReason, status?: string): string {
+export function resolveLockTooltip(
+  t: TFunction,
+  reason: FieldLockReason,
+  status?: string,
+  opts?: { soft?: boolean; unlocked?: boolean },
+): string {
+  // Soft lock, not yet unlocked → prompt the user that editing needs confirmation.
+  if (opts?.soft && !opts.unlocked) {
+    return t("form.lock.softLocked", "Locked — editing requires confirmation. Click to confirm.");
+  }
   if (reason === "immutable") {
     return t("form.lock.immutable", "This field cannot be changed after creation");
   }
@@ -67,48 +90,81 @@ export function FieldLockBadge({
   status,
   className,
   canBypass,
+  soft,
   unlocked,
   onToggle,
 }: FieldLockBadgeProps) {
   const { t } = useTranslation();
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
-  // Bypass-eligible actor → interactive unlock toggle.
-  if (canBypass) {
+  // Interactive unlock toggle — bypass-eligible actor OR a soft (advisory) lock.
+  if (canBypass || soft) {
+    // A soft lock that is still locked needs the two-step confirmation dialog
+    // before unlocking. canBypass (and the re-lock direction) toggle immediately.
+    const needsConfirm = soft === true && unlocked !== true;
     const tooltip = unlocked
       ? t("form.lock.unlocked", "Unlocked — you may edit this field")
-      : t("form.lock.canOverride", "Locked — you may override. Click to unlock.");
+      : soft
+        ? resolveLockTooltip(t, reason, status, { soft: true, unlocked: false })
+        : t("form.lock.canOverride", "Locked — you may override. Click to unlock.");
     const Icon = unlocked ? LockOpen : Lock;
+
     return (
-      <TooltipProvider delayDuration={300}>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              // The badge renders inside the field's <Label> (an HTML <label>),
-              // so a bare click would bubble up and trigger the label's default
-              // behavior (focusing / activating the associated input). Prevent
-              // and stop it so the toggle only flips the unlock state.
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                onToggle?.();
-              }}
-              className={`inline-flex items-center ${className ?? ""}`}
-              aria-label={t("form.lock.toggleAriaLabel", "Toggle field lock")}
-              aria-pressed={unlocked === true}
-            >
-              <Icon className={ICON_CLASS} />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="top" className="text-xs">
-            {tooltip}
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <>
+        <TooltipProvider delayDuration={300}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                // The badge renders inside the field's <Label> (an HTML <label>),
+                // so a bare click would bubble up and trigger the label's default
+                // behavior (focusing / activating the associated input). Prevent
+                // and stop it so the toggle only flips the unlock state.
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  if (needsConfirm) {
+                    // Two-step confirmation: open the dialog; onToggle fires on confirm.
+                    setConfirmOpen(true);
+                  } else {
+                    onToggle?.();
+                  }
+                }}
+                className={`inline-flex items-center ${className ?? ""}`}
+                aria-label={t("form.lock.toggleAriaLabel", "Toggle field lock")}
+                aria-pressed={unlocked === true}
+              >
+                <Icon className={ICON_CLASS} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top" className="text-xs">
+              {tooltip}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+        {needsConfirm && (
+          <ConfirmDialog
+            open={confirmOpen}
+            onOpenChange={setConfirmOpen}
+            variant="default"
+            title={t("form.lock.confirmTitle", "Confirm editing a locked field")}
+            description={t(
+              "form.lock.confirmBody",
+              "This field is locked in the current state. Are you sure you want to edit it?",
+            )}
+            confirmLabel={t("form.lock.confirmOk", "Yes, edit")}
+            cancelLabel={t("form.lock.confirmCancel", "Cancel")}
+            onConfirm={() => {
+              setConfirmOpen(false);
+              onToggle?.();
+            }}
+          />
+        )}
+      </>
     );
   }
 
-  // Static (non-bypass) badge — preserved byte-for-byte from the original.
+  // Static (non-bypass, non-soft) badge — preserved byte-for-byte from the original.
   const tooltip = resolveLockTooltip(t, reason, status);
 
   return (

--- a/addons/adapter-ui/cap-adapter-ui/src/components/field-lock-badge.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/field-lock-badge.tsx
@@ -61,21 +61,24 @@ interface FieldLockBadgeProps {
  */
 export function resolveLockTooltip(
   t: TFunction,
-  reason: FieldLockReason,
-  status?: string,
-  opts?: { soft?: boolean; unlocked?: boolean },
+  opts: {
+    reason: FieldLockReason;
+    status?: string;
+    soft?: boolean;
+    unlocked?: boolean;
+  },
 ): string {
   // Soft lock, not yet unlocked → prompt the user that editing needs confirmation.
-  if (opts?.soft && !opts.unlocked) {
+  if (opts.soft && !opts.unlocked) {
     return t("form.lock.softLocked", "Locked — editing requires confirmation. Click to confirm.");
   }
-  if (reason === "immutable") {
+  if (opts.reason === "immutable") {
     return t("form.lock.immutable", "This field cannot be changed after creation");
   }
-  if (status) {
+  if (opts.status) {
     return t("form.lock.lockedInState", {
       defaultValue: 'Locked because the record is in state "{{status}}"',
-      status,
+      status: opts.status,
     });
   }
   return t("form.lock.locked", "This field is locked in the current state");
@@ -112,7 +115,7 @@ export function FieldLockBadge({
     const tooltip = unlocked
       ? t("form.lock.unlocked", "Unlocked — you may edit this field")
       : soft
-        ? resolveLockTooltip(t, reason, status, { soft: true, unlocked: false })
+        ? resolveLockTooltip(t, { reason, status, soft: true, unlocked: false })
         : t("form.lock.canOverride", "Locked — you may override. Click to unlock.");
     const Icon = unlocked ? LockOpen : Lock;
 
@@ -172,7 +175,7 @@ export function FieldLockBadge({
   }
 
   // Static (non-bypass, non-soft) badge — preserved byte-for-byte from the original.
-  const tooltip = resolveLockTooltip(t, reason, status);
+  const tooltip = resolveLockTooltip(t, { reason, status });
 
   return (
     <TooltipProvider delayDuration={300}>

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
@@ -104,7 +104,12 @@
       "ariaLabel": "Locked field",
       "canOverride": "Locked — you may override. Click to unlock.",
       "unlocked": "Unlocked — you may edit this field",
-      "toggleAriaLabel": "Toggle field lock"
+      "toggleAriaLabel": "Toggle field lock",
+      "softLocked": "Locked — editing requires confirmation. Click to confirm.",
+      "confirmTitle": "Confirm editing a locked field",
+      "confirmBody": "This field is locked in the current state. Are you sure you want to edit it?",
+      "confirmOk": "Yes, edit",
+      "confirmCancel": "Cancel"
     },
     "overlayFields": "Custom Fields"
   },

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
@@ -105,9 +105,9 @@
       "canOverride": "已锁定 — 你有权限覆盖，点击解锁",
       "unlocked": "已解锁 — 可编辑此字段",
       "toggleAriaLabel": "切换字段锁定",
-      "softLocked": "已锁定 — 编辑需确认,点击确认",
+      "softLocked": "已锁定 — 编辑需确认，点击确认",
       "confirmTitle": "确认编辑锁定字段",
-      "confirmBody": "该字段在当前状态下已锁定。确定要编辑它吗?",
+      "confirmBody": "该字段在当前状态下已锁定。确定要编辑它吗？",
       "confirmOk": "确定编辑",
       "confirmCancel": "取消"
     },

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
@@ -104,7 +104,12 @@
       "ariaLabel": "已锁定字段",
       "canOverride": "已锁定 — 你有权限覆盖，点击解锁",
       "unlocked": "已解锁 — 可编辑此字段",
-      "toggleAriaLabel": "切换字段锁定"
+      "toggleAriaLabel": "切换字段锁定",
+      "softLocked": "已锁定 — 编辑需确认,点击确认",
+      "confirmTitle": "确认编辑锁定字段",
+      "confirmBody": "该字段在当前状态下已锁定。确定要编辑它吗?",
+      "confirmOk": "确定编辑",
+      "confirmCancel": "取消"
     },
     "overlayFields": "自定义字段"
   },

--- a/addons/adapter-ui/cap-adapter-ui/src/lib/field-lock-state.ts
+++ b/addons/adapter-ui/cap-adapter-ui/src/lib/field-lock-state.ts
@@ -38,6 +38,12 @@ export interface FieldLockState {
   locked: boolean;
   /** Which rule locked it (only set when `locked` is true). */
   reason?: FieldLockReason;
+  /**
+   * Enforcement mode of the lock (only set when `locked`). `"hard"` blocks the
+   * write; `"soft"` is advisory — the UI requires a two-step confirmation
+   * before accepting the change (Spec 63 §4.2). `immutable` is always `"hard"`.
+   */
+  mode?: "hard" | "soft";
   /** For `locked` reason: the condition that matched (for tooltip detail). */
   condition?: LockCondition;
 }
@@ -77,7 +83,8 @@ export function computeFieldLockState(args: ComputeFieldLockStateArgs): FieldLoc
   //    that the engine would refuse to change.
   const isImmutable = fieldDef.immutable === true || fieldDef.readonly === true;
   if (isEditMode && isImmutable) {
-    return { locked: true, reason: "immutable" };
+    // `immutable` is always hard — `lockMode` only governs conditional locks.
+    return { locked: true, reason: "immutable", mode: "hard" };
   }
 
   // 2. Conditional lock. Per-field `lockWhen` wins; otherwise fall back to
@@ -89,7 +96,13 @@ export function computeFieldLockState(args: ComputeFieldLockStateArgs): FieldLoc
     (lockAllowFields?.includes(fieldName) || isSystemField ? undefined : lockAllWhen);
 
   if (lockCondition && matchesLockCondition(record, lockCondition)) {
-    return { locked: true, reason: "locked", condition: lockCondition };
+    // Conditional lock honors the field's `lockMode` (Spec 63 §4.2, default hard).
+    return {
+      locked: true,
+      reason: "locked",
+      mode: fieldDef.lockMode === "soft" ? "soft" : "hard",
+      condition: lockCondition,
+    };
   }
 
   return UNLOCKED;

--- a/addons/lock/cap-lock/__tests__/capability.test.ts
+++ b/addons/lock/cap-lock/__tests__/capability.test.ts
@@ -22,7 +22,7 @@ function makeContext(): FieldLockCheckContext {
 }
 
 function makeViolations(): FieldLockViolation[] {
-  return [{ field: "amount", type: "locked", message: 'Field "amount" is locked' }];
+  return [{ field: "amount", type: "locked", mode: "hard", message: 'Field "amount" is locked' }];
 }
 
 describe("cap-lock capability metadata", () => {

--- a/addons/lock/cap-lock/__tests__/field-lock-interceptor.test.ts
+++ b/addons/lock/cap-lock/__tests__/field-lock-interceptor.test.ts
@@ -41,13 +41,29 @@ function makeActor(groups: string[] = []): Actor {
 
 function makeViolations(): FieldLockViolation[] {
   return [
-    { field: "amount", type: "locked", message: 'Field "amount" is locked in state "submitted"' },
+    {
+      field: "amount",
+      type: "locked",
+      mode: "hard",
+      message: 'Field "amount" is locked in state "submitted"',
+    },
     {
       field: "code",
       type: "immutable",
+      mode: "hard",
       message: 'Field "code" is immutable and cannot be modified',
     },
   ];
+}
+
+/** A single soft (advisory) conditional-lock violation. */
+function softViolation(field = "amount"): FieldLockViolation {
+  return { field, type: "locked", mode: "soft", message: `Field "${field}" is locked` };
+}
+
+/** A single hard conditional-lock violation. */
+function hardViolation(field = "supplier"): FieldLockViolation {
+  return { field, type: "locked", mode: "hard", message: `Field "${field}" is locked` };
 }
 
 function makeContext(overrides?: Partial<FieldLockCheckContext>): FieldLockCheckContext {
@@ -282,6 +298,75 @@ describe("cap-lock field-lock-check interceptor", () => {
       // Must not throw despite no logger.
       const result = await handler(makeViolations(), makeContext());
       expect(result).toEqual([]);
+    });
+  });
+
+  // ── Soft locks (Spec 63 §4.2 SOFT_LOCK) ───────────────────────────
+  describe("soft locks", () => {
+    it("soft-only violation → suppressed (advisory allow) and audited as 'soft'", async () => {
+      const { handler, logger } = buildHandler({ config: {} });
+      const ctx = makeContext({ actor: makeActor([]) });
+
+      const result = await handler([softViolation("amount")], ctx);
+
+      expect(result).toEqual([]);
+      const log = logger.calls.find((c) => c.context?.reason === "soft");
+      expect(log).toBeDefined();
+      expect(log?.level).toBe("info");
+      expect(log?.context).toMatchObject({
+        capability: "lock",
+        reason: "soft",
+        fields: ["amount"],
+      });
+    });
+
+    it("mixed soft + hard → only hard returned, soft subset audited", async () => {
+      const { handler, logger } = buildHandler({ config: {} });
+      const ctx = makeContext({ actor: makeActor([]) });
+      const input = [softViolation("amount"), hardViolation("supplier")];
+
+      const result = await handler(input, ctx);
+
+      // Hard violation still blocks; soft is dropped.
+      expect(result).toEqual([hardViolation("supplier")]);
+      const log = logger.calls.find((c) => c.context?.reason === "soft");
+      expect(log).toBeDefined();
+      // Only the soft field is reported in the soft audit entry.
+      expect(log?.context).toMatchObject({ fields: ["amount"], violationCount: 1 });
+    });
+
+    it("soft is NOT actor-gated → any actor proceeds without a bypass group", async () => {
+      const { handler } = buildHandler({ config: { bypassGroups: ["admin"] } });
+      // Actor has no groups, so an actor-level bypass would NOT apply — yet a
+      // soft lock is still allowed-with-audit (the UI confirmation is the gate).
+      const ctx = makeContext({ actor: makeActor(["staff"]) });
+
+      const result = await handler([softViolation("amount")], ctx);
+
+      expect(result).toEqual([]);
+    });
+
+    it("soft + shadowMode → all suppressed, audited as 'shadow' (shadow wins, no 'soft' log)", async () => {
+      const { handler, logger } = buildHandler({ config: { shadowMode: true } });
+      const ctx = makeContext({ actor: makeActor([]) });
+
+      const result = await handler([softViolation("amount"), hardViolation("supplier")], ctx);
+
+      expect(result).toEqual([]);
+      expect(logger.calls.find((c) => c.context?.reason === "shadow")).toBeDefined();
+      // Shadow short-circuits before the soft partition — no separate soft log.
+      expect(logger.calls.find((c) => c.context?.reason === "soft")).toBeUndefined();
+    });
+
+    it("soft + bypass group → all suppressed, audited as 'bypass' (bypass wins, no 'soft' log)", async () => {
+      const { handler, logger } = buildHandler({ config: { bypassGroups: ["admin"] } });
+      const ctx = makeContext({ actor: makeActor(["admin"]) });
+
+      const result = await handler([softViolation("amount"), hardViolation("supplier")], ctx);
+
+      expect(result).toEqual([]);
+      expect(logger.calls.find((c) => c.context?.reason === "bypass")).toBeDefined();
+      expect(logger.calls.find((c) => c.context?.reason === "soft")).toBeUndefined();
     });
   });
 });

--- a/addons/lock/cap-lock/src/field-lock-interceptor.ts
+++ b/addons/lock/cap-lock/src/field-lock-interceptor.ts
@@ -23,7 +23,12 @@
  *  1. Shadow mode      — `shadowMode: true`.
  *  2. Bypass groups    — actor belongs to ANY `bypassGroups` entry.
  *  3. Tolerance period — `toleranceMs > 0` AND record age < toleranceMs.
- *  4. Otherwise        — return violations UNCHANGED (block, fail-closed).
+ *  4. Soft locks       — `violation.mode === "soft"`: advisory, the soft
+ *                        violations are audited and dropped; any hard violations
+ *                        still block (return the hard subset). NOT actor-gated —
+ *                        the UI two-step confirmation is the deliberateness gate.
+ *  5. Otherwise        — block (fail-closed): return the (hard) violations
+ *                        UNCHANGED so core re-throws.
  */
 
 import type { FieldLockCheckContext, FieldLockViolation, Logger } from "@linchkit/core";
@@ -31,7 +36,7 @@ import { evaluateActorBypass } from "./bypass";
 import type { CapLockPolicy } from "./config";
 
 /** Reason an audited suppression occurred — surfaced in the audit log. */
-export type LockSuppressionReason = "shadow" | "bypass" | "tolerance";
+export type LockSuppressionReason = "shadow" | "bypass" | "tolerance" | "soft";
 
 /** Options for {@link createFieldLockInterceptor}. */
 export interface FieldLockInterceptorOptions {
@@ -124,10 +129,13 @@ export function createFieldLockInterceptor(
       return violations;
     }
 
-    const audit = (reason: LockSuppressionReason): void => {
+    const audit = (
+      reason: LockSuppressionReason,
+      audited: readonly FieldLockViolation[] = violations,
+    ): void => {
       logger?.info(
-        `cap-lock suppressed ${violations.length} field-lock violation(s) (${reason})`,
-        buildAuditContext({ reason, context, violations }),
+        `cap-lock suppressed ${audited.length} field-lock violation(s) (${reason})`,
+        buildAuditContext({ reason, context, violations: audited }),
       );
     };
 
@@ -163,8 +171,24 @@ export function createFieldLockInterceptor(
       }
     }
 
-    // 4. No policy matched — BLOCK. Return the violations UNCHANGED so core
-    //    re-throws with the full per-field detail (fail-closed default).
-    return violations;
+    // 4. Soft locks (Spec 63 §4.2 SOFT_LOCK). A soft violation is ADVISORY:
+    //    cap-lock allows the write but records an audit entry. The deliberateness
+    //    gate is the UI's two-step confirmation, NOT an actor capability, so this
+    //    branch is deliberately NOT routed through `evaluateActorBypass` — any
+    //    actor may proceed past a soft lock. Hard violations in the same set still
+    //    block, so we partition and return only the hard subset.
+    const soft = violations.filter((v) => v.mode === "soft");
+    // No soft locks: this is the fail-closed default — return the violations
+    // UNCHANGED (same reference) so cap-lock with no matching knob is a pure
+    // no-op over core, which re-throws with the full per-field detail.
+    if (soft.length === 0) {
+      return violations;
+    }
+
+    audit("soft", soft);
+
+    // 5. Soft violations are dropped (advisory allow); any HARD violations in
+    //    the same set still block. Returns `[]` for the soft-only allow.
+    return violations.filter((v) => v.mode !== "soft");
   };
 }

--- a/packages/core/__tests__/field-lock-mode.test.ts
+++ b/packages/core/__tests__/field-lock-mode.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Spec 63 §4.2 SOFT_LOCK — `FieldLockViolation.mode` classification.
+ *
+ * Unit-level coverage of `checkFieldLocks`: every emitted violation carries a
+ * `mode` ("hard" | "soft"). `immutable` is always hard; a conditional `locked`
+ * violation honors the field's `lockMode` (default hard).
+ */
+
+import { describe, expect, it } from "bun:test";
+import { checkFieldLocks } from "../src/engine/field-lock-checker";
+import type { FieldDefinition } from "../src/types/entity";
+
+describe("Spec 63 §4.2 — FieldLockViolation.mode", () => {
+  it("immutable violation is always mode=hard", () => {
+    const fields: Record<string, FieldDefinition> = {
+      code: { type: "string", immutable: true },
+    };
+    const violations = checkFieldLocks({
+      fields,
+      existingRecord: { code: "ORIG" },
+      input: { code: "NEW" },
+    });
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.type).toBe("immutable");
+    expect(violations[0]?.mode).toBe("hard");
+  });
+
+  it("conditional lock defaults to mode=hard when lockMode is unset", () => {
+    const fields: Record<string, FieldDefinition> = {
+      amount: { type: "number", lockWhen: { state: "submitted" } },
+    };
+    const violations = checkFieldLocks({
+      fields,
+      existingRecord: { status: "submitted", amount: 100 },
+      input: { amount: 200 },
+    });
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.type).toBe("locked");
+    expect(violations[0]?.mode).toBe("hard");
+  });
+
+  it("conditional lock with lockMode=soft yields mode=soft", () => {
+    const fields: Record<string, FieldDefinition> = {
+      amount: { type: "number", lockWhen: { state: "submitted" }, lockMode: "soft" },
+    };
+    const violations = checkFieldLocks({
+      fields,
+      existingRecord: { status: "submitted", amount: 100 },
+      input: { amount: 200 },
+    });
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.type).toBe("locked");
+    expect(violations[0]?.mode).toBe("soft");
+  });
+
+  it("lockMode=soft does NOT soften an immutable field (immutable stays hard)", () => {
+    const fields: Record<string, FieldDefinition> = {
+      // Contradictory authoring: immutable + soft. Immutable always wins hard.
+      code: { type: "string", immutable: true, lockMode: "soft" },
+    };
+    const violations = checkFieldLocks({
+      fields,
+      existingRecord: { code: "ORIG" },
+      input: { code: "NEW" },
+    });
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.type).toBe("immutable");
+    expect(violations[0]?.mode).toBe("hard");
+  });
+
+  it("entity-level lockAllWhen on a soft field still emits mode=soft", () => {
+    const fields: Record<string, FieldDefinition> = {
+      amount: { type: "number", lockMode: "soft" },
+    };
+    const violations = checkFieldLocks({
+      fields,
+      lockAllWhen: { state: "submitted" },
+      existingRecord: { status: "submitted", amount: 100 },
+      input: { amount: 200 },
+    });
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.type).toBe("locked");
+    expect(violations[0]?.mode).toBe("soft");
+  });
+});

--- a/packages/core/__tests__/interceptors.test.ts
+++ b/packages/core/__tests__/interceptors.test.ts
@@ -34,7 +34,7 @@ const ctx: FieldLockCheckContext = {
 };
 
 function violation(field: string): FieldLockViolation {
-  return { field, type: "immutable", message: `Field "${field}" is immutable` };
+  return { field, type: "immutable", mode: "hard", message: `Field "${field}" is immutable` };
 }
 
 /** Logger spy that records every error call. */

--- a/packages/core/src/engine/field-lock-checker.ts
+++ b/packages/core/src/engine/field-lock-checker.ts
@@ -74,11 +74,19 @@ export const SYSTEM_FIELD_NAMES = new Set([
 
 export type FieldLockViolationType = "immutable" | "locked";
 
+/** Lock enforcement mode for a {@link FieldLockViolation} (Spec 63 §4.2). */
+export type FieldLockMode = "hard" | "soft";
+
 export interface FieldLockViolation {
   /** Field name that violated a lock rule */
   field: string;
   /** Which rule was violated */
   type: FieldLockViolationType;
+  /**
+   * Enforcement mode — `hard` blocks; `soft` is advisory (cap-lock allows+audits,
+   * UI confirms). `immutable` violations are always `hard`.
+   */
+  mode: FieldLockMode;
   /** For `locked` violations: the lock condition that triggered the block */
   condition?: LockCondition;
   /** Human-readable violation message */
@@ -303,6 +311,8 @@ export function checkFieldLocks(args: FieldLockCheckArgs): FieldLockViolation[] 
       violations.push({
         field: fieldName,
         type: "immutable",
+        // `immutable` is always hard — `lockMode` only governs conditional locks.
+        mode: "hard",
         message: `Field "${fieldName}" is immutable and cannot be modified`,
       });
       // Don't also report this field as locked — immutable is more specific.
@@ -331,6 +341,9 @@ export function checkFieldLocks(args: FieldLockCheckArgs): FieldLockViolation[] 
       violations.push({
         field: fieldName,
         type: "locked",
+        // Conditional locks honor the field's `lockMode` (default hard). A soft
+        // lock is advisory: cap-lock allows+audits it and the UI confirms.
+        mode: field.lockMode === "soft" ? "soft" : "hard",
         condition: lockCondition,
         message: `Field "${fieldName}" is locked${statusMsg}`,
       });

--- a/packages/core/src/engine/index.ts
+++ b/packages/core/src/engine/index.ts
@@ -56,6 +56,7 @@ export { type ConditionContext, evaluateCondition, resolveField } from "./condit
 export {
   checkFieldLocks,
   type FieldLockCheckArgs,
+  type FieldLockMode,
   type FieldLockViolation,
   type FieldLockViolationType,
   matchesLockCondition,

--- a/packages/core/src/exports/client/engines.ts
+++ b/packages/core/src/exports/client/engines.ts
@@ -44,6 +44,7 @@ export {
 export {
   checkFieldLocks,
   type FieldLockCheckArgs,
+  type FieldLockMode,
   type FieldLockViolation,
   type FieldLockViolationType,
   matchesLockCondition,

--- a/packages/core/src/types/entity.ts
+++ b/packages/core/src/types/entity.ts
@@ -101,6 +101,16 @@ export interface BaseFieldDefinition extends FieldConstraints {
    * field.
    */
   lockWhen?: LockCondition;
+  /**
+   * Lock enforcement mode for this field's CONDITIONAL lock (`lockWhen`, or the
+   * entity-level `lockAllWhen` covering it). Spec 63 §4.2 SOFT_LOCK.
+   *  - "hard" (default) — a matching lock blocks the write (validation.field.locked).
+   *  - "soft" — ADVISORY: cap-lock allows the write with an audit entry, and the
+   *    UI requires an explicit two-step confirmation before accepting the change.
+   *    Without cap-lock installed, soft falls back to hard (core still emits the
+   *    violation — fail-safe). Does NOT affect `immutable` (always hard).
+   */
+  lockMode?: "hard" | "soft";
   /** Data masking configuration. When set, field values are masked based on strategy unless actor has unmask permission. */
   masking?: MaskingConfig;
   /** Whether this field stores translatable content (i18n). When true, values are stored as JSONB { locale: value }. */
@@ -371,6 +381,8 @@ export interface EntityExtension {
 export type FieldOverrideProps = Partial<FieldConstraints> & {
   readonly?: boolean;
   lockWhen?: LockCondition;
+  /** Lock enforcement mode for the conditional lock — `"hard"` (default) or `"soft"` (Spec 63 §4.2). */
+  lockMode?: "hard" | "soft";
 };
 
 export interface EntityOverride {


### PR DESCRIPTION
## What

Implements **SOFT_LOCK** (Spec 63 §4.2 "Two-step confirmation" + §5.2), the remaining cap-lock field-lock feature. A field can declare `lockMode: 'soft'`; a soft conditional lock is **advisory** — the write is allowed (and audited by cap-lock), with the deliberateness gate being a **UI two-step confirmation** rather than a hard server block.

Design (advisory + UI confirm) chosen by the project owner. `lockMode` governs a field's **conditional** lock (`lockWhen` / entity `lockAllWhen`) only; `immutable` is always hard. Without cap-lock installed, a soft lock **falls back to hard** (core still emits the violation — fail-safe).

## How it flows

1. **Core** declares `lockMode` and stamps each `FieldLockViolation` with a required `mode: 'hard' | 'soft'` (immutable → hard; conditional → the field's `lockMode`). Core enforcement is unchanged — it still emits the violation; `mode` is metadata cap-lock and the UI read.
2. **cap-lock**'s `field-lock-check` interceptor adds a soft branch (after shadow / bypass / tolerance): soft violations are audited (`reason: 'soft'`) and dropped (advisory allow); any hard violations in the same set still block. **Not actor-gated** — the UI confirmation is the gate. When no soft lock matches, it returns the violation set by the **same reference**, preserving the fail-closed, byte-identical no-op contract from #445/#447.
3. **Introspection** (#437 `FieldMeta`) exposes `lockMode` so the client knows a field is soft.
4. **UI** (adapter-ui): the #449 `FieldLockBadge` unlock toggle now, for a soft lock, opens a `ConfirmDialog` (the two-step) before unlocking the field for editing — available to any actor. The bypass-group path (immediate unlock, #449) and the static lock path are unchanged. `auto-form` treats a field as unlockable if its lock is soft OR the actor can bypass.

## Boundaries / safety

- Core enforcement semantics are unchanged (soft is declaration metadata; the behavior difference lives entirely in cap-lock — consistent with Spec 63 §4 "core defines slot, capability provides advanced behavior").
- `cloneInterceptorInput`'s deep clone propagates the new `mode` field automatically (no change there).
- Soft lock requires cap-lock; absent it, the field is hard-locked (fail-safe).

## Test plan

- `packages/core`: **3892 pass / 0 fail** (new `field-lock-mode.test.ts`; all `FieldLockViolation` construction sites updated for the now-required `mode`).
- `addons/lock/cap-lock`: **48 / 0** (new soft-partition tests: soft-only, mixed soft+hard, not-actor-gated, shadow-wins, bypass-wins).
- `addons/adapter-ui/cap-adapter-ui`: **377 / 0**; `addons/adapter-server/cap-adapter-server`: **665 / 0** (30 DB-gated skips).
- `bun run check` (biome): clean. Changed files are typecheck-clean (the only `tsc` errors are 3 pre-existing ones in `packages/cli/mcp-dev/generation-tools.ts` — an MCP-SDK / zod-4.3.6 skew under local Bun 1.2.18, not reproduced in CI; unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced soft lock mode for fields—advisory locks that require user confirmation to edit, distinct from hard locks that prevent editing entirely.
  * Enhanced lock UI with confirmation dialogs when unlocking soft-locked fields.

* **Internationalization**
  * Added English and Chinese translations for lock state management and confirmation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->