### PR TITLE
feat(core): wire business-rule evaluation into the action execution path (Spec 23 §1.1, phase 1)

### DIFF
--- a/.changeset/wire-rule-evaluation.md
+++ b/.changeset/wire-rule-evaluation.md
@@ -1,0 +1,19 @@
+---
+"@linchkit/core": minor
+"@linchkit/cap-adapter-server": minor
+"@linchkit/cli": patch
+---
+
+feat(core): wire business-rule evaluation into the action execution path (Spec 23 §1.1, phase 1)
+
+`defineRule()` business rules are now evaluated during action execution. Previously the rule engine (`evaluateRules`) was a tested-but-unwired pure function: rule effects (block / warn / enrich / require_approval / execute_action) were collected by the engine but never applied when an action ran through the executor, so rules did not fire end-to-end.
+
+`createActionExecutor` gains an optional `rules?: RuleDefinition[]`. When provided, the executor runs `collectRules(actionName, rules)` + `evaluateRules` after input validation and before the write, and applies the pre-write decision effects:
+
+- **block** → aborts the action with the block reason(s); the handler and write never run.
+- **enrich** → merges `setFields` into the input that reaches the handler / write path.
+- **warn** → surfaces messages on `ActionResult.warnings`; the action still succeeds.
+
+Only rules whose `trigger.action` targets the running action fire; `skipRules` (approved re-execution) is honored. Conditions are evaluated against the validated input — record-state conditions (reading the pre-existing record) and the post-commit effects (`require_approval`, `execute_action`, `trigger_flow`) land in follow-up phases.
+
+The capability-aggregated rule set is now injected at every production executor construction site (adapter-server `createRuntimeContext`, CLI `dev` and `exec`). Non-breaking: when `rules` is omitted (tests, minimal setups) behavior is unchanged.

--- a/addons/adapter-server/cap-adapter-server/src/assemble-schema.ts
+++ b/addons/adapter-server/cap-adapter-server/src/assemble-schema.ts
@@ -209,6 +209,7 @@ export function assembleDevSchema(
     states: contributions.states,
     views: contributions.views,
     middlewares: contributions.middlewares,
+    rules: contributions.rules,
     ai: options?.aiService,
     capabilityNames,
   });

--- a/addons/adapter-server/cap-adapter-server/src/runtime-context.ts
+++ b/addons/adapter-server/cap-adapter-server/src/runtime-context.ts
@@ -19,6 +19,7 @@ import type {
   ExecutionLogger,
   InterfaceDefinition,
   MiddlewareRegistration,
+  RuleDefinition,
   StateDefinition,
   TransactionManager,
   ViewDefinition,
@@ -55,6 +56,8 @@ export interface RuntimeContextOptions {
   actions?: ActionDefinition[];
   states?: StateDefinition[];
   views?: ViewDefinition[];
+  /** Business rules (defineRule) — evaluated by the action executor (Spec 23 §1.1). */
+  rules?: RuleDefinition[];
   middlewares?: MiddlewareRegistration[];
   /** Interface definitions — registered before schemas so field injection/validation works */
   interfaces?: InterfaceDefinition[];
@@ -127,6 +130,8 @@ export function createRuntimeContext(options?: RuntimeContextOptions): RuntimeCo
     // Strict type/constraint input validation in production + staging; dev/test
     // stay lenient (toy inputs). Sourced from the canonical environment policy.
     strictValidation: detectEnvironment().features.strictValidation,
+    // Business rules evaluated during action execution (Spec 23 §1.1).
+    rules: options?.rules,
   });
 
   // Register actions

--- a/packages/cli/src/commands/dev-wiring.ts
+++ b/packages/cli/src/commands/dev-wiring.ts
@@ -245,6 +245,8 @@ export async function wireDevEngines(input: WireDevEnginesInput): Promise<WireDe
     interceptorRegistry,
     // Strict input validation follows the detected environment (prod/staging).
     strictValidation: environment.features.strictValidation,
+    // Business rules evaluated during action execution (Spec 23 §1.1).
+    rules,
   });
   for (const action of actionRegistry.getAll()) {
     executor.registry.register(action);

--- a/packages/cli/src/commands/exec.ts
+++ b/packages/cli/src/commands/exec.ts
@@ -199,6 +199,8 @@ async function bootstrapCommandLayer(): Promise<{
       logger: consoleLogger,
       // Strict input validation follows the detected environment (prod/staging).
       strictValidation: environment.features.strictValidation,
+      // Business rules evaluated during action execution (Spec 23 §1.1).
+      rules: collected.rules,
     });
     for (const action of actionRegistry.getAll()) {
       executor.registry.register(action);

--- a/packages/core/__tests__/action-engine-rule-integration.test.ts
+++ b/packages/core/__tests__/action-engine-rule-integration.test.ts
@@ -19,21 +19,25 @@ import type { RuleDefinition } from "../src/types/rule";
 
 const actor: Actor = { type: "human", id: "user-1", groups: ["staff"] };
 
-/** Captures the last create() write so tests can assert enrich reached the write path. */
+/** Captures writes so tests can assert enrich reached the handler + write paths. */
 interface Captured {
   created: Record<string, unknown> | null;
+  updated: { id: string; data: Record<string, unknown> } | null;
   handlerInput: Record<string, unknown> | null;
 }
 
 function makeDataProvider(captured: Captured): DataProvider {
   return {
-    get: async () => ({}),
+    get: async (_entity, id) => ({ id }),
     query: async () => [],
     create: async (_entity, data) => {
       captured.created = data;
       return { id: "req_1", ...data };
     },
-    update: async (_entity, id, data) => ({ id, ...data }),
+    update: async (_entity, id, data) => {
+      captured.updated = { id, data };
+      return { id, ...data };
+    },
     delete: async () => {},
     count: async () => 0,
   };
@@ -55,6 +59,18 @@ function makeAction(captured: Captured): ActionDefinition {
   };
 }
 
+/** Declarative UPDATE action (no handler) — writes setFields resolved from input. */
+function makeDeclarativeUpdateAction(): ActionDefinition {
+  return {
+    name: "tag_request",
+    entity: "request",
+    label: "Tag Request",
+    policy: { mode: "sync", transaction: false },
+    exposure: "all",
+    setFields: { region: "$input.region" },
+  };
+}
+
 function blockRule(): RuleDefinition {
   return {
     name: "block_overlimit",
@@ -69,7 +85,7 @@ describe("Action Engine ↔ Rule Engine integration (Spec 23 §1.1)", () => {
   let captured: Captured;
 
   beforeEach(() => {
-    captured = { created: null, handlerInput: null };
+    captured = { created: null, updated: null, handlerInput: null };
   });
 
   function build(rules: RuleDefinition[] | undefined) {
@@ -78,6 +94,7 @@ describe("Action Engine ↔ Rule Engine integration (Spec 23 §1.1)", () => {
       rules,
     });
     executor.registry.register(makeAction(captured));
+    executor.registry.register(makeDeclarativeUpdateAction());
     return executor;
   }
 
@@ -114,6 +131,26 @@ describe("Action Engine ↔ Rule Engine integration (Spec 23 §1.1)", () => {
     expect(result.success).toBe(true);
     expect(captured.handlerInput).toMatchObject({ amount: 10, region: "emea", priority: 3 });
     expect(captured.created).toMatchObject({ region: "emea", priority: 3 });
+  });
+
+  it("enrich: reaches DECLARATIVE writes too ($input.* resolves rule-enriched fields)", async () => {
+    // Regression (codex review): the no-handler declarative path read raw
+    // `input`, so `setFields: { region: "$input.region" }` resolved to the
+    // pre-enrichment value and the rule effect was silently dropped.
+    const enrich: RuleDefinition = {
+      name: "stamp_region_decl",
+      label: "Stamp region (declarative)",
+      trigger: { action: "tag_request" },
+      condition: { field: "target.id", operator: "not_null" },
+      effect: { type: "enrich", setFields: { region: "emea" } },
+    };
+    const executor = build([enrich]);
+    // Caller supplies only the record id — `region` comes from the rule.
+    const result = await executor.execute("tag_request", { id: "req_1" }, actor);
+
+    expect(result.success).toBe(true);
+    expect(captured.updated).not.toBeNull();
+    expect(captured.updated?.data).toMatchObject({ region: "emea" });
   });
 
   it("warn: warning messages surface on the result, action still succeeds", async () => {

--- a/packages/core/__tests__/action-engine-rule-integration.test.ts
+++ b/packages/core/__tests__/action-engine-rule-integration.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Action Engine ↔ Rule Engine integration (Spec 23 §1.1).
+ *
+ * These tests exercise the REAL execution path: a business rule (`defineRule`)
+ * is injected into `createActionExecutor({ rules })` and we assert it actually
+ * fires when the action runs through `executor.execute(...)` — NOT by calling
+ * `evaluateRules` directly. This is the load-bearing wiring: before it, rule
+ * effects (block / warn / enrich) were collected by the pure rule engine but
+ * never applied during action execution.
+ *
+ * Phase 1 covers block / warn / enrich (pre-write decision effects).
+ * require_approval / execute_action / trigger_flow land in later phases.
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import { createActionExecutor, type DataProvider } from "../src/engine/action-engine";
+import type { ActionDefinition, Actor } from "../src/types/action";
+import type { RuleDefinition } from "../src/types/rule";
+
+const actor: Actor = { type: "human", id: "user-1", groups: ["staff"] };
+
+/** Captures the last create() write so tests can assert enrich reached the write path. */
+interface Captured {
+  created: Record<string, unknown> | null;
+  handlerInput: Record<string, unknown> | null;
+}
+
+function makeDataProvider(captured: Captured): DataProvider {
+  return {
+    get: async () => ({}),
+    query: async () => [],
+    create: async (_entity, data) => {
+      captured.created = data;
+      return { id: "req_1", ...data };
+    },
+    update: async (_entity, id, data) => ({ id, ...data }),
+    delete: async () => {},
+    count: async () => 0,
+  };
+}
+
+/** Action whose handler records ctx.input and writes it via ctx.create. */
+function makeAction(captured: Captured): ActionDefinition {
+  return {
+    name: "submit_request",
+    entity: "request",
+    label: "Submit Request",
+    policy: { mode: "sync", transaction: false },
+    exposure: "all",
+    handler: async (ctx) => {
+      captured.handlerInput = { ...(ctx.input as Record<string, unknown>) };
+      const record = await ctx.create("request", ctx.input as Record<string, unknown>);
+      return record;
+    },
+  };
+}
+
+function blockRule(): RuleDefinition {
+  return {
+    name: "block_overlimit",
+    label: "Block over-limit amount",
+    trigger: { action: "submit_request" },
+    condition: { field: "target.amount", operator: "gt", value: 1000 },
+    effect: { type: "block", message: "Amount exceeds the limit", reason: "exceeds_limit" },
+  };
+}
+
+describe("Action Engine ↔ Rule Engine integration (Spec 23 §1.1)", () => {
+  let captured: Captured;
+
+  beforeEach(() => {
+    captured = { created: null, handlerInput: null };
+  });
+
+  function build(rules: RuleDefinition[] | undefined) {
+    const executor = createActionExecutor({
+      dataProvider: makeDataProvider(captured),
+      rules,
+    });
+    executor.registry.register(makeAction(captured));
+    return executor;
+  }
+
+  it("block: a matching block rule aborts the action before the write", async () => {
+    const executor = build([blockRule()]);
+    const result = await executor.execute("submit_request", { amount: 5000 }, actor);
+
+    expect(result.success).toBe(false);
+    expect((result.data as { error?: string }).error).toContain("exceeds_limit");
+    // The handler/write never ran.
+    expect(captured.handlerInput).toBeNull();
+    expect(captured.created).toBeNull();
+  });
+
+  it("block: the action proceeds when the block condition does not match", async () => {
+    const executor = build([blockRule()]);
+    const result = await executor.execute("submit_request", { amount: 500 }, actor);
+
+    expect(result.success).toBe(true);
+    expect(captured.created).toMatchObject({ amount: 500 });
+  });
+
+  it("enrich: rule-set fields reach the handler and the write", async () => {
+    const enrich: RuleDefinition = {
+      name: "stamp_region",
+      label: "Stamp region",
+      trigger: { action: "submit_request" },
+      condition: { field: "target.amount", operator: "gte", value: 0 },
+      effect: { type: "enrich", setFields: { region: "emea", priority: 3 } },
+    };
+    const executor = build([enrich]);
+    const result = await executor.execute("submit_request", { amount: 10 }, actor);
+
+    expect(result.success).toBe(true);
+    expect(captured.handlerInput).toMatchObject({ amount: 10, region: "emea", priority: 3 });
+    expect(captured.created).toMatchObject({ region: "emea", priority: 3 });
+  });
+
+  it("warn: warning messages surface on the result, action still succeeds", async () => {
+    const warn: RuleDefinition = {
+      name: "warn_large",
+      label: "Warn on large amount",
+      trigger: { action: "submit_request" },
+      condition: { field: "target.amount", operator: "gt", value: 100 },
+      effect: { type: "warn", message: "Large amount — please double-check" },
+    };
+    const executor = build([warn]);
+    const result = await executor.execute("submit_request", { amount: 500 }, actor);
+
+    expect(result.success).toBe(true);
+    expect(result.warnings).toEqual(["Large amount — please double-check"]);
+    expect(captured.created).toMatchObject({ amount: 500 });
+  });
+
+  it("filtering: a rule targeting a different action does NOT fire", async () => {
+    const otherRule: RuleDefinition = {
+      name: "block_other",
+      label: "Block other action",
+      trigger: { action: "delete_request" },
+      condition: { field: "target.amount", operator: "gt", value: 0 },
+      effect: { type: "block", message: "should not apply" },
+    };
+    const executor = build([otherRule]);
+    const result = await executor.execute("submit_request", { amount: 9999 }, actor);
+
+    expect(result.success).toBe(true);
+    expect(captured.created).toMatchObject({ amount: 9999 });
+  });
+
+  it("back-compat: no rules option → action runs unchanged", async () => {
+    const executor = build(undefined);
+    const result = await executor.execute("submit_request", { amount: 9999 }, actor);
+
+    expect(result.success).toBe(true);
+    expect(result.warnings).toBeUndefined();
+    expect(captured.created).toMatchObject({ amount: 9999 });
+  });
+
+  it("skipRules: a blocking rule listed in skipRules is bypassed (approved re-execution)", async () => {
+    const executor = build([blockRule()]);
+    const result = await executor.execute("submit_request", { amount: 5000 }, actor, {
+      skipRules: ["block_overlimit"],
+    });
+
+    expect(result.success).toBe(true);
+    expect(captured.created).toMatchObject({ amount: 5000 });
+  });
+});

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -27,6 +27,7 @@ import {
   redactMetaForLog,
 } from "../types/execution-meta";
 import type { Logger } from "../types/logger";
+import type { RuleDefinition } from "../types/rule";
 import {
   checkFieldLocks,
   type FieldLockViolation,
@@ -49,6 +50,7 @@ import {
 } from "./action-helpers";
 import { ActionRegistry } from "./action-registry";
 import { hashBehaviorAffectingMeta } from "./meta-keys";
+import { collectRules, evaluateRules } from "./rule-engine";
 
 // Framework-reserved `_`-prefixed system meta keys are defined as
 // `FRAMEWORK_RESERVED_META_KEYS` in `../types/execution-meta` so they are
@@ -259,6 +261,17 @@ export interface ActionExecutorOptions {
    * legitimately send.
    */
   strictValidation?: boolean;
+  /**
+   * Business rules (`defineRule`) evaluated during action execution
+   * (Spec 23 §1.1). When omitted, no rule evaluation runs — back-compat for
+   * tests and minimal setups. Production wiring injects the capability-
+   * aggregated rule set. Only rules whose `trigger.action` targets the running
+   * action fire (filtered by `collectRules`). In this phase, `block` aborts the
+   * write, `enrich` augments the input, and `warn` surfaces on the result;
+   * `require_approval` / `execute_action` / `trigger_flow` are handled in
+   * follow-up phases.
+   */
+  rules?: RuleDefinition[];
 }
 
 /**
@@ -382,6 +395,7 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
     entityRegistry,
     interceptorRegistry,
     strictValidation = false,
+    rules,
   } = options;
 
   /** Silent noop logger — used when no logger is injected */
@@ -801,6 +815,65 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
       };
     }
 
+    // Step 4c: Business-rule evaluation (Spec 23 §1.1). Runs after input
+    // validation and before the write so `block` aborts cleanly, `enrich`
+    // augments the input that reaches the handler/write path, and `warn`
+    // surfaces on the result. Only action-triggered rules for THIS action fire
+    // (filtered by collectRules). Conditions are evaluated against the validated
+    // input; the pre-existing record is not yet threaded in (that lands with the
+    // require_approval phase), so input-shape guards work today while
+    // record-state guards arrive in a follow-up. require_approval /
+    // execute_action / trigger_flow effects are collected but not yet acted on
+    // here — also follow-up phases.
+    let effectiveInput: Record<string, unknown> = inputValidation.value ?? input;
+    const ruleWarnings: string[] = [];
+    if (rules && rules.length > 0) {
+      const applicableRules = collectRules(actionName, rules);
+      if (applicableRules.length > 0) {
+        const ruleOutput = await evaluateRules(
+          applicableRules,
+          {
+            target: effectiveInput,
+            actor: { type: actor.type, id: actor.id, groups: actor.groups ?? [] },
+            meta: resolvedMeta,
+          },
+          { skipRules: execOptions?.skipRules, metrics },
+        );
+        if (ruleOutput.blocked) {
+          const reason = ruleOutput.blockReasons.join("; ") || "Blocked by rule";
+          await logExecution({
+            id: executionId,
+            action: actionName,
+            entity: action.entity,
+            actor,
+            input,
+            status: "failed",
+            error: { message: reason },
+            meta: metaSnapshot,
+            startedAt,
+          });
+          return {
+            success: false,
+            data: {
+              error: reason,
+              context: {
+                action: actionName,
+                entity: action.entity,
+                constraint: "rule_block",
+                expected: reason,
+                suggestion: ruleOutput.contexts[0]?.suggestion ?? reason,
+              },
+            } as T,
+            executionId,
+          };
+        }
+        if (Object.keys(ruleOutput.enrichFields).length > 0) {
+          effectiveInput = { ...effectiveInput, ...ruleOutput.enrichFields };
+        }
+        for (const warn of ruleOutput.warnings) ruleWarnings.push(warn.message);
+      }
+    }
+
     // Build ActionContext
     const childExecutionIds: string[] = [];
     const pendingEvents: PendingEvent[] = [];
@@ -1103,12 +1176,13 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
     // the meta snapshot. `resolvedMeta` and `metaSnapshot` are in scope here.
 
     const ctx: ActionContext = {
-      // In strict mode, forward the sanitized (allowlisted) payload so undeclared
-      // keys stripped by validation never reach handlers / the write path. Falls
-      // back to the original input on the lenient path (dev/test). System fields
+      // `effectiveInput` = the sanitized (allowlisted) payload — in strict mode
+      // undeclared keys stripped by validation never reach handlers / the write
+      // path; lenient (dev/test) falls back to the original input. System fields
       // are retained by the validator, so update/lock logic that reads `input.id`
-      // is unaffected.
-      input: inputValidation.value ?? input,
+      // is unaffected. Rule `enrich` effects (Step 4c) have already been merged
+      // into `effectiveInput`.
+      input: effectiveInput,
       actor,
       tenantId: execOptions?.tenantId,
       logger,
@@ -1628,6 +1702,7 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
         success: true,
         data: resultData as T,
         record,
+        warnings: ruleWarnings.length > 0 ? ruleWarnings : undefined,
         executionId,
       };
     } catch (err) {

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -1527,15 +1527,19 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
         if (action.handler) {
           resultData = await action.handler(ctx);
         } else {
-          // Declarative action — no handler needed
-          const recordIdLocal = input.id as string | undefined;
+          // Declarative action — no handler needed. Use `effectiveInput` (the
+          // validated + rule-enriched payload) so `enrich` effects and strict
+          // sanitization apply to declarative writes exactly as they do on the
+          // handler path (ctx.input). Reading raw `input` here would silently
+          // drop rule-enriched fields and `$input.*` references to them.
+          const recordIdLocal = effectiveInput.id as string | undefined;
 
           if (recordIdLocal) {
             const updates: Record<string, unknown> = {};
 
             if (action.setFields) {
               for (const [key, value] of Object.entries(action.setFields)) {
-                updates[key] = resolveFieldExpression(value, input, actor);
+                updates[key] = resolveFieldExpression(value, effectiveInput, actor);
               }
             }
 

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -398,6 +398,11 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
     rules,
   } = options;
 
+  // Per-action cache of collected+priority-sorted rules. `rules` is fixed for
+  // the executor's lifetime, so collectRules() output is stable per action name
+  // — cache it to avoid re-filtering and re-sorting on every execution.
+  const applicableRulesCache = new Map<string, RuleDefinition[]>();
+
   /** Silent noop logger — used when no logger is injected */
   const noopFn = () => {};
   const noopLogger: Logger = { debug: noopFn, info: noopFn, warn: noopFn, error: noopFn };
@@ -828,7 +833,11 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
     let effectiveInput: Record<string, unknown> = inputValidation.value ?? input;
     const ruleWarnings: string[] = [];
     if (rules && rules.length > 0) {
-      const applicableRules = collectRules(actionName, rules);
+      let applicableRules = applicableRulesCache.get(actionName);
+      if (applicableRules === undefined) {
+        applicableRules = collectRules(actionName, rules);
+        applicableRulesCache.set(actionName, applicableRules);
+      }
       if (applicableRules.length > 0) {
         const ruleOutput = await evaluateRules(
           applicableRules,
@@ -847,7 +856,9 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
             entity: action.entity,
             actor,
             input,
-            status: "failed",
+            // Policy/authorization-style block (consistent with exposure,
+            // field-lock, and state-transition blocks) — not an execution failure.
+            status: "blocked",
             error: { message: reason },
             meta: metaSnapshot,
             startedAt,


### PR DESCRIPTION
## Why

While scoping `trigger_flow` (Spec 26), I found that **`defineRule()` business rules are not wired into the live action-execution path at all**. `evaluateRules` is a tested-but-unwired pure function — no non-test code calls it; the action engine never imports it; even the e2e approval test hand-constructs the `require_approval` effect rather than producing it from a rule. So `block` / `warn` / `enrich` / `require_approval` / `execute_action` effects are collected by the rule engine but **never applied when an action runs**. Spec 23 §1.1 specifies that rules are evaluated during action execution and the result "returns to the Action Engine" — so this is a real, foundational gap, not a Minimal-Core capability deferral (the rule/action/approval engines all already live in core).

This is **phase 1 of 3**: wire the pre-write decision effects. require_approval (phase 2, control-flow) and the post-commit effects `execute_action` + `trigger_flow` (phase 3) follow.

## What

`createActionExecutor` gains an optional `rules?: RuleDefinition[]`. After input validation and before the write, the executor runs `collectRules(actionName, rules)` + `evaluateRules` and applies:

- **block** → aborts with the block reason(s); handler + write never run.
- **enrich** → merges `setFields` into the effective input that reaches **both** the handler (`ctx.input`) and the declarative write path (`setFields` / `$input.*`).
- **warn** → surfaces on `ActionResult.warnings`; the action still succeeds.

Only rules whose `trigger.action` targets the running action fire; `skipRules` (approved re-execution) is honored. Mirrors the field-lock-checker pattern (Spec 63): a core executor responsibility, optional dependency, no-op when omitted.

The capability-aggregated rule set is injected at **every** production executor construction site so the feature is live, not dormant:
- `adapter-server` `createRuntimeContext` (via `assembleDevSchema`) — `RuntimeContextOptions` gains `rules`.
- CLI `dev` (`dev-wiring`) and CLI `exec`.

## Scope / limitations (documented, follow-ups)

- Conditions evaluate against the **validated input**; record-state conditions (reading the pre-existing record) arrive with the require_approval phase.
- `require_approval` / `execute_action` / `trigger_flow` effects are not yet acted on here.

## Cross-model review (codex)

| Finding | Severity | Verdict | Action |
|---|---|---|---|
| Declarative writes (no-handler `setFields` / `$input.*`) read raw `input`, silently dropping rule `enrich` for declarative actions | P2 | **Confirmed real** (the handler path used `ctx.input` = enriched, but the declarative branch read raw `input`; this also meant strict-mode sanitization was skipped there) | **Fixed** — declarative branch now uses `effectiveInput`; added a declarative-path regression test |

## Test plan

New `packages/core/__tests__/action-engine-rule-integration.test.ts` exercises the **real** executor path (`createActionExecutor({ rules })` → `executor.execute`), not `evaluateRules` directly:
- block aborts before write (handler/write never run); block doesn't fire when condition is false
- enrich reaches the handler write **and** the declarative `$input.*` write
- warn surfaces on `result.warnings`
- action-name filtering (a rule for another action doesn't fire)
- `skipRules` bypass
- back-compat: omitting `rules` is unchanged

Full `bun run test` PASS (294 batches); biome clean; typecheck clean on changed files. No `any`/`!`. Non-breaking. Changeset included (`@linchkit/core` minor, `@linchkit/cap-adapter-server` minor, `@linchkit/cli` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Business rules now evaluate automatically during action execution, not as a separate step.
  * Rule effects—blocking actions, enriching inputs with additional fields, and issuing warnings—are applied in the execution flow.
  * Specific rules can be skipped on a per-action basis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->