### PR TITLE
feat(ui): add React error boundaries + fix mis-located react-table dep

### DIFF
--- a/addons/adapter-ui/cap-adapter-ui/__tests__/error-boundary.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/error-boundary.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Tests for the `ErrorBoundary` recovery logic.
+ *
+ * The existing test setup is logic-only (no happy-dom / jsdom), so the full
+ * render lifecycle (child throws → fallback mounts → Retry resets) cannot be
+ * exercised here. Instead we cover the load-bearing pure piece: the static
+ * `getDerivedStateFromError` mapping that React calls to switch the boundary
+ * into its error state. The `render()` branch selection (function fallback vs
+ * static node vs default) is trivial enough to be obviously correct given this
+ * state shape.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { ErrorBoundary } from "../src/components/error-boundary";
+
+describe("ErrorBoundary.getDerivedStateFromError", () => {
+  test("captures the thrown error into boundary state", () => {
+    const error = new Error("boom");
+    const next = ErrorBoundary.getDerivedStateFromError(error);
+    expect(next).toEqual({ error });
+    expect(next.error?.message).toBe("boom");
+  });
+
+  test("preserves error identity (so the fallback can read message/stack)", () => {
+    const error = new Error("render failed");
+    const next = ErrorBoundary.getDerivedStateFromError(error);
+    expect(next.error).toBe(error);
+  });
+});

--- a/addons/adapter-ui/cap-adapter-ui/__tests__/error-boundary.test.ts
+++ b/addons/adapter-ui/cap-adapter-ui/__tests__/error-boundary.test.ts
@@ -26,4 +26,10 @@ describe("ErrorBoundary.getDerivedStateFromError", () => {
     const next = ErrorBoundary.getDerivedStateFromError(error);
     expect(next.error).toBe(error);
   });
+
+  test("normalizes non-Error thrown values into Error objects", () => {
+    const next = ErrorBoundary.getDerivedStateFromError("string error");
+    expect(next.error).toBeInstanceOf(Error);
+    expect(next.error?.message).toBe("string error");
+  });
 });

--- a/addons/adapter-ui/cap-adapter-ui/package.json
+++ b/addons/adapter-ui/cap-adapter-ui/package.json
@@ -32,6 +32,7 @@
     "@linchkit/ui-kit": "workspace:*",
     "@tanstack/react-query": "^5.95.2",
     "@tanstack/react-router": "^1.168.2",
+    "@tanstack/react-table": "^8.21.3",
     "@tiptap/extension-link": "^3.20.5",
     "@tiptap/extension-placeholder": "^3.20.5",
     "@tiptap/pm": "^3.20.5",

--- a/addons/adapter-ui/cap-adapter-ui/src/app.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/app.tsx
@@ -20,6 +20,7 @@ const queryClient = new QueryClient({
 import "./i18n"; // Initialize i18n before rendering
 import "./lib/builtin-panels"; // Register built-in record panels
 import { resolveCapabilityPageComponent } from "./capability-page-registry";
+import { ErrorBoundary } from "./components/error-boundary";
 import { AuthProvider } from "./hooks/use-auth";
 import { CenteredLayout } from "./layouts/centered";
 import { FullscreenLayout } from "./layouts/fullscreen";
@@ -117,7 +118,13 @@ function getLayoutRoute(layout: PageLayout) {
 function createCapabilityPageRoute(page: PageRegistration, authEnabled: boolean) {
   const parentRoute = getLayoutRoute(page.layout);
   const ResolvedComponent = resolveCapabilityPageComponent(page);
-  const component = () => <ResolvedComponent {...(page.props ?? {})} />;
+  // Per-page boundary at the dynamic-render seam: a broken capability page
+  // shows the fallback instead of crashing the surrounding shell.
+  const component = () => (
+    <ErrorBoundary>
+      <ResolvedComponent {...(page.props ?? {})} />
+    </ErrorBoundary>
+  );
 
   return createRoute({
     getParentRoute: () => parentRoute,
@@ -285,10 +292,12 @@ export function App() {
   }
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <AuthProvider>
-        <RouterProvider router={router} />
-      </AuthProvider>
-    </QueryClientProvider>
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <RouterProvider router={router} />
+        </AuthProvider>
+      </QueryClientProvider>
+    </ErrorBoundary>
   );
 }

--- a/addons/adapter-ui/cap-adapter-ui/src/app.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/app.tsx
@@ -292,7 +292,10 @@ export function App() {
   }
 
   return (
-    <ErrorBoundary>
+    // Root catch-all: a render error in the providers/router shows the fallback
+    // instead of a white screen. On Retry, clear the query cache so any
+    // corrupted/failed queries are dropped and refetched fresh.
+    <ErrorBoundary onReset={() => queryClient.clear()}>
       <QueryClientProvider client={queryClient}>
         <AuthProvider>
           <RouterProvider router={router} />

--- a/addons/adapter-ui/cap-adapter-ui/src/components/error-boundary.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/error-boundary.tsx
@@ -69,8 +69,10 @@ function DefaultErrorFallback({ error, reset }: { error: Error; reset: () => voi
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   state: ErrorBoundaryState = { error: null };
 
-  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
-    return { error };
+  static getDerivedStateFromError(error: unknown): ErrorBoundaryState {
+    // React can surface non-Error throws (strings, plain objects, null).
+    // Normalize so the fallback can always safely read `error.message`.
+    return { error: error instanceof Error ? error : new Error(String(error)) };
   }
 
   componentDidCatch(error: Error, info: ErrorInfo): void {

--- a/addons/adapter-ui/cap-adapter-ui/src/components/error-boundary.tsx
+++ b/addons/adapter-ui/cap-adapter-ui/src/components/error-boundary.tsx
@@ -1,0 +1,102 @@
+/**
+ * ErrorBoundary — catches render errors in its subtree and shows a fallback
+ * instead of white-screening the whole SPA.
+ *
+ * React only supports error catching via a class component
+ * (`getDerivedStateFromError` + `componentDidCatch`), so this is intentionally
+ * a class. The default fallback is a small i18n-friendly panel built from
+ * ui-kit primitives with a Retry button that resets the boundary.
+ *
+ * Happy-path behavior is unchanged: a boundary only renders the fallback once a
+ * child throws during render.
+ */
+
+import { Alert, AlertDescription, AlertTitle, Button } from "@linchkit/ui-kit/components";
+import { AlertTriangleIcon } from "lucide-react";
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+
+/** A render function fallback receives the caught error and a reset callback. */
+export type ErrorBoundaryFallbackRender = (error: Error, reset: () => void) => ReactNode;
+
+export interface ErrorBoundaryProps {
+  /**
+   * Fallback UI when a child throws. Either a static node, or a render function
+   * receiving the error and a `reset` callback to clear the boundary state.
+   * Omitted → the built-in `DefaultErrorFallback` panel is used.
+   */
+  fallback?: ReactNode | ErrorBoundaryFallbackRender;
+  /** Called when the boundary is reset (Retry). Use to re-trigger data loads. */
+  onReset?: () => void;
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * Default fallback panel. Kept as its own function component so it can use
+ * hooks (`useTranslation`) — the ErrorBoundary class itself cannot.
+ */
+function DefaultErrorFallback({ error, reset }: { error: Error; reset: () => void }) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex w-full items-center justify-center p-6">
+      <Alert variant="destructive" className="max-w-md">
+        <AlertTriangleIcon />
+        <AlertTitle>{t("errors.boundaryTitle", "Something went wrong")}</AlertTitle>
+        <AlertDescription>
+          <p>
+            {t(
+              "errors.boundaryDescription",
+              "An unexpected error occurred while rendering this view.",
+            )}
+          </p>
+          {error.message ? (
+            <p className="text-muted-foreground text-xs break-words">{error.message}</p>
+          ) : null}
+          <Button variant="outline" size="sm" className="mt-2" onClick={reset}>
+            {t("common.retry", "Retry")}
+          </Button>
+        </AlertDescription>
+      </Alert>
+    </div>
+  );
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Match the client logging convention used across src/components.
+    console.error("[ErrorBoundary] Render error:", error, info.componentStack);
+  }
+
+  private readonly reset = (): void => {
+    this.setState({ error: null });
+    this.props.onReset?.();
+  };
+
+  render(): ReactNode {
+    const { error } = this.state;
+    const { fallback, children } = this.props;
+
+    if (error) {
+      if (typeof fallback === "function") {
+        return fallback(error, this.reset);
+      }
+      if (fallback !== undefined) {
+        return fallback;
+      }
+      return <DefaultErrorFallback error={error} reset={this.reset} />;
+    }
+
+    return children;
+  }
+}

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/en.json
@@ -274,7 +274,9 @@
     "dataLoadFailed": "Failed to load records.",
     "recordNotFound": "Record \"{{id}}\" not found.",
     "recordLoadFailed": "Failed to load record.",
-    "failedToLoadData": "Failed to load data"
+    "failedToLoadData": "Failed to load data",
+    "boundaryTitle": "Something went wrong",
+    "boundaryDescription": "An unexpected error occurred while rendering this view."
   },
   "theme": {
     "light": "Light",

--- a/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
+++ b/addons/adapter-ui/cap-adapter-ui/src/i18n/locales/zh-CN.json
@@ -274,7 +274,9 @@
     "dataLoadFailed": "加载数据失败。",
     "recordNotFound": "未找到记录「{{id}}」。",
     "recordLoadFailed": "加载记录失败。",
-    "failedToLoadData": "数据加载失败"
+    "failedToLoadData": "数据加载失败",
+    "boundaryTitle": "出错了",
+    "boundaryDescription": "渲染此视图时发生意外错误。"
   },
   "theme": {
     "light": "浅色",


### PR DESCRIPTION
## What (Stage-3 UI hardening — the audit's only clean frontend wins)

A read-only scout verified the audit's frontend "reinvention" flags against current `main`. Most were over-flagged: "duplicated debounce" is false (1 impl, 2 callers), "@tanstack/react-table" is used-not-duplicated (auto-list is built on it), "auto-form vs react-hook-form" is a 1432-line LinchKit-specific form (field-lock/onchange/masking/meta-model) and RHF isn't even installed, and "fetch vs react-query" is a ~19-site behavior-changing migration (caching/refetch semantics). Those two are large, UX/contract-changing, decision-gated — **not** in this PR. This PR ships the two genuinely clean, behavior-preserving wins.

### 1. React error boundaries (real gap)
The UI had **zero** error boundaries — any uncaught render error white-screened the whole SPA.
- New `ErrorBoundary` class (`src/components/error-boundary.tsx`): `getDerivedStateFromError` + `componentDidCatch` (logs via `console.error`, the client convention). Props: `fallback?` (node or `(error, reset) => node`), `onReset?`, `children`. Default fallback = i18n-friendly ui-kit `Alert` panel + a Retry button that resets the boundary. **No new dependency** (React needs a class for error catching; hand-rolled).
- Wired in `app.tsx`: wraps the **router root** (must-have) AND each **capability page** at the dynamic-render seam (`createCapabilityPageRoute`) so one broken page can't crash the shell.
- i18n keys `errors.boundaryTitle` / `errors.boundaryDescription` (en + zh-CN); reuses `common.retry`. **Happy-path behavior unchanged** (a boundary only acts when a child throws).

### 2. Dependency hygiene
- `@tanstack/react-table` is imported at runtime by cap-adapter-ui (`auto-list`) but was declared only in the workspace root — a phantom dep that worked via Bun hoisting. Now declared in `cap-adapter-ui/package.json` at the exact lockfile version `^8.21.3` (no lockfile/code change).

## Test plan
- The UI package has no React component (DOM) test infra — confirmed all existing `__tests__/*` are logic-only `.test.ts`. Did not scaffold one (out of scope). Added a logic-only test for `getDerivedStateFromError` (error→state mapping): 2/2 pass.
- Full `bun run test` PASS (294 batches); typecheck clean on changed files; biome clean.

No `any`/`!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added error boundaries app-wide and per page to show a fallback UI and allow retry without crashing the whole app.

* **Tests**
  * Added tests verifying error normalization, preservation of Error instances, and derived-state handling.

* **Chores**
  * Added a table library dependency.
  * Added English and Chinese error boundary translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->