### PR TITLE
feat(core): wire require_approval + record-state into rule evaluation (Spec 23 §1.1, phase 2)

### DIFF
--- a/.changeset/wire-require-approval.md
+++ b/.changeset/wire-require-approval.md
@@ -1,0 +1,17 @@
+---
+"@linchkit/core": minor
+"@linchkit/cap-adapter-server": minor
+"@linchkit/cli": patch
+---
+
+feat(core): wire require_approval + record-state into rule evaluation (Spec 23 §1.1, phase 2)
+
+Builds on the phase-1 wiring (block/warn/enrich). The action executor now handles the `require_approval` rule effect and evaluates rule conditions against the pre-existing record.
+
+**require_approval.** `createActionExecutor` gains an optional `approvalEngine` (`ActionApprovalSuspender`) plus a late-binding `executor.setApprovalEngine()` seam (the executor and the approval engine are mutually dependent — the engine re-executes actions via the executor). When a `require_approval` rule fires, the executor suspends the action: it calls `approvalEngine.createRequest({ action, input, actor, effect, triggerRules, ... })` and returns the `ApprovalPendingResult` instead of writing. `ApprovalEngine.approve()` later re-executes with `skipRules = triggerRules` so the approval rule does not re-fire. When no approval engine is wired, a `require_approval` effect lets the action proceed (best-effort gate, not a silent hard block).
+
+**Record-state conditions.** Rule evaluation moved after provider setup so that, for updates (input carries an `id`), the executor reads the current record via the tenant-scoped provider and evaluates conditions against `{ ...record, ...input }`. Rules can now reference existing field values (e.g. "block edits when status is closed"), with input overriding record state. A read failure degrades to input-only.
+
+**Wiring (all production paths).** CLI `dev` calls `executor.setApprovalEngine(approvalEngine)`. The adapter-server `createRuntimeContext` now constructs an approval engine (in-memory store; persistence via `DrizzleApprovalStore` is a boot-path follow-up), wires it both ways (executor ↔ engine, re-execution via the CommandLayer), and exposes it on `RuntimeContext`; `dev` / `dev-app` pass it to `createServer` so the approval API routes work. Previously the server had **no** approval engine, so server-side `require_approval` never functioned.
+
+Tests: `action-engine-rule-integration.test.ts` adds require_approval (suspend → pending, no write; no-engine → proceeds; `setApprovalEngine` seam; skipRules bypass) and record-state (record-derived condition fires; input overrides record) cases — all through the real executor. Non-breaking: omitting `rules` / `approvalEngine` preserves prior behavior. No `any`/`!`.

--- a/addons/adapter-server/cap-adapter-server/src/dev-app.ts
+++ b/addons/adapter-server/cap-adapter-server/src/dev-app.ts
@@ -100,6 +100,7 @@ export function createDevApp(
     ...serverOverrides,
     executor: runtime.executor,
     commandLayer: runtime.commandLayer,
+    approvalEngine: runtime.approvalEngine,
     executionLogger: runtime.executionLogger,
     entityRegistry: runtime.entityRegistry,
     views: runtime.views,

--- a/addons/adapter-server/cap-adapter-server/src/dev.ts
+++ b/addons/adapter-server/cap-adapter-server/src/dev.ts
@@ -115,6 +115,7 @@ const server = createServer(graphqlSchema, {
   host,
   executor: runtime.executor,
   commandLayer: runtime.commandLayer,
+  approvalEngine: runtime.approvalEngine,
   executionLogger: runtime.executionLogger,
   entityRegistry: runtime.entityRegistry,
   views: runtime.views,

--- a/addons/adapter-server/cap-adapter-server/src/runtime-context.ts
+++ b/addons/adapter-server/cap-adapter-server/src/runtime-context.ts
@@ -13,6 +13,7 @@ import type {
   ActionExecutor,
   AIService,
   ApprovalEngine,
+  ApprovalStore,
   CommandLayer,
   DataProvider,
   EntityDefinition,
@@ -69,6 +70,12 @@ export interface RuntimeContextOptions {
   views?: ViewDefinition[];
   /** Business rules (defineRule) — evaluated by the action executor (Spec 23 §1.1). */
   rules?: RuleDefinition[];
+  /**
+   * Approval store backing `require_approval` rule effects. Defaults to an
+   * in-memory store (lost on restart); inject a `DrizzleApprovalStore` for
+   * persistent approvals in production.
+   */
+  approvalStore?: ApprovalStore;
   middlewares?: MiddlewareRegistration[];
   /** Interface definitions — registered before schemas so field injection/validation works */
   interfaces?: InterfaceDefinition[];
@@ -154,9 +161,9 @@ export function createRuntimeContext(options?: RuntimeContextOptions): RuntimeCo
 
   // Approval store — shared between the CommandLayer's approval verifier and
   // the approval engine so re-execution on approve is recognized as authorized.
-  // In-memory by default (persistence via DrizzleApprovalStore is a boot-path
-  // follow-up).
-  const approvalStore = new InMemoryApprovalStore();
+  // Defaults to in-memory; the boot path can inject a DrizzleApprovalStore for
+  // persistent approvals.
+  const approvalStore = options?.approvalStore ?? new InMemoryApprovalStore();
 
   // Build command layer. The TM is plumbed through so `executeBatch` can run
   // `all_or_nothing` without per-call wiring; without one, batch callers must

--- a/addons/adapter-server/cap-adapter-server/src/runtime-context.ts
+++ b/addons/adapter-server/cap-adapter-server/src/runtime-context.ts
@@ -28,6 +28,7 @@ import type {
 import {
   createActionExecutor,
   createApprovalEngine,
+  createApprovalVerifier,
   createCommandLayer,
   createInterfaceRegistry,
   createNoopAIService,
@@ -151,13 +152,21 @@ export function createRuntimeContext(options?: RuntimeContextOptions): RuntimeCo
     }
   }
 
+  // Approval store — shared between the CommandLayer's approval verifier and
+  // the approval engine so re-execution on approve is recognized as authorized.
+  // In-memory by default (persistence via DrizzleApprovalStore is a boot-path
+  // follow-up).
+  const approvalStore = new InMemoryApprovalStore();
+
   // Build command layer. The TM is plumbed through so `executeBatch` can run
   // `all_or_nothing` without per-call wiring; without one, batch callers must
   // use `strategy: "partial"` (the engine returns BATCH_TX_MANAGER_REQUIRED
-  // otherwise).
+  // otherwise). `verifyApproval` lets ApprovalEngine.approve() replay an action
+  // through the pipeline (skipping auth/exposure/permission) via its approvalId.
   const commandLayer = createCommandLayer({
     executor,
     transactionManager: options?.transactionManager,
+    verifyApproval: createApprovalVerifier(approvalStore),
   });
   if (options?.middlewares) {
     for (const mw of options.middlewares) {
@@ -165,13 +174,12 @@ export function createRuntimeContext(options?: RuntimeContextOptions): RuntimeCo
     }
   }
 
-  // Approval engine for `require_approval` rule effects (Spec 23 §1.1). Built
-  // with an in-memory store (persistence via DrizzleApprovalStore is a boot-path
-  // follow-up). Re-execution on approve routes through the CommandLayer. Wired
-  // both ways: the engine re-executes via the executor, and the executor
-  // suspends actions into the engine when a rule requires approval.
+  // Approval engine for `require_approval` rule effects (Spec 23 §1.1).
+  // Re-execution on approve routes through the CommandLayer. Wired both ways:
+  // the engine re-executes via the executor, and the executor suspends actions
+  // into the engine when a rule requires approval.
   const approvalEngine = createApprovalEngine({
-    store: new InMemoryApprovalStore(),
+    store: approvalStore,
     eventBus: options?.eventBus,
     commandLayer,
   });

--- a/addons/adapter-server/cap-adapter-server/src/runtime-context.ts
+++ b/addons/adapter-server/cap-adapter-server/src/runtime-context.ts
@@ -12,6 +12,7 @@ import type {
   ActionDefinition,
   ActionExecutor,
   AIService,
+  ApprovalEngine,
   CommandLayer,
   DataProvider,
   EntityDefinition,
@@ -26,12 +27,14 @@ import type {
 } from "@linchkit/core";
 import {
   createActionExecutor,
+  createApprovalEngine,
   createCommandLayer,
   createInterfaceRegistry,
   createNoopAIService,
   createStateMachine,
   detectEnvironment,
   EntityRegistry,
+  InMemoryApprovalStore,
   InMemoryExecutionLogger,
   InMemoryStore,
 } from "@linchkit/core/server";
@@ -40,6 +43,13 @@ export interface RuntimeContext {
   entityRegistry: EntityRegistry;
   executor: ActionExecutor;
   commandLayer: CommandLayer;
+  /**
+   * Approval engine for `require_approval` rule effects. Wired into the
+   * executor so an action suspends into an approval request, and re-executes
+   * via the CommandLayer on approve. Uses an in-memory store by default —
+   * persistence (DrizzleApprovalStore) is injected by the boot path.
+   */
+  approvalEngine: ApprovalEngine;
   /** DataProvider used by both action executor and GraphQL query resolvers */
   dataProvider: DataProvider;
   executionLogger: ExecutionLogger;
@@ -155,6 +165,19 @@ export function createRuntimeContext(options?: RuntimeContextOptions): RuntimeCo
     }
   }
 
+  // Approval engine for `require_approval` rule effects (Spec 23 §1.1). Built
+  // with an in-memory store (persistence via DrizzleApprovalStore is a boot-path
+  // follow-up). Re-execution on approve routes through the CommandLayer. Wired
+  // both ways: the engine re-executes via the executor, and the executor
+  // suspends actions into the engine when a rule requires approval.
+  const approvalEngine = createApprovalEngine({
+    store: new InMemoryApprovalStore(),
+    eventBus: options?.eventBus,
+    commandLayer,
+  });
+  approvalEngine.setExecutor(executor);
+  executor.setApprovalEngine(approvalEngine);
+
   // Register views grouped by schema
   const views = new Map<string, ViewDefinition[]>();
   if (options?.views) {
@@ -169,6 +192,7 @@ export function createRuntimeContext(options?: RuntimeContextOptions): RuntimeCo
     entityRegistry,
     executor,
     commandLayer,
+    approvalEngine,
     dataProvider,
     executionLogger,
     views,

--- a/packages/cli/src/commands/dev-wiring.ts
+++ b/packages/cli/src/commands/dev-wiring.ts
@@ -287,6 +287,10 @@ export async function wireDevEngines(input: WireDevEnginesInput): Promise<WireDe
     commandLayer,
     enforceAssignee: false, // M0b: not enforced yet
   });
+  // Wire the approval engine back into the executor so a `require_approval`
+  // rule effect suspends the action into an approval request (Spec 23 §1.1).
+  // Late-bound because the engine itself re-executes actions via the executor.
+  executor.setApprovalEngine(approvalEngine);
 
   // ── AI Audit Logger — always created (lightweight, no external deps) ──
   const aiAuditLogger = new AIAuditLogger({

--- a/packages/core/__tests__/action-engine-rule-integration.test.ts
+++ b/packages/core/__tests__/action-engine-rule-integration.test.ts
@@ -13,8 +13,13 @@
  */
 
 import { beforeEach, describe, expect, it } from "bun:test";
-import { createActionExecutor, type DataProvider } from "../src/engine/action-engine";
+import {
+  type ActionApprovalSuspender,
+  createActionExecutor,
+  type DataProvider,
+} from "../src/engine/action-engine";
 import type { ActionDefinition, Actor } from "../src/types/action";
+import type { ApprovalPendingResult } from "../src/types/approval";
 import type { RuleDefinition } from "../src/types/rule";
 
 const actor: Actor = { type: "human", id: "user-1", groups: ["staff"] };
@@ -24,11 +29,13 @@ interface Captured {
   created: Record<string, unknown> | null;
   updated: { id: string; data: Record<string, unknown> } | null;
   handlerInput: Record<string, unknown> | null;
+  /** Extra fields the mock `get` returns for a record — drives record-state tests. */
+  existingFields: Record<string, unknown>;
 }
 
 function makeDataProvider(captured: Captured): DataProvider {
   return {
-    get: async (_entity, id) => ({ id }),
+    get: async (_entity, id) => ({ id, ...captured.existingFields }),
     query: async () => [],
     create: async (_entity, data) => {
       captured.created = data;
@@ -81,17 +88,47 @@ function blockRule(): RuleDefinition {
   };
 }
 
+function approvalRule(): RuleDefinition {
+  return {
+    name: "approve_large",
+    label: "Require approval for large amount",
+    trigger: { action: "submit_request" },
+    condition: { field: "target.amount", operator: "gt", value: 1000 },
+    effect: { type: "require_approval", level: "manager", message: "Needs manager sign-off" },
+  };
+}
+
+/** Captures the createRequest call so tests can assert the suspend happened. */
+interface ApprovalCapture {
+  request: Parameters<ActionApprovalSuspender["createRequest"]>[0] | null;
+}
+
+function makeApprovalEngine(cap: ApprovalCapture): ActionApprovalSuspender {
+  return {
+    createRequest: async (opts) => {
+      cap.request = opts;
+      return {
+        status: "pending_approval",
+        approvalId: "appr_1",
+        message: "Pending approval",
+        level: opts.effect.level,
+      };
+    },
+  };
+}
+
 describe("Action Engine ↔ Rule Engine integration (Spec 23 §1.1)", () => {
   let captured: Captured;
 
   beforeEach(() => {
-    captured = { created: null, updated: null, handlerInput: null };
+    captured = { created: null, updated: null, handlerInput: null, existingFields: {} };
   });
 
-  function build(rules: RuleDefinition[] | undefined) {
+  function build(rules: RuleDefinition[] | undefined, approvalEngine?: ActionApprovalSuspender) {
     const executor = createActionExecutor({
       dataProvider: makeDataProvider(captured),
       rules,
+      approvalEngine,
     });
     executor.registry.register(makeAction(captured));
     executor.registry.register(makeDeclarativeUpdateAction());
@@ -201,5 +238,92 @@ describe("Action Engine ↔ Rule Engine integration (Spec 23 §1.1)", () => {
 
     expect(result.success).toBe(true);
     expect(captured.created).toMatchObject({ amount: 5000 });
+  });
+
+  it("require_approval: suspends the action into an approval request (no write)", async () => {
+    const apprCap: ApprovalCapture = { request: null };
+    const executor = build([approvalRule()], makeApprovalEngine(apprCap));
+    const result = await executor.execute("submit_request", { amount: 5000 }, actor);
+
+    const pending = result.data as ApprovalPendingResult;
+    expect(pending.status).toBe("pending_approval");
+    expect(pending.level).toBe("manager");
+    // createRequest received the effect + the triggering rule name(s).
+    expect(apprCap.request?.effect.level).toBe("manager");
+    expect(apprCap.request?.triggerRules).toEqual(["approve_large"]);
+    // The action was suspended — the write never ran.
+    expect(captured.created).toBeNull();
+  });
+
+  it("require_approval: with no approval engine wired, the action proceeds (no silent block)", async () => {
+    const executor = build([approvalRule()]); // no approvalEngine
+    const result = await executor.execute("submit_request", { amount: 5000 }, actor);
+
+    expect(result.success).toBe(true);
+    expect(captured.created).toMatchObject({ amount: 5000 });
+  });
+
+  it("require_approval: setApprovalEngine late-binding seam works", async () => {
+    const apprCap: ApprovalCapture = { request: null };
+    const executor = build([approvalRule()]); // constructed without an engine
+    executor.setApprovalEngine(makeApprovalEngine(apprCap));
+    const result = await executor.execute("submit_request", { amount: 5000 }, actor);
+
+    expect((result.data as ApprovalPendingResult).status).toBe("pending_approval");
+    expect(apprCap.request).not.toBeNull();
+    expect(captured.created).toBeNull();
+  });
+
+  it("require_approval: skipRules bypasses the gate (approved re-execution proceeds)", async () => {
+    const apprCap: ApprovalCapture = { request: null };
+    const executor = build([approvalRule()], makeApprovalEngine(apprCap));
+    const result = await executor.execute("submit_request", { amount: 5000 }, actor, {
+      skipRules: ["approve_large"],
+    });
+
+    expect(result.success).toBe(true);
+    expect(apprCap.request).toBeNull(); // gate skipped — no new request
+    expect(captured.created).toMatchObject({ amount: 5000 });
+  });
+
+  it("record-state: a rule reading the pre-existing record fires (status from the DB, not input)", async () => {
+    // The current record is "closed"; the caller's input does not carry status.
+    captured.existingFields = { status: "closed" };
+    const blockClosed: RuleDefinition = {
+      name: "block_closed",
+      label: "Block edits to closed records",
+      trigger: { action: "tag_request" },
+      condition: { field: "target.status", operator: "eq", value: "closed" },
+      effect: { type: "block", message: "Record is closed", reason: "record_closed" },
+    };
+    const executor = build([blockClosed]);
+    // tag_request is an update (input carries an id) → executor reads the record.
+    const result = await executor.execute("tag_request", { id: "req_1", region: "x" }, actor);
+
+    expect(result.success).toBe(false);
+    expect((result.data as { error?: string }).error).toContain("record_closed");
+    expect(captured.updated).toBeNull(); // blocked before the write
+  });
+
+  it("record-state: input overrides record state in the rule's target view", async () => {
+    // Record is "closed", but the caller's input flips status to "open" — the
+    // merged target should reflect the input, so the block does NOT fire.
+    captured.existingFields = { status: "closed" };
+    const blockClosed: RuleDefinition = {
+      name: "block_closed_2",
+      label: "Block edits to closed records",
+      trigger: { action: "tag_request" },
+      condition: { field: "target.status", operator: "eq", value: "closed" },
+      effect: { type: "block", message: "Record is closed" },
+    };
+    const executor = build([blockClosed]);
+    const result = await executor.execute(
+      "tag_request",
+      { id: "req_1", status: "open", region: "x" },
+      actor,
+    );
+
+    expect(result.success).toBe(true);
+    expect(captured.updated).not.toBeNull();
   });
 });

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -957,7 +957,7 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
         // degrades to input-only — the rule simply can't see record state.
         let ruleTarget: Record<string, unknown> = effectiveInput;
         const ruleRecordId = effectiveInput.id;
-        if (typeof ruleRecordId === "string" && ruleRecordId.length > 0) {
+        if (action.entity && typeof ruleRecordId === "string" && ruleRecordId.length > 0) {
           // Read through the parent's transactional provider when this is a
           // nested action inside an open transaction, so the rule sees the
           // parent's uncommitted writes (Spec 26 §1.1); otherwise the

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -958,8 +958,13 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
         let ruleTarget: Record<string, unknown> = effectiveInput;
         const ruleRecordId = effectiveInput.id;
         if (typeof ruleRecordId === "string" && ruleRecordId.length > 0) {
+          // Read through the parent's transactional provider when this is a
+          // nested action inside an open transaction, so the rule sees the
+          // parent's uncommitted writes (Spec 26 §1.1); otherwise the
+          // tenant-scoped baseProvider. A read failure degrades to input-only.
+          const ruleReadProvider = parentTxProvider ?? baseProvider;
           try {
-            const existing = await baseProvider.get(action.entity, ruleRecordId, queryOptions);
+            const existing = await ruleReadProvider.get(action.entity, ruleRecordId, queryOptions);
             if (existing) ruleTarget = { ...existing, ...effectiveInput };
           } catch {
             // Not readable — fall back to input-only evaluation.
@@ -1034,8 +1039,9 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
             entity: action.entity,
             actor,
             input,
-            // Suspended pending approval — a policy decision, not a failure.
-            status: "blocked",
+            // Suspended pending approval — distinct from a hard block/failure so
+            // execution-log consumers can surface it as awaiting sign-off.
+            status: "pending_approval",
             error: { message: `Pending approval (${pending.level})` },
             meta: metaSnapshot,
             startedAt,

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -16,6 +16,7 @@ import { getCurrentTrace } from "../observability/trace-context";
 import { createTenantAwareDataProvider } from "../security/tenant-isolation";
 import type { ActionContext, ActionResult, Actor } from "../types/action";
 import type { AIService } from "../types/ai";
+import type { ApprovalPendingResult } from "../types/approval";
 import type { FieldDefinition, LockCondition } from "../types/entity";
 import type { ExecutionLogEntry, ExecutionLogger } from "../types/execution-log";
 import type { ExecutionMeta } from "../types/execution-meta";
@@ -27,7 +28,7 @@ import {
   redactMetaForLog,
 } from "../types/execution-meta";
 import type { Logger } from "../types/logger";
-import type { RuleDefinition } from "../types/rule";
+import type { RequireApprovalEffect, RuleDefinition } from "../types/rule";
 import {
   checkFieldLocks,
   type FieldLockViolation,
@@ -160,6 +161,29 @@ export interface ExecuteOptions {
 
 // ── ActionExecutor ──────────────────────────────────────────
 
+/**
+ * Minimal approval surface the executor needs to suspend an action when a
+ * `require_approval` rule effect fires. Kept structural (a subset of
+ * ApprovalEngine.createRequest's options) rather than importing `ApprovalEngine`
+ * directly, because approval-engine.ts imports `ActionExecutor` from here — a
+ * structural type avoids the module cycle while staying type-checked against the
+ * canonical {@link RequireApprovalEffect} / {@link ApprovalPendingResult}.
+ */
+export interface ActionApprovalSuspender {
+  createRequest(options: {
+    action: string;
+    entity?: string;
+    recordId?: string;
+    input: Record<string, unknown>;
+    actor: Actor;
+    executionId: string;
+    effect: RequireApprovalEffect;
+    triggerRules: string[];
+    tenantId?: string;
+    meta?: Record<string, unknown>;
+  }): Promise<ApprovalPendingResult>;
+}
+
 export interface ActionExecutor {
   readonly registry: ActionRegistry;
 
@@ -169,6 +193,14 @@ export interface ActionExecutor {
     actor: Actor,
     options?: ExecuteOptions,
   ): Promise<ActionResult<T>>;
+
+  /**
+   * Late-bind the approval engine used to suspend actions on `require_approval`
+   * rule effects. Deferred because the executor and the approval engine are
+   * mutually dependent (the engine re-executes actions via this executor), so
+   * one must be constructed first and wired to the other afterwards.
+   */
+  setApprovalEngine(engine: ActionApprovalSuspender): void;
 }
 
 // ── Transactional event collection ──────────────────────────
@@ -272,6 +304,14 @@ export interface ActionExecutorOptions {
    * follow-up phases.
    */
   rules?: RuleDefinition[];
+  /**
+   * Approval engine used to suspend an action when a `require_approval` rule
+   * effect fires (Spec 23 §1.1 / Spec 09). Optional — when omitted, a
+   * require_approval effect lets the action proceed (no silent hard block).
+   * May also be wired after construction via `executor.setApprovalEngine` to
+   * break the executor ↔ approval-engine dependency cycle.
+   */
+  approvalEngine?: ActionApprovalSuspender;
 }
 
 /**
@@ -402,6 +442,13 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
   // the executor's lifetime, so collectRules() output is stable per action name
   // — cache it to avoid re-filtering and re-sorting on every execution.
   const applicableRulesCache = new Map<string, RuleDefinition[]>();
+
+  // Approval engine for `require_approval` rule effects. Late-bindable because
+  // the executor and the approval engine are mutually dependent.
+  let approvalEngineRef = options.approvalEngine;
+  function setApprovalEngine(engine: ActionApprovalSuspender): void {
+    approvalEngineRef = engine;
+  }
 
   /** Silent noop logger — used when no logger is injected */
   const noopFn = () => {};
@@ -820,70 +867,14 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
       };
     }
 
-    // Step 4c: Business-rule evaluation (Spec 23 §1.1). Runs after input
-    // validation and before the write so `block` aborts cleanly, `enrich`
-    // augments the input that reaches the handler/write path, and `warn`
-    // surfaces on the result. Only action-triggered rules for THIS action fire
-    // (filtered by collectRules). Conditions are evaluated against the validated
-    // input; the pre-existing record is not yet threaded in (that lands with the
-    // require_approval phase), so input-shape guards work today while
-    // record-state guards arrive in a follow-up. require_approval /
-    // execute_action / trigger_flow effects are collected but not yet acted on
-    // here — also follow-up phases.
+    // `effectiveInput` carries the validated payload plus any rule `enrich`
+    // fields; `ruleWarnings` collects rule `warn` messages. Both are populated
+    // by Step 4c (business-rule evaluation), which runs further down — after
+    // provider setup — so rule conditions can read the pre-existing record.
+    // `let`, not `const`: Step 4c below reassigns this when a rule `enrich`
+    // effect merges its setFields into the input.
     let effectiveInput: Record<string, unknown> = inputValidation.value ?? input;
     const ruleWarnings: string[] = [];
-    if (rules && rules.length > 0) {
-      let applicableRules = applicableRulesCache.get(actionName);
-      if (applicableRules === undefined) {
-        applicableRules = collectRules(actionName, rules);
-        applicableRulesCache.set(actionName, applicableRules);
-      }
-      if (applicableRules.length > 0) {
-        const ruleOutput = await evaluateRules(
-          applicableRules,
-          {
-            target: effectiveInput,
-            actor: { type: actor.type, id: actor.id, groups: actor.groups ?? [] },
-            meta: resolvedMeta,
-          },
-          { skipRules: execOptions?.skipRules, metrics },
-        );
-        if (ruleOutput.blocked) {
-          const reason = ruleOutput.blockReasons.join("; ") || "Blocked by rule";
-          await logExecution({
-            id: executionId,
-            action: actionName,
-            entity: action.entity,
-            actor,
-            input,
-            // Policy/authorization-style block (consistent with exposure,
-            // field-lock, and state-transition blocks) — not an execution failure.
-            status: "blocked",
-            error: { message: reason },
-            meta: metaSnapshot,
-            startedAt,
-          });
-          return {
-            success: false,
-            data: {
-              error: reason,
-              context: {
-                action: actionName,
-                entity: action.entity,
-                constraint: "rule_block",
-                expected: reason,
-                suggestion: ruleOutput.contexts[0]?.suggestion ?? reason,
-              },
-            } as T,
-            executionId,
-          };
-        }
-        if (Object.keys(ruleOutput.enrichFields).length > 0) {
-          effectiveInput = { ...effectiveInput, ...ruleOutput.enrichFields };
-        }
-        for (const warn of ruleOutput.warnings) ruleWarnings.push(warn.message);
-      }
-    }
 
     // Build ActionContext
     const childExecutionIds: string[] = [];
@@ -941,6 +932,123 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
      * transaction declaration on its child.
      */
     let inTransaction = false;
+
+    // ── Step 4c: Business-rule evaluation (Spec 23 §1.1) ───────────
+    //
+    // Runs after provider setup and before the write. `block` aborts the
+    // action, `require_approval` suspends it into an approval request, `enrich`
+    // augments the input that reaches the handler/write path, and `warn`
+    // surfaces on the result. Conditions are evaluated against the merged view
+    // of the pre-existing record (for updates) and the validated input, so both
+    // input-shape and record-state guards work. Only action-triggered rules for
+    // THIS action fire (filtered + priority-sorted by collectRules). The
+    // `execute_action` / `trigger_flow` effects are collected but not yet acted
+    // on here — a follow-up phase handles those post-commit.
+    if (rules && rules.length > 0) {
+      let applicableRules = applicableRulesCache.get(actionName);
+      if (applicableRules === undefined) {
+        applicableRules = collectRules(actionName, rules);
+        applicableRulesCache.set(actionName, applicableRules);
+      }
+      if (applicableRules.length > 0) {
+        // Record-state context: for an update (input carries an id), read the
+        // current record via the tenant-scoped baseProvider so conditions can
+        // reference existing field values. A read failure (not found / access)
+        // degrades to input-only — the rule simply can't see record state.
+        let ruleTarget: Record<string, unknown> = effectiveInput;
+        const ruleRecordId = effectiveInput.id;
+        if (typeof ruleRecordId === "string" && ruleRecordId.length > 0) {
+          try {
+            const existing = await baseProvider.get(action.entity, ruleRecordId, queryOptions);
+            if (existing) ruleTarget = { ...existing, ...effectiveInput };
+          } catch {
+            // Not readable — fall back to input-only evaluation.
+          }
+        }
+
+        const ruleOutput = await evaluateRules(
+          applicableRules,
+          {
+            target: ruleTarget,
+            actor: { type: actor.type, id: actor.id, groups: actor.groups ?? [] },
+            meta: resolvedMeta,
+          },
+          { skipRules: execOptions?.skipRules, metrics },
+        );
+
+        if (ruleOutput.blocked) {
+          const reason = ruleOutput.blockReasons.join("; ") || "Blocked by rule";
+          await logExecution({
+            id: executionId,
+            action: actionName,
+            entity: action.entity,
+            actor,
+            input,
+            // Policy/authorization-style block (consistent with exposure,
+            // field-lock, and state-transition blocks) — not an execution failure.
+            status: "blocked",
+            error: { message: reason },
+            meta: metaSnapshot,
+            startedAt,
+          });
+          return {
+            success: false,
+            data: {
+              error: reason,
+              context: {
+                action: actionName,
+                entity: action.entity,
+                constraint: "rule_block",
+                expected: reason,
+                suggestion: ruleOutput.contexts[0]?.suggestion ?? reason,
+              },
+            } as T,
+            executionId,
+          };
+        }
+
+        // require_approval: suspend the action into an approval request instead
+        // of writing. ApprovalEngine.approve() later re-executes the action with
+        // `skipRules = triggerRules`, so the approval rule does not re-fire. When
+        // no approval engine is wired (minimal setups), fall through and let the
+        // action proceed — the gate is best-effort, not a silent hard block.
+        if (ruleOutput.requiredApproval && approvalEngineRef) {
+          const triggerRules = ruleOutput.results
+            .filter((r) => r.triggered && r.effect?.type === "require_approval")
+            .map((r) => r.rule);
+          const pending = await approvalEngineRef.createRequest({
+            action: actionName,
+            entity: action.entity,
+            recordId: typeof ruleRecordId === "string" ? ruleRecordId : undefined,
+            input: effectiveInput,
+            actor,
+            executionId,
+            effect: ruleOutput.requiredApproval,
+            triggerRules,
+            tenantId: execOptions?.tenantId,
+            meta: resolvedMeta.toJSON(),
+          });
+          await logExecution({
+            id: executionId,
+            action: actionName,
+            entity: action.entity,
+            actor,
+            input,
+            // Suspended pending approval — a policy decision, not a failure.
+            status: "blocked",
+            error: { message: `Pending approval (${pending.level})` },
+            meta: metaSnapshot,
+            startedAt,
+          });
+          return { success: false, data: pending as T, executionId };
+        }
+
+        if (Object.keys(ruleOutput.enrichFields).length > 0) {
+          effectiveInput = { ...effectiveInput, ...ruleOutput.enrichFields };
+        }
+        for (const warn of ruleOutput.warnings) ruleWarnings.push(warn.message);
+      }
+    }
 
     // ── Step 4b: Field-lock preflight for declarative updates ──────
     //
@@ -1803,5 +1911,6 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
   return {
     registry,
     execute,
+    setApprovalEngine,
   };
 }

--- a/packages/core/src/engine/action-engine.ts
+++ b/packages/core/src/engine/action-engine.ts
@@ -952,9 +952,18 @@ export function createActionExecutor(options: ActionExecutorOptions): ActionExec
       }
       if (applicableRules.length > 0) {
         // Record-state context: for an update (input carries an id), read the
-        // current record via the tenant-scoped baseProvider so conditions can
-        // reference existing field values. A read failure (not found / access)
-        // degrades to input-only — the rule simply can't see record state.
+        // current record so conditions can reference existing field values. A
+        // read failure (not found / access) degrades to input-only.
+        //
+        // Snapshot caveat (tracked follow-up): for a TOP-LEVEL transactional
+        // action this read happens before `runInTransaction` opens, so a
+        // concurrent commit between here and the write could make a
+        // record-state `block` / `require_approval` decision on a slightly
+        // stale snapshot. Hardening this means evaluating rules inside the
+        // write transaction — the same in-tx relocation field-lock enforcement
+        // took (PR #203) — which also requires moving ctx/enrich assembly into
+        // the tx, so it is deferred to a focused follow-up. Nested actions
+        // already read through the parent's tx provider below.
         let ruleTarget: Record<string, unknown> = effectiveInput;
         const ruleRecordId = effectiveInput.id;
         if (action.entity && typeof ruleRecordId === "string" && ruleRecordId.length > 0) {

--- a/packages/core/src/exports/client/engines.ts
+++ b/packages/core/src/exports/client/engines.ts
@@ -74,7 +74,6 @@ export {
   executeOverlayProposal,
 } from "../../engine/overlay-proposal-executor";
 export type { PermissionRegistry } from "../../engine/permission-engine";
-
 export type {
   EffectVerificationPayload,
   EffectVerificationRecord,
@@ -104,7 +103,6 @@ export type {
   RollbackInsightEmitter,
   RollbackInsightEmitterOptions,
 } from "../../engine/rollback-insight-emitter";
-
 export type {
   RuleEvalInput,
   RuleEvalOptions,
@@ -112,3 +110,4 @@ export type {
 } from "../../engine/rule-engine";
 export type { StateMachine } from "../../engine/state-machine";
 export type { ValidationContext } from "../../engine/validation-engine";
+export type { ApprovalStore } from "../../types/approval";


### PR DESCRIPTION
## Why

Phase 2 of wiring `defineRule()` business rules into the action-execution path (phase 1 = block/warn/enrich, #460). Adds the `require_approval` effect and lets rule conditions read the pre-existing record. The adapter-server **never constructed an approval engine**, so server-side `require_approval` could never function — this PR builds + wires one into the server runtime.

## What

**require_approval.** `createActionExecutor` gains optional `approvalEngine` (`ActionApprovalSuspender` — a structural subset of `ApprovalEngine.createRequest` to avoid a module cycle) + a late-binding `executor.setApprovalEngine()` seam (executor and engine are mutually dependent). When a require_approval rule fires, the executor suspends: `createRequest({...})` → returns `ApprovalPendingResult` instead of writing. `approve()` re-executes with `skipRules = triggerRules`. No engine wired → action proceeds (best-effort gate).

**Record-state.** Rule evaluation moved after provider setup; for updates the executor reads the current record and evaluates against `{ ...record, ...input }` (input overrides; read failure → input-only).

**Wiring (all prod paths).** CLI `dev` → `setApprovalEngine`. adapter-server `createRuntimeContext` constructs + wires + exposes the engine on `RuntimeContext`; `dev`/`dev-app` pass it to `createServer` (in-memory store; Drizzle persistence is a follow-up).

## Cross-model review (codex) — all confirmed + fixed

| Finding | Sev | Fix |
|---|---|---|
| Nested-tx rule read used `baseProvider`, missing the parent's uncommitted writes | P2 | Read via `parentTxProvider ?? baseProvider` (Spec 26 §1.1) |
| runtime-context CommandLayer lacked an approval verifier → `approve()` replays re-gated | P2 | Build CommandLayer with `createApprovalVerifier(approvalStore)` over the same store |
| Suspend logged `blocked` instead of `pending_approval` | P2 | Log `pending_approval` |

## Test plan

`action-engine-rule-integration.test.ts` (14 cases, all via the real executor): require_approval (suspend→pending/no write; no-engine→proceeds; setApprovalEngine seam; skipRules bypass) + record-state (record-derived condition fires; input overrides) + phase-1 cases. Full `bun run test` PASS; biome clean; typecheck clean on changed files. Non-breaking. No `any`/`!`. Changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Actions can be suspended into approval workflows when rules specify require_approval
  * Rule evaluation for updates now merges current record state with input before deciding effects
  * Action executor can be wired to an approval engine to suspend and later resume executions
  * Pending approvals are recorded as part of the execution lifecycle

* **Tests**
  * Added integration tests covering approval suspension, late-binding, bypass, and record-state targeting

* **Documentation**
  * Changeset documents approval wiring and runtime behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->