### PR TITLE
feat(lock): dependency-free lock.override notification seam (Spec 63 §4.2)

### DIFF
--- a/addons/lock/cap-lock/__tests__/field-lock-interceptor.test.ts
+++ b/addons/lock/cap-lock/__tests__/field-lock-interceptor.test.ts
@@ -10,6 +10,7 @@
 import { beforeEach, describe, expect, it } from "bun:test";
 import type { Actor, FieldLockCheckContext, FieldLockViolation, Logger } from "@linchkit/core";
 import { resolveCapLockPolicy } from "../src/config";
+import type { LockOverrideEvent } from "../src/events";
 import {
   createFieldLockInterceptor,
   type FieldLockInterceptorOptions,
@@ -367,6 +368,160 @@ describe("cap-lock field-lock-check interceptor", () => {
       expect(result).toEqual([]);
       expect(logger.calls.find((c) => c.context?.reason === "bypass")).toBeDefined();
       expect(logger.calls.find((c) => c.context?.reason === "soft")).toBeUndefined();
+    });
+  });
+
+  // ── Override notification event (Spec 63 §4.2 Notification) ────────
+  describe("lock.override event emission", () => {
+    /** Build a handler with an event-capture sink (1:1 with the audit log). */
+    function buildEventHandler(
+      partial: Partial<FieldLockInterceptorOptions> & {
+        config?: Parameters<typeof resolveCapLockPolicy>[0];
+      },
+    ) {
+      const events: LockOverrideEvent[] = [];
+      const handler = createFieldLockInterceptor({
+        policy: resolveCapLockPolicy(partial.config),
+        now: partial.now ?? (() => Date.parse("2026-01-01T00:01:00Z")),
+        emitEvent: (e) => events.push(e),
+      });
+      return { handler, events };
+    }
+
+    it("bypass → emits one event with reason 'bypass' and the suppressed fields", async () => {
+      const { handler, events } = buildEventHandler({ config: { bypassGroups: ["admin"] } });
+      const ctx = makeContext({ actor: makeActor(["staff", "admin"]) });
+
+      await handler(makeViolations(), ctx);
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({
+        type: "lock.override",
+        reason: "bypass",
+        entity: "purchase_request",
+        recordId: "r1",
+        actorId: "user-1",
+        actorType: "human",
+        tenantId: "t1",
+        fields: ["amount", "code"],
+      });
+    });
+
+    it("shadow → emits one event with reason 'shadow' and all violation fields", async () => {
+      const { handler, events } = buildEventHandler({ config: { shadowMode: true } });
+
+      await handler(makeViolations(), makeContext());
+
+      expect(events).toHaveLength(1);
+      expect(events[0]?.reason).toBe("shadow");
+      expect(events[0]?.fields).toEqual(["amount", "code"]);
+    });
+
+    it("tolerance → emits one event with reason 'tolerance'", async () => {
+      const { handler, events } = buildEventHandler({
+        config: { toleranceMs: 5 * 60 * 1000 },
+        now: () => Date.parse("2026-01-01T00:01:00Z"),
+      });
+      const ctx = makeContext({
+        record: { id: "r1", status: "submitted", created_at: "2026-01-01T00:00:00Z" },
+      });
+
+      await handler(makeViolations(), ctx);
+
+      expect(events).toHaveLength(1);
+      expect(events[0]?.reason).toBe("tolerance");
+    });
+
+    it("soft (mixed) → emits one event with reason 'soft' and ONLY the soft fields", async () => {
+      const { handler, events } = buildEventHandler({ config: {} });
+      const ctx = makeContext({ actor: makeActor([]) });
+
+      const result = await handler([softViolation("amount"), hardViolation("supplier")], ctx);
+
+      // Hard violation still blocks; soft is dropped.
+      expect(result).toEqual([hardViolation("supplier")]);
+      expect(events).toHaveLength(1);
+      expect(events[0]?.reason).toBe("soft");
+      // Mirrors `audit("soft", soft)` — only the soft subset's fields.
+      expect(events[0]?.fields).toEqual(["amount"]);
+    });
+
+    it("fail-closed default (no knob, no soft) → no event AND original violations by reference", async () => {
+      const { handler, events } = buildEventHandler({
+        config: { shadowMode: false, bypassGroups: ["admin"], toleranceMs: 1000 },
+        now: () => Date.parse("2026-01-01T01:00:00Z"),
+      });
+      const ctx = makeContext({ actor: makeActor(["staff"]) });
+      const input = makeViolations();
+
+      const result = await handler(input, ctx);
+
+      expect(events).toHaveLength(0);
+      expect(result).toBe(input); // unchanged reference (fail-closed)
+    });
+
+    it("empty violation set → no event emitted", async () => {
+      const { handler, events } = buildEventHandler({ config: { shadowMode: true } });
+
+      await handler([], makeContext());
+
+      expect(events).toHaveLength(0);
+    });
+
+    it("no emitEvent injected → byte-identical suppression behavior, no throw", async () => {
+      const logger = createFakeLogger();
+      const handler = createFieldLockInterceptor({
+        policy: resolveCapLockPolicy({ shadowMode: true }),
+        logger,
+        now: () => Date.parse("2026-01-01T00:01:00Z"),
+      });
+
+      const result = await handler(makeViolations(), makeContext());
+
+      expect(result).toEqual([]);
+      expect(logger.calls.find((c) => c.context?.reason === "shadow")).toBeDefined();
+    });
+
+    it("sink throws → suppression result is still returned (error does not propagate)", async () => {
+      const logger = createFakeLogger();
+      const handler = createFieldLockInterceptor({
+        policy: resolveCapLockPolicy({ shadowMode: true }),
+        logger,
+        now: () => Date.parse("2026-01-01T00:01:00Z"),
+        emitEvent: () => {
+          throw new Error("boom");
+        },
+      });
+
+      const result = await handler(makeViolations(), makeContext());
+
+      // Allowed write must NOT be turned into a throw; result is the suppression.
+      expect(result).toEqual([]);
+      // The faulty sink is noted at warn level.
+      expect(logger.calls.find((c) => c.level === "warn")).toBeDefined();
+    });
+
+    it("recordId: string id surfaces; non-string/absent id is omitted", async () => {
+      // String id → surfaced.
+      const withId = buildEventHandler({ config: { shadowMode: true } });
+      await withId.handler(
+        makeViolations(),
+        makeContext({ record: { id: "rec-42", status: "submitted" } }),
+      );
+      expect(withId.events[0]?.recordId).toBe("rec-42");
+
+      // No id on the record → omitted (undefined).
+      const noId = buildEventHandler({ config: { shadowMode: true } });
+      await noId.handler(makeViolations(), makeContext({ record: { status: "submitted" } }));
+      expect(noId.events[0]?.recordId).toBeUndefined();
+
+      // Non-string id (number) → omitted (undefined), no coercion.
+      const numId = buildEventHandler({ config: { shadowMode: true } });
+      await numId.handler(
+        makeViolations(),
+        makeContext({ record: { id: 7, status: "submitted" } }),
+      );
+      expect(numId.events[0]?.recordId).toBeUndefined();
     });
   });
 });

--- a/addons/lock/cap-lock/__tests__/field-lock-interceptor.test.ts
+++ b/addons/lock/cap-lock/__tests__/field-lock-interceptor.test.ts
@@ -501,6 +501,43 @@ describe("cap-lock field-lock-check interceptor", () => {
       expect(logger.calls.find((c) => c.level === "warn")).toBeDefined();
     });
 
+    it("async sink rejects → suppression returns, rejection is isolated (no unhandled rejection)", async () => {
+      const logger = createFakeLogger();
+      const handler = createFieldLockInterceptor({
+        policy: resolveCapLockPolicy({ shadowMode: true }),
+        logger,
+        now: () => Date.parse("2026-01-01T00:01:00Z"),
+        // A Promise-returning sink that rejects — the common async-dispatch case.
+        emitEvent: () => Promise.reject(new Error("async boom")),
+      });
+
+      // The handler's own promise must resolve to the suppression result and must
+      // NOT reject — the async rejection is caught inside the interceptor.
+      const result = await handler(makeViolations(), makeContext());
+      expect(result).toEqual([]);
+
+      // Let the queued .catch microtask run, then assert it was logged at warn.
+      await Promise.resolve();
+      expect(logger.calls.find((c) => c.level === "warn")).toBeDefined();
+    });
+
+    it("async sink resolves → event still emitted, no error", async () => {
+      const events: LockOverrideEvent[] = [];
+      const handler = createFieldLockInterceptor({
+        policy: resolveCapLockPolicy({ shadowMode: true }),
+        now: () => Date.parse("2026-01-01T00:01:00Z"),
+        emitEvent: (e) => {
+          events.push(e);
+          return Promise.resolve();
+        },
+      });
+
+      const result = await handler(makeViolations(), makeContext());
+      expect(result).toEqual([]);
+      expect(events).toHaveLength(1);
+      expect(events[0]?.reason).toBe("shadow");
+    });
+
     it("recordId: string id surfaces; non-string/absent id is omitted", async () => {
       // String id → surfaced.
       const withId = buildEventHandler({ config: { shadowMode: true } });

--- a/addons/lock/cap-lock/src/events.ts
+++ b/addons/lock/cap-lock/src/events.ts
@@ -1,0 +1,71 @@
+/**
+ * cap-lock override notification seam (Spec 63 §4.2 "Notification — Notify
+ * stakeholders when locked fields are force-modified").
+ *
+ * The `field-lock-check` interceptor suppresses lock violations under one of its
+ * policy escape hatches (shadow / bypass / tolerance / soft). When that happens a
+ * locked field is being force-modified, so cap-lock emits a structured
+ * `lock.override` event through an INJECTED sink — mirroring exactly how the
+ * audit `logger` is injected. cap-lock takes ZERO notification/event-bus
+ * dependency: the host decides where the event goes (an EventHandler →
+ * send_notification, the execution log, etc.). When no sink is injected, no event
+ * is emitted and behavior is byte-identical to core's default enforcement.
+ */
+
+import type { FieldLockCheckContext, FieldLockViolation } from "@linchkit/core";
+// Type-only import: does NOT create a runtime cycle, so the builder can live here
+// while the interceptor imports `buildLockOverrideEvent` back. The public
+// `LockSuppressionReason` export from index.ts continues to come from the
+// interceptor module.
+import type { LockSuppressionReason } from "./field-lock-interceptor";
+
+/** Discriminant/type tag for the override notification event. */
+export const LOCK_OVERRIDE_EVENT = "lock.override" as const;
+
+/**
+ * Structured event emitted once per suppression, 1:1 with the audit log, when a
+ * locked field is force-modified. The host maps this to a notification or an
+ * execution-log entry.
+ */
+export interface LockOverrideEvent {
+  /** Always "lock.override". */
+  type: typeof LOCK_OVERRIDE_EVENT;
+  /** Which policy escape hatch allowed the write. */
+  reason: LockSuppressionReason;
+  /** Entity whose locked field(s) were force-modified. */
+  entity: string;
+  /** The persisted record's id, when present on the context record. */
+  recordId?: string;
+  /** Actor who performed the override. */
+  actorId: string;
+  actorType: string;
+  /** Tenant scope, when known. */
+  tenantId?: string;
+  /** Field names whose lock violations were suppressed. */
+  fields: string[];
+}
+
+/**
+ * Pure builder for a {@link LockOverrideEvent}. Mirrors the audit context shape:
+ * the `fields`/`reason` come from the audited violation subset so the event is
+ * 1:1 with the audit-log entry. Coerces `record.id` safely (it is
+ * `Record<string, unknown>`) and only surfaces it when it is a string.
+ */
+export function buildLockOverrideEvent(opts: {
+  reason: LockSuppressionReason;
+  context: FieldLockCheckContext;
+  violations: readonly FieldLockViolation[];
+}): LockOverrideEvent {
+  const { reason, context, violations } = opts;
+  const rawId = context.record.id;
+  return {
+    type: LOCK_OVERRIDE_EVENT,
+    reason,
+    entity: context.entity,
+    recordId: typeof rawId === "string" ? rawId : undefined,
+    actorId: context.actor.id,
+    actorType: context.actor.type,
+    tenantId: context.tenantId,
+    fields: violations.map((v) => v.field),
+  };
+}

--- a/addons/lock/cap-lock/src/factory.ts
+++ b/addons/lock/cap-lock/src/factory.ts
@@ -38,8 +38,9 @@ export interface CapLockOptions {
    * Optional sink for `lock.override` events (Spec 63 §4.2 Notification). Wired
    * the same way as `logger`. When omitted, no events are emitted. cap-lock takes
    * no notification/event-bus dependency — the host decides where the event goes.
+   * May be sync or async; the interceptor isolates both throws and rejections.
    */
-  emitEvent?: (event: LockOverrideEvent) => void;
+  emitEvent?: (event: LockOverrideEvent) => void | Promise<void>;
 }
 
 export function createCapLock(options?: CapLockOptions): CapabilityDefinition {

--- a/addons/lock/cap-lock/src/factory.ts
+++ b/addons/lock/cap-lock/src/factory.ts
@@ -12,6 +12,7 @@
 import type { CapabilityDefinition, InterceptorRegistration, Logger } from "@linchkit/core";
 import { defineCapability } from "@linchkit/core";
 import { type CapLockPolicy, capLockConfig, resolveCapLockPolicy } from "./config";
+import type { LockOverrideEvent } from "./events";
 import { createFieldLockInterceptor } from "./field-lock-interceptor";
 import { buildLockGraphQLExtension } from "./graphql";
 
@@ -33,6 +34,12 @@ export interface CapLockOptions {
    * evaluation. Defaults to `Date.now` inside the interceptor.
    */
   now?: () => number;
+  /**
+   * Optional sink for `lock.override` events (Spec 63 §4.2 Notification). Wired
+   * the same way as `logger`. When omitted, no events are emitted. cap-lock takes
+   * no notification/event-bus dependency — the host decides where the event goes.
+   */
+  emitEvent?: (event: LockOverrideEvent) => void;
 }
 
 export function createCapLock(options?: CapLockOptions): CapabilityDefinition {
@@ -42,6 +49,7 @@ export function createCapLock(options?: CapLockOptions): CapabilityDefinition {
     policy,
     logger: options?.logger,
     now: options?.now,
+    emitEvent: options?.emitEvent,
   });
 
   const interceptors: InterceptorRegistration[] = [
@@ -56,7 +64,7 @@ export function createCapLock(options?: CapLockOptions): CapabilityDefinition {
     name: "cap-lock",
     label: "Field Lock Policy",
     description:
-      "Advanced field-lock policy: shadow mode, bypass groups, tolerance period, and audit trail over core field-lock enforcement",
+      "Advanced field-lock policy: shadow mode, bypass groups, tolerance period, audit trail, and override notifications over core field-lock enforcement",
     type: "standard",
     category: "system",
     version: "1.0.0",

--- a/addons/lock/cap-lock/src/field-lock-interceptor.ts
+++ b/addons/lock/cap-lock/src/field-lock-interceptor.ts
@@ -34,6 +34,7 @@
 import type { FieldLockCheckContext, FieldLockViolation, Logger } from "@linchkit/core";
 import { evaluateActorBypass } from "./bypass";
 import type { CapLockPolicy } from "./config";
+import { buildLockOverrideEvent, type LockOverrideEvent } from "./events";
 
 /** Reason an audited suppression occurred — surfaced in the audit log. */
 export type LockSuppressionReason = "shadow" | "bypass" | "tolerance" | "soft";
@@ -54,6 +55,14 @@ export interface FieldLockInterceptorOptions {
    * fine; the seam exists purely so tests can pin "now".
    */
   now?: () => number;
+  /**
+   * Fire-and-forget sink for "locked field force-modified" events (Spec 63 §4.2
+   * Notification). Called once per suppression, 1:1 with the audit log. Injected
+   * exactly like `logger`; when omitted, no event is emitted. The host maps the
+   * event to a notification / execution-log entry, keeping cap-lock free of any
+   * notification or event-bus dependency.
+   */
+  emitEvent?: (event: LockOverrideEvent) => void;
 }
 
 /**
@@ -116,7 +125,7 @@ export function createFieldLockInterceptor(
   violations: FieldLockViolation[],
   context: FieldLockCheckContext,
 ) => Promise<FieldLockViolation[]> {
-  const { policy, logger } = options;
+  const { policy, logger, emitEvent } = options;
   const now = options.now ?? Date.now;
 
   return async (
@@ -137,6 +146,17 @@ export function createFieldLockInterceptor(
         `cap-lock suppressed ${audited.length} field-lock violation(s) (${reason})`,
         buildAuditContext({ reason, context, violations: audited }),
       );
+      // Spec 63 §4.2 Notification: emit a structured override event 1:1 with the
+      // audit log. The host wires the sink (EventHandler / execution log); cap-lock
+      // stays dependency-free. A faulty sink must never turn an allowed write into
+      // a throw, so the emit is fully isolated.
+      if (emitEvent) {
+        try {
+          emitEvent(buildLockOverrideEvent({ reason, context, violations: audited }));
+        } catch (err) {
+          logger?.warn("cap-lock emitEvent sink threw; event dropped", { error: String(err) });
+        }
+      }
     };
 
     // 1 & 2. Actor-level escape hatches — shadow mode, then bypass groups.

--- a/addons/lock/cap-lock/src/field-lock-interceptor.ts
+++ b/addons/lock/cap-lock/src/field-lock-interceptor.ts
@@ -61,8 +61,12 @@ export interface FieldLockInterceptorOptions {
    * exactly like `logger`; when omitted, no event is emitted. The host maps the
    * event to a notification / execution-log entry, keeping cap-lock free of any
    * notification or event-bus dependency.
+   *
+   * May be sync or async (notification dispatch / event-bus publish typically
+   * returns a `Promise`). Both a synchronous throw AND an async rejection are
+   * isolated by the interceptor so a faulty sink can never break the write path.
    */
-  emitEvent?: (event: LockOverrideEvent) => void;
+  emitEvent?: (event: LockOverrideEvent) => void | Promise<void>;
 }
 
 /**
@@ -149,10 +153,21 @@ export function createFieldLockInterceptor(
       // Spec 63 §4.2 Notification: emit a structured override event 1:1 with the
       // audit log. The host wires the sink (EventHandler / execution log); cap-lock
       // stays dependency-free. A faulty sink must never turn an allowed write into
-      // a throw, so the emit is fully isolated.
+      // a throw, so the emit is fully isolated — for BOTH a synchronous throw and
+      // an async rejection (the sink is likely a Promise-returning dispatch).
       if (emitEvent) {
         try {
-          emitEvent(buildLockOverrideEvent({ reason, context, violations: audited }));
+          const result = emitEvent(
+            buildLockOverrideEvent({ reason, context, violations: audited }),
+          );
+          if (result instanceof Promise) {
+            // Swallow async rejection so it never becomes an unhandled rejection.
+            result.catch((err: unknown) => {
+              logger?.warn("cap-lock emitEvent sink rejected; event dropped", {
+                error: String(err),
+              });
+            });
+          }
         } catch (err) {
           logger?.warn("cap-lock emitEvent sink threw; event dropped", { error: String(err) });
         }

--- a/addons/lock/cap-lock/src/index.ts
+++ b/addons/lock/cap-lock/src/index.ts
@@ -14,6 +14,9 @@ export { capLock } from "./capability";
 // Config schema + policy resolver
 export type { CapLockPolicy } from "./config";
 export { capLockConfig, resolveCapLockPolicy } from "./config";
+// Override notification event (Spec 63 §4.2) — dependency-free emit seam
+export type { LockOverrideEvent } from "./events";
+export { buildLockOverrideEvent, LOCK_OVERRIDE_EVENT } from "./events";
 // Factory (custom config + logger + clock injection)
 export type { CapLockOptions } from "./factory";
 export { createCapLock } from "./factory";


### PR DESCRIPTION
## What

Adds the **override notification** seam to `addons/lock/cap-lock` — Spec 63 §4.2 lists a cap-lock feature *"Notification — Notify stakeholders when locked fields are force-modified"*. This wires the emit point for it **without giving cap-lock any notification or event-bus dependency**.

When the `field-lock-check` interceptor **suppresses** lock violations (a locked field is force-modified via shadow / bypass / tolerance / soft), it now emits a structured `lock.override` event through an **injected `emitEvent` sink** — wired exactly like the existing audit `logger`. The emit is folded into the interceptor's `audit()` helper, so it fires **once per suppression, 1:1 with the audit log**. The host maps the event to a notification (an EventHandler → `send_notification`) or the execution log; cap-lock stays recipient-agnostic and dependency-free (IoC — mirrors how #449 used `graphqlExtensions` and how the `Logger` is injected).

## Design decision (owner-delegated)

The one semantic ambiguity in the spec — does *"force-modified"* mean **override-decided** (interceptor preflight) or **write-confirmed** (post-write)? — was resolved as **override-decided at the interceptor suppression point**:

- Reuses the existing audit context, so the event is 1:1 with the audit log.
- Keeps the single-source-of-truth (`evaluateActorBypass`) intact.
- Needs **no core change** (write-confirmed semantics would require threading the suppression flag into the post-write `record.updated`/`action.succeeded` events — out of scope for a cap-lock-only PR).

**Recipient resolution** lives in the host's EventHandler; cap-lock only emits.

## API

- `src/events.ts` (new): `LOCK_OVERRIDE_EVENT` (`"lock.override"`), `LockOverrideEvent` type, `buildLockOverrideEvent(...)` pure builder.
- `CapLockOptions.emitEvent?` + `FieldLockInterceptorOptions.emitEvent?` — optional `(event: LockOverrideEvent) => void`, injected like `logger`.

Event payload: `{ type, reason: "shadow"|"bypass"|"tolerance"|"soft", entity, recordId?, actorId, actorType, tenantId?, fields[] }`.

## Safety / boundaries

- **No sink injected → no event**, behavior byte-identical to core (no-op contract from #445/#447 preserved).
- The empty-violation early return and the **fail-closed default path never emit**.
- A **throwing sink is isolated** (try/catch) — an allowed write can never be turned into a throw; the failure is noted at `warn`.
- `recordId` only surfaced when `record.id` is a string (safe coercion; no `any`, no `!`).
- **No new dependency**; no import of cap-notification or core EventBus.

## Test plan

- `addons/lock/cap-lock`: **57 / 0** — new "lock.override event emission" block: bypass / shadow / tolerance / soft(mixed → only soft fields) / fail-closed-no-event / empty-no-event / no-sink-byte-identical / throwing-sink-isolated, plus `recordId` string/absent/non-string coverage.
- `bun run test` (full batched): PASS. `bun run typecheck`: clean (the only `tsc` errors are 3 pre-existing `packages/cli/.../generation-tools.ts` local Bun-skew errors, not in CI). `bun run check` (biome): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
