### PR TITLE
feat(server): harden GraphQL with graphql-armor depth/cost limits + prod introspection lockdown

### DIFF
--- a/addons/adapter-server/cap-adapter-server/__tests__/graphql-armor.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/graphql-armor.test.ts
@@ -53,11 +53,10 @@ const deptPurchaseLink: RelationDefinition = {
 
 // ── Setup ──────────────────────────────────────────────────────────
 
-const PORT = 32177;
-const GQL_URL = `http://localhost:${PORT}/graphql`;
-
 let store: InMemoryStore;
 let app: ReturnType<typeof createServer>;
+// Bound to a random free port (port 0) in beforeAll to avoid cross-test collisions.
+let gqlUrl: string;
 
 beforeAll(() => {
   store = new InMemoryStore();
@@ -70,9 +69,9 @@ beforeAll(() => {
     }
   }
 
-  const schemaMap = new Map<string, EntityDefinition>();
-  schemaMap.set("department", departmentSchema);
-  schemaMap.set("purchase_request", purchaseRequestSchema);
+  const entityMap = new Map<string, EntityDefinition>();
+  entityMap.set("department", departmentSchema);
+  entityMap.set("purchase_request", purchaseRequestSchema);
 
   const graphqlSchema = buildGraphQLSchema(schemas, {
     executor,
@@ -80,8 +79,15 @@ beforeAll(() => {
     relations: [deptPurchaseLink],
   });
 
-  app = createServer(graphqlSchema, { dataProvider: store, schemaMap });
-  app.listen(PORT);
+  // `entityMap` (not `schemaMap`) is the option createServer reads + injects
+  // into the GraphQL context.
+  app = createServer(graphqlSchema, { dataProvider: store, entityMap });
+  // Listen on port 0 → the OS assigns a free port; capture it so parallel test
+  // files never collide on a fixed port.
+  app.listen(0);
+  const port = app.server?.port;
+  if (!port) throw new Error("graphql-armor test server failed to bind a port");
+  gqlUrl = `http://localhost:${port}/graphql`;
 });
 
 afterAll(() => {
@@ -89,7 +95,7 @@ afterAll(() => {
 });
 
 async function gql(query: string) {
-  const res = await fetch(GQL_URL, {
+  const res = await fetch(gqlUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ query }),

--- a/addons/adapter-server/cap-adapter-server/__tests__/graphql-armor.test.ts
+++ b/addons/adapter-server/cap-adapter-server/__tests__/graphql-armor.test.ts
@@ -1,0 +1,211 @@
+/**
+ * GraphQL hardening (security audit) — graphql-armor depth/cost guards.
+ *
+ * The GraphQL schema is auto-generated from the meta-model with bidirectional
+ * relation fields, so `department { purchaseRequests { department { ... } } }`
+ * can recurse without bound — a DoS vector. These tests verify that:
+ *   1. A query exceeding the configured max depth is REJECTED with a GraphQL
+ *      validation error (no data resolution).
+ *   2. A normal-depth relation query still SUCCEEDS unaffected.
+ *   3. Introspection stays enabled in the test environment (tests depend on it
+ *      and `ignoreIntrospection` keeps it exempt from the depth/cost caps).
+ *
+ * Mirrors the server-construction pattern in e2e-relations.test.ts.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import type { EntityDefinition, RelationDefinition } from "@linchkit/core";
+import { createActionExecutor, InMemoryStore } from "@linchkit/core/server";
+import { buildGraphQLSchema, generateCrudActions } from "../src/graphql/build-schema";
+import { createServer } from "../src/server";
+
+// ── Schema + bidirectional relation (cycle source) ─────────────────
+
+const departmentSchema: EntityDefinition = {
+  name: "department",
+  label: "Department",
+  fields: {
+    name: { type: "string", required: true, label: "Name" },
+    code: { type: "string", required: true, label: "Code" },
+  },
+};
+
+const purchaseRequestSchema: EntityDefinition = {
+  name: "purchase_request",
+  label: "Purchase Request",
+  fields: {
+    title: { type: "string", required: true, label: "Title" },
+    amount: { type: "number", required: true, label: "Amount" },
+    department_id: { type: "string", label: "Department ID" },
+  },
+};
+
+// Bidirectional one-to-many: department.purchaseRequests <-> purchase_request.department
+const deptPurchaseLink: RelationDefinition = {
+  name: "department_purchase_requests",
+  from: "department",
+  to: "purchase_request",
+  cardinality: "one_to_many",
+  fromName: "purchase_requests",
+  toName: "department",
+  label: { from: "Purchase Requests", to: "Department" },
+};
+
+// ── Setup ──────────────────────────────────────────────────────────
+
+const PORT = 32177;
+const GQL_URL = `http://localhost:${PORT}/graphql`;
+
+let store: InMemoryStore;
+let app: ReturnType<typeof createServer>;
+
+beforeAll(() => {
+  store = new InMemoryStore();
+  const executor = createActionExecutor({ dataProvider: store });
+
+  const schemas = [departmentSchema, purchaseRequestSchema];
+  for (const schema of schemas) {
+    for (const action of generateCrudActions(schema)) {
+      executor.registry.register(action);
+    }
+  }
+
+  const schemaMap = new Map<string, EntityDefinition>();
+  schemaMap.set("department", departmentSchema);
+  schemaMap.set("purchase_request", purchaseRequestSchema);
+
+  const graphqlSchema = buildGraphQLSchema(schemas, {
+    executor,
+    dataProvider: store,
+    relations: [deptPurchaseLink],
+  });
+
+  app = createServer(graphqlSchema, { dataProvider: store, schemaMap });
+  app.listen(PORT);
+});
+
+afterAll(() => {
+  app.stop();
+});
+
+async function gql(query: string) {
+  const res = await fetch(GQL_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ query }),
+  });
+  return res.json() as Promise<{
+    data?: Record<string, unknown> | null;
+    errors?: Array<{ message: string }>;
+  }>;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+describe("GraphQL armor depth limit", () => {
+  test("rejects a query that exceeds the max depth (relation cycle)", async () => {
+    // Build a deeply-nested bidirectional cycle well past GRAPHQL_MAX_DEPTH (12).
+    // Each department→purchaseRequests→department pair adds 2 levels; this
+    // query reaches a depth of ~16, exceeding the cap.
+    const deepQuery = `
+      query {
+        department(id: "x") {
+          purchaseRequests {
+            department {
+              purchaseRequests {
+                department {
+                  purchaseRequests {
+                    department {
+                      purchaseRequests {
+                        department {
+                          purchaseRequests {
+                            department {
+                              purchaseRequests {
+                                department {
+                                  purchaseRequests {
+                                    id
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `;
+
+    const result = await gql(deepQuery);
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.length ?? 0).toBeGreaterThan(0);
+    // armor's max-depth validation rejects before resolution → no data.
+    const message = result.errors?.map((e) => e.message).join(" ") ?? "";
+    expect(message.toLowerCase()).toContain("depth");
+    expect(result.data == null).toBe(true);
+  });
+
+  test("allows a normal-depth relation query", async () => {
+    await store.create("department", { id: "dept_ok", name: "Ops", code: "OPS" });
+
+    // department → purchaseRequests → department → name is well under the cap.
+    const result = await gql(`
+      query {
+        department(id: "dept_ok") {
+          id
+          name
+          purchaseRequests {
+            id
+            title
+            department {
+              id
+              name
+            }
+          }
+        }
+      }
+    `);
+
+    expect(result.errors).toBeUndefined();
+    const dept = result.data?.department as Record<string, unknown> | null;
+    expect(dept?.id).toBe("dept_ok");
+    expect(dept?.name).toBe("Ops");
+  });
+
+  test("introspection stays enabled in the test environment", async () => {
+    // ignoreIntrospection (armor default) keeps the standard introspection
+    // query — which is itself deep — exempt from the depth/cost caps, and the
+    // non-production env leaves introspection on.
+    const result = await gql(`
+      query {
+        __schema {
+          queryType { name }
+          types {
+            name
+            fields {
+              name
+              type {
+                name
+                ofType {
+                  name
+                  ofType {
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `);
+
+    expect(result.errors).toBeUndefined();
+    const schema = result.data?.__schema as { queryType: { name: string } } | undefined;
+    expect(schema?.queryType.name).toBe("Query");
+  });
+});

--- a/addons/adapter-server/cap-adapter-server/package.json
+++ b/addons/adapter-server/cap-adapter-server/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@elysiajs/cors": "^1.4.1",
+    "@escape.tech/graphql-armor": "^3.2.0",
     "elysia": "^1.4.28",
     "graphql": "^16.13.1",
     "graphql-yoga": "^5.18.1",

--- a/addons/adapter-server/cap-adapter-server/src/server.ts
+++ b/addons/adapter-server/cap-adapter-server/src/server.ts
@@ -6,6 +6,7 @@
  */
 
 import { cors } from "@elysiajs/cors";
+import { EnvelopArmorPlugin } from "@escape.tech/graphql-armor";
 import type {
   ActionExecutor,
   Actor,
@@ -41,10 +42,14 @@ import type {
   InMemoryMetricsCollector,
   OnchangeEvaluator,
 } from "@linchkit/core/server";
-import { createTenantAwareDataProvider, getCurrentTrace } from "@linchkit/core/server";
+import {
+  createTenantAwareDataProvider,
+  detectEnvironment,
+  getCurrentTrace,
+} from "@linchkit/core/server";
 import { Elysia } from "elysia";
-import type { GraphQLSchema } from "graphql";
-import { createYoga } from "graphql-yoga";
+import { type GraphQLSchema, NoSchemaIntrospectionCustomRule } from "graphql";
+import { createYoga, type Plugin } from "graphql-yoga";
 import { createRelationDataLoaders } from "./graphql/relation-dataloader";
 import { mountProposalAPI } from "./proposal-api";
 import { mountActionRoutes } from "./routes/action-api";
@@ -217,6 +222,38 @@ export interface ServerOptions {
 export { parseAcceptLanguage } from "./routes/shared";
 
 /**
+ * GraphQL hardening limits (security audit follow-up).
+ *
+ * The GraphQL schema is auto-generated from the meta-model and exposes
+ * bidirectional relation fields, so a query like `a { b { a { b ... } } }`
+ * can recurse without bound and trigger compounding N+1 fan-out — a DoS
+ * vector. graphql-armor's `maxDepth` + `costLimit` envelop validations cap
+ * both the nesting depth and the estimated query cost before resolution.
+ *
+ * Depth accounting (graphql-armor): each nested selection set adds 1. List
+ * queries wrap rows in `xList { items { ... } }`, which already consumes two
+ * levels before the first relation hop. The deepest *legitimate* queries the
+ * app issues today reach ~5 levels (e.g. `departmentList { items {
+ * purchaseRequests { department { name } } } }` — a two-hop bidirectional
+ * traversal, or the field-meta introspection-of-lock-metadata queries).
+ * `12` leaves comfortable headroom (>2x the deepest legit query) for richer
+ * relation chains while still capping unbounded relation cycles to a handful
+ * of round-trips.
+ */
+const GRAPHQL_MAX_DEPTH = 12;
+
+/**
+ * Max estimated query cost (graphql-armor `costLimit`). With the plugin
+ * defaults (objectCost 2, scalarCost 1, depthCostFactor 1.5) a normal
+ * paginated relation query costs well under 1000; armor's own default is
+ * 5000. We keep a generous `15000` ceiling so legitimate wide/deep reads pass
+ * while a maliciously fanned-out recursive query — whose cost grows
+ * factorially with depth — is rejected. Introspection is exempt by default
+ * (`ignoreIntrospection: true`), so tooling/tests are unaffected.
+ */
+const GRAPHQL_MAX_COST = 15_000;
+
+/**
  * Create an Elysia server with GraphQL, health check, and REST action endpoints.
  *
  * @param graphqlSchema - A GraphQL schema built via buildGraphQLSchema()
@@ -240,12 +277,49 @@ export function createServer(
   // Track current schema for hot-reload support
   let currentSchema = graphqlSchema;
 
+  // Resolve the runtime environment via the canonical core helper
+  // (BUN_ENV > NODE_ENV; "development"/"test" → non-production). Both
+  // development AND test are treated as non-production so local tooling and
+  // the test suite keep introspection + the GraphiQL landing page; production
+  // and staging lock both down.
+  const environment = detectEnvironment();
+  const isNonProduction = !environment.isProduction;
+
+  // ── GraphQL hardening (security audit) ───────────────────────
+  // graphql-armor wraps the envelop validation phase with query-depth and
+  // cost ceilings. Both protections ignore introspection by default, so
+  // schema tooling and the test suite (which rely on introspection) are
+  // unaffected. blockFieldSuggestion strips "did you mean …" hints from
+  // validation errors so a probing actor cannot reconstruct the schema even
+  // when introspection is disabled in production.
+  const yogaPlugins: Plugin[] = [
+    EnvelopArmorPlugin({
+      maxDepth: { n: GRAPHQL_MAX_DEPTH },
+      costLimit: { maxCost: GRAPHQL_MAX_COST },
+      blockFieldSuggestion: { enabled: true },
+    }),
+  ];
+
+  // Disable schema introspection in production/staging only. In dev/test it
+  // stays on (GraphiQL + tests depend on it). Implemented as a thin envelop
+  // validation rule using graphql-js's built-in NoSchemaIntrospectionCustomRule,
+  // avoiding an extra runtime dependency.
+  if (!isNonProduction) {
+    yogaPlugins.push({
+      onValidate({ addValidationRule }) {
+        addValidationRule(NoSchemaIntrospectionCustomRule);
+      },
+    });
+  }
+
   // Create graphql-yoga instance with actor + tenant context factory
   const yoga = createYoga({
     schema: () => currentSchema,
     graphqlEndpoint: graphqlPath,
-    // Landing page serves as GraphQL playground in development
-    landingPage: true,
+    // GraphiQL landing page is a dev/test convenience only; never expose the
+    // interactive playground in production/staging.
+    landingPage: isNonProduction,
+    plugins: yogaPlugins,
     // Build GraphQL context with actor, tenant isolation, locale, data provider, and masking context for link resolvers
     context: async ({ request }) => {
       const actor = resolveRequestActor

--- a/bun.lock
+++ b/bun.lock
@@ -86,6 +86,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@elysiajs/cors": "^1.4.1",
+        "@escape.tech/graphql-armor": "^3.2.0",
         "dataloader": "^2.2.3",
         "elysia": "^1.4.28",
         "graphql": "^16.13.1",
@@ -816,6 +817,22 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "https://registry.npmmirror.com/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "https://registry.npmmirror.com/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "@escape.tech/graphql-armor": ["@escape.tech/graphql-armor@3.2.0", "", { "dependencies": { "@escape.tech/graphql-armor-block-field-suggestions": "3.0.1", "@escape.tech/graphql-armor-cost-limit": "2.4.3", "@escape.tech/graphql-armor-max-aliases": "2.6.2", "@escape.tech/graphql-armor-max-depth": "2.4.2", "@escape.tech/graphql-armor-max-directives": "2.3.1", "@escape.tech/graphql-armor-max-tokens": "2.5.1", "graphql": "^16.10.0" }, "peerDependencies": { "@apollo/server": "^4.0.0 || ^5.0.0", "@envelop/core": "^5.0.0", "@escape.tech/graphql-armor-types": "0.7.0" }, "optionalPeers": ["@apollo/server", "@envelop/core", "@escape.tech/graphql-armor-types"] }, "sha512-0tG2YOIPiDg2Oe7uEqkYl808VK9OKRyXx4NBa3w+N9XV6NaQ4XxGkDJMtps0lx5DANe10d6nbf6Ml2Z6vekPwA=="],
+
+    "@escape.tech/graphql-armor-block-field-suggestions": ["@escape.tech/graphql-armor-block-field-suggestions@3.0.1", "", { "dependencies": { "graphql": "^16.10.0" }, "optionalDependencies": { "@envelop/core": "^5.2.3" } }, "sha512-pZ+5aFgGW/pUul7nDOZ3PoeWAd9kLDspQ0R+fpz2aTjdIT0yI+f+ZbAGeTVmr5RypRDwjwokG/HjWoxTYTcRwQ=="],
+
+    "@escape.tech/graphql-armor-cost-limit": ["@escape.tech/graphql-armor-cost-limit@2.4.3", "", { "dependencies": { "graphql": "^16.10.0" }, "optionalDependencies": { "@envelop/core": "^5.2.3", "@escape.tech/graphql-armor-types": "0.7.0" } }, "sha512-fLZTlJjrjinpNhbv5VP6f8Ce4MiQzbcHtCNaCPVaHqArTEbN7vDnlVLiH+VcmZBmOwU6Si97lKdlOXWNgB5ytw=="],
+
+    "@escape.tech/graphql-armor-max-aliases": ["@escape.tech/graphql-armor-max-aliases@2.6.2", "", { "dependencies": { "graphql": "^16.10.0" }, "optionalDependencies": { "@envelop/core": "^5.2.3", "@escape.tech/graphql-armor-types": "0.7.0" } }, "sha512-SDk7pAzY6gutsdZ3NlyY55RrytrCPxJJxSN/DBfIGKphTrfBvKQWTnioQ9OlLP9kPjCE6XM5UWwGt7uqbpKSYA=="],
+
+    "@escape.tech/graphql-armor-max-depth": ["@escape.tech/graphql-armor-max-depth@2.4.2", "", { "dependencies": { "graphql": "^16.10.0" }, "optionalDependencies": { "@envelop/core": "^5.2.3", "@escape.tech/graphql-armor-types": "0.7.0" } }, "sha512-J9fbW1+W4u3GAcf19wwS0zrNGICCbWn/glvopCoC11Ga0reXvGwgr8EcyuHjTFLL7+pPvWAeVhP4qo6hybcB9w=="],
+
+    "@escape.tech/graphql-armor-max-directives": ["@escape.tech/graphql-armor-max-directives@2.3.1", "", { "dependencies": { "graphql": "^16.10.0" }, "optionalDependencies": { "@envelop/core": "^5.2.3", "@escape.tech/graphql-armor-types": "0.7.0" } }, "sha512-YieT/NrTgZdLu3hzWfCgpmUKO1o/7Im9C4TI0e4O85Wa+zLit/DzHO4ZCIY//w8nkBf1KStkA1pD/v0daEfY5Q=="],
+
+    "@escape.tech/graphql-armor-max-tokens": ["@escape.tech/graphql-armor-max-tokens@2.5.1", "", { "dependencies": { "graphql": "^16.10.0" }, "optionalDependencies": { "@envelop/core": "^5.2.3", "@escape.tech/graphql-armor-types": "0.7.0" } }, "sha512-XHui2npOz7Jn8shBZqfyeocWhdl0pUbKiaWmvbF+5rvNoRIGMgwMtaVhmf9ia8oGGbd+cx5EYo1v+oKHzIm79w=="],
+
+    "@escape.tech/graphql-armor-types": ["@escape.tech/graphql-armor-types@0.7.0", "", { "dependencies": { "graphql": "^16.0.0" } }, "sha512-RHxyyp6PDgS6NAPnnmB6JdmUJ6oqhpSHFbsglGWeCcnNzceA5AkQFpir7VIDbVyS8LNC1xhipOtk7f9ycrIemQ=="],
 
     "@fastify/busboy": ["@fastify/busboy@3.2.0", "https://registry.npmmirror.com/@fastify/busboy/-/busboy-3.2.0.tgz", {}, "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA=="],
 


### PR DESCRIPTION
## What (security: GraphQL DoS surface)

The GraphQL schema is **auto-generated from the meta-model with bidirectional relation fields**, so a cyclic query `a { b { a { b … } } }` can recurse without bound and trigger compounding N+1 fan-out — a DoS vector. The endpoint also served the GraphiQL **landing page** and **introspection** in every environment.

Hardens `createYoga` in `server.ts` with **`@escape.tech/graphql-armor`** (owner-approved dependency) + production lockdown.

## Changes

**graphql-armor envelop plugin** (verified config against the installed type defs):
- `maxDepth: { n: 12 }` — >2× the deepest legitimate query (~5 levels: list wrapper + two-hop relation traversal). Caps unbounded relation cycles to a handful of round-trips.
- `costLimit: { maxCost: 15000 }` — generous vs normal reads (<1000) but trips factorial fan-out. Both ignore introspection by default → tooling/tests unaffected.
- `blockFieldSuggestion` — strips "did you mean …" hints so a prober can't reconstruct the schema from validation errors.

**Production hardening** (via the canonical `detectEnvironment()`; **development AND test count as non-production**, so local tooling + the suite keep introspection/GraphiQL):
- `landingPage` gated on non-production — no interactive playground in prod/staging.
- Introspection disabled in prod/staging via graphql-js's built-in `NoSchemaIntrospectionCustomRule` (a thin envelop validation rule) — **no second dependency**.

## Why not hand-roll

A hand-rolled depth limiter is exactly the kind of wheel-reinvention the audit is removing; graphql-armor is the graphql-yoga-recommended standard for this. Introspection-disabling reuses a graphql-js built-in rather than adding `@graphql-yoga/plugin-disable-introspection`.

## Test plan

- New `graphql-armor.test.ts` (mirrors the bidirectional `department ↔ purchase_request` relation server setup): a depth-exceeding cyclic query is **rejected** with a depth error + null data; a normal-depth relation query **succeeds**; introspection still works in the test env.
- `addons/adapter-server`: **673 / 0** (+30 DB-skip) — **no legitimate query needed a higher limit**. Full `bun run test` PASS. `bun run typecheck` clean; `bun run check` (biome) clean.
- Dependency: `@escape.tech/graphql-armor@^3.2.0` (MIT; transitive `@escape.tech/graphql-armor-*` + `@envelop/core` peer already provided by graphql-yoga 5.x). `bun.lock` updated.

Audit follow-up (Stage 1: GraphQL hardening). No `any`/`!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced GraphQL security by implementing query depth and cost limits to prevent malicious query exploitation.
  * Disabled schema introspection and field suggestions in production and staging environments for improved security.

* **Tests**
  * Added comprehensive test suite validating GraphQL hardening against recursive queries while ensuring normal queries remain functional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->