### PR TITLE
refactor(ai): de-duplicate the JSON-extraction helpers onto a single source

### DIFF
--- a/addons/ai-provider/cap-ai-provider/src/intent-resolver.ts
+++ b/addons/ai-provider/cap-ai-provider/src/intent-resolver.ts
@@ -21,8 +21,13 @@
  */
 
 import type { ActionDefinition, AIService, AITraceContext } from "@linchkit/core";
+// Shared string-aware balanced JSON-object extractor — single source of truth in
+// core (re-exported below so this module's public surface + tests are unchanged).
+import { extractFirstJsonObject } from "@linchkit/core/ai";
 import { z } from "zod";
 import { type ActionCatalogEntry, buildIntentSystemPrompt } from "./intent-prompt";
+
+export { extractFirstJsonObject };
 
 // ── Public types ─────────────────────────────────────────────
 
@@ -362,71 +367,6 @@ function extractJsonCandidate(raw: string): string | null {
   const end = trimmed.lastIndexOf("}");
   if (start === -1 || end === -1 || end <= start) return null;
   return trimmed.slice(start, end + 1);
-}
-
-/**
- * Walk `text` once and return the first balanced top-level JSON object as
- * a substring (inclusive of the outer braces), or `null` if no balanced
- * object exists.
- *
- * Tracks brace depth while ignoring `{` / `}` that appear inside string
- * literals. Honors `\\` and `\"` escapes inside strings so an escaped quote
- * does not accidentally close the string scanner.
- *
- * Intentionally simple — no JSON5, no regex backtracking. The output is
- * still passed to `JSON.parse`, which is the source of truth for structural
- * validity.
- */
-export function extractFirstJsonObject(text: string): string | null {
-  const start = text.indexOf("{");
-  if (start === -1) return null;
-
-  let depth = 0;
-  let inString = false;
-  let escapeNext = false;
-
-  for (let i = start; i < text.length; i++) {
-    const ch = text[i];
-
-    if (inString) {
-      if (escapeNext) {
-        // Previous char was a backslash — consume this char literally,
-        // even if it is a quote.
-        escapeNext = false;
-        continue;
-      }
-      if (ch === "\\") {
-        escapeNext = true;
-        continue;
-      }
-      if (ch === '"') {
-        inString = false;
-      }
-      continue;
-    }
-
-    if (ch === '"') {
-      inString = true;
-      continue;
-    }
-    if (ch === "{") {
-      depth++;
-      continue;
-    }
-    if (ch === "}") {
-      depth--;
-      if (depth === 0) {
-        return text.slice(start, i + 1);
-      }
-      if (depth < 0) {
-        // Unbalanced — bail out rather than return a malformed slice.
-        return null;
-      }
-    }
-  }
-
-  // Reached end of input without closing the outer object.
-  return null;
 }
 
 interface ReconciledInput {

--- a/packages/core/src/ai/intent-prompt.ts
+++ b/packages/core/src/ai/intent-prompt.ts
@@ -250,7 +250,12 @@ export function parseAiResponse(raw: string): AiResponse | null {
   return result.data;
 }
 
-function extractJsonCandidate(raw: string): string | null {
+/**
+ * Extract a JSON-object candidate substring from a raw AI response: strips a
+ * Markdown code fence, fast-paths a bare object, else falls back to the
+ * string-aware balanced extractor. Shared by the schema-intent parser.
+ */
+export function extractJsonCandidate(raw: string): string | null {
   const trimmed = raw.trim();
   if (trimmed.length === 0) return null;
 

--- a/packages/core/src/ai/schema-intent-prompt.ts
+++ b/packages/core/src/ai/schema-intent-prompt.ts
@@ -19,7 +19,7 @@
 
 // Reuse the intent resolver's tolerant JSON extractor — same parser, no
 // second implementation to keep in sync.
-import { extractFirstJsonObject } from "./intent-prompt";
+import { extractJsonCandidate } from "./intent-prompt";
 import type { SchemaIntentEntity } from "./schema-intent-types";
 
 // ── System prompt builder ────────────────────────────────────
@@ -188,13 +188,4 @@ function inferKind(rec: Record<string, unknown>): ParsedSchemaIntent["kind"] | n
   if (rec.rule && typeof rec.rule === "object") return "add_rule";
   if (typeof rec.question === "string" && rec.question.trim().length > 0) return "clarification";
   return "no_match";
-}
-
-function extractJsonCandidate(raw: string): string | null {
-  const trimmed = raw.trim();
-  if (trimmed.length === 0) return null;
-  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
-  if (fenced?.[1]) return fenced[1].trim();
-  if (trimmed.startsWith("{") && trimmed.endsWith("}")) return trimmed;
-  return extractFirstJsonObject(trimmed);
 }


### PR DESCRIPTION
## What (Stage-2 de-dup: the one clean, non-breaking win)

The string-aware JSON-object extractor and the code-fence candidate extractor were copy-pasted across three AI-parsing sites. This consolidates the **behavior-identical** copies onto one source of truth — a behavior-preserving refactor (net −64 lines).

- `extractFirstJsonObject` (the brace-depth/string-escape scanner) had a byte-equivalent duplicate in `cap-ai-provider/src/intent-resolver.ts`. It now imports the canonical core impl from `@linchkit/core/ai` and re-exports it, so the module's public surface + its `#262` hardening tests are unchanged (they now guard the shared impl).
- `extractJsonCandidate` was duplicated verbatim between `intent-prompt.ts` and `schema-intent-prompt.ts` (same package) → now exported once from `intent-prompt.ts` and imported by `schema-intent-prompt.ts`.

## What was deliberately NOT merged

The addon's `extractJsonCandidate` / `parseAiResponse` keep an extra first/last-brace fallback that the core copies lack — those variants are **not** byte-equivalent, so collapsing them would change behavior. Left as-is (this PR is behavior-preserving only).

## Context (Stage 2 audit verification)

The "造轮子" audit flagged several de-dup targets. Two read-only scouts verified each against current `main` and found most were **false positives**: the "two Proposal engines" are complementary pipeline stages (AI-authoring+safety vs governance) that merely share a class name; the "4 condition mini-languages" already centralize on `condition-evaluator.ts` (lock/alert are genuinely different grammars); "dual auth providers" is a clean contract+impl split. The remaining real items (trim unused-but-public API: `DrizzleAuthProvider`/Saga/`ProposalCodeGenerator`; the `generateObject` refactor that drops legacy tolerance + needs eval re-baselining) are product/breaking-change decisions, deferred. This PR is the only autonomously-shippable, non-breaking de-dup.

## Test plan

- `cap-ai-provider/__tests__/intent-resolver.test.ts` (incl. the `#262` `extractFirstJsonObject` hardening suite) — green via the re-exported core impl.
- core `schema-intent-resolver` parser tests — green (shared `extractJsonCandidate`).
- Full `bun run test` PASS (294 batches); typecheck clean on changed files; biome clean.

No `any`/`!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated shared JSON extraction utilities across modules to reduce code duplication and improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->